### PR TITLE
feat: Microsoft Teams frontend via Power Automate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "cheerio": "^1.2.0",
         "croner": "^10.0.1",
         "grammy": "^1.41.1",
+        "marked": "^17.0.5",
         "picocolors": "^1.1.1",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
@@ -5095,6 +5096,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
+      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cheerio": "^1.2.0",
     "croner": "^10.0.1",
     "grammy": "^1.41.1",
+    "marked": "^17.0.5",
     "picocolors": "^1.1.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",

--- a/prompts/teams.md
+++ b/prompts/teams.md
@@ -9,7 +9,7 @@ ALL messages to the user MUST be sent using the `send_message` tool. Do NOT outp
 
 ### The `send_message` tool
 
-- `send_message(text="Hello!")` — send a message (Markdown supported)
+- `send_message(text="Hello!")` — send a message
 - `send_message_with_buttons(text="Pick", rows=[[{"text":"Docs","url":"https://..."}]])` — with link buttons
 
 ### Other tools
@@ -29,8 +29,25 @@ You don't have to respond to every message. If a message doesn't need a response
 
 Webhook-based integration — no reactions, media uploads, message editing, typing indicators.
 
-### Style
+### Formatting rules for Teams
 
+Messages render as Adaptive Cards. The formatting engine is NOT standard Markdown.
+
+What WORKS:
+- **bold** and _italic_
+- [links](https://example.com)
+- Fenced code blocks (triple backticks) — these render as monospace text in a grey box
+- Numbered and bulleted lists
+
+What does NOT work (will break the card or display raw characters):
+- Inline code with backticks — do NOT use `code` style, just write the text plain
+- Headings with # — use **bold** text instead
+- Tables — use aligned text or lists instead
+- Images/media — not supported via webhook
+
+Style:
 - Concise. No filler.
-- Markdown: **bold**, _italic_, `code`, ```code blocks```, [links](url).
+- Use **bold** for emphasis, _italic_ for secondary emphasis.
+- Use fenced code blocks for code, commands, or structured output.
+- Never use inline backticks — they don't render and break formatting.
 - In chats, use names naturally.

--- a/prompts/teams.md
+++ b/prompts/teams.md
@@ -42,12 +42,12 @@ What WORKS:
 What does NOT work (will break the card or display raw characters):
 - Inline code with backticks — do NOT use `code` style, just write the text plain
 - Headings with # — use **bold** text instead
-- Tables — use aligned text or lists instead
+- Markdown tables — put tabular data inside fenced code blocks instead (whitespace alignment is preserved)
 - Images/media — not supported via webhook
 
 Style:
 - Concise. No filler.
 - Use **bold** for emphasis, _italic_ for secondary emphasis.
-- Use fenced code blocks for code, commands, or structured output.
+- Use fenced code blocks for code, commands, structured output, and tables.
 - Never use inline backticks — they don't render and break formatting.
 - In chats, use names naturally.

--- a/prompts/teams.md
+++ b/prompts/teams.md
@@ -1,0 +1,34 @@
+## Teams Mode
+
+You are running in a Microsoft Teams channel via Power Automate webhooks.
+Messages arrive as `[SenderName]: message text`. Use names naturally.
+
+### Message delivery
+
+ALL messages to the user MUST be sent using the `send_message` tool. Do NOT output plain text — it will be sent automatically.
+
+### Available tools
+
+- `send_message(text)` — send a message to the channel
+- `send_message_with_buttons(text, rows)` — send with clickable buttons (links only)
+- `read_chat_history(limit)` — read past messages
+- `search_chat_history(query)` — search by keyword
+
+### Limitations
+
+This is a webhook-based integration. The following are NOT available:
+- Reactions, stickers, media uploads (photos, files, voice)
+- Message editing or deletion
+- Message pinning or forwarding
+- Typing indicators
+
+### Choosing not to respond
+
+You don't have to respond to every message. If a message doesn't need a response, simply produce NO output at all.
+
+### Style
+
+- Concise. No filler.
+- Markdown: **bold**, _italic_, `code`, ```code blocks```, [links](url).
+- Teams Adaptive Cards render Markdown natively.
+- In channels, use names naturally when addressing people.

--- a/prompts/teams.md
+++ b/prompts/teams.md
@@ -1,34 +1,36 @@
 ## Teams Mode
 
-You are running in a Microsoft Teams channel via Power Automate webhooks.
+You are running in a Microsoft Teams group chat via Power Automate webhooks + Graph API.
 Messages arrive as `[SenderName]: message text`. Use names naturally.
 
-### Message delivery
+### CRITICAL: Message delivery
 
-ALL messages to the user MUST be sent using the `send_message` tool. Do NOT output plain text — it will be sent automatically.
+ALL messages to the user MUST be sent using the `send_message` tool. Do NOT output plain text as your response — any text you output will be sent to the chat automatically, so use the send_message tool instead. If you decide NOT to respond, end your turn without outputting any text at all — not even internal thoughts or reasoning.
 
-### Available tools
+### The `send_message` tool
 
-- `send_message(text)` — send a message to the channel
-- `send_message_with_buttons(text, rows)` — send with clickable buttons (links only)
-- `read_chat_history(limit)` — read past messages
-- `search_chat_history(query)` — search by keyword
+- `send_message(text="Hello!")` — send a message (Markdown supported)
+- `send_message_with_buttons(text="Pick", rows=[[{"text":"Docs","url":"https://..."}]])` — with link buttons
 
-### Limitations
+### Other tools
 
-This is a webhook-based integration. The following are NOT available:
-- Reactions, stickers, media uploads (photos, files, voice)
-- Message editing or deletion
-- Message pinning or forwarding
-- Typing indicators
+- `web_search(query)` — search the web
+- `fetch_url(url)` — fetch & parse a URL
+- `create_cron_job` / `list_cron_jobs` / `edit_cron_job` / `delete_cron_job` — scheduled jobs
+- `get_chat_info()` — info about the current chat
 
 ### Choosing not to respond
 
-You don't have to respond to every message. If a message doesn't need a response, simply produce NO output at all.
+You don't have to respond to every message. If a message doesn't need a response:
+- Simply don't call any tools and produce NO output at all.
+- NEVER write internal thoughts or reasoning — it all gets sent.
+
+### Limitations
+
+Webhook-based integration — no reactions, media uploads, message editing, typing indicators.
 
 ### Style
 
 - Concise. No filler.
 - Markdown: **bold**, _italic_, `code`, ```code blocks```, [links](url).
-- Teams Adaptive Cards render Markdown natively.
-- In channels, use names naturally when addressing people.
+- In chats, use names naturally.

--- a/src/__tests__/dispatcher.test.ts
+++ b/src/__tests__/dispatcher.test.ts
@@ -62,7 +62,7 @@ describe("dispatcher", () => {
       source: "message",
     });
 
-    expect(deps.context.acquire).toHaveBeenCalledWith(456);
+    expect(deps.context.acquire).toHaveBeenCalledWith(456, "456");
     expect(deps.context.release).toHaveBeenCalledWith(456);
   });
 

--- a/src/__tests__/teams-frontend.test.ts
+++ b/src/__tests__/teams-frontend.test.ts
@@ -25,7 +25,7 @@ describe("teams formatting", () => {
       expect(attachment.contentType).toBe("application/vnd.microsoft.card.adaptive");
       const content = attachment.content as Record<string, unknown>;
       expect(content.type).toBe("AdaptiveCard");
-      expect(content.version).toBe("1.4");
+      expect(content.version).toBe("1.6");
       const body = content.body as Array<Record<string, unknown>>;
       expect(body[0].text).toBe("Hello Teams!");
       expect(body[0].wrap).toBe(true);

--- a/src/__tests__/teams-frontend.test.ts
+++ b/src/__tests__/teams-frontend.test.ts
@@ -25,7 +25,7 @@ describe("teams formatting", () => {
       expect(attachment.contentType).toBe("application/vnd.microsoft.card.adaptive");
       const content = attachment.content as Record<string, unknown>;
       expect(content.type).toBe("AdaptiveCard");
-      expect(content.version).toBe("1.6");
+      expect(content.version).toBe("1.4");
       const body = content.body as Array<Record<string, unknown>>;
       expect(body[0].text).toBe("Hello Teams!");
       expect(body[0].wrap).toBe(true);

--- a/src/__tests__/teams-frontend.test.ts
+++ b/src/__tests__/teams-frontend.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(), logError: vi.fn(), logWarn: vi.fn(), logDebug: vi.fn(),
+}));
+
+vi.mock("../core/plugin.js", () => ({
+  handlePluginAction: vi.fn(async () => null),
+}));
+
+// ── Test formatting module ──────────────────────────────────────────────────
+
+const { buildAdaptiveCard, splitTeamsMessage, stripHtml } = await import(
+  "../frontend/teams/formatting.js"
+);
+
+describe("teams formatting", () => {
+
+  describe("buildAdaptiveCard", () => {
+    it("builds a basic card with text", () => {
+      const card = buildAdaptiveCard("Hello Teams!");
+      expect(card.type).toBe("message");
+      expect(card.attachments).toHaveLength(1);
+      const attachment = (card.attachments as Array<Record<string, unknown>>)[0];
+      expect(attachment.contentType).toBe("application/vnd.microsoft.card.adaptive");
+      const content = attachment.content as Record<string, unknown>;
+      expect(content.type).toBe("AdaptiveCard");
+      expect(content.version).toBe("1.4");
+      const body = content.body as Array<Record<string, unknown>>;
+      expect(body[0].text).toBe("Hello Teams!");
+      expect(body[0].wrap).toBe(true);
+    });
+
+    it("includes URL buttons as OpenUrl actions", () => {
+      const card = buildAdaptiveCard("Pick one:", [
+        { text: "Docs", url: "https://docs.example.com" },
+        { text: "Repo", url: "https://github.com/example" },
+      ]);
+      const content = ((card.attachments as unknown[])[0] as Record<string, unknown>).content as Record<string, unknown>;
+      const actions = content.actions as Array<Record<string, unknown>>;
+      expect(actions).toHaveLength(2);
+      expect(actions[0].type).toBe("Action.OpenUrl");
+      expect(actions[0].title).toBe("Docs");
+      expect(actions[0].url).toBe("https://docs.example.com");
+    });
+
+    it("includes non-URL buttons as Submit actions", () => {
+      const card = buildAdaptiveCard("Choose:", [
+        { text: "Option A" },
+        { text: "Option B" },
+      ]);
+      const content = ((card.attachments as unknown[])[0] as Record<string, unknown>).content as Record<string, unknown>;
+      const actions = content.actions as Array<Record<string, unknown>>;
+      expect(actions[0].type).toBe("Action.Submit");
+      expect(actions[0].data).toEqual({ choice: "Option A" });
+    });
+
+    it("omits actions when no buttons provided", () => {
+      const card = buildAdaptiveCard("No buttons");
+      const content = ((card.attachments as unknown[])[0] as Record<string, unknown>).content as Record<string, unknown>;
+      expect(content.actions).toBeUndefined();
+    });
+
+    it("omits actions for empty button array", () => {
+      const card = buildAdaptiveCard("Empty buttons", []);
+      const content = ((card.attachments as unknown[])[0] as Record<string, unknown>).content as Record<string, unknown>;
+      expect(content.actions).toBeUndefined();
+    });
+  });
+
+  describe("splitTeamsMessage", () => {
+    it("returns single chunk for short messages", () => {
+      expect(splitTeamsMessage("short")).toEqual(["short"]);
+    });
+
+    it("splits on paragraph boundaries", () => {
+      const text = "A".repeat(5000) + "\n\n" + "B".repeat(5000) + "\n\n" + "C".repeat(100);
+      const chunks = splitTeamsMessage(text, 6000);
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+      expect(chunks[0]).toContain("A");
+    });
+
+    it("falls back to line boundaries when no paragraph break", () => {
+      const text = Array.from({ length: 200 }, (_, i) => `Line ${i}`).join("\n");
+      const chunks = splitTeamsMessage(text, 500);
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(500);
+      }
+    });
+
+    it("hard splits when no newlines available", () => {
+      const text = "X".repeat(25000);
+      const chunks = splitTeamsMessage(text, 10000);
+      expect(chunks.length).toBe(3);
+    });
+
+    it("default max is 10000 characters", () => {
+      const text = "Y".repeat(15000);
+      const chunks = splitTeamsMessage(text);
+      expect(chunks.length).toBe(2);
+    });
+  });
+
+  describe("stripHtml", () => {
+    it("strips HTML tags", () => {
+      expect(stripHtml("<p>Hello <b>world</b></p>")).toBe("Hello world");
+    });
+
+    it("handles nested tags", () => {
+      expect(stripHtml("<div><p>Text <em>here</em></p></div>")).toBe("Text here");
+    });
+
+    it("returns plain text unchanged", () => {
+      expect(stripHtml("no html here")).toBe("no html here");
+    });
+
+    it("handles empty string", () => {
+      expect(stripHtml("")).toBe("");
+    });
+
+    it("decodes HTML entities", () => {
+      expect(stripHtml("<p>&amp; &lt; &gt;</p>")).toBe("& < >");
+    });
+
+    it("handles Teams-style HTML with mentions", () => {
+      const html = '<p><at id="0">User Name</at> hello there</p>';
+      const result = stripHtml(html);
+      expect(result).toContain("User Name");
+      expect(result).toContain("hello there");
+    });
+  });
+});
+
+// ── Test action handler ─────────────────────────────────────────────────────
+
+describe("teams actions", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("send_message posts to webhook and increments messages", async () => {
+    vi.doMock("../frontend/teams/proxy-fetch.js", () => ({
+      proxyFetch: vi.fn(async () => ({ ok: true, text: async () => "" })),
+    }));
+
+    const { Gateway } = await import("../core/gateway.js");
+    const { createTeamsActionHandler } = await import("../frontend/teams/actions.js");
+
+    const gateway = new Gateway();
+    gateway.setContext(123);
+    const handler = createTeamsActionHandler("https://webhook.example.com", gateway);
+
+    const result = await handler({ action: "send_message", text: "Hello Teams!" }, 123);
+    expect(result?.ok).toBe(true);
+    expect(result?.message_id).toBeDefined();
+    expect(gateway.getMessageCount(123)).toBe(1);
+    gateway.clearContext(123);
+  });
+
+  it("send_message returns ok for empty text (no-op)", async () => {
+    const { Gateway } = await import("../core/gateway.js");
+    const { createTeamsActionHandler } = await import("../frontend/teams/actions.js");
+    const gateway = new Gateway();
+    const handler = createTeamsActionHandler("https://webhook.example.com", gateway);
+
+    const result = await handler({ action: "send_message", text: "" }, 123);
+    expect(result?.ok).toBe(true);
+  });
+
+  it("send_message handles webhook failure", async () => {
+    vi.doMock("../frontend/teams/proxy-fetch.js", () => ({
+      proxyFetch: vi.fn(async () => ({ ok: false, status: 500, text: async () => "Internal Error" })),
+    }));
+
+    const { Gateway } = await import("../core/gateway.js");
+    const { createTeamsActionHandler } = await import("../frontend/teams/actions.js");
+    const gateway = new Gateway();
+    const handler = createTeamsActionHandler("https://webhook.example.com", gateway);
+
+    const result = await handler({ action: "send_message", text: "fail" }, 123);
+    expect(result?.ok).toBe(false);
+    expect(result?.error).toContain("failed");
+  });
+
+  it("get_chat_info returns channel info", async () => {
+    const { Gateway } = await import("../core/gateway.js");
+    const { createTeamsActionHandler } = await import("../frontend/teams/actions.js");
+    const gateway = new Gateway();
+    const handler = createTeamsActionHandler("https://webhook.example.com", gateway);
+
+    const result = await handler({ action: "get_chat_info" }, 456);
+    expect(result?.ok).toBe(true);
+    expect(result?.type).toBe("channel");
+    expect(result?.id).toBe(456);
+  });
+
+  it("unsupported actions return ok (graceful no-ops)", async () => {
+    const { Gateway } = await import("../core/gateway.js");
+    const { createTeamsActionHandler } = await import("../frontend/teams/actions.js");
+    const gateway = new Gateway();
+    const handler = createTeamsActionHandler("https://webhook.example.com", gateway);
+
+    for (const action of ["react", "edit_message", "delete_message", "pin_message", "unpin_message", "forward_message"]) {
+      const result = await handler({ action }, 123);
+      expect(result?.ok).toBe(true);
+    }
+  });
+
+  it("unknown actions return null", async () => {
+    const { Gateway } = await import("../core/gateway.js");
+    const { createTeamsActionHandler } = await import("../frontend/teams/actions.js");
+    const gateway = new Gateway();
+    const handler = createTeamsActionHandler("https://webhook.example.com", gateway);
+
+    const result = await handler({ action: "totally_unknown" }, 123);
+    expect(result).toBeNull();
+  });
+});
+
+// ── Test proxy-fetch ────────────────────────────────────────────────────────
+
+describe("proxy-fetch", () => {
+  it("exports proxyFetch function", async () => {
+    const { proxyFetch } = await import("../frontend/teams/proxy-fetch.js");
+    expect(typeof proxyFetch).toBe("function");
+  });
+});
+
+// ── Test graph client types ─────────────────────────────────────────────────
+
+describe("graph module exports", () => {
+  it("exports initGraphClient and GraphClient", async () => {
+    const graph = await import("../frontend/teams/graph.js");
+    expect(typeof graph.initGraphClient).toBe("function");
+    expect(typeof graph.GraphClient).toBe("function");
+    expect(typeof graph.deviceCodeAuth).toBe("function");
+  });
+});

--- a/src/backend/claude-sdk/index.ts
+++ b/src/backend/claude-sdk/index.ts
@@ -75,21 +75,23 @@ export async function handleMessage(
       ...(() => {
         const frontends = Array.isArray(config.frontend) ? config.frontend : [config.frontend];
         const bridgeUrl = `http://127.0.0.1:${bridgePortFn()}`;
-        const env = { TALON_BRIDGE_URL: bridgeUrl, TALON_CHAT_ID: chatId };
+        const mcpEnv = { TALON_BRIDGE_URL: bridgeUrl, TALON_CHAT_ID: chatId };
         const servers: Record<string, { command: string; args: string[]; env: Record<string, string> }> = {};
+        // Resolve tsx from Talon's node_modules (cwd may be ~/.talon/workspace/ which has no node_modules)
+        const tsxImport = resolve(import.meta.dirname ?? ".", "../../node_modules/tsx/dist/esm/index.mjs");
 
         if (frontends.includes("telegram")) {
           servers["telegram-tools"] = {
             command: "node",
-            args: ["--import", "tsx", resolve(import.meta.dirname ?? ".", "tools.ts")],
-            env,
+            args: ["--import", tsxImport, resolve(import.meta.dirname ?? ".", "tools.ts")],
+            env: mcpEnv,
           };
         }
         if (frontends.includes("teams")) {
           servers["teams-tools"] = {
             command: "node",
-            args: ["--import", "tsx", resolve(import.meta.dirname ?? ".", "../../frontend/teams/tools.ts")],
-            env,
+            args: ["--import", tsxImport, resolve(import.meta.dirname ?? ".", "../../frontend/teams/tools.ts")],
+            env: mcpEnv,
           };
         }
         return servers;

--- a/src/backend/claude-sdk/index.ts
+++ b/src/backend/claude-sdk/index.ts
@@ -71,21 +71,29 @@ export async function handleMessage(
     ],
     ...thinkingConfig,
     mcpServers: {
-      // Only register Telegram tools when Telegram frontend is active
-      ...((Array.isArray(config.frontend) ? config.frontend : [config.frontend]).includes("telegram") ? {
-        "telegram-tools": {
-          command: "node",
-          args: [
-            "--import",
-            "tsx",
-            resolve(import.meta.dirname ?? ".", "tools.ts"),
-          ],
-          env: {
-            TALON_BRIDGE_URL: `http://127.0.0.1:${bridgePortFn()}`,
-            TALON_CHAT_ID: chatId,
-          },
-        },
-      } : {}),
+      // Register frontend-specific MCP tools based on active frontend
+      ...(() => {
+        const frontends = Array.isArray(config.frontend) ? config.frontend : [config.frontend];
+        const bridgeUrl = `http://127.0.0.1:${bridgePortFn()}`;
+        const env = { TALON_BRIDGE_URL: bridgeUrl, TALON_CHAT_ID: chatId };
+        const servers: Record<string, { command: string; args: string[]; env: Record<string, string> }> = {};
+
+        if (frontends.includes("telegram")) {
+          servers["telegram-tools"] = {
+            command: "node",
+            args: ["--import", "tsx", resolve(import.meta.dirname ?? ".", "tools.ts")],
+            env,
+          };
+        }
+        if (frontends.includes("teams")) {
+          servers["teams-tools"] = {
+            command: "node",
+            args: ["--import", "tsx", resolve(import.meta.dirname ?? ".", "../../frontend/teams/tools.ts")],
+            env,
+          };
+        }
+        return servers;
+      })(),
       ...getPluginMcpServers(`http://127.0.0.1:${bridgePortFn()}`, chatId),
     },
     ...(session.sessionId ? { resume: session.sessionId } : {}),

--- a/src/backend/claude-sdk/index.ts
+++ b/src/backend/claude-sdk/index.ts
@@ -78,7 +78,8 @@ export async function handleMessage(
         const mcpEnv = { TALON_BRIDGE_URL: bridgeUrl, TALON_CHAT_ID: chatId };
         const servers: Record<string, { command: string; args: string[]; env: Record<string, string> }> = {};
         // Resolve tsx from Talon's node_modules (cwd may be ~/.talon/workspace/ which has no node_modules)
-        const tsxImport = resolve(import.meta.dirname ?? ".", "../../node_modules/tsx/dist/esm/index.mjs");
+        // Resolve tsx from the package root (3 levels up from src/backend/claude-sdk/)
+        const tsxImport = resolve(import.meta.dirname ?? ".", "../../../node_modules/tsx/dist/esm/index.mjs");
 
         if (frontends.includes("telegram")) {
           servers["telegram-tools"] = {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,11 @@ type Config = {
   apiHash?: string;
   maxMessageLength: number;
   plugins?: unknown[];
+  // Teams
+  teamsWebhookUrl?: string;
+  teamsWebhookSecret?: string;
+  teamsWebhookPort?: number;
+  teamsBotDisplayName?: string;
 };
 
 const DEFAULTS: Config = {
@@ -81,6 +86,7 @@ function isConfigured(config: Config): boolean {
   return fes.every((fe) => {
     if (fe === "telegram") return !!config.botToken;
     if (fe === "terminal") return true;
+    if (fe === "teams") return !!config.teamsWebhookUrl;
     return false;
   });
 }
@@ -100,6 +106,7 @@ async function runSetup(): Promise<void> {
     options: [
       { value: "telegram", label: `Telegram  ${pc.dim("\u2014 bot via @BotFather")}` },
       { value: "terminal", label: `Terminal  ${pc.dim("\u2014 local CLI chat")}` },
+      { value: "teams", label: `Teams     ${pc.dim("\u2014 Microsoft Teams via Power Automate")}` },
     ],
     required: true,
   });
@@ -152,6 +159,61 @@ async function runSetup(): Promise<void> {
     }
   }
 
+  let teamsWebhookUrl: string | undefined;
+  let teamsWebhookSecret: string | undefined;
+  let teamsWebhookPort: number | undefined;
+  let teamsBotDisplayName: string | undefined;
+
+  if (selectedFrontends.includes("teams")) {
+    p.note(
+      "Set up two Power Automate workflows in Teams:\n" +
+      "1. Send: 'Post to a channel when a webhook request is received' — copy the URL below\n" +
+      "2. Receive: 'When a new channel message is added' → HTTP POST to your Talon endpoint",
+      "Teams Setup",
+    );
+
+    const url = await p.text({
+      message: "Power Automate webhook URL (for sending to Teams)",
+      placeholder: "https://prod-XX.westus.logic.azure.com/workflows/...",
+      initialValue: config.teamsWebhookUrl || undefined,
+      validate: (v) => {
+        if (!v) return "Webhook URL is required";
+        try { new URL(v); } catch { return "Must be a valid URL"; }
+      },
+    });
+    if (p.isCancel(url)) { p.cancel("Cancelled."); process.exit(0); }
+    teamsWebhookUrl = url;
+
+    const secret = await p.text({
+      message: "Webhook secret for inbound verification",
+      placeholder: "optional — shared secret to verify incoming webhooks",
+      initialValue: config.teamsWebhookSecret || "",
+    }) as string;
+    if (p.isCancel(secret)) { p.cancel("Cancelled."); process.exit(0); }
+    if (secret) teamsWebhookSecret = secret;
+
+    const port = await p.text({
+      message: "Webhook receiver port",
+      placeholder: "19878",
+      initialValue: config.teamsWebhookPort ? String(config.teamsWebhookPort) : "19878",
+      validate: (v) => {
+        if (!v) return "Port is required";
+        const n = parseInt(v, 10);
+        if (isNaN(n) || n < 1024 || n > 65535) return "Port must be 1024-65535";
+      },
+    });
+    if (p.isCancel(port)) { p.cancel("Cancelled."); process.exit(0); }
+    teamsWebhookPort = parseInt(port as string, 10);
+
+    const botName = await p.text({
+      message: "Bot display name in Teams (for echo loop prevention)",
+      placeholder: "optional — e.g. 'Talon Bot'",
+      initialValue: config.teamsBotDisplayName || "",
+    }) as string;
+    if (p.isCancel(botName)) { p.cancel("Cancelled."); process.exit(0); }
+    if (botName) teamsBotDisplayName = botName;
+  }
+
   const model = await p.select({
     message: "Default model",
     initialValue: config.model,
@@ -180,6 +242,11 @@ async function runSetup(): Promise<void> {
     apiId, apiHash,
     maxMessageLength: config.maxMessageLength,
     plugins: config.plugins,
+    // Teams
+    teamsWebhookUrl: selectedFrontends.includes("teams") ? teamsWebhookUrl : undefined,
+    teamsWebhookSecret: selectedFrontends.includes("teams") ? teamsWebhookSecret : undefined,
+    teamsWebhookPort: selectedFrontends.includes("teams") ? teamsWebhookPort : undefined,
+    teamsBotDisplayName: selectedFrontends.includes("teams") ? teamsBotDisplayName : undefined,
   };
 
   const s = p.spinner();
@@ -222,6 +289,7 @@ async function showStatus(): Promise<void> {
     const fes = Array.isArray(config.frontend) ? config.frontend : [config.frontend];
     console.log(`  ${pc.dim("Frontend")} ${fes.join(", ")}`);
     if (fes.includes("telegram")) console.log(`  ${pc.dim("Token")}    ${config.botToken ? pc.green("configured") : pc.red("not set")}`);
+    if (fes.includes("teams")) console.log(`  ${pc.dim("Teams")}    ${config.teamsWebhookUrl ? pc.green("configured") : pc.red("not set")}`);
     console.log(`  ${pc.dim("Model")}    ${config.model}`);
     console.log(`  ${pc.dim("Config")}   ${pc.dim(CONFIG_FILE)}\n`);
     console.log(`  Start with ${pc.cyan("talon start")} or ${pc.cyan("talon chat")}\n`);
@@ -251,6 +319,12 @@ async function viewConfig(): Promise<void> {
     console.log(`  ${pc.dim("Bot token")}        ${maskToken(config.botToken)}`);
     console.log(`  ${pc.dim("Admin")}            ${config.adminUserId || pc.dim("not set")}`);
     console.log(`  ${pc.dim("Userbot")}          ${config.apiId ? pc.green("configured") : pc.dim("not set")}`);
+  }
+  if (fes.includes("teams")) {
+    console.log(`  ${pc.dim("Teams webhook")}    ${config.teamsWebhookUrl ? pc.green("configured") : pc.red("not set")}`);
+    console.log(`  ${pc.dim("Teams secret")}     ${config.teamsWebhookSecret ? pc.green("set") : pc.dim("not set")}`);
+    console.log(`  ${pc.dim("Teams port")}       ${config.teamsWebhookPort || 19878}`);
+    console.log(`  ${pc.dim("Teams bot name")}   ${config.teamsBotDisplayName || pc.dim("not set")}`);
   }
   console.log(`  ${pc.dim("Model")}            ${config.model}`);
   console.log(`  ${pc.dim("Concurrency")}      ${config.concurrency}`);
@@ -359,7 +433,7 @@ async function mainMenu(): Promise<void> {
   const config = loadConfig();
   const statusDot = running ? `${pc.green("\u25CF")} running` : `${pc.red("\u25CF")} stopped`;
   const fes = Array.isArray(config.frontend) ? config.frontend : [config.frontend];
-  const frontendLabel = fes.map((f) => f === "telegram" ? "Telegram" : "Terminal").join(" + ");
+  const frontendLabel = fes.map((f) => f === "telegram" ? "Telegram" : f === "teams" ? "Teams" : "Terminal").join(" + ");
 
   const action = await p.select({
     message: `Talon ${statusDot} ${pc.dim(`(${frontendLabel})`)}`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -400,6 +400,15 @@ async function startChat(): Promise<void> {
 
   const { config } = await bootstrap({ frontendNames: ["terminal"] });
 
+  // Override frontend for the backend — talon chat always uses terminal,
+  // regardless of what the config file says. This prevents the backend from
+  // spawning telegram-tools or teams-tools MCP servers and ensures the
+  // system prompt loads terminal.md instead of teams.md/telegram.md.
+  (config as Record<string, unknown>).frontend = "terminal";
+  const { rebuildSystemPrompt } = await import("./util/config.js");
+  const { getPluginPromptAdditions } = await import("./core/plugin.js");
+  rebuildSystemPrompt(config, getPluginPromptAdditions());
+
   const gateway = new Gateway();
   const frontend = createTerminalFrontend(config, gateway);
   await frontend.init();

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -85,7 +85,7 @@ async function executeInner(params: ExecuteParams): Promise<ExecuteResult> {
   const reqId = randomBytes(4).toString("hex");
 
   logDebug("dispatcher", `[${reqId}] ${params.source} chat=${params.chatId} started (active=${activeCount})`);
-  context.acquire(params.numericChatId);
+  context.acquire(params.numericChatId, params.chatId);
 
   let typingTimer: ReturnType<typeof setInterval> | undefined;
   try {

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -24,7 +24,7 @@ import type { FrontendActionHandler } from "./types.js";
 
 // ── Per-chat context state ───────────────────────────────────────────────────
 
-type ChatContext = { refCount: number; messagesSent: number };
+type ChatContext = { refCount: number; messagesSent: number; stringId?: string };
 
 // ── Retry helper (stateless — standalone export) ─────────────────────────────
 
@@ -63,15 +63,24 @@ export class Gateway {
 
   // ── Per-chat context management ──────────────────────────────────────────
 
-  setContext(chatId: number): void {
+  setContext(chatId: number, stringId?: string): void {
     const ctx = this.chatContexts.get(chatId);
     if (ctx) {
       ctx.refCount++;
       log("gateway", `Context ref++ for chat ${chatId} (refCount=${ctx.refCount})`);
     } else {
-      this.chatContexts.set(chatId, { refCount: 1, messagesSent: 0 });
-      log("gateway", `Context acquired for chat ${chatId}`);
+      this.chatContexts.set(chatId, { refCount: 1, messagesSent: 0, stringId });
+      log("gateway", `Context acquired for chat ${chatId}${stringId ? ` (${stringId})` : ""}`);
     }
+  }
+
+  /** Find a numeric chatId by its string ID (used for Teams-style non-numeric chat IDs). */
+  private findContextByStringId(stringId: string): number | null {
+    if (!stringId) return null;
+    for (const [numId, ctx] of this.chatContexts) {
+      if (ctx.stringId === stringId) return numId;
+    }
+    return null;
   }
 
   clearContext(chatId?: number | string): void {
@@ -110,9 +119,16 @@ export class Gateway {
   // ── Action dispatch ────────────────────────────────────────────────────────
 
   private async handleAction(body: Record<string, unknown>): Promise<unknown> {
-    // Route by _chatId from the MCP subprocess request
-    const chatId = body._chatId ? Number(body._chatId) : null;
-    if (!chatId || !this.chatContexts.has(chatId)) {
+    // Route by _chatId from the MCP subprocess request.
+    // _chatId may be a string (Teams: "teams_chat_19:...") or numeric string (Telegram: "123456").
+    // The context map is keyed by numeric chatId, so try direct parse first,
+    // then fall back to searching active contexts.
+    const rawChatId = body._chatId ? String(body._chatId) : "";
+    const numericId = Number(rawChatId);
+    const chatId = !isNaN(numericId) && this.chatContexts.has(numericId)
+      ? numericId
+      : this.findContextByStringId(rawChatId);
+    if (!chatId) {
       return { ok: false, error: "No active chat context" };
     }
 

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -332,6 +332,9 @@ export function getPluginMcpServers(
 ): Record<string, McpServerConfig> {
   const servers: Record<string, McpServerConfig> = {};
 
+  // Resolve tsx from Talon's own node_modules (not cwd which may be ~/.talon/workspace/)
+  const tsxPath = resolve(import.meta.dirname ?? ".", "../../node_modules/tsx/dist/esm/index.mjs");
+
   for (const { plugin, envVars } of registry.all) {
     if (!plugin.mcpServerPath) continue;
 
@@ -339,7 +342,7 @@ export function getPluginMcpServers(
       command: process.platform === "win32" ? "npx" : "node",
       args: process.platform === "win32"
         ? ["tsx", plugin.mcpServerPath]
-        : ["--import", "tsx", plugin.mcpServerPath],
+        : ["--import", tsxPath, plugin.mcpServerPath],
       env: {
         TALON_BRIDGE_URL: bridgeUrl,
         TALON_CHAT_ID: chatId,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -43,7 +43,7 @@ export interface QueryBackend {
  * can reach the messaging platform.
  */
 export interface ContextManager {
-  acquire(chatId: number): void;
+  acquire(chatId: number, stringId?: string): void;
   release(chatId: number): void;
   getMessageCount(chatId: number): number;
 }

--- a/src/frontend/teams/actions.ts
+++ b/src/frontend/teams/actions.ts
@@ -1,0 +1,100 @@
+/**
+ * Teams action handler — routes MCP tool calls to Teams via Power Automate webhook.
+ */
+
+import type { ActionResult, FrontendActionHandler } from "../../core/types.js";
+import type { Gateway } from "../../core/gateway.js";
+import { buildAdaptiveCard, splitTeamsMessage } from "./formatting.js";
+import { log, logError } from "../../util/log.js";
+
+/**
+ * POST an Adaptive Card to the Power Automate workflow webhook URL.
+ */
+async function postToTeams(webhookUrl: string, text: string): Promise<void> {
+  const chunks = splitTeamsMessage(text);
+  for (const chunk of chunks) {
+    const card = buildAdaptiveCard(chunk);
+    const resp = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(card),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new Error(`Teams webhook POST failed: ${resp.status} ${body}`);
+    }
+  }
+}
+
+export function createTeamsActionHandler(
+  webhookUrl: string,
+  gateway: Gateway,
+): FrontendActionHandler {
+  return async (body, chatId): Promise<ActionResult | null> => {
+    const action = body.action as string;
+
+    switch (action) {
+      case "send_message": {
+        const text = String(body.text ?? "");
+        if (!text) return { ok: true, message_id: Date.now() };
+        try {
+          await postToTeams(webhookUrl, text);
+          gateway.incrementMessages(chatId);
+          log("teams", `Sent message to chat ${chatId} (${text.length} chars)`);
+          return { ok: true, message_id: Date.now() };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          logError("teams", `send_message failed: ${msg}`);
+          return { ok: false, error: msg };
+        }
+      }
+
+      case "send_message_with_buttons": {
+        const text = String(body.text ?? "");
+        const rows = body.rows as Array<Array<{ text: string; url?: string }>> | undefined;
+        const buttons = rows?.flat().map((b) => ({ text: b.text, url: b.url }));
+        try {
+          const card = buildAdaptiveCard(text, buttons);
+          const resp = await fetch(webhookUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(card),
+            signal: AbortSignal.timeout(15_000),
+          });
+          if (!resp.ok) throw new Error(`${resp.status}`);
+          gateway.incrementMessages(chatId);
+          return { ok: true, message_id: Date.now() };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          logError("teams", `send_message_with_buttons failed: ${msg}`);
+          return { ok: false, error: msg };
+        }
+      }
+
+      // Graceful no-ops for unsupported actions
+      case "react":
+      case "edit_message":
+      case "delete_message":
+      case "pin_message":
+      case "unpin_message":
+      case "forward_message":
+      case "copy_message":
+      case "send_chat_action":
+        return { ok: true };
+
+      case "get_chat_info":
+        return {
+          ok: true,
+          id: chatId,
+          type: "channel",
+          title: "Teams Channel",
+        };
+
+      default:
+        return null;
+    }
+  };
+}
+
+export { postToTeams };

--- a/src/frontend/teams/actions.ts
+++ b/src/frontend/teams/actions.ts
@@ -6,6 +6,7 @@ import type { ActionResult, FrontendActionHandler } from "../../core/types.js";
 import type { Gateway } from "../../core/gateway.js";
 import { buildAdaptiveCard, splitTeamsMessage } from "./formatting.js";
 import { log, logError } from "../../util/log.js";
+import { proxyFetch } from "./proxy-fetch.js";
 
 /**
  * POST an Adaptive Card to the Power Automate workflow webhook URL.
@@ -14,7 +15,7 @@ async function postToTeams(webhookUrl: string, text: string): Promise<void> {
   const chunks = splitTeamsMessage(text);
   for (const chunk of chunks) {
     const card = buildAdaptiveCard(chunk);
-    const resp = await fetch(webhookUrl, {
+    const resp = await proxyFetch(webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(card),
@@ -56,7 +57,7 @@ export function createTeamsActionHandler(
         const buttons = rows?.flat().map((b) => ({ text: b.text, url: b.url }));
         try {
           const card = buildAdaptiveCard(text, buttons);
-          const resp = await fetch(webhookUrl, {
+          const resp = await proxyFetch(webhookUrl, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(card),

--- a/src/frontend/teams/formatting.ts
+++ b/src/frontend/teams/formatting.ts
@@ -36,13 +36,23 @@ function markdownToCardBody(text: string): CardElement[] {
         body.push({ type: "TextBlock", text: cleanInline(token.text), wrap: true });
         break;
 
-      case "code":
+      case "code": {
+        // Each line as a separate TextBlock to preserve newlines
+        const lines = (token.text as string).split("\n");
         body.push({
           type: "Container",
           style: "emphasis",
-          items: [{ type: "TextBlock", text: token.text, wrap: true, fontType: "Monospace", size: "Small" }],
+          items: lines.map((line) => ({
+            type: "TextBlock",
+            text: line || " ",
+            wrap: false,
+            fontType: "Monospace",
+            size: "Small",
+            spacing: "None",
+          })),
         });
         break;
+      }
 
       case "list": {
         const listToken = token as Record<string, unknown>;

--- a/src/frontend/teams/formatting.ts
+++ b/src/frontend/teams/formatting.ts
@@ -92,6 +92,13 @@ function buildCardBody(text: string): Array<Record<string, unknown>> {
     body.push({ type: "TextBlock", text: text || " ", wrap: true });
   }
 
+  // Strip inline backticks from TextBlocks — Teams doesn't render them
+  for (const el of body) {
+    if (el.type === "TextBlock" && typeof el.text === "string") {
+      el.text = (el.text as string).replace(/`([^`]+)`/g, "$1");
+    }
+  }
+
   return body;
 }
 

--- a/src/frontend/teams/formatting.ts
+++ b/src/frontend/teams/formatting.ts
@@ -1,0 +1,85 @@
+/**
+ * Teams message formatting — Adaptive Cards + HTML stripping.
+ */
+
+import * as cheerio from "cheerio";
+
+/** Max safe message length for a single Adaptive Card TextBlock. */
+const MAX_CHUNK = 10_000;
+
+/**
+ * Build an Adaptive Card payload for the Power Automate webhook.
+ * TextBlock renders Markdown natively in Teams.
+ */
+export function buildAdaptiveCard(
+  text: string,
+  buttons?: Array<{ text: string; url?: string }>,
+): Record<string, unknown> {
+  const card: Record<string, unknown> = {
+    type: "AdaptiveCard",
+    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+    version: "1.4",
+    body: [{ type: "TextBlock", text, wrap: true }],
+  };
+
+  if (buttons && buttons.length > 0) {
+    card.actions = buttons.map((b) =>
+      b.url
+        ? { type: "Action.OpenUrl", title: b.text, url: b.url }
+        : { type: "Action.Submit", title: b.text, data: { choice: b.text } },
+    );
+  }
+
+  return {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        contentUrl: null,
+        content: card,
+      },
+    ],
+  };
+}
+
+/**
+ * Split a long message into chunks that each fit within an Adaptive Card.
+ * Splits on paragraph boundaries when possible.
+ */
+export function splitTeamsMessage(text: string, maxLen = MAX_CHUNK): string[] {
+  if (text.length <= maxLen) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLen) {
+    // Try to split on a double newline (paragraph boundary)
+    let splitIdx = remaining.lastIndexOf("\n\n", maxLen);
+    if (splitIdx < maxLen * 0.3) {
+      // If no good paragraph break, try single newline
+      splitIdx = remaining.lastIndexOf("\n", maxLen);
+    }
+    if (splitIdx < maxLen * 0.3) {
+      // Hard split at maxLen
+      splitIdx = maxLen;
+    }
+    chunks.push(remaining.slice(0, splitIdx).trimEnd());
+    remaining = remaining.slice(splitIdx).trimStart();
+  }
+  if (remaining) chunks.push(remaining);
+  return chunks;
+}
+
+/**
+ * Strip HTML tags and decode entities from inbound Teams message HTML.
+ * Falls back to plain regex if cheerio fails.
+ */
+export function stripHtml(html: string): string {
+  if (!html || !html.includes("<")) return html;
+  try {
+    const $ = cheerio.load(html, { xml: false });
+    return $.text().trim();
+  } catch {
+    return html.replace(/<[^>]*>/g, "").trim();
+  }
+}

--- a/src/frontend/teams/formatting.ts
+++ b/src/frontend/teams/formatting.ts
@@ -10,9 +10,10 @@ const MAX_CHUNK = 10_000;
 /**
  * Build an Adaptive Card payload for the Power Automate webhook.
  *
- * Handles code blocks specially — Adaptive Card TextBlocks don't support
- * fenced code blocks (```), so we split the message into alternating
- * TextBlock (for prose) and CodeBlock (for code) elements.
+ * Fenced code blocks (```) are converted to monospace TextBlocks with
+ * a grey background, since Adaptive Card TextBlocks don't support
+ * markdown code fences and CodeBlock requires schema v1.6+ which
+ * Power Automate webhooks don't support.
  */
 export function buildAdaptiveCard(
   text: string,
@@ -23,7 +24,7 @@ export function buildAdaptiveCard(
   const card: Record<string, unknown> = {
     type: "AdaptiveCard",
     $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-    version: "1.6",
+    version: "1.4",
     body,
   };
 
@@ -48,43 +49,45 @@ export function buildAdaptiveCard(
 }
 
 /**
- * Build the card body elements, splitting code blocks into CodeBlock elements
- * and prose into TextBlock elements.
+ * Build card body — splits code blocks into monospace-styled containers.
  */
 function buildCardBody(text: string): Array<Record<string, unknown>> {
   const body: Array<Record<string, unknown>> = [];
 
   // Split on fenced code blocks: ```lang\ncode\n```
-  const codeBlockRegex = /```(\w*)\n([\s\S]*?)```/g;
+  const codeBlockRegex = /```\w*\n([\s\S]*?)```/g;
   let lastIndex = 0;
   let match;
 
   while ((match = codeBlockRegex.exec(text)) !== null) {
-    // Text before this code block
     const before = text.slice(lastIndex, match.index).trim();
     if (before) {
       body.push({ type: "TextBlock", text: before, wrap: true });
     }
 
-    // The code block itself
-    const language = match[1] || "plaintext";
-    const code = match[2].trimEnd();
+    // Render code as a monospace TextBlock inside a grey Container
+    const code = match[1].trimEnd();
     body.push({
-      type: "CodeBlock",
-      language,
-      codeSnippet: code,
+      type: "Container",
+      style: "emphasis",
+      bleed: false,
+      items: [{
+        type: "TextBlock",
+        text: code,
+        wrap: true,
+        fontType: "Monospace",
+        size: "Small",
+      }],
     });
 
     lastIndex = match.index + match[0].length;
   }
 
-  // Remaining text after last code block (or all text if no code blocks)
   const remaining = text.slice(lastIndex).trim();
   if (remaining) {
     body.push({ type: "TextBlock", text: remaining, wrap: true });
   }
 
-  // Fallback: if nothing was added (empty text), add empty TextBlock
   if (body.length === 0) {
     body.push({ type: "TextBlock", text: text || " ", wrap: true });
   }

--- a/src/frontend/teams/formatting.ts
+++ b/src/frontend/teams/formatting.ts
@@ -4,22 +4,27 @@
 
 import * as cheerio from "cheerio";
 
-/** Max safe message length for a single Adaptive Card TextBlock. */
+/** Max safe message length for a single Adaptive Card. */
 const MAX_CHUNK = 10_000;
 
 /**
  * Build an Adaptive Card payload for the Power Automate webhook.
- * TextBlock renders Markdown natively in Teams.
+ *
+ * Handles code blocks specially — Adaptive Card TextBlocks don't support
+ * fenced code blocks (```), so we split the message into alternating
+ * TextBlock (for prose) and CodeBlock (for code) elements.
  */
 export function buildAdaptiveCard(
   text: string,
   buttons?: Array<{ text: string; url?: string }>,
 ): Record<string, unknown> {
+  const body = buildCardBody(text);
+
   const card: Record<string, unknown> = {
     type: "AdaptiveCard",
     $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-    version: "1.4",
-    body: [{ type: "TextBlock", text, wrap: true }],
+    version: "1.6",
+    body,
   };
 
   if (buttons && buttons.length > 0) {
@@ -40,6 +45,51 @@ export function buildAdaptiveCard(
       },
     ],
   };
+}
+
+/**
+ * Build the card body elements, splitting code blocks into CodeBlock elements
+ * and prose into TextBlock elements.
+ */
+function buildCardBody(text: string): Array<Record<string, unknown>> {
+  const body: Array<Record<string, unknown>> = [];
+
+  // Split on fenced code blocks: ```lang\ncode\n```
+  const codeBlockRegex = /```(\w*)\n([\s\S]*?)```/g;
+  let lastIndex = 0;
+  let match;
+
+  while ((match = codeBlockRegex.exec(text)) !== null) {
+    // Text before this code block
+    const before = text.slice(lastIndex, match.index).trim();
+    if (before) {
+      body.push({ type: "TextBlock", text: before, wrap: true });
+    }
+
+    // The code block itself
+    const language = match[1] || "plaintext";
+    const code = match[2].trimEnd();
+    body.push({
+      type: "CodeBlock",
+      language,
+      codeSnippet: code,
+    });
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Remaining text after last code block (or all text if no code blocks)
+  const remaining = text.slice(lastIndex).trim();
+  if (remaining) {
+    body.push({ type: "TextBlock", text: remaining, wrap: true });
+  }
+
+  // Fallback: if nothing was added (empty text), add empty TextBlock
+  if (body.length === 0) {
+    body.push({ type: "TextBlock", text: text || " ", wrap: true });
+  }
+
+  return body;
 }
 
 /**

--- a/src/frontend/teams/formatting.ts
+++ b/src/frontend/teams/formatting.ts
@@ -37,14 +37,16 @@ function markdownToCardBody(text: string): CardElement[] {
         break;
 
       case "code": {
-        // Each line as a separate TextBlock to preserve newlines
+        // Each line as a separate TextBlock to preserve newlines.
+        // Replace spaces with non-breaking spaces (\u00a0) to preserve alignment —
+        // Teams TextBlock collapses consecutive regular spaces.
         const lines = (token.text as string).split("\n");
         body.push({
           type: "Container",
           style: "emphasis",
           items: lines.map((line) => ({
             type: "TextBlock",
-            text: line || " ",
+            text: (line || " ").replace(/ /g, "\u00a0"),
             wrap: false,
             fontType: "Monospace",
             size: "Small",

--- a/src/frontend/teams/formatting.ts
+++ b/src/frontend/teams/formatting.ts
@@ -1,25 +1,113 @@
 /**
- * Teams message formatting — Adaptive Cards + HTML stripping.
+ * Teams message formatting — markdown to Adaptive Cards + HTML stripping.
+ *
+ * Uses `marked` lexer to parse markdown into tokens, then converts each
+ * token to the appropriate Adaptive Card element:
+ *   - Paragraphs/text → TextBlock (with bold/italic markdown, no backticks)
+ *   - Fenced code blocks → monospace TextBlock in emphasis Container
+ *   - Lists → TextBlock with bullet/number prefixes
+ *   - Headings → bold TextBlock
  */
 
 import * as cheerio from "cheerio";
+import { marked } from "marked";
 
 /** Max safe message length for a single Adaptive Card. */
 const MAX_CHUNK = 10_000;
 
+// ── Markdown → Adaptive Card ──────────────────────────────────────────────
+
+type CardElement = Record<string, unknown>;
+
+/**
+ * Convert markdown text to Adaptive Card body elements.
+ */
+function markdownToCardBody(text: string): CardElement[] {
+  const body: CardElement[] = [];
+  const tokens = marked.lexer(text);
+
+  for (const token of tokens) {
+    switch (token.type) {
+      case "heading":
+        body.push({ type: "TextBlock", text: `**${cleanInline(token.text)}**`, wrap: true, size: "Medium", weight: "Bolder" });
+        break;
+
+      case "paragraph":
+        body.push({ type: "TextBlock", text: cleanInline(token.text), wrap: true });
+        break;
+
+      case "code":
+        body.push({
+          type: "Container",
+          style: "emphasis",
+          items: [{ type: "TextBlock", text: token.text, wrap: true, fontType: "Monospace", size: "Small" }],
+        });
+        break;
+
+      case "list": {
+        const listToken = token as Record<string, unknown>;
+        const items = listToken.items as Array<{ text: string }>;
+        const ordered = listToken.ordered as boolean;
+        const lines = items.map((item, i) => {
+          const prefix = ordered ? `${i + 1}. ` : "- ";
+          return prefix + cleanInline(item.text);
+        });
+        body.push({ type: "TextBlock", text: lines.join("\n"), wrap: true });
+        break;
+      }
+
+      case "blockquote": {
+        const bqToken = token as Record<string, unknown>;
+        body.push({
+          type: "Container",
+          style: "emphasis",
+          items: [{ type: "TextBlock", text: cleanInline(String(bqToken.text ?? "")), wrap: true, isSubtle: true }],
+        });
+        break;
+      }
+
+      case "hr":
+        body.push({ type: "TextBlock", text: "───────────────────────────────", wrap: false, isSubtle: true });
+        break;
+
+      case "space":
+        break; // skip whitespace tokens
+
+      default:
+        // Fallback: render as plain text
+        if ("text" in token && typeof token.text === "string" && token.text.trim()) {
+          body.push({ type: "TextBlock", text: cleanInline(token.text), wrap: true });
+        }
+        break;
+    }
+  }
+
+  if (body.length === 0) {
+    body.push({ type: "TextBlock", text: text || " ", wrap: true });
+  }
+
+  return body;
+}
+
+/**
+ * Clean inline markdown for Teams TextBlock compatibility.
+ * Teams supports **bold** and _italic_ but NOT `inline code`.
+ */
+function cleanInline(text: string): string {
+  // Remove inline backticks — Teams doesn't render them
+  return text.replace(/`([^`]+)`/g, "$1");
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+
 /**
  * Build an Adaptive Card payload for the Power Automate webhook.
- *
- * Fenced code blocks (```) are converted to monospace TextBlocks with
- * a grey background, since Adaptive Card TextBlocks don't support
- * markdown code fences and CodeBlock requires schema v1.6+ which
- * Power Automate webhooks don't support.
  */
 export function buildAdaptiveCard(
   text: string,
   buttons?: Array<{ text: string; url?: string }>,
 ): Record<string, unknown> {
-  const body = buildCardBody(text);
+  const body = markdownToCardBody(text);
 
   const card: Record<string, unknown> = {
     type: "AdaptiveCard",
@@ -49,60 +137,6 @@ export function buildAdaptiveCard(
 }
 
 /**
- * Build card body — splits code blocks into monospace-styled containers.
- */
-function buildCardBody(text: string): Array<Record<string, unknown>> {
-  const body: Array<Record<string, unknown>> = [];
-
-  // Split on fenced code blocks: ```lang\ncode\n```
-  const codeBlockRegex = /```\w*\n([\s\S]*?)```/g;
-  let lastIndex = 0;
-  let match;
-
-  while ((match = codeBlockRegex.exec(text)) !== null) {
-    const before = text.slice(lastIndex, match.index).trim();
-    if (before) {
-      body.push({ type: "TextBlock", text: before, wrap: true });
-    }
-
-    // Render code as a monospace TextBlock inside a grey Container
-    const code = match[1].trimEnd();
-    body.push({
-      type: "Container",
-      style: "emphasis",
-      bleed: false,
-      items: [{
-        type: "TextBlock",
-        text: code,
-        wrap: true,
-        fontType: "Monospace",
-        size: "Small",
-      }],
-    });
-
-    lastIndex = match.index + match[0].length;
-  }
-
-  const remaining = text.slice(lastIndex).trim();
-  if (remaining) {
-    body.push({ type: "TextBlock", text: remaining, wrap: true });
-  }
-
-  if (body.length === 0) {
-    body.push({ type: "TextBlock", text: text || " ", wrap: true });
-  }
-
-  // Strip inline backticks from TextBlocks — Teams doesn't render them
-  for (const el of body) {
-    if (el.type === "TextBlock" && typeof el.text === "string") {
-      el.text = (el.text as string).replace(/`([^`]+)`/g, "$1");
-    }
-  }
-
-  return body;
-}
-
-/**
  * Split a long message into chunks that each fit within an Adaptive Card.
  * Splits on paragraph boundaries when possible.
  */
@@ -113,14 +147,11 @@ export function splitTeamsMessage(text: string, maxLen = MAX_CHUNK): string[] {
   let remaining = text;
 
   while (remaining.length > maxLen) {
-    // Try to split on a double newline (paragraph boundary)
     let splitIdx = remaining.lastIndexOf("\n\n", maxLen);
     if (splitIdx < maxLen * 0.3) {
-      // If no good paragraph break, try single newline
       splitIdx = remaining.lastIndexOf("\n", maxLen);
     }
     if (splitIdx < maxLen * 0.3) {
-      // Hard split at maxLen
       splitIdx = maxLen;
     }
     chunks.push(remaining.slice(0, splitIdx).trimEnd());
@@ -132,7 +163,6 @@ export function splitTeamsMessage(text: string, maxLen = MAX_CHUNK): string[] {
 
 /**
  * Strip HTML tags and decode entities from inbound Teams message HTML.
- * Falls back to plain regex if cheerio fails.
  */
 export function stripHtml(html: string): string {
   if (!html || !html.includes("<")) return html;

--- a/src/frontend/teams/graph.ts
+++ b/src/frontend/teams/graph.ts
@@ -1,0 +1,295 @@
+/**
+ * Microsoft Graph API integration — device code auth + chat message polling.
+ *
+ * Uses the Microsoft Graph PowerShell well-known client ID (no app registration needed).
+ * Authenticates via device code flow, then polls a Teams GROUP CHAT for new messages.
+ *
+ * Key: Chat.Read scope does NOT require admin consent (unlike ChannelMessage.Read.All).
+ * Tokens are persisted to disk so re-auth is only needed when refresh tokens expire.
+ */
+
+import { existsSync, readFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import writeFileAtomic from "write-file-atomic";
+import { log, logError, logWarn } from "../../util/log.js";
+import { proxyFetch } from "./proxy-fetch.js";
+import { dirs } from "../../util/paths.js";
+import { stripHtml } from "./formatting.js";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** Microsoft Graph PowerShell — supports arbitrary delegated scopes, no app registration. */
+const CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e";
+const TENANT = "organizations";
+const AUTH_BASE = `https://login.microsoftonline.com/${TENANT}/oauth2/v2.0`;
+const GRAPH_BASE = "https://graph.microsoft.com/v1.0";
+const SCOPES = "Chat.Read Chat.ReadBasic User.Read offline_access";
+
+const TOKEN_FILE = resolve(dirs.data, "teams-tokens.json");
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type StoredTokens = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number; // epoch ms
+  chatId?: string;
+  chatTopic?: string;
+  userId?: string;
+};
+
+type DeviceCodeResponse = {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+  message: string;
+};
+
+type TokenResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+};
+
+export type ChatMessage = {
+  id: string;
+  text: string;
+  senderName: string;
+  senderId: string;
+  chatId: string;
+  createdDateTime: string;
+  messageType: string;
+};
+
+// ── Token storage ────────────────────────────────────────────────────────────
+
+function loadTokens(): StoredTokens | null {
+  try {
+    if (existsSync(TOKEN_FILE)) {
+      return JSON.parse(readFileSync(TOKEN_FILE, "utf-8"));
+    }
+  } catch { /* corrupt */ }
+  return null;
+}
+
+function saveTokens(tokens: StoredTokens): void {
+  if (!existsSync(dirs.data)) mkdirSync(dirs.data, { recursive: true });
+  writeFileAtomic.sync(TOKEN_FILE, JSON.stringify(tokens, null, 2) + "\n");
+}
+
+// ── OAuth helpers ────────────────────────────────────────────────────────────
+
+async function postForm(url: string, params: Record<string, string>): Promise<Record<string, unknown>> {
+  const body = new URLSearchParams(params).toString();
+  const resp = await proxyFetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+    signal: AbortSignal.timeout(15_000),
+  });
+  return (await resp.json()) as Record<string, unknown>;
+}
+
+async function refreshAccessToken(refreshToken: string): Promise<StoredTokens | null> {
+  const data = (await postForm(`${AUTH_BASE}/token`, {
+    grant_type: "refresh_token",
+    client_id: CLIENT_ID,
+    refresh_token: refreshToken,
+    scope: SCOPES,
+  })) as TokenResponse;
+
+  if (data.error) {
+    logError("teams", `Token refresh failed: ${data.error_description || data.error}`);
+    return null;
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token || refreshToken,
+    expiresAt: Date.now() + data.expires_in * 1000 - 60_000, // 1 min buffer
+  };
+}
+
+// ── Device code flow ─────────────────────────────────────────────────────────
+
+export async function deviceCodeAuth(): Promise<StoredTokens> {
+  const dcResp = (await postForm(`${AUTH_BASE}/devicecode`, {
+    client_id: CLIENT_ID,
+    scope: SCOPES,
+  })) as unknown as DeviceCodeResponse;
+
+  // Print instructions for the user
+  console.log();
+  console.log(`  To sign in, open: ${dcResp.verification_uri}`);
+  console.log(`  Enter code: ${dcResp.user_code}`);
+  console.log();
+  log("teams", `Device code auth: go to ${dcResp.verification_uri} and enter ${dcResp.user_code}`);
+
+  // Poll for token
+  const pollInterval = (dcResp.interval || 5) * 1000;
+  const deadline = Date.now() + dcResp.expires_in * 1000;
+
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, pollInterval));
+
+    const tokenResp = (await postForm(`${AUTH_BASE}/token`, {
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      client_id: CLIENT_ID,
+      device_code: dcResp.device_code,
+    })) as TokenResponse;
+
+    if (tokenResp.access_token) {
+      log("teams", "Device code auth successful");
+      const tokens: StoredTokens = {
+        accessToken: tokenResp.access_token,
+        refreshToken: tokenResp.refresh_token || "",
+        expiresAt: Date.now() + tokenResp.expires_in * 1000 - 60_000,
+      };
+      saveTokens(tokens);
+      return tokens;
+    }
+
+    if (tokenResp.error === "authorization_pending") continue;
+    if (tokenResp.error === "slow_down") {
+      await new Promise((r) => setTimeout(r, 5000));
+      continue;
+    }
+
+    throw new Error(`Auth failed: ${tokenResp.error_description || tokenResp.error}`);
+  }
+
+  throw new Error("Device code auth timed out (15 minutes)");
+}
+
+// ── Graph API client ─────────────────────────────────────────────────────────
+
+export class GraphClient {
+  private tokens: StoredTokens;
+
+  constructor(tokens: StoredTokens) {
+    this.tokens = tokens;
+  }
+
+  private async ensureValidToken(): Promise<string> {
+    if (Date.now() < this.tokens.expiresAt) {
+      return this.tokens.accessToken;
+    }
+
+    log("teams", "Refreshing access token...");
+    const refreshed = await refreshAccessToken(this.tokens.refreshToken);
+    if (!refreshed) throw new Error("Token refresh failed — re-authentication needed");
+
+    this.tokens = { ...this.tokens, ...refreshed };
+    saveTokens(this.tokens);
+    return this.tokens.accessToken;
+  }
+
+  private async graphGet(path: string): Promise<Record<string, unknown>> {
+    const token = await this.ensureValidToken();
+    const resp = await proxyFetch(`${GRAPH_BASE}${path}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new Error(`Graph API ${path} failed: ${resp.status} ${body}`);
+    }
+
+    return (await resp.json()) as Record<string, unknown>;
+  }
+
+  // ── User info ──────────────────────────────────────────────────────────
+
+  async getMe(): Promise<{ id: string; displayName: string }> {
+    const data = await this.graphGet("/me?$select=id,displayName");
+    return { id: data.id as string, displayName: data.displayName as string };
+  }
+
+  // ── Chat discovery ─────────────────────────────────────────────────────
+
+  async listChats(): Promise<Array<{ id: string; topic: string | null; chatType: string }>> {
+    const data = await this.graphGet("/me/chats?$top=50");
+    const chats = data.value as Array<Record<string, unknown>>;
+    return chats.map((c) => ({
+      id: c.id as string,
+      topic: (c.topic as string) || null,
+      chatType: c.chatType as string,
+    }));
+  }
+
+  // ── Message reading ────────────────────────────────────────────────────
+
+  async getChatMessages(chatId: string, top = 20): Promise<ChatMessage[]> {
+    const data = await this.graphGet(
+      `/me/chats/${chatId}/messages?$top=${top}`,
+    );
+
+    const raw = data.value as Array<Record<string, unknown>>;
+    return raw
+      .filter((m) => (m.messageType as string) === "message")
+      .map((m) => {
+        const from = m.from as Record<string, unknown> | null;
+        const user = from?.user as Record<string, unknown> | null;
+        const body = m.body as { contentType: string; content: string };
+
+        let text = body.content || "";
+        if (body.contentType === "html") {
+          text = stripHtml(text);
+        }
+
+        return {
+          id: m.id as string,
+          text,
+          senderName: (user?.displayName as string) || "Unknown",
+          senderId: (user?.id as string) || "",
+          chatId,
+          createdDateTime: m.createdDateTime as string,
+          messageType: m.messageType as string,
+        };
+      });
+  }
+
+  // ── Stored config ──────────────────────────────────────────────────────
+
+  getStoredChatId(): string | undefined { return this.tokens.chatId; }
+  getStoredChatTopic(): string | undefined { return this.tokens.chatTopic; }
+  getStoredUserId(): string | undefined { return this.tokens.userId; }
+
+  saveChatConfig(chatId: string, chatTopic: string, userId: string): void {
+    this.tokens.chatId = chatId;
+    this.tokens.chatTopic = chatTopic;
+    this.tokens.userId = userId;
+    saveTokens(this.tokens);
+  }
+}
+
+// ── Init helper ──────────────────────────────────────────────────────────────
+
+/**
+ * Initialize the Graph client — loads stored tokens or runs device code flow.
+ */
+export async function initGraphClient(): Promise<GraphClient> {
+  // Clear old tokens that used channel scopes
+  const stored = loadTokens();
+
+  if (stored && stored.refreshToken) {
+    log("teams", "Found stored tokens, validating...");
+    const refreshed = await refreshAccessToken(stored.refreshToken);
+    if (refreshed) {
+      const tokens = { ...stored, ...refreshed };
+      saveTokens(tokens);
+      log("teams", "Tokens refreshed successfully");
+      return new GraphClient(tokens);
+    }
+    logWarn("teams", "Stored tokens expired, re-authenticating...");
+  }
+
+  const tokens = await deviceCodeAuth();
+  return new GraphClient(tokens);
+}

--- a/src/frontend/teams/index.ts
+++ b/src/frontend/teams/index.ts
@@ -1,33 +1,24 @@
 /**
- * Teams frontend — bidirectional messaging via Power Automate webhooks.
+ * Teams frontend — bidirectional messaging via Power Automate + Graph API.
  *
  * SEND (Talon → Teams):  POST Adaptive Cards to a Power Automate workflow webhook URL.
- * RECEIVE (Teams → Talon): HTTP server receives POSTs from a Power Automate flow
- *                          triggered by "When a new channel message is added".
+ * RECEIVE (Teams → Talon): Poll group chat messages via Microsoft Graph API
+ *                          using Chat.Read scope (no admin consent needed).
  *
- * No Azure AD, no Bot Framework — just webhooks.
+ * No Azure AD app registration, no Bot Framework, no admin consent.
  */
 
-import { createServer, type Server } from "node:http";
 import { createHash } from "node:crypto";
 import type { TalonConfig } from "../../util/config.js";
 import type { ContextManager } from "../../core/types.js";
 import type { Gateway } from "../../core/gateway.js";
-import { log, logError, logWarn } from "../../util/log.js";
-import { createTeamsActionHandler, postToTeams } from "./actions.js";
-import { stripHtml, splitTeamsMessage, buildAdaptiveCard } from "./formatting.js";
+import { log, logError } from "../../util/log.js";
+import { createTeamsActionHandler } from "./actions.js";
+import { splitTeamsMessage, buildAdaptiveCard } from "./formatting.js";
+import { initGraphClient, type GraphClient, type ChatMessage } from "./graph.js";
+import { proxyFetch } from "./proxy-fetch.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
-
-/** Payload shape from the Power Automate flow. */
-type InboundMessage = {
-  text?: string;
-  htmlContent?: string;
-  senderName?: string;
-  channelId?: string;
-  teamId?: string;
-  messageId?: string;
-};
 
 export type TeamsFrontend = {
   context: ContextManager;
@@ -42,23 +33,11 @@ export type TeamsFrontend = {
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
- * Derive a stable 32-bit numeric chat ID from team + channel identifiers.
- * This gives each Teams channel a unique ID for the gateway context system.
+ * Derive a stable 32-bit numeric chat ID from the Graph chat ID string.
  */
-function deriveNumericChatId(teamId: string, channelId: string): number {
-  const hash = createHash("sha256").update(`${teamId}_${channelId}`).digest();
-  // Use unsigned 32-bit int, ensure positive
+function deriveNumericChatId(chatId: string): number {
+  const hash = createHash("sha256").update(chatId).digest();
   return hash.readUInt32BE(0);
-}
-
-/** Read the full request body as a string. */
-function readBody(req: import("node:http").IncomingMessage): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
-    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
-    req.on("error", reject);
-  });
 }
 
 // ── Frontend factory ─────────────────────────────────────────────────────────
@@ -68,11 +47,15 @@ export function createTeamsFrontend(
   gateway: Gateway,
 ): TeamsFrontend {
   const webhookUrl = (config as Record<string, unknown>).teamsWebhookUrl as string;
-  const webhookSecret = (config as Record<string, unknown>).teamsWebhookSecret as string | undefined;
-  const webhookPort = ((config as Record<string, unknown>).teamsWebhookPort as number) || 19878;
   const botDisplayName = ((config as Record<string, unknown>).teamsBotDisplayName as string) || "";
+  const pollIntervalMs = ((config as Record<string, unknown>).teamsGraphPollMs as number) || 10_000;
+  const configChatTopic = ((config as Record<string, unknown>).teamsChatTopic as string) || "";
 
-  let webhookServer: Server | null = null;
+  let graphClient: GraphClient | null = null;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let lastSeenMessageId: string | null = null;
+  let myUserId: string | null = null;
+  let polling = false;
 
   const context: ContextManager = {
     acquire: (chatId: number) => gateway.setContext(chatId),
@@ -92,7 +75,7 @@ export function createTeamsFrontend(
         const chunks = splitTeamsMessage(text);
         for (const chunk of chunks) {
           const card = buildAdaptiveCard(chunk);
-          await fetch(webhookUrl, {
+          await proxyFetch(webhookUrl, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(card),
@@ -112,114 +95,205 @@ export function createTeamsFrontend(
       const port = await gateway.start(19876);
       log("teams", `Gateway on port ${port}`);
 
-      // Start the inbound webhook server
-      const { execute } = await import("../../core/dispatcher.js");
+      // Authenticate with Microsoft Graph
+      log("teams", "Initializing Microsoft Graph client...");
+      graphClient = await initGraphClient();
 
-      webhookServer = createServer(async (req, res) => {
-        // Health check
-        if (req.method === "GET" && req.url === "/health") {
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ ok: true, frontend: "teams" }));
-          return;
+      // Get our own user ID (to filter out our own messages)
+      const me = await graphClient.getMe();
+      myUserId = me.id;
+      log("teams", `Authenticated as: ${me.displayName} (${me.id})`);
+
+      // Discover or load chat
+      let chatId = graphClient.getStoredChatId();
+
+      if (!chatId) {
+        log("teams", "No chat configured, discovering...");
+        const chats = await graphClient.listChats();
+
+        if (chats.length === 0) throw new Error("No chats found");
+
+        // Try to match by topic name if configured
+        let selectedChat = chats[0];
+        if (configChatTopic) {
+          const match = chats.find((c) =>
+            c.topic?.toLowerCase().includes(configChatTopic.toLowerCase()),
+          );
+          if (match) selectedChat = match;
+          else log("teams", `No chat matching topic "${configChatTopic}", using most recent`);
         }
 
-        // Only accept POST to /teams-webhook
-        if (req.method !== "POST" || req.url !== "/teams-webhook") {
-          res.writeHead(404);
-          res.end("Not found");
-          return;
+        chatId = selectedChat.id;
+        const topic = selectedChat.topic || "(unnamed chat)";
+
+        graphClient.saveChatConfig(chatId, topic, myUserId);
+        log("teams", `Configured chat: ${topic} [${selectedChat.chatType}]`);
+      } else {
+        log("teams", `Using chat: ${graphClient.getStoredChatTopic() || chatId}`);
+      }
+
+      // Seed lastSeenMessageId from current messages (don't process old messages)
+      try {
+        const existing = await graphClient.getChatMessages(chatId, 5);
+        if (existing.length > 0) {
+          lastSeenMessageId = existing[0].id;
+          log("teams", `Seeded last message ID: ${lastSeenMessageId}`);
         }
-
-        // Respond immediately — Power Automate has short timeouts
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ ok: true }));
-
-        try {
-          const rawBody = await readBody(req);
-
-          // Verify shared secret if configured
-          if (webhookSecret) {
-            const headerSecret = req.headers["x-webhook-secret"] as string | undefined;
-            if (headerSecret !== webhookSecret) {
-              logWarn("teams", "Rejected webhook: invalid secret");
-              return;
-            }
-          }
-
-          let msg: InboundMessage;
-          try {
-            msg = JSON.parse(rawBody);
-          } catch {
-            logWarn("teams", "Rejected webhook: invalid JSON");
-            return;
-          }
-
-          // Extract message text
-          let text = msg.text?.trim() || "";
-          if (!text && msg.htmlContent) {
-            text = stripHtml(msg.htmlContent);
-          }
-          if (!text) {
-            log("teams", "Skipped empty message");
-            return;
-          }
-
-          const senderName = msg.senderName || "Unknown";
-
-          // Skip messages from the bot itself to prevent echo loops
-          if (botDisplayName && senderName.toLowerCase() === botDisplayName.toLowerCase()) {
-            log("teams", "Skipped own message (echo loop prevention)");
-            return;
-          }
-
-          const teamId = msg.teamId || "default";
-          const channelId = msg.channelId || "default";
-          const numericChatId = deriveNumericChatId(teamId, channelId);
-          const chatId = `teams_${teamId}_${channelId}`;
-
-          log("teams", `Message from ${senderName} in ${chatId}: ${text.slice(0, 80)}...`);
-
-          // Execute the query asynchronously
-          execute({
-            chatId,
-            numericChatId,
-            prompt: `[${senderName}]: ${text}`,
-            senderName,
-            isGroup: true,
-            messageId: msg.messageId ? Number(msg.messageId) : undefined,
-            source: "message",
-          }).catch((err) => {
-            logError("teams", `execute failed: ${err instanceof Error ? err.message : err}`);
-          });
-        } catch (err) {
-          logError("teams", `Webhook handler error: ${err instanceof Error ? err.message : err}`);
-        }
-      });
-
-      await new Promise<void>((resolve, reject) => {
-        webhookServer!.once("error", reject);
-        webhookServer!.listen(webhookPort, "0.0.0.0", () => {
-          log("teams", `Webhook receiver on 0.0.0.0:${webhookPort}`);
-          resolve();
-        });
-      });
+      } catch (err) {
+        logError("teams", `Failed to seed messages: ${err instanceof Error ? err.message : err}`);
+      }
     },
 
     async start() {
+      if (!graphClient) throw new Error("Graph client not initialized");
+
+      const chatId = graphClient.getStoredChatId()!;
+      const { execute } = await import("../../core/dispatcher.js");
+
       log("teams", "Teams frontend running");
-      log("teams", `Send webhook: ${webhookUrl.slice(0, 60)}...`);
-      log("teams", `Receive endpoint: POST http://0.0.0.0:${webhookPort}/teams-webhook`);
+      log("teams", `Send: Power Automate webhook`);
+      log("teams", `Receive: Graph API chat polling every ${pollIntervalMs / 1000}s`);
+
+      // ── Poll loop ──────────────────────────────────────────────────────
+      async function poll(): Promise<void> {
+        if (polling) return;
+        polling = true;
+
+        try {
+          const messages = await graphClient!.getChatMessages(chatId, 20);
+
+          // Find new messages — messages are returned newest first
+          // IDs are opaque strings, so compare by createdDateTime
+          const newMessages: ChatMessage[] = [];
+          for (const msg of messages) {
+            if (lastSeenMessageId && msg.id === lastSeenMessageId) break;
+            newMessages.push(msg);
+          }
+
+          if (newMessages.length > 0) {
+            lastSeenMessageId = newMessages[0].id;
+          }
+
+          // Process in chronological order (oldest first)
+          for (const msg of newMessages.reverse()) {
+            if (!msg.text.trim()) continue;
+
+            // Skip bot/workflow messages by display name (echo loop prevention).
+            // We do NOT filter by user ID — the authenticated user also sends
+            // real messages that Talon should respond to.
+            if (botDisplayName && msg.senderName.toLowerCase() === botDisplayName.toLowerCase()) {
+              continue;
+            }
+
+            const numericChatId = deriveNumericChatId(msg.chatId);
+            const talonChatId = `teams_chat_${msg.chatId}`;
+
+            // ── Slash commands ──
+            const trimmed = msg.text.trim().toLowerCase();
+            if (trimmed === "/reset") {
+              const { resetSession } = await import("../../storage/sessions.js");
+              const { clearHistory } = await import("../../storage/history.js");
+              resetSession(talonChatId);
+              clearHistory(talonChatId);
+              log("teams", `Session reset by ${msg.senderName}`);
+              const card = buildAdaptiveCard("Session cleared.");
+              await proxyFetch(webhookUrl, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(card),
+                signal: AbortSignal.timeout(15_000),
+              }).catch(() => {});
+              continue;
+            }
+            if (trimmed === "/status") {
+              const { getSessionInfo } = await import("../../storage/sessions.js");
+              const info = getSessionInfo(talonChatId);
+              const u = info.usage;
+              const cacheHit = (u.totalInputTokens + u.totalCacheRead) > 0
+                ? Math.round((u.totalCacheRead / (u.totalInputTokens + u.totalCacheRead)) * 100) : 0;
+              const statusText = `**Session** turns: ${info.turns} · $${u.estimatedCostUsd.toFixed(4)} · ${cacheHit}% cache\n\nin: ${u.totalInputTokens.toLocaleString()} · out: ${u.totalOutputTokens.toLocaleString()} tokens`;
+              const card = buildAdaptiveCard(statusText);
+              await proxyFetch(webhookUrl, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(card),
+                signal: AbortSignal.timeout(15_000),
+              }).catch(() => {});
+              continue;
+            }
+            if (trimmed === "/help") {
+              const helpText = "**Commands:**\n- `/reset` — clear session & history\n- `/status` — session stats\n- `/help` — this message";
+              const card = buildAdaptiveCard(helpText);
+              await proxyFetch(webhookUrl, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(card),
+                signal: AbortSignal.timeout(15_000),
+              }).catch(() => {});
+              continue;
+            }
+
+            log("teams", `[${msg.senderName}]: ${msg.text.slice(0, 80)}${msg.text.length > 80 ? "..." : ""}`);
+
+            execute({
+              chatId: talonChatId,
+              numericChatId,
+              prompt: `[${msg.senderName}]: ${msg.text}`,
+              senderName: msg.senderName,
+              isGroup: true,
+              source: "message",
+              onStreamDelta: (_accumulated, phase) => {
+                if (phase) log("teams", `  phase: ${phase}`);
+              },
+              onToolUse: (toolName, input) => {
+                const detail = (input.command ?? input.action ?? input.query ?? input.url ?? input.name ?? "") as string;
+                log("teams", `  tool: ${toolName}${detail ? ` — ${String(detail).slice(0, 100)}` : ""}`);
+              },
+            }).then(async (result) => {
+              // If tools didn't already send a message, deliver the final text
+              if (result.bridgeMessageCount === 0 && result.text?.trim()) {
+                try {
+                  const chunks = splitTeamsMessage(result.text);
+                  for (const chunk of chunks) {
+                    const card = buildAdaptiveCard(chunk);
+                    const resp = await proxyFetch(webhookUrl, {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify(card),
+                      signal: AbortSignal.timeout(30_000),
+                    });
+                    if (!resp.ok) {
+                      logError("teams", `Webhook send failed: ${resp.status} ${await resp.text().catch(() => "")}`);
+                    }
+                  }
+                  log("teams", `Sent response (${result.text.length} chars)`);
+                } catch (sendErr) {
+                  logError("teams", `Send failed: ${sendErr instanceof Error ? sendErr.message : sendErr}`);
+                }
+              }
+            }).catch((err) => {
+              logError("teams", `execute failed: ${err instanceof Error ? err.message : err}`);
+            });
+          }
+        } catch (err) {
+          logError("teams", `Poll error: ${err instanceof Error ? err.message : err}`);
+        } finally {
+          polling = false;
+        }
+      }
+
+      // Initial poll, then interval
+      await poll();
+      pollTimer = setInterval(poll, pollIntervalMs);
 
       // Hold process open
       await new Promise(() => {});
     },
 
     async stop() {
-      if (webhookServer) {
-        await new Promise<void>((resolve) => {
-          webhookServer!.close(() => resolve());
-        });
-        webhookServer = null;
+      if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
       }
       await gateway.stop();
       log("teams", "Teams frontend stopped");

--- a/src/frontend/teams/index.ts
+++ b/src/frontend/teams/index.ts
@@ -58,7 +58,7 @@ export function createTeamsFrontend(
   let polling = false;
 
   const context: ContextManager = {
-    acquire: (chatId: number) => gateway.setContext(chatId),
+    acquire: (chatId: number, stringId?: string) => gateway.setContext(chatId, stringId),
     release: (chatId: number) => gateway.clearContext(chatId),
     getMessageCount: (chatId: number) => gateway.getMessageCount(chatId),
   };

--- a/src/frontend/teams/index.ts
+++ b/src/frontend/teams/index.ts
@@ -1,0 +1,228 @@
+/**
+ * Teams frontend — bidirectional messaging via Power Automate webhooks.
+ *
+ * SEND (Talon → Teams):  POST Adaptive Cards to a Power Automate workflow webhook URL.
+ * RECEIVE (Teams → Talon): HTTP server receives POSTs from a Power Automate flow
+ *                          triggered by "When a new channel message is added".
+ *
+ * No Azure AD, no Bot Framework — just webhooks.
+ */
+
+import { createServer, type Server } from "node:http";
+import { createHash } from "node:crypto";
+import type { TalonConfig } from "../../util/config.js";
+import type { ContextManager } from "../../core/types.js";
+import type { Gateway } from "../../core/gateway.js";
+import { log, logError, logWarn } from "../../util/log.js";
+import { createTeamsActionHandler, postToTeams } from "./actions.js";
+import { stripHtml, splitTeamsMessage, buildAdaptiveCard } from "./formatting.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** Payload shape from the Power Automate flow. */
+type InboundMessage = {
+  text?: string;
+  htmlContent?: string;
+  senderName?: string;
+  channelId?: string;
+  teamId?: string;
+  messageId?: string;
+};
+
+export type TeamsFrontend = {
+  context: ContextManager;
+  sendTyping: (chatId: number) => Promise<void>;
+  sendMessage: (chatId: number, text: string) => Promise<void>;
+  getBridgePort: () => number;
+  init: () => Promise<void>;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Derive a stable 32-bit numeric chat ID from team + channel identifiers.
+ * This gives each Teams channel a unique ID for the gateway context system.
+ */
+function deriveNumericChatId(teamId: string, channelId: string): number {
+  const hash = createHash("sha256").update(`${teamId}_${channelId}`).digest();
+  // Use unsigned 32-bit int, ensure positive
+  return hash.readUInt32BE(0);
+}
+
+/** Read the full request body as a string. */
+function readBody(req: import("node:http").IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+// ── Frontend factory ─────────────────────────────────────────────────────────
+
+export function createTeamsFrontend(
+  config: TalonConfig,
+  gateway: Gateway,
+): TeamsFrontend {
+  const webhookUrl = (config as Record<string, unknown>).teamsWebhookUrl as string;
+  const webhookSecret = (config as Record<string, unknown>).teamsWebhookSecret as string | undefined;
+  const webhookPort = ((config as Record<string, unknown>).teamsWebhookPort as number) || 19878;
+  const botDisplayName = ((config as Record<string, unknown>).teamsBotDisplayName as string) || "";
+
+  let webhookServer: Server | null = null;
+
+  const context: ContextManager = {
+    acquire: (chatId: number) => gateway.setContext(chatId),
+    release: (chatId: number) => gateway.clearContext(chatId),
+    getMessageCount: (chatId: number) => gateway.getMessageCount(chatId),
+  };
+
+  return {
+    context,
+
+    // Teams has no typing indicator via webhooks
+    sendTyping: async () => {},
+
+    sendMessage: async (_chatId: number, text: string) => {
+      if (!text.trim()) return;
+      try {
+        const chunks = splitTeamsMessage(text);
+        for (const chunk of chunks) {
+          const card = buildAdaptiveCard(chunk);
+          await fetch(webhookUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(card),
+            signal: AbortSignal.timeout(15_000),
+          });
+        }
+      } catch (err) {
+        logError("teams", `sendMessage failed: ${err instanceof Error ? err.message : err}`);
+      }
+    },
+
+    getBridgePort: () => gateway.getPort(),
+
+    async init() {
+      // Register action handler with the gateway
+      gateway.setFrontendHandler(createTeamsActionHandler(webhookUrl, gateway));
+      const port = await gateway.start(19876);
+      log("teams", `Gateway on port ${port}`);
+
+      // Start the inbound webhook server
+      const { execute } = await import("../../core/dispatcher.js");
+
+      webhookServer = createServer(async (req, res) => {
+        // Health check
+        if (req.method === "GET" && req.url === "/health") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true, frontend: "teams" }));
+          return;
+        }
+
+        // Only accept POST to /teams-webhook
+        if (req.method !== "POST" || req.url !== "/teams-webhook") {
+          res.writeHead(404);
+          res.end("Not found");
+          return;
+        }
+
+        // Respond immediately — Power Automate has short timeouts
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+
+        try {
+          const rawBody = await readBody(req);
+
+          // Verify shared secret if configured
+          if (webhookSecret) {
+            const headerSecret = req.headers["x-webhook-secret"] as string | undefined;
+            if (headerSecret !== webhookSecret) {
+              logWarn("teams", "Rejected webhook: invalid secret");
+              return;
+            }
+          }
+
+          let msg: InboundMessage;
+          try {
+            msg = JSON.parse(rawBody);
+          } catch {
+            logWarn("teams", "Rejected webhook: invalid JSON");
+            return;
+          }
+
+          // Extract message text
+          let text = msg.text?.trim() || "";
+          if (!text && msg.htmlContent) {
+            text = stripHtml(msg.htmlContent);
+          }
+          if (!text) {
+            log("teams", "Skipped empty message");
+            return;
+          }
+
+          const senderName = msg.senderName || "Unknown";
+
+          // Skip messages from the bot itself to prevent echo loops
+          if (botDisplayName && senderName.toLowerCase() === botDisplayName.toLowerCase()) {
+            log("teams", "Skipped own message (echo loop prevention)");
+            return;
+          }
+
+          const teamId = msg.teamId || "default";
+          const channelId = msg.channelId || "default";
+          const numericChatId = deriveNumericChatId(teamId, channelId);
+          const chatId = `teams_${teamId}_${channelId}`;
+
+          log("teams", `Message from ${senderName} in ${chatId}: ${text.slice(0, 80)}...`);
+
+          // Execute the query asynchronously
+          execute({
+            chatId,
+            numericChatId,
+            prompt: `[${senderName}]: ${text}`,
+            senderName,
+            isGroup: true,
+            messageId: msg.messageId ? Number(msg.messageId) : undefined,
+            source: "message",
+          }).catch((err) => {
+            logError("teams", `execute failed: ${err instanceof Error ? err.message : err}`);
+          });
+        } catch (err) {
+          logError("teams", `Webhook handler error: ${err instanceof Error ? err.message : err}`);
+        }
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        webhookServer!.once("error", reject);
+        webhookServer!.listen(webhookPort, "0.0.0.0", () => {
+          log("teams", `Webhook receiver on 0.0.0.0:${webhookPort}`);
+          resolve();
+        });
+      });
+    },
+
+    async start() {
+      log("teams", "Teams frontend running");
+      log("teams", `Send webhook: ${webhookUrl.slice(0, 60)}...`);
+      log("teams", `Receive endpoint: POST http://0.0.0.0:${webhookPort}/teams-webhook`);
+
+      // Hold process open
+      await new Promise(() => {});
+    },
+
+    async stop() {
+      if (webhookServer) {
+        await new Promise<void>((resolve) => {
+          webhookServer!.close(() => resolve());
+        });
+        webhookServer = null;
+      }
+      await gateway.stop();
+      log("teams", "Teams frontend stopped");
+    },
+  };
+}

--- a/src/frontend/teams/proxy-fetch.ts
+++ b/src/frontend/teams/proxy-fetch.ts
@@ -1,0 +1,28 @@
+/**
+ * Proxy-aware fetch — uses HTTP_PROXY/HTTPS_PROXY env vars if set.
+ * Node's built-in fetch() does NOT respect proxy env vars by default.
+ */
+
+import { ProxyAgent } from "undici";
+
+const proxyUrl =
+  process.env.https_proxy ||
+  process.env.HTTPS_PROXY ||
+  process.env.http_proxy ||
+  process.env.HTTP_PROXY ||
+  "";
+
+const dispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined;
+
+/**
+ * Drop-in replacement for global fetch() that routes through the system proxy.
+ */
+export async function proxyFetch(
+  url: string | URL,
+  init?: RequestInit & { dispatcher?: unknown },
+): Promise<Response> {
+  return fetch(url, {
+    ...init,
+    ...(dispatcher ? { dispatcher } : {}),
+  } as RequestInit);
+}

--- a/src/frontend/teams/tools.ts
+++ b/src/frontend/teams/tools.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * MCP server — Teams tools for the Claude Agent SDK.
+ * Communicates with the main bot process via HTTP bridge.
+ *
+ * Teams-specific: only exposes tools that work via Power Automate webhooks.
+ * No reactions, no media uploads, no message editing/deletion.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const BRIDGE_URL = process.env.TALON_BRIDGE_URL || "http://127.0.0.1:19876";
+const CHAT_ID = process.env.TALON_CHAT_ID || "";
+
+async function callBridge(
+  action: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const resp = await fetch(`${BRIDGE_URL}/action`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action, _chatId: CHAT_ID, ...params }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Bridge error (${resp.status}): ${text}`);
+  }
+  return resp.json();
+}
+
+function textResult(result: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+} {
+  const r = result as { text?: string; error?: string };
+  return {
+    content: [
+      { type: "text" as const, text: r.text ?? JSON.stringify(result) },
+    ],
+  };
+}
+
+const server = new McpServer({ name: "teams-tools", version: "1.0.0" });
+
+// ── Send message ─────────────────────────────────────────────────────────────
+
+server.tool(
+  "send_message",
+  `Send a message to the Teams chat. Supports Markdown formatting.
+
+Examples:
+  send_message(text="Hello!")
+  send_message(text="Here's a **bold** message with \`code\`")`,
+  {
+    text: z.string().describe("Message text. Supports Markdown."),
+  },
+  async (params) => textResult(await callBridge("send_message", params)),
+);
+
+server.tool(
+  "send_message_with_buttons",
+  `Send a message with clickable link buttons. Buttons appear below the message as Adaptive Card actions.
+
+Example: send_message_with_buttons(text="Choose:", rows=[[{"text":"Docs","url":"https://..."}]])`,
+  {
+    text: z.string().describe("Message text"),
+    rows: z
+      .array(
+        z.array(
+          z.object({
+            text: z.string().describe("Button label"),
+            url: z.string().optional().describe("URL to open when clicked"),
+          }),
+        ),
+      )
+      .describe("Button rows"),
+  },
+  async (params) => textResult(await callBridge("send_message_with_buttons", params)),
+);
+
+// ── Chat info ────────────────────────────────────────────────────────────────
+
+server.tool(
+  "get_chat_info",
+  "Get info about the current chat.",
+  {},
+  async () => textResult(await callBridge("get_chat_info", {})),
+);
+
+// ── Web tools ────────────────────────────────────────────────────────────────
+
+server.tool(
+  "web_search",
+  "Search the web. Returns titles, URLs, and snippets.",
+  {
+    query: z.string().describe("Search query"),
+    limit: z.number().optional().describe("Max results (default 5, max 10)"),
+  },
+  async (params) => textResult(await callBridge("web_search", params)),
+);
+
+server.tool(
+  "fetch_url",
+  "Fetch a URL — web pages return text content, images are downloaded to workspace.",
+  {
+    url: z.string().describe("The URL to fetch"),
+  },
+  async (params) => textResult(await callBridge("fetch_url", params)),
+);
+
+// ── Cron jobs ────────────────────────────────────────────────────────────────
+
+server.tool(
+  "create_cron_job",
+  `Create a persistent recurring scheduled job. Jobs survive restarts.
+
+Cron format: "minute hour day month weekday" (5 fields)
+Examples:
+  "0 9 * * *"     = every day at 9:00 AM
+  "*/15 * * * *"  = every 15 minutes
+
+Type "message" sends the content as a text message.
+Type "query" runs the content as a Claude prompt with full tool access.`,
+  {
+    name: z.string().describe("Human-readable name for the job"),
+    schedule: z.string().describe("Cron expression (5-field)"),
+    type: z.enum(["message", "query"]).describe("Job type"),
+    content: z.string().describe("Message text or query prompt"),
+    timezone: z.string().optional().describe("IANA timezone"),
+  },
+  async (params) => textResult(await callBridge("create_cron_job", params)),
+);
+
+server.tool(
+  "list_cron_jobs",
+  "List all cron jobs in the current chat.",
+  {},
+  async () => textResult(await callBridge("list_cron_jobs", {})),
+);
+
+server.tool(
+  "edit_cron_job",
+  "Edit an existing cron job.",
+  {
+    job_id: z.string().describe("Job ID to edit"),
+    name: z.string().optional(),
+    schedule: z.string().optional(),
+    type: z.enum(["message", "query"]).optional(),
+    content: z.string().optional(),
+    enabled: z.boolean().optional(),
+    timezone: z.string().optional(),
+  },
+  async (params) => textResult(await callBridge("edit_cron_job", params)),
+);
+
+server.tool(
+  "delete_cron_job",
+  "Delete a cron job permanently.",
+  {
+    job_id: z.string().describe("Job ID to delete"),
+  },
+  async (params) => textResult(await callBridge("delete_cron_job", params)),
+);
+
+// ── Start ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  console.error("MCP server error:", err);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,10 @@ if (selectedFrontend === "terminal") {
   const { createTerminalFrontend } = await import("./frontend/terminal/index.js");
   frontend = createTerminalFrontend(config, gateway);
   log("bot", "Frontend: Terminal");
+} else if (selectedFrontend === "teams") {
+  const { createTeamsFrontend } = await import("./frontend/teams/index.js");
+  frontend = createTeamsFrontend(config, gateway);
+  log("bot", "Frontend: Teams");
 } else {
   const { createTelegramFrontend } = await import("./frontend/telegram/index.js");
   frontend = createTelegramFrontend(config, gateway);

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -11,7 +11,7 @@ const pluginEntrySchema = z.object({
   config: z.record(z.string(), z.unknown()).optional(),
 });
 
-const frontendEnum = z.enum(["telegram", "terminal"]);
+const frontendEnum = z.enum(["telegram", "terminal", "teams"]);
 
 const configSchema = z.object({
   frontend: z.union([frontendEnum, z.array(frontendEnum)]).default("telegram"),
@@ -28,6 +28,12 @@ const configSchema = z.object({
   braveApiKey: z.string().optional(),
   searxngUrl: z.string().default("http://localhost:8080"),
   plugins: z.array(pluginEntrySchema).default([]),
+
+  // Teams frontend (Power Automate webhooks)
+  teamsWebhookUrl: z.string().url().optional(),
+  teamsWebhookSecret: z.string().optional(),
+  teamsWebhookPort: z.number().int().min(1024).max(65535).default(19878),
+  teamsBotDisplayName: z.string().optional(),
 });
 
 export type TalonConfig = z.infer<typeof configSchema> & {
@@ -176,6 +182,9 @@ export function loadConfig(): TalonConfig {
   for (const fe of frontends) {
     if (fe === "telegram" && !parsed.botToken) {
       throw new Error(`Telegram frontend requires "botToken" in ${CONFIG_FILE}. Run "talon setup" to configure.`);
+    }
+    if (fe === "teams" && !parsed.teamsWebhookUrl) {
+      throw new Error(`Teams frontend requires "teamsWebhookUrl" in ${CONFIG_FILE}. Run "talon setup" to configure.`);
     }
   }
 

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -34,6 +34,10 @@ const configSchema = z.object({
   teamsWebhookSecret: z.string().optional(),
   teamsWebhookPort: z.number().int().min(1024).max(65535).default(19878),
   teamsBotDisplayName: z.string().optional(),
+  teamsTeamName: z.string().optional(),
+  teamsChannelName: z.string().optional(),
+  teamsChatTopic: z.string().optional(),
+  teamsGraphPollMs: z.number().int().min(5000).default(10000),
 });
 
 export type TalonConfig = z.infer<typeof configSchema> & {

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -28,7 +28,8 @@ export type LogComponent =
   | "cron"
   | "dispatcher"
   | "gateway"
-  | "plugin";
+  | "plugin"
+  | "teams";
 
 const LOG_FILE = files.log;
 


### PR DESCRIPTION
## Summary

- Microsoft Teams frontend using Power Automate webhooks + Microsoft Graph API
- Send messages via Adaptive Cards, receive via Graph API chat polling
- OAuth device code flow (no Azure AD app registration needed)
- Proper markdown→Adaptive Card conversion using `marked` lexer
- Code blocks render as monospace text with preserved whitespace alignment
- 21 NPUW plugin tools fully working on Teams

## Key changes

- `src/frontend/teams/` — 6 files: index, actions, tools, graph, formatting, proxy-fetch
- `prompts/teams.md` — Teams-specific formatting rules for Claude
- Gateway string chatId support (Teams uses non-numeric chat IDs)
- MCP subprocess tsx resolution fix (absolute path from node_modules)
- `talon chat` overrides config.frontend to prevent wrong tools leaking

## Fixes included

- MCP subprocess crash when cwd is ~/.talon/workspace (no node_modules)
- Teams MCP tools "No active chat context" (string→numeric chatId mapping)
- Code blocks in Adaptive Cards (v1.4 Container + monospace + non-breaking spaces)
- Inline backtick stripping (Teams TextBlock doesn't support them)
- Frontend tool leak in terminal mode when config says teams

## Test plan

- [x] 24 Teams-specific tests (formatting, actions, proxy, graph exports)
- [x] 629 total tests passing
- [x] Manual testing: plain text, markdown, code blocks, tables, buttons
- [x] Jenkins tools working end-to-end on Teams

🤖 Generated with [Claude Code](https://claude.com/claude-code)