### PR TITLE
Add daily memory files for per-day notes and context injection

### DIFF
--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -33,7 +33,7 @@ You have access ONLY to filesystem tools (Read, Write, Edit, Bash, Glob, Grep). 
 - Add new entries where appropriate
 - Keep entries concise and factual — no padding, no narrative
 - Preserve all existing structure and sections
-- Also write daily memory summaries to `{{dailyMemoryDir}}/YYYY-MM-DD.md` for each day of logs you processed. Include key learnings, conversation summaries, and follow-ups. Keep these concise — they are injected into conversation context.
+- Also write daily memory summaries to `{{dailyMemoryDir}}/YYYY-MM-DD.md` for each day of logs you processed. Include key learnings, conversation summaries, and follow-ups. Keep these concise — the bot reads them on demand for context.
 
 ### Stage 4 — Prune
 

--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -33,6 +33,7 @@ You have access ONLY to filesystem tools (Read, Write, Edit, Bash, Glob, Grep). 
 - Add new entries where appropriate
 - Keep entries concise and factual — no padding, no narrative
 - Preserve all existing structure and sections
+- Also write daily memory summaries to `{{dailyMemoryDir}}/YYYY-MM-DD.md` for each day of logs you processed. Include key learnings, conversation summaries, and follow-ups. Keep these concise — they are injected into conversation context.
 
 ### Stage 4 — Prune
 

--- a/prompts/heartbeat.md
+++ b/prompts/heartbeat.md
@@ -19,7 +19,7 @@ If the instructions file does not exist or is empty, perform these default tasks
 
 1. **Review recent logs** — Check `{{logsDir}}/` for log files dated after `{{lastRunIso}}`. If `{{lastRunIso}}` is `never`, treat it as the beginning of time and review all available logs. Extract any new facts, preferences, or notable events.
 2. **Update memory** — Merge any new information into `{{memoryFile}}`, keeping entries concise and factual.
-3. **Update daily notes** — Write today's learnings, observations, corrections, and follow-ups to `{{dailyMemoryFile}}`. Keep entries concise — this file is injected into conversation context.
+3. **Update daily notes** — Write today's learnings, observations, corrections, and follow-ups to `{{dailyMemoryFile}}`. Keep entries concise — the bot reads this file on demand for context.
 4. **Workspace hygiene** — Note any issues but do not delete files unless the instructions explicitly say to.
 
 ## Rules

--- a/prompts/heartbeat.md
+++ b/prompts/heartbeat.md
@@ -9,6 +9,7 @@ You have access ONLY to filesystem tools (Read, Write, Edit, Bash, Glob, Grep). 
 - Logs directory: `{{logsDir}}`
 - Last heartbeat: `{{lastRunIso}}`
 - Run number: #{{runCount}}
+- Today's daily memory: `{{dailyMemoryFile}}`
 
 ## Instructions
 
@@ -18,7 +19,8 @@ If the instructions file does not exist or is empty, perform these default tasks
 
 1. **Review recent logs** — Check `{{logsDir}}/` for log files dated after `{{lastRunIso}}`. If `{{lastRunIso}}` is `never`, treat it as the beginning of time and review all available logs. Extract any new facts, preferences, or notable events.
 2. **Update memory** — Merge any new information into `{{memoryFile}}`, keeping entries concise and factual.
-3. **Workspace hygiene** — Note any issues but do not delete files unless the instructions explicitly say to.
+3. **Update daily notes** — Write today's learnings, observations, corrections, and follow-ups to `{{dailyMemoryFile}}`. Keep entries concise — this file is injected into conversation context.
+4. **Workspace hygiene** — Note any issues but do not delete files unless the instructions explicitly say to.
 
 ## Rules
 

--- a/src/__tests__/daily-log.test.ts
+++ b/src/__tests__/daily-log.test.ts
@@ -196,6 +196,33 @@ describe("daily-log", () => {
       expect(() => cleanupOldLogs()).not.toThrow();
     });
 
+    it("ignores non-YYYY-MM-DD.md files in daily memory dir", async () => {
+      const { cleanupOldLogs } = await import("../storage/daily-log.js");
+      mkdirSync(LOGS_DIR, { recursive: true });
+      mkdirSync(DAILY_MEM_DIR, { recursive: true });
+
+      // A file that would sort before the cutoff but doesn't match the pattern
+      writeFileSync(join(DAILY_MEM_DIR, "2020-summary.md"), "should survive");
+      writeFileSync(join(DAILY_MEM_DIR, "notes.md"), "also should survive");
+
+      cleanupOldLogs();
+
+      const remaining = readdirSync(DAILY_MEM_DIR);
+      expect(remaining).toContain("2020-summary.md");
+      expect(remaining).toContain("notes.md");
+    });
+
+    it("ignores non-YYYY-MM-DD.md files in logs dir", async () => {
+      const { cleanupOldLogs } = await import("../storage/daily-log.js");
+      mkdirSync(LOGS_DIR, { recursive: true });
+
+      writeFileSync(join(LOGS_DIR, "2020-summary.md"), "should survive");
+
+      cleanupOldLogs();
+
+      expect(readdirSync(LOGS_DIR)).toContain("2020-summary.md");
+    });
+
     it("does not delete recent daily memory files", async () => {
       const { cleanupOldLogs } = await import("../storage/daily-log.js");
       mkdirSync(LOGS_DIR, { recursive: true });

--- a/src/__tests__/daily-log.test.ts
+++ b/src/__tests__/daily-log.test.ts
@@ -17,6 +17,7 @@ vi.mock("../util/log.js", () => ({
 }));
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { toYMD } from "../util/time.js";
 
 // Use a unique temp directory for each test run
 const TEST_ROOT = join(tmpdir(), `talon-daily-log-test-${Date.now()}`);
@@ -173,13 +174,13 @@ describe("daily-log", () => {
       // Create an old daily memory file (40 days ago)
       const oldDate = new Date();
       oldDate.setDate(oldDate.getDate() - 40);
-      const oldName = oldDate.toISOString().slice(0, 10) + ".md";
+      const oldName = toYMD(oldDate) + ".md";
       writeFileSync(join(DAILY_MEM_DIR, oldName), "old daily memory");
 
       // Create a recent daily memory file (5 days ago)
       const recentDate = new Date();
       recentDate.setDate(recentDate.getDate() - 5);
-      const recentName = recentDate.toISOString().slice(0, 10) + ".md";
+      const recentName = toYMD(recentDate) + ".md";
       writeFileSync(join(DAILY_MEM_DIR, recentName), "recent daily memory");
 
       cleanupOldLogs();
@@ -230,7 +231,7 @@ describe("daily-log", () => {
 
       const recentDate = new Date();
       recentDate.setDate(recentDate.getDate() - 3);
-      const recentName = recentDate.toISOString().slice(0, 10) + ".md";
+      const recentName = toYMD(recentDate) + ".md";
       writeFileSync(join(DAILY_MEM_DIR, recentName), "keep me");
 
       cleanupOldLogs();

--- a/src/__tests__/daily-log.test.ts
+++ b/src/__tests__/daily-log.test.ts
@@ -156,6 +156,62 @@ describe("daily-log", () => {
     });
   });
 
+  describe("cleanupOldLogs — daily memory files", () => {
+    const DAILY_MEM_DIR = join(
+      TEST_ROOT,
+      ".talon",
+      "workspace",
+      "memory",
+      "daily",
+    );
+
+    it("deletes daily memory files older than 30 days", async () => {
+      const { cleanupOldLogs } = await import("../storage/daily-log.js");
+      mkdirSync(LOGS_DIR, { recursive: true });
+      mkdirSync(DAILY_MEM_DIR, { recursive: true });
+
+      // Create an old daily memory file (40 days ago)
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 40);
+      const oldName = oldDate.toISOString().slice(0, 10) + ".md";
+      writeFileSync(join(DAILY_MEM_DIR, oldName), "old daily memory");
+
+      // Create a recent daily memory file (5 days ago)
+      const recentDate = new Date();
+      recentDate.setDate(recentDate.getDate() - 5);
+      const recentName = recentDate.toISOString().slice(0, 10) + ".md";
+      writeFileSync(join(DAILY_MEM_DIR, recentName), "recent daily memory");
+
+      cleanupOldLogs();
+
+      const remaining = readdirSync(DAILY_MEM_DIR);
+      expect(remaining).not.toContain(oldName);
+      expect(remaining).toContain(recentName);
+    });
+
+    it("handles missing daily memory directory gracefully", async () => {
+      const { cleanupOldLogs } = await import("../storage/daily-log.js");
+      // Create logs dir but NOT the daily memory dir
+      mkdirSync(LOGS_DIR, { recursive: true });
+      expect(() => cleanupOldLogs()).not.toThrow();
+    });
+
+    it("does not delete recent daily memory files", async () => {
+      const { cleanupOldLogs } = await import("../storage/daily-log.js");
+      mkdirSync(LOGS_DIR, { recursive: true });
+      mkdirSync(DAILY_MEM_DIR, { recursive: true });
+
+      const recentDate = new Date();
+      recentDate.setDate(recentDate.getDate() - 3);
+      const recentName = recentDate.toISOString().slice(0, 10) + ".md";
+      writeFileSync(join(DAILY_MEM_DIR, recentName), "keep me");
+
+      cleanupOldLogs();
+
+      expect(readdirSync(DAILY_MEM_DIR)).toContain(recentName);
+    });
+  });
+
   describe("appendDailyLogResponse", () => {
     it("writes bot response with chat title context", async () => {
       const { appendDailyLogResponse, getLogsDir } =

--- a/src/__tests__/dream.test.ts
+++ b/src/__tests__/dream.test.ts
@@ -55,6 +55,7 @@ vi.mock("../util/paths.js", () => ({
     workspace: "/fake/.talon/workspace",
     data: "/fake/.talon/data",
     memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
   },
 }));
 
@@ -180,6 +181,7 @@ describe("forceDream", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 
@@ -215,6 +217,7 @@ describe("readDreamState — edge cases", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
   });
@@ -465,6 +468,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 
@@ -510,6 +514,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 
@@ -555,6 +560,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 
@@ -606,6 +612,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -649,6 +656,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     const queryMock = vi.fn(async function* () {});
@@ -702,6 +710,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -753,6 +762,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 
@@ -796,6 +806,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -844,6 +855,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -892,6 +904,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     const queryMock = vi.fn(async function* () {});
@@ -938,6 +951,7 @@ describe("runDreamAgent — timeout arrow fn fires after DREAM_TIMEOUT_MS", () =
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     // query never resolves — so the 10-minute timeout wins the race
@@ -995,6 +1009,7 @@ describe("maybeStartDream — () => {} catch callback on executeDream rejection"
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 

--- a/src/__tests__/dream.test.ts
+++ b/src/__tests__/dream.test.ts
@@ -181,7 +181,7 @@ describe("forceDream", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 
@@ -217,7 +217,7 @@ describe("readDreamState — edge cases", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
   });
@@ -468,7 +468,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 
@@ -514,7 +514,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 
@@ -560,7 +560,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 
@@ -612,7 +612,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -656,7 +656,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     const queryMock = vi.fn(async function* () {});
@@ -710,7 +710,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -762,7 +762,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 
@@ -806,7 +806,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -855,7 +855,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -904,7 +904,7 @@ describe("dream error paths", () => {
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     const queryMock = vi.fn(async function* () {});
@@ -951,7 +951,7 @@ describe("runDreamAgent — timeout arrow fn fires after DREAM_TIMEOUT_MS", () =
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
     // query never resolves — so the 10-minute timeout wins the race
@@ -1009,7 +1009,7 @@ describe("maybeStartDream — () => {} catch callback on executeDream rejection"
         workspace: "/fake/.talon/workspace",
         data: "/fake/.talon/data",
         memory: "/fake/.talon/workspace/memory",
-    dailyMemory: "/fake/.talon/workspace/memory/daily",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
 

--- a/src/__tests__/heartbeat.test.ts
+++ b/src/__tests__/heartbeat.test.ts
@@ -61,6 +61,7 @@ vi.mock("../util/paths.js", () => ({
     workspace: "/fake/.talon/workspace",
     data: "/fake/.talon/data",
     memory: "/fake/.talon/workspace/memory",
+    dailyMemory: "/fake/.talon/workspace/memory/daily",
     prompts: "/fake/.talon/prompts",
   },
 }));

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -141,7 +141,8 @@ async function runDreamAgent(lastRunTimestamp: number): Promise<string> {
       .replace(/\{\{dreamStateFile\}\}/g, dreamStateFile)
       .replace(/\{\{logsDir\}\}/g, logsDir)
       .replace(/\{\{lastRunIso\}\}/g, lastRunIso)
-      .replace(/\{\{memoryFile\}\}/g, memoryFile);
+      .replace(/\{\{memoryFile\}\}/g, memoryFile)
+      .replace(/\{\{dailyMemoryDir\}\}/g, dirs.dailyMemory);
   } catch {
     throw new Error(`Failed to read dream prompt from ${promptPath}`);
   }

--- a/src/core/heartbeat.ts
+++ b/src/core/heartbeat.ts
@@ -240,6 +240,10 @@ async function runHeartbeatAgent(
   const memoryFile = pathFiles.memory;
   const workspace = configRef.workspace ?? dirs.workspace;
   const instructionsFile = resolve(workspace, "heartbeat-instructions.md");
+  const dailyMemoryFile = resolve(
+    dirs.dailyMemory,
+    `${new Date().toISOString().slice(0, 10)}.md`,
+  );
 
   // Load prompt template from the prompts directory (seeded to ~/.talon/prompts/)
   const promptPath = resolve(dirs.prompts, "heartbeat.md");
@@ -252,6 +256,7 @@ async function runHeartbeatAgent(
       .replace(/\{\{lastRunIso\}\}/g, lastRunIso)
       .replace(/\{\{memoryFile\}\}/g, memoryFile)
       .replace(/\{\{instructionsFile\}\}/g, instructionsFile)
+      .replace(/\{\{dailyMemoryFile\}\}/g, dailyMemoryFile)
       .replace(/\{\{runCount\}\}/g, String(runCount))
       .replace(/\{\{intervalMinutes\}\}/g, String(intervalMinutesRef));
   } catch {

--- a/src/core/heartbeat.ts
+++ b/src/core/heartbeat.ts
@@ -16,6 +16,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { files as pathFiles, dirs } from "../util/paths.js";
 import { log, logError, logWarn } from "../util/log.js";
+import { toYMD } from "../util/time.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -240,10 +241,7 @@ async function runHeartbeatAgent(
   const memoryFile = pathFiles.memory;
   const workspace = configRef.workspace ?? dirs.workspace;
   const instructionsFile = resolve(workspace, "heartbeat-instructions.md");
-  const dailyMemoryFile = resolve(
-    dirs.dailyMemory,
-    `${new Date().toISOString().slice(0, 10)}.md`,
-  );
+  const dailyMemoryFile = resolve(dirs.dailyMemory, `${toYMD(new Date())}.md`);
 
   // Load prompt template from the prompts directory (seeded to ~/.talon/prompts/)
   const promptPath = resolve(dirs.prompts, "heartbeat.md");

--- a/src/storage/daily-log.ts
+++ b/src/storage/daily-log.ts
@@ -91,6 +91,9 @@ export function getLogsDir(): string {
   return LOGS_DIR;
 }
 
+/** Matches YYYY-MM-DD.md filenames strictly. */
+const DAILY_FILE_RE = /^\d{4}-\d{2}-\d{2}\.md$/;
+
 /** Remove daily logs older than MAX_LOG_DAYS. Called on startup. */
 export function cleanupOldLogs(): void {
   try {
@@ -101,8 +104,7 @@ export function cleanupOldLogs(): void {
 
     let deleted = 0;
     for (const file of readdirSync(LOGS_DIR)) {
-      // Log files are named YYYY-MM-DD.md
-      if (file.endsWith(".md") && file < cutoffStr) {
+      if (DAILY_FILE_RE.test(file) && file < cutoffStr) {
         try {
           unlinkSync(resolve(LOGS_DIR, file));
           deleted++;
@@ -128,7 +130,7 @@ export function cleanupOldLogs(): void {
 
     let deletedMem = 0;
     for (const file of readdirSync(dailyMemDir)) {
-      if (file.endsWith(".md") && file < cutoffMem) {
+      if (DAILY_FILE_RE.test(file) && file < cutoffMem) {
         try {
           unlinkSync(resolve(dailyMemDir, file));
           deletedMem++;

--- a/src/storage/daily-log.ts
+++ b/src/storage/daily-log.ts
@@ -98,30 +98,31 @@ const DAILY_FILE_RE = /^\d{4}-\d{2}-\d{2}\.md$/;
 /** Remove daily logs older than MAX_LOG_DAYS. Called on startup. */
 export function cleanupOldLogs(): void {
   try {
-    if (!existsSync(LOGS_DIR)) return;
-    const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - MAX_LOG_DAYS);
-    const cutoffStr = cutoff.toISOString().slice(0, 10);
+    if (existsSync(LOGS_DIR)) {
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - MAX_LOG_DAYS);
+      const cutoffStr = cutoff.toISOString().slice(0, 10);
 
-    let deleted = 0;
-    for (const file of readdirSync(LOGS_DIR)) {
-      if (DAILY_FILE_RE.test(file) && file < cutoffStr) {
-        try {
-          unlinkSync(resolve(LOGS_DIR, file));
-          deleted++;
-        } catch {
-          /* skip */
+      let deleted = 0;
+      for (const file of readdirSync(LOGS_DIR)) {
+        if (DAILY_FILE_RE.test(file) && file < cutoffStr) {
+          try {
+            unlinkSync(resolve(LOGS_DIR, file));
+            deleted++;
+          } catch {
+            /* skip */
+          }
         }
       }
-    }
-    if (deleted > 0) {
-      logInfo("workspace", `Cleaned up ${deleted} old daily log(s)`);
+      if (deleted > 0) {
+        logInfo("workspace", `Cleaned up ${deleted} old daily log(s)`);
+      }
     }
   } catch {
     /* skip */
   }
 
-  // Also clean up old daily memory files
+  // Clean up old daily memory files (independent of logs dir)
   try {
     const dailyMemDir = dirs.dailyMemory;
     if (!existsSync(dailyMemDir)) return;

--- a/src/storage/daily-log.ts
+++ b/src/storage/daily-log.ts
@@ -117,4 +117,30 @@ export function cleanupOldLogs(): void {
   } catch {
     /* skip */
   }
+
+  // Also clean up old daily memory files
+  try {
+    const dailyMemDir = dirs.dailyMemory;
+    if (!existsSync(dailyMemDir)) return;
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - MAX_LOG_DAYS);
+    const cutoffMem = cutoffDate.toISOString().slice(0, 10);
+
+    let deletedMem = 0;
+    for (const file of readdirSync(dailyMemDir)) {
+      if (file.endsWith(".md") && file < cutoffMem) {
+        try {
+          unlinkSync(resolve(dailyMemDir, file));
+          deletedMem++;
+        } catch {
+          /* skip */
+        }
+      }
+    }
+    if (deletedMem > 0) {
+      logInfo("workspace", `Cleaned up ${deletedMem} old daily memory file(s)`);
+    }
+  } catch {
+    /* skip */
+  }
 }

--- a/src/storage/daily-log.ts
+++ b/src/storage/daily-log.ts
@@ -13,6 +13,7 @@ import {
 import { resolve } from "node:path";
 import { log as logInfo, logError } from "../util/log.js";
 import { dirs } from "../util/paths.js";
+import { toYMD } from "../util/time.js";
 
 const LOGS_DIR = dirs.logs;
 const MAX_LOG_DAYS = 30; // Keep last 30 days of logs
@@ -126,7 +127,7 @@ export function cleanupOldLogs(): void {
     if (!existsSync(dailyMemDir)) return;
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - MAX_LOG_DAYS);
-    const cutoffMem = cutoffDate.toISOString().slice(0, 10);
+    const cutoffMem = toYMD(cutoffDate);
 
     let deletedMem = 0;
     for (const file of readdirSync(dailyMemDir)) {

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -166,6 +166,24 @@ function loadSystemPrompt(
     loaded.push("memory");
   }
 
+  // Inject daily memory notes (today + yesterday)
+  const dailyMemoryDir = dirs.dailyMemory;
+  const today = new Date().toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 86_400_000)
+    .toISOString()
+    .slice(0, 10);
+  const dailyParts: string[] = [];
+  for (const dateStr of [today, yesterday]) {
+    const content = readOptionalFile(resolve(dailyMemoryDir, `${dateStr}.md`));
+    if (content) dailyParts.push(content);
+  }
+  if (dailyParts.length > 0) {
+    parts.push(
+      `## Recent Daily Notes\n\nYour daily notes from recent days. Update today's file at \`~/.talon/workspace/memory/daily/${today}.md\` as you learn things.\n\n${dailyParts.join("\n\n---\n\n")}`,
+    );
+    loaded.push("daily-memory");
+  }
+
   const loadedKey = loaded.join(" + ");
   if (loadedKey && loadedKey !== lastLoggedPromptKey) {
     log("config", `System prompt: ${loadedKey}`);
@@ -217,6 +235,7 @@ function loadSystemPrompt(
 
 You have a workspace directory at \`~/.talon/workspace/\`. This is your home — organize it however you want.
 - \`~/.talon/workspace/memory/memory.md\` is your persistent memory file. Update it when you learn important things.
+- \`~/.talon/workspace/memory/daily/YYYY-MM-DD.md\` is your daily notes file. Write observations, learnings, corrections, and follow-ups here throughout the day. Keep entries concise.
 - Daily interaction logs are saved to \`~/.talon/workspace/logs/\` automatically.
 - Files users send you (photos, docs, voice) are saved to \`~/.talon/workspace/uploads/\`.
 - Persistent cron jobs are managed via the cron tools.

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -166,27 +166,11 @@ function loadSystemPrompt(
     loaded.push("memory");
   }
 
-  // Inject daily memory notes (today + yesterday, timezone-aware)
-  const dailyMemoryDir = dirs.dailyMemory;
-  const { today, yesterday } = todayAndYesterday();
-  const dailyParts: string[] = [];
-  const DAILY_MEMORY_MAX_BYTES = 10_240; // 10KB cap per file
-  for (const dateStr of [today, yesterday]) {
-    let content = readOptionalFile(resolve(dailyMemoryDir, `${dateStr}.md`));
-    if (content) {
-      if (content.length > DAILY_MEMORY_MAX_BYTES) {
-        content =
-          content.slice(0, DAILY_MEMORY_MAX_BYTES) + "\n\n... (truncated)";
-      }
-      dailyParts.push(content);
-    }
-  }
-  if (dailyParts.length > 0) {
-    parts.push(
-      `## Recent Daily Notes\n\nYour daily notes from recent days. Update today's file at \`~/.talon/workspace/memory/daily/${today}.md\` as you learn things.\n\n${dailyParts.join("\n\n---\n\n")}`,
-    );
-    loaded.push("daily-memory");
-  }
+  // Point the bot at daily memory files (read on demand, not injected)
+  const { today } = todayAndYesterday();
+  parts.push(
+    `## Daily Memory\n\nYour daily notes are stored in \`${dirs.dailyMemory}/\`. Today's file is \`${today}.md\`. Use the Read tool to check recent daily notes when you need context from previous days.`,
+  );
 
   const loadedKey = loaded.join(" + ");
   if (loadedKey && loadedKey !== lastLoggedPromptKey) {

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -175,7 +175,8 @@ function loadSystemPrompt(
     let content = readOptionalFile(resolve(dailyMemoryDir, `${dateStr}.md`));
     if (content) {
       if (content.length > DAILY_MEMORY_MAX_BYTES) {
-        content = content.slice(0, DAILY_MEMORY_MAX_BYTES) + "\n\n... (truncated)";
+        content =
+          content.slice(0, DAILY_MEMORY_MAX_BYTES) + "\n\n... (truncated)";
       }
       dailyParts.push(content);
     }

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -9,7 +9,7 @@ import { resolve } from "node:path";
 import writeFileAtomic from "write-file-atomic";
 import { z } from "zod";
 import { dirs, files as pathFiles } from "./paths.js";
-import { setTimezone, formatFullDatetime } from "./time.js";
+import { setTimezone, formatFullDatetime, todayAndYesterday } from "./time.js";
 import { log } from "./log.js";
 
 // ── Config schema ───────────────────────────────────────────────────────────
@@ -166,16 +166,19 @@ function loadSystemPrompt(
     loaded.push("memory");
   }
 
-  // Inject daily memory notes (today + yesterday)
+  // Inject daily memory notes (today + yesterday, timezone-aware)
   const dailyMemoryDir = dirs.dailyMemory;
-  const today = new Date().toISOString().slice(0, 10);
-  const yesterday = new Date(Date.now() - 86_400_000)
-    .toISOString()
-    .slice(0, 10);
+  const { today, yesterday } = todayAndYesterday();
   const dailyParts: string[] = [];
+  const DAILY_MEMORY_MAX_BYTES = 10_240; // 10KB cap per file
   for (const dateStr of [today, yesterday]) {
-    const content = readOptionalFile(resolve(dailyMemoryDir, `${dateStr}.md`));
-    if (content) dailyParts.push(content);
+    let content = readOptionalFile(resolve(dailyMemoryDir, `${dateStr}.md`));
+    if (content) {
+      if (content.length > DAILY_MEMORY_MAX_BYTES) {
+        content = content.slice(0, DAILY_MEMORY_MAX_BYTES) + "\n\n... (truncated)";
+      }
+      dailyParts.push(content);
+    }
   }
   if (dailyParts.length > 0) {
     parts.push(

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -14,6 +14,7 @@
  *       media-index.json
  *     workspace/               User-facing workspace (memory, uploads, logs)
  *       memory/
+ *         daily/               Per-day memory notes (YYYY-MM-DD.md)
  *       uploads/
  *       stickers/
  *       logs/

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -42,6 +42,8 @@ export const dirs = {
   logs: resolve(TALON_ROOT, "workspace", "logs"),
   /** Memory: ~/.talon/workspace/memory/ */
   memory: resolve(TALON_ROOT, "workspace", "memory"),
+  /** Daily memory notes: ~/.talon/workspace/memory/daily/ */
+  dailyMemory: resolve(TALON_ROOT, "workspace", "memory", "daily"),
   /** Sticker packs: ~/.talon/workspace/stickers/ */
   stickers: resolve(TALON_ROOT, "workspace", "stickers"),
   /** Prompt files: ~/.talon/prompts/ */

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -29,12 +29,12 @@ function toHHMM(date: Date): string {
 }
 
 /** Format a Date in the configured timezone as YYYY-MM-DD. */
-function toYMD(date: Date): string {
+export function toYMD(date: Date): string {
   return date.toLocaleDateString("en-CA", { timeZone: getTimezone() }); // en-CA gives YYYY-MM-DD
 }
 
 /** Get "today" and "yesterday" date strings in the configured timezone. */
-function todayAndYesterday(): { today: string; yesterday: string } {
+export function todayAndYesterday(): { today: string; yesterday: string } {
   const now = new Date();
   const today = toYMD(now);
   const yd = new Date(now.getTime() - 86_400_000);

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -134,6 +134,7 @@ export function initWorkspace(root: string): void {
   // Ensure subdirectories exist
   for (const sub of [
     dirs.memory,
+    dirs.dailyMemory,
     dirs.uploads,
     dirs.logs,
     dirs.stickers,


### PR DESCRIPTION
## Summary
- Adds per-day memory files (`~/.talon/workspace/memory/daily/YYYY-MM-DD.md`) for the bot to write observations, learnings, corrections, and follow-ups throughout the day
- These are the bot's own notes — separate from raw conversation logs and the long-term `memory.md`
- The system prompt references the daily memory directory so the bot can read files on demand (not injected into the prompt, to preserve caching)

## How it works
- **Real-time**: Bot can write to today's daily file during conversations via the Write tool
- **Heartbeat** (hourly): Reviews logs and updates today's daily memory via `{{dailyMemoryFile}}` template variable
- **Dream** (12h): Consolidates daily memories into `memory.md` for long-term storage via `{{dailyMemoryDir}}` template variable
- **Cleanup**: Daily memory files older than 30 days are pruned alongside conversation logs (timezone-aware, validated `YYYY-MM-DD.md` pattern)

## Information lifecycle
Daily notes (short-term) → dream consolidation → memory.md (long-term) → daily files age out

## Key design decisions
- Daily memory is **referenced, not injected** into the system prompt — avoids prompt bloat and preserves prompt caching
- All date computations are **timezone-aware** using `toYMD()` / `todayAndYesterday()` from `time.ts`
- Cleanup validates the `YYYY-MM-DD.md` filename pattern before deleting

## Files changed (12)
- `src/util/paths.ts` — new `dirs.dailyMemory` constant
- `src/util/time.ts` — export `toYMD()` and `todayAndYesterday()`
- `src/util/workspace.ts` — create `memory/daily/` directory on startup
- `src/util/config.ts` — reference daily memory dir in system prompt
- `src/storage/daily-log.ts` — timezone-aware 30-day cleanup for daily memory files
- `src/core/heartbeat.ts` — `{{dailyMemoryFile}}` template variable (timezone-aware)
- `src/core/dream.ts` — `{{dailyMemoryDir}}` template variable
- `prompts/heartbeat.md` — daily notes in default tasks
- `prompts/dream.md` — daily memory in consolidation stage
- `src/__tests__/heartbeat.test.ts` — updated path mock
- `src/__tests__/dream.test.ts` — updated path mock
- `src/__tests__/daily-log.test.ts` — daily memory cleanup tests

## Test plan
- [x] Type check passes
- [x] Full test suite: 1284 tests passing across 43 files
- [x] Prettier formatting clean
- [x] Fully additive — zero breaking changes to existing memory system

🤖 Generated with [Claude Code](https://claude.com/claude-code)