### PR TITLE
Fix cache hit percentage calculation

### DIFF
--- a/src/backend/claude-sdk/index.ts
+++ b/src/backend/claude-sdk/index.ts
@@ -408,9 +408,9 @@ export async function handleMessage(
   // The remaining currentBlockText is the final response text
   allResponseText += currentBlockText;
 
-  const totalPrompt = inputTokens + cacheRead + cacheWrite;
+  const cacheTotal = inputTokens + cacheRead;
   const cacheHitPct =
-    totalPrompt > 0 ? Math.round((cacheRead / totalPrompt) * 100) : 0;
+    cacheTotal > 0 ? Math.round((cacheRead / cacheTotal) * 100) : 0;
 
   log(
     "agent",

--- a/src/frontend/telegram/commands.ts
+++ b/src/frontend/telegram/commands.ts
@@ -436,10 +436,9 @@ export function registerCommands(bot: Bot, config: TalonConfig): void {
       "\u2588".repeat(filled) + "\u2591".repeat(barLen - filled);
     const contextWarn = contextPct >= 80 ? " \u26A0\uFE0F consider /reset" : "";
 
-    const totalPrompt =
-      u.totalInputTokens + u.totalCacheRead + u.totalCacheWrite;
+    const cacheTotal = u.totalInputTokens + u.totalCacheRead;
     const cacheHitPct =
-      totalPrompt > 0 ? Math.round((u.totalCacheRead / totalPrompt) * 100) : 0;
+      cacheTotal > 0 ? Math.round((u.totalCacheRead / cacheTotal) * 100) : 0;
 
     const avgResponseMs =
       info.turns > 0 && u.totalResponseMs


### PR DESCRIPTION
## Summary
- Cache hit % was calculated as `cache_read / (input + cache_read + cache_write)`, which incorrectly included cache writes in the denominator — diluting the metric
- Now calculates as `cache_read / (input + cache_read)`, which accurately reflects how much of the readable prompt was served from cache
- Fixed in both the agent response logging (`claude-sdk/index.ts`) and the `/status` command display (`commands.ts`)

## Test plan
- [ ] Run `/status` and verify cache hit % looks reasonable
- [ ] Check agent logs show corrected cache percentages

🤖 Generated with [Claude Code](https://claude.com/claude-code)