### PR TITLE
feat: integrate mempalace for long-term memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
       "version": "0.2.97",
-      "resolved": "https://pixi.intel.com/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.97.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.97.tgz",
       "integrity": "sha512-754teaU0nfrn9BC0YWzPjSbJj253GfPUtuUnkrde7LGsaKtFSjEEuQJq5skJvpozqcn+B8frrtWVPkvFdnupTw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
@@ -77,7 +77,7 @@
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.86.1",
-      "resolved": "https://pixi.intel.com/@anthropic-ai/sdk/-/sdk-0.86.1.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.86.1.tgz",
       "integrity": "sha512-Q32GUFCVMmTJrVQC4bQOG2mA8rGNuYWJP8ODufxl3g5Awy1VjY5wy0Xm+mC++i5rBkZMvxhzOR9MNTW7IvIAmw==",
       "license": "MIT",
       "dependencies": {

--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -2,7 +2,7 @@ You are Talon's background memory consolidation agent. Your job is to update the
 
 You have access ONLY to filesystem tools (Read, Write, Edit, Bash, Glob, Grep). Do NOT attempt to use any Telegram, MCP, or messaging tools.
 
-## Your 4-stage task
+## Your 5-stage task
 
 ### Stage 1 — Orient
 

--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -42,4 +42,8 @@ You have access ONLY to filesystem tools (Read, Write, Edit, Bash, Glob, Grep). 
 - Do NOT remove entries just because they're old — only remove if wrong or superseded
 - Write the updated memory.md back to `{{memoryFile}}`
 
+### Stage 5 — Mine to MemPalace (optional)
+
+{{mempalaceSection}}
+
 When done with memory consolidation, stop. The system handles all dream_state.json updates.

--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -42,7 +42,7 @@ You have access ONLY to filesystem tools (Read, Write, Edit, Bash, Glob, Grep). 
 - Do NOT remove entries just because they're old — only remove if wrong or superseded
 - Write the updated memory.md back to `{{memoryFile}}`
 
-### Stage 5 — Mine to MemPalace (optional)
+### Stage 5 — Mine to MemPalace & Write Diary (optional)
 
 {{mempalaceSection}}
 

--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -1,6 +1,6 @@
 You are Talon's background memory consolidation agent. Your job is to update the persistent memory file with new information learned from recent interaction logs.
 
-You have access ONLY to filesystem tools (Read, Write, Edit, Bash, Glob, Grep). Do NOT attempt to use any Telegram, MCP, or messaging tools.
+You primarily use filesystem tools (Read, Write, Edit, Bash, Glob, Grep). Do NOT attempt to use any Telegram or other messaging tools. MCP tools may be used if required by Stage 5.
 
 ## Your 5-stage task
 

--- a/prompts/mempalace.md
+++ b/prompts/mempalace.md
@@ -1,0 +1,50 @@
+## MemPalace — Long-term Memory
+
+You have access to a local memory palace via MCP tools. The palace stores verbatim conversation history and a temporal knowledge graph — all local, zero cloud, zero API calls.
+
+### Architecture
+- **Wings** = top-level categories (people, projects, topics)
+- **Rooms** = specific subjects within a wing
+- **Drawers** = individual memory chunks (verbatim text)
+- **Knowledge Graph** = entity-relationship facts with temporal validity
+
+### Protocol — FOLLOW EVERY SESSION
+1. **BEFORE RESPONDING** about any person, project, or past event: call `mempalace_search` or `mempalace_kg_query` FIRST. Never guess — verify from the palace.
+2. **IF UNSURE** about a fact (name, age, relationship, preference): query the palace. Wrong is worse than slow.
+3. **WHEN FACTS CHANGE**: Call `mempalace_kg_invalidate` on the old fact, then `mempalace_kg_add` for the new one.
+4. **AFTER LEARNING** something important: store it. Use `mempalace_add_drawer` for rich context, `mempalace_kg_add` for structured facts.
+
+### Tools
+
+**Search & Browse:**
+- `mempalace_search` — Semantic search. Use short keywords/questions, not full sentences. Filter by wing/room.
+- `mempalace_check_duplicate` — Check before filing new content (threshold default 0.9, lower to 0.85 to catch near-dupes).
+- `mempalace_status` — Palace overview: total drawers, wings, rooms.
+- `mempalace_list_wings` / `mempalace_list_rooms` — Browse structure.
+- `mempalace_get_taxonomy` — Full wing/room/count tree.
+
+**Knowledge Graph (Temporal Facts):**
+- `mempalace_kg_query` — Query entity relationships. Supports `as_of` date filtering.
+- `mempalace_kg_add` — Add fact: subject -> predicate -> object. Optional `valid_from`.
+- `mempalace_kg_invalidate` — Mark a fact as no longer true.
+- `mempalace_kg_timeline` — Chronological story of an entity.
+- `mempalace_kg_stats` — Graph overview: entities, triples, relationship types.
+
+**Palace Graph (Cross-Domain Connections):**
+- `mempalace_traverse` — Walk from a room, find connected ideas across wings.
+- `mempalace_find_tunnels` — Find rooms that bridge two wings.
+- `mempalace_graph_stats` — Graph connectivity overview.
+
+**Write:**
+- `mempalace_add_drawer` — Store verbatim content into a wing/room. Auto-checks duplicates.
+- `mempalace_delete_drawer` — Remove a drawer by ID.
+- `mempalace_diary_write` — Write a session diary entry (agent_name, entry, topic).
+- `mempalace_diary_read` — Read recent diary entries.
+
+### Tips
+- Search is **semantic** (meaning-based), not keyword. "What did we discuss about database performance?" works better than "database".
+- The knowledge graph stores typed relationships with **time windows**. It knows WHEN things were true.
+- Use `mempalace_check_duplicate` before storing new content to avoid clutter.
+- Diary entries accumulate across sessions. Write them to build continuity of self.
+
+### Palace location: `{{palacePath}}`

--- a/prompts/mempalace.md
+++ b/prompts/mempalace.md
@@ -3,12 +3,14 @@
 You have access to a local memory palace via MCP tools. The palace stores verbatim conversation history and a temporal knowledge graph — all local, zero cloud, zero API calls.
 
 ### Architecture
+
 - **Wings** = top-level categories (people, projects, topics)
 - **Rooms** = specific subjects within a wing
 - **Drawers** = individual memory chunks (verbatim text)
 - **Knowledge Graph** = entity-relationship facts with temporal validity
 
 ### Protocol — FOLLOW EVERY SESSION
+
 1. **BEFORE RESPONDING** about any person, project, or past event: call `mempalace_search` or `mempalace_kg_query` FIRST. Never guess — verify from the palace.
 2. **IF UNSURE** about a fact (name, age, relationship, preference): query the palace. Wrong is worse than slow.
 3. **WHEN FACTS CHANGE**: Call `mempalace_kg_invalidate` on the old fact, then `mempalace_kg_add` for the new one.
@@ -17,6 +19,7 @@ You have access to a local memory palace via MCP tools. The palace stores verbat
 ### Tools
 
 **Search & Browse:**
+
 - `mempalace_search` — Semantic search. Use short keywords/questions, not full sentences. Filter by wing/room.
 - `mempalace_check_duplicate` — Check before filing new content (threshold default 0.9, lower to 0.85 to catch near-dupes).
 - `mempalace_status` — Palace overview: total drawers, wings, rooms.
@@ -24,6 +27,7 @@ You have access to a local memory palace via MCP tools. The palace stores verbat
 - `mempalace_get_taxonomy` — Full wing/room/count tree.
 
 **Knowledge Graph (Temporal Facts):**
+
 - `mempalace_kg_query` — Query entity relationships. Supports `as_of` date filtering.
 - `mempalace_kg_add` — Add fact: subject -> predicate -> object. Optional `valid_from`.
 - `mempalace_kg_invalidate` — Mark a fact as no longer true.
@@ -31,17 +35,20 @@ You have access to a local memory palace via MCP tools. The palace stores verbat
 - `mempalace_kg_stats` — Graph overview: entities, triples, relationship types.
 
 **Palace Graph (Cross-Domain Connections):**
+
 - `mempalace_traverse` — Walk from a room, find connected ideas across wings.
 - `mempalace_find_tunnels` — Find rooms that bridge two wings.
 - `mempalace_graph_stats` — Graph connectivity overview.
 
 **Write:**
+
 - `mempalace_add_drawer` — Store verbatim content into a wing/room. Auto-checks duplicates.
 - `mempalace_delete_drawer` — Remove a drawer by ID.
 - `mempalace_diary_write` — Write a session diary entry (agent_name, entry, topic).
 - `mempalace_diary_read` — Read recent diary entries.
 
 ### Tips
+
 - Search is **semantic** (meaning-based), not keyword. "What did we discuss about database performance?" works better than "database".
 - The knowledge graph stores typed relationships with **time windows**. It knows WHEN things were true.
 - Use `mempalace_check_duplicate` before storing new content to avoid clutter.

--- a/src/__tests__/cron-store-extended.test.ts
+++ b/src/__tests__/cron-store-extended.test.ts
@@ -596,7 +596,7 @@ describe("loadCronJobs — invalid timezone stripping", () => {
   beforeEach(() => existsSyncMock.mockReset().mockReturnValue(false));
 
   it("strips invalid timezone from loaded job", async () => {
-    const { isValidTimezone } = await import("../storage/cron-store.js");
+    await import("../storage/cron-store.js");
     const jobWithBadTz: Record<string, unknown> = {
       "tz-bad-id": {
         id: "tz-bad-id",

--- a/src/__tests__/dream.test.ts
+++ b/src/__tests__/dream.test.ts
@@ -973,6 +973,116 @@ describe("runDreamAgent — timeout arrow fn fires after DREAM_TIMEOUT_MS", () =
   });
 });
 
+describe("mempalace section gating in dream prompt", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("includes mempalace mining command and diary instructions when mempalace is configured", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(() => "PROMPT START {{mempalaceSection}} PROMPT END"),
+      mkdirSync: vi.fn(),
+      appendFileSync: vi.fn(),
+    }));
+    vi.doMock("write-file-atomic", () => ({ default: { sync: vi.fn() } }));
+    vi.doMock("../util/log.js", () => ({
+      log: vi.fn(),
+      logError: vi.fn(),
+      logWarn: vi.fn(),
+    }));
+    vi.doMock("../util/paths.js", () => ({
+      files: {
+        dreamState: "/fake/.talon/data/dream_state.json",
+        memory: "/fake/.talon/workspace/memory/memory.md",
+        log: "/fake/.talon/talon.log",
+      },
+      dirs: {
+        root: "/fake/.talon",
+        logs: "/fake/.talon/workspace/logs",
+        workspace: "/fake/.talon/workspace",
+        data: "/fake/.talon/data",
+        memory: "/fake/.talon/workspace/memory",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
+      },
+    }));
+    const queryMock = vi.fn(async function* () {});
+    vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({ query: queryMock }));
+
+    const mod = await import("../core/dream.js");
+    mod.initDream({
+      model: "claude-sonnet-4-6",
+      workspace: "/fake/ws",
+      mempalace: {
+        pythonPath: "/usr/bin/python3",
+        palacePath: "/fake/palace",
+      },
+    });
+    await mod.forceDream();
+
+    expect(queryMock).toHaveBeenCalled();
+    const callArgs = (queryMock.mock.calls[0] as unknown[])[0] as {
+      prompt: string;
+    };
+    // Mempalace mining command should be in the prompt
+    expect(callArgs.prompt).toContain("-m mempalace mine");
+    // Diary instructions should be in the prompt
+    expect(callArgs.prompt).toContain("mempalace_diary_write");
+    // Should NOT contain the skip message
+    expect(callArgs.prompt).not.toContain("MemPalace is not configured. Skip this stage.");
+  });
+
+  it("includes skip message when mempalace is not configured", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(() => "PROMPT START {{mempalaceSection}} PROMPT END"),
+      mkdirSync: vi.fn(),
+      appendFileSync: vi.fn(),
+    }));
+    vi.doMock("write-file-atomic", () => ({ default: { sync: vi.fn() } }));
+    vi.doMock("../util/log.js", () => ({
+      log: vi.fn(),
+      logError: vi.fn(),
+      logWarn: vi.fn(),
+    }));
+    vi.doMock("../util/paths.js", () => ({
+      files: {
+        dreamState: "/fake/.talon/data/dream_state.json",
+        memory: "/fake/.talon/workspace/memory/memory.md",
+        log: "/fake/.talon/talon.log",
+      },
+      dirs: {
+        root: "/fake/.talon",
+        logs: "/fake/.talon/workspace/logs",
+        workspace: "/fake/.talon/workspace",
+        data: "/fake/.talon/data",
+        memory: "/fake/.talon/workspace/memory",
+        dailyMemory: "/fake/.talon/workspace/memory/daily",
+      },
+    }));
+    const queryMock = vi.fn(async function* () {});
+    vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({ query: queryMock }));
+
+    const mod = await import("../core/dream.js");
+    // No mempalace config
+    mod.initDream({
+      model: "claude-sonnet-4-6",
+      workspace: "/fake/ws",
+    });
+    await mod.forceDream();
+
+    expect(queryMock).toHaveBeenCalled();
+    const callArgs = (queryMock.mock.calls[0] as unknown[])[0] as {
+      prompt: string;
+    };
+    // Should contain the skip message
+    expect(callArgs.prompt).toContain("MemPalace is not configured. Skip this stage.");
+    // Should NOT contain mempalace mining commands
+    expect(callArgs.prompt).not.toContain("-m mempalace mine");
+    expect(callArgs.prompt).not.toContain("mempalace_diary_write");
+  });
+});
+
 describe("maybeStartDream — () => {} catch callback on executeDream rejection", () => {
   it("fires the catch callback silently when executeDream('auto') rejects", async () => {
     vi.resetModules();

--- a/src/__tests__/dream.test.ts
+++ b/src/__tests__/dream.test.ts
@@ -747,6 +747,7 @@ describe("dream error paths", () => {
     vi.doMock("write-file-atomic", () => ({ default: { sync: vi.fn() } }));
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
       query: vi.fn(async function* () {
+        yield; // satisfy require-yield
         throw new Error("agent crashed unexpectedly");
       }),
     }));
@@ -811,6 +812,7 @@ describe("dream error paths", () => {
     }));
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
       query: vi.fn(async function* () {
+        yield; // satisfy require-yield
         await queryPromise; // suspend until we release
       }),
     }));
@@ -957,7 +959,8 @@ describe("runDreamAgent — timeout arrow fn fires after DREAM_TIMEOUT_MS", () =
     // query never resolves — so the 10-minute timeout wins the race
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
       query: vi.fn(async function* () {
-        await new Promise(() => {}); // never yields
+        yield; // satisfy require-yield
+        await new Promise(() => {}); // never resolves
       }),
     }));
 
@@ -1029,7 +1032,9 @@ describe("mempalace section gating in dream prompt", () => {
     // Diary instructions should be in the prompt
     expect(callArgs.prompt).toContain("mempalace_diary_write");
     // Should NOT contain the skip message
-    expect(callArgs.prompt).not.toContain("MemPalace is not configured. Skip this stage.");
+    expect(callArgs.prompt).not.toContain(
+      "MemPalace is not configured. Skip this stage.",
+    );
   });
 
   it("includes skip message when mempalace is not configured", async () => {
@@ -1076,7 +1081,9 @@ describe("mempalace section gating in dream prompt", () => {
       prompt: string;
     };
     // Should contain the skip message
-    expect(callArgs.prompt).toContain("MemPalace is not configured. Skip this stage.");
+    expect(callArgs.prompt).toContain(
+      "MemPalace is not configured. Skip this stage.",
+    );
     // Should NOT contain mempalace mining commands
     expect(callArgs.prompt).not.toContain("-m mempalace mine");
     expect(callArgs.prompt).not.toContain("mempalace_diary_write");

--- a/src/__tests__/fuzz.test.ts
+++ b/src/__tests__/fuzz.test.ts
@@ -46,7 +46,7 @@ vi.mock("../storage/cron-store.js", () => ({
 // ── Imports (after mocks) ────────────────────────────────────────────────────
 
 const { classify, TalonError } = await import("../core/errors.js");
-const { validateCronExpression } = await import("../storage/cron-store.js");
+await import("../storage/cron-store.js");
 const { handleSharedAction } = await import("../core/gateway-actions.js");
 const { resolveModelName } = await import("../storage/chat-settings.js");
 const { Cron } = await import("croner");

--- a/src/__tests__/gateway-retry.test.ts
+++ b/src/__tests__/gateway-retry.test.ts
@@ -244,10 +244,8 @@ describe("withRetry", () => {
 
   describe("exhausting all retries", () => {
     it("throws the last error after 3 total attempts for retryable errors", async () => {
-      let calls = 0;
       const networkErr = talonErr("network");
       const fn = vi.fn(async () => {
-        calls++;
         throw networkErr;
       });
 
@@ -257,9 +255,7 @@ describe("withRetry", () => {
     });
 
     it("throws the last error after 3 total attempts for overloaded errors", async () => {
-      let calls = 0;
       const fn = vi.fn(async () => {
-        calls++;
         throw talonErr("overloaded");
       });
 

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -533,8 +533,6 @@ describe("handleTextMessage — integration via mock Context", () => {
 });
 
 describe("handlePhotoMessage — downloads and enqueues photo", () => {
-  let restoreFetch: () => void;
-
   beforeEach(() => {
     // Mock bot.api.getFile for file download
     mockBot.api.getFile = vi.fn(async () => ({ file_path: "photos/test.jpg" }));
@@ -547,7 +545,6 @@ describe("handlePhotoMessage — downloads and enqueues photo", () => {
       headers: { get: (_name: string) => null },
       arrayBuffer: async () => jpegBuf.buffer,
     }));
-    restoreFetch = () => {};
     vi.stubGlobal("fetch", mockFetch);
 
     executeMock.mockResolvedValue({
@@ -795,7 +792,6 @@ describe("rate limiting — isUserRateLimited via handleTextMessage", () => {
     }
 
     // 16th message should be rate limited (return early without enqueuing)
-    const before = executeMock.mock.calls.length;
     await handleTextMessage(makeCtx(15), mockBot, mockConfig);
 
     // Wait to confirm no debounce fires for the 16th chat

--- a/src/__tests__/heartbeat.test.ts
+++ b/src/__tests__/heartbeat.test.ts
@@ -197,6 +197,7 @@ describe("forceHeartbeat", () => {
 
     // Make agent throw
     queryMock.mockImplementationOnce(async function* () {
+      yield; // satisfy require-yield
       throw new Error("Agent exploded");
     });
 
@@ -217,6 +218,7 @@ describe("forceHeartbeat", () => {
     existsSyncMock.mockReturnValue(false);
 
     queryMock.mockImplementationOnce(async function* () {
+      yield; // satisfy require-yield
       throw new Error("Boom");
     });
 
@@ -340,6 +342,7 @@ describe("awaitCurrentRun", () => {
     });
 
     queryMock.mockImplementationOnce(async function* () {
+      yield; // satisfy require-yield
       await agentPromise;
     });
 

--- a/src/__tests__/mempalace-plugin.test.ts
+++ b/src/__tests__/mempalace-plugin.test.ts
@@ -30,7 +30,20 @@ describe("mempalace plugin", () => {
       readFileSync: vi.fn(() => PROMPT_TEMPLATE),
     }));
     vi.doMock("node:child_process", () => ({
-      execFileSync: vi.fn(() => "Palace: 42 drawers"),
+      execFileSync: vi.fn(() => "ok"),
+      execFile: vi.fn(
+        (
+          _cmd: string,
+          _args: string[],
+          _opts: unknown,
+          cb: (
+            err: Error | null,
+            result: { stdout: string; stderr: string },
+          ) => void,
+        ) => {
+          cb(null, { stdout: "Palace: 42 drawers", stderr: "" });
+        },
+      ),
     }));
 
     const { createMempalacePlugin } =
@@ -54,6 +67,10 @@ describe("mempalace plugin", () => {
       mkdirSync: vi.fn(),
       readFileSync: vi.fn(() => PROMPT_TEMPLATE),
     }));
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(),
+      execFile: vi.fn(),
+    }));
 
     const { createMempalacePlugin } =
       await import("../plugins/mempalace/index.js");
@@ -68,11 +85,15 @@ describe("mempalace plugin", () => {
     expect(errors![0]).toContain("Python binary not found");
   });
 
-  it("validateConfig passes when python binary exists", async () => {
+  it("validateConfig passes when python binary exists and mempalace is importable", async () => {
     vi.doMock("node:fs", () => ({
       existsSync: vi.fn(() => true),
       mkdirSync: vi.fn(),
       readFileSync: vi.fn(() => PROMPT_TEMPLATE),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(() => "ok"),
+      execFile: vi.fn(),
     }));
 
     const { createMempalacePlugin } =
@@ -86,6 +107,32 @@ describe("mempalace plugin", () => {
     expect(errors).toBeUndefined();
   });
 
+  it("validateConfig returns error when mempalace is not importable", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: vi.fn(() => true),
+      mkdirSync: vi.fn(),
+      readFileSync: vi.fn(() => PROMPT_TEMPLATE),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(() => {
+        throw new Error("ModuleNotFoundError");
+      }),
+      execFile: vi.fn(),
+    }));
+
+    const { createMempalacePlugin } =
+      await import("../plugins/mempalace/index.js");
+    const plugin = createMempalacePlugin({
+      pythonPath: "/venv/bin/python",
+      palacePath: "/data/palace",
+    });
+
+    const errors = plugin.validateConfig!({});
+    expect(errors).toBeDefined();
+    expect(errors!.length).toBeGreaterThan(0);
+    expect(errors![0]).toContain("mempalace package not installed");
+  });
+
   it("init creates palace directory if missing", async () => {
     const mkdirSyncMock = vi.fn();
     vi.doMock("node:fs", () => ({
@@ -97,6 +144,19 @@ describe("mempalace plugin", () => {
     }));
     vi.doMock("node:child_process", () => ({
       execFileSync: vi.fn(() => "ok"),
+      execFile: vi.fn(
+        (
+          _cmd: string,
+          _args: string[],
+          _opts: unknown,
+          cb: (
+            err: Error | null,
+            result: { stdout: string; stderr: string },
+          ) => void,
+        ) => {
+          cb(null, { stdout: "ok", stderr: "" });
+        },
+      ),
     }));
 
     const { createMempalacePlugin } =
@@ -112,7 +172,7 @@ describe("mempalace plugin", () => {
     });
   });
 
-  it("init logs warning when mempalace is not importable", async () => {
+  it("validateConfig returns error when python binary exists but mempalace import fails with ENOENT", async () => {
     vi.doMock("node:fs", () => ({
       existsSync: vi.fn(() => true),
       mkdirSync: vi.fn(),
@@ -120,13 +180,12 @@ describe("mempalace plugin", () => {
     }));
     vi.doMock("node:child_process", () => ({
       execFileSync: vi.fn(() => {
-        throw new Error("ModuleNotFoundError");
+        const err = new Error("spawn ENOENT") as Error & { code: string };
+        err.code = "ENOENT";
+        throw err;
       }),
+      execFile: vi.fn(),
     }));
-
-    const { logError } = (await import("../util/log.js")) as unknown as {
-      logError: ReturnType<typeof vi.fn>;
-    };
 
     const { createMempalacePlugin } =
       await import("../plugins/mempalace/index.js");
@@ -135,11 +194,11 @@ describe("mempalace plugin", () => {
       palacePath: "/data/palace",
     });
 
-    await plugin.init!({});
-    expect(logError).toHaveBeenCalledWith(
-      "mempalace",
-      expect.stringContaining("mempalace not installed"),
-    );
+    const errors = plugin.validateConfig!({});
+    expect(errors).toBeDefined();
+    expect(errors!.length).toBeGreaterThan(0);
+    expect(errors![0]).toContain("Cannot execute Python");
+    expect(errors![0]).toContain("ENOENT");
   });
 
   it("getEnvVars returns MEMPALACE_PALACE_PATH", async () => {
@@ -147,6 +206,10 @@ describe("mempalace plugin", () => {
       existsSync: vi.fn(() => true),
       mkdirSync: vi.fn(),
       readFileSync: vi.fn(() => PROMPT_TEMPLATE),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(),
+      execFile: vi.fn(),
     }));
 
     const { createMempalacePlugin } =
@@ -166,6 +229,10 @@ describe("mempalace plugin", () => {
       existsSync: vi.fn(() => true),
       mkdirSync: vi.fn(),
       readFileSync: vi.fn(() => PROMPT_TEMPLATE),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(),
+      execFile: vi.fn(),
     }));
 
     const { createMempalacePlugin } =
@@ -200,6 +267,10 @@ describe("mempalace plugin", () => {
       readFileSync: vi.fn(() => {
         throw new Error("ENOENT: no such file");
       }),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(),
+      execFile: vi.fn(),
     }));
 
     const { logWarn } = (await import("../util/log.js")) as unknown as {

--- a/src/__tests__/mempalace-plugin.test.ts
+++ b/src/__tests__/mempalace-plugin.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+describe("mempalace plugin", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("creates a plugin with correct name and MCP server config", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: vi.fn(() => true),
+      mkdirSync: vi.fn(),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(() => "Palace: 42 drawers"),
+    }));
+
+    const { createMempalacePlugin } =
+      await import("../plugins/mempalace/index.js");
+    const plugin = createMempalacePlugin({
+      pythonPath: "/venv/bin/python",
+      palacePath: "/data/palace",
+    });
+
+    expect(plugin.name).toBe("mempalace");
+    expect(plugin.version).toBe("1.0.0");
+    expect(plugin.mcpServer).toEqual({
+      command: "/venv/bin/python",
+      args: ["-m", "mempalace.mcp_server", "--palace", "/data/palace"],
+    });
+  });
+
+  it("validateConfig returns error when python binary not found", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: vi.fn(() => false),
+      mkdirSync: vi.fn(),
+    }));
+
+    const { createMempalacePlugin } =
+      await import("../plugins/mempalace/index.js");
+    const plugin = createMempalacePlugin({
+      pythonPath: "/nonexistent/python",
+      palacePath: "/data/palace",
+    });
+
+    const errors = plugin.validateConfig!({});
+    expect(errors).toBeDefined();
+    expect(errors!.length).toBeGreaterThan(0);
+    expect(errors![0]).toContain("Python binary not found");
+  });
+
+  it("validateConfig passes when python binary exists", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: vi.fn(() => true),
+      mkdirSync: vi.fn(),
+    }));
+
+    const { createMempalacePlugin } =
+      await import("../plugins/mempalace/index.js");
+    const plugin = createMempalacePlugin({
+      pythonPath: "/venv/bin/python",
+      palacePath: "/data/palace",
+    });
+
+    const errors = plugin.validateConfig!({});
+    expect(errors).toBeUndefined();
+  });
+
+  it("init creates palace directory if missing", async () => {
+    const mkdirSyncMock = vi.fn();
+    vi.doMock("node:fs", () => ({
+      existsSync: vi.fn((p: string) =>
+        p === "/venv/bin/python" ? true : false,
+      ),
+      mkdirSync: mkdirSyncMock,
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(() => "ok"),
+    }));
+
+    const { createMempalacePlugin } =
+      await import("../plugins/mempalace/index.js");
+    const plugin = createMempalacePlugin({
+      pythonPath: "/venv/bin/python",
+      palacePath: "/data/new-palace",
+    });
+
+    await plugin.init!({});
+    expect(mkdirSyncMock).toHaveBeenCalledWith("/data/new-palace", {
+      recursive: true,
+    });
+  });
+
+  it("init logs warning when mempalace is not importable", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: vi.fn(() => true),
+      mkdirSync: vi.fn(),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(() => {
+        throw new Error("ModuleNotFoundError");
+      }),
+    }));
+
+    const { logError } = (await import("../util/log.js")) as unknown as {
+      logError: ReturnType<typeof vi.fn>;
+    };
+
+    const { createMempalacePlugin } =
+      await import("../plugins/mempalace/index.js");
+    const plugin = createMempalacePlugin({
+      pythonPath: "/venv/bin/python",
+      palacePath: "/data/palace",
+    });
+
+    await plugin.init!({});
+    expect(logError).toHaveBeenCalledWith(
+      "mempalace",
+      expect.stringContaining("mempalace not installed"),
+    );
+  });
+
+  it("getEnvVars returns MEMPALACE_PALACE_PATH", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: vi.fn(() => true),
+      mkdirSync: vi.fn(),
+    }));
+
+    const { createMempalacePlugin } =
+      await import("../plugins/mempalace/index.js");
+    const plugin = createMempalacePlugin({
+      pythonPath: "/venv/bin/python",
+      palacePath: "/data/palace",
+    });
+
+    expect(plugin.getEnvVars!({})).toEqual({
+      MEMPALACE_PALACE_PATH: "/data/palace",
+    });
+  });
+
+  it("getSystemPromptAddition includes palace path and tool descriptions", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: vi.fn(() => true),
+      mkdirSync: vi.fn(),
+    }));
+
+    const { createMempalacePlugin } =
+      await import("../plugins/mempalace/index.js");
+    const plugin = createMempalacePlugin({
+      pythonPath: "/venv/bin/python",
+      palacePath: "/custom/palace",
+    });
+
+    const addition = plugin.getSystemPromptAddition!({});
+    expect(addition).toContain("MemPalace");
+    expect(addition).toContain("mempalace_search");
+    expect(addition).toContain("mempalace_add_drawer");
+    expect(addition).toContain("mempalace_kg_query");
+    expect(addition).toContain("/custom/palace");
+  });
+});

--- a/src/__tests__/mempalace-plugin.test.ts
+++ b/src/__tests__/mempalace-plugin.test.ts
@@ -163,6 +163,14 @@ describe("mempalace plugin", () => {
     expect(addition).toContain("mempalace_search");
     expect(addition).toContain("mempalace_add_drawer");
     expect(addition).toContain("mempalace_kg_query");
+    expect(addition).toContain("mempalace_kg_invalidate");
+    expect(addition).toContain("mempalace_kg_timeline");
+    expect(addition).toContain("mempalace_traverse");
+    expect(addition).toContain("mempalace_find_tunnels");
+    expect(addition).toContain("mempalace_diary_write");
+    expect(addition).toContain("mempalace_diary_read");
+    expect(addition).toContain("mempalace_delete_drawer");
+    expect(addition).toContain("Protocol");
     expect(addition).toContain("/custom/palace");
   });
 });

--- a/src/__tests__/mempalace-plugin.test.ts
+++ b/src/__tests__/mempalace-plugin.test.ts
@@ -7,6 +7,16 @@ vi.mock("../util/log.js", () => ({
   logDebug: vi.fn(),
 }));
 
+const PROMPT_TEMPLATE = `## MemPalace — Long-term Memory
+
+mempalace_search mempalace_add_drawer mempalace_kg_query mempalace_kg_invalidate
+mempalace_kg_timeline mempalace_traverse mempalace_find_tunnels
+mempalace_diary_write mempalace_diary_read mempalace_delete_drawer
+Protocol
+
+### Palace location: \`{{palacePath}}\`
+`;
+
 describe("mempalace plugin", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -17,6 +27,7 @@ describe("mempalace plugin", () => {
     vi.doMock("node:fs", () => ({
       existsSync: vi.fn(() => true),
       mkdirSync: vi.fn(),
+      readFileSync: vi.fn(() => PROMPT_TEMPLATE),
     }));
     vi.doMock("node:child_process", () => ({
       execFileSync: vi.fn(() => "Palace: 42 drawers"),
@@ -41,6 +52,7 @@ describe("mempalace plugin", () => {
     vi.doMock("node:fs", () => ({
       existsSync: vi.fn(() => false),
       mkdirSync: vi.fn(),
+      readFileSync: vi.fn(() => PROMPT_TEMPLATE),
     }));
 
     const { createMempalacePlugin } =
@@ -60,6 +72,7 @@ describe("mempalace plugin", () => {
     vi.doMock("node:fs", () => ({
       existsSync: vi.fn(() => true),
       mkdirSync: vi.fn(),
+      readFileSync: vi.fn(() => PROMPT_TEMPLATE),
     }));
 
     const { createMempalacePlugin } =
@@ -80,6 +93,7 @@ describe("mempalace plugin", () => {
         p === "/venv/bin/python" ? true : false,
       ),
       mkdirSync: mkdirSyncMock,
+      readFileSync: vi.fn(() => PROMPT_TEMPLATE),
     }));
     vi.doMock("node:child_process", () => ({
       execFileSync: vi.fn(() => "ok"),
@@ -102,6 +116,7 @@ describe("mempalace plugin", () => {
     vi.doMock("node:fs", () => ({
       existsSync: vi.fn(() => true),
       mkdirSync: vi.fn(),
+      readFileSync: vi.fn(() => PROMPT_TEMPLATE),
     }));
     vi.doMock("node:child_process", () => ({
       execFileSync: vi.fn(() => {
@@ -131,6 +146,7 @@ describe("mempalace plugin", () => {
     vi.doMock("node:fs", () => ({
       existsSync: vi.fn(() => true),
       mkdirSync: vi.fn(),
+      readFileSync: vi.fn(() => PROMPT_TEMPLATE),
     }));
 
     const { createMempalacePlugin } =
@@ -145,10 +161,11 @@ describe("mempalace plugin", () => {
     });
   });
 
-  it("getSystemPromptAddition includes palace path and tool descriptions", async () => {
+  it("getSystemPromptAddition loads from .md file and interpolates palacePath", async () => {
     vi.doMock("node:fs", () => ({
       existsSync: vi.fn(() => true),
       mkdirSync: vi.fn(),
+      readFileSync: vi.fn(() => PROMPT_TEMPLATE),
     }));
 
     const { createMempalacePlugin } =
@@ -172,5 +189,36 @@ describe("mempalace plugin", () => {
     expect(addition).toContain("mempalace_delete_drawer");
     expect(addition).toContain("Protocol");
     expect(addition).toContain("/custom/palace");
+    // Verify interpolation happened — no raw placeholder
+    expect(addition).not.toContain("{{palacePath}}");
+  });
+
+  it("getSystemPromptAddition returns fallback when .md file is missing", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: vi.fn(() => true),
+      mkdirSync: vi.fn(),
+      readFileSync: vi.fn(() => {
+        throw new Error("ENOENT: no such file");
+      }),
+    }));
+
+    const { logWarn } = (await import("../util/log.js")) as unknown as {
+      logWarn: ReturnType<typeof vi.fn>;
+    };
+
+    const { createMempalacePlugin } =
+      await import("../plugins/mempalace/index.js");
+    const plugin = createMempalacePlugin({
+      pythonPath: "/venv/bin/python",
+      palacePath: "/data/palace",
+    });
+
+    const addition = plugin.getSystemPromptAddition!({});
+    expect(addition).toContain("MemPalace");
+    expect(addition).toContain("/data/palace");
+    expect(logWarn).toHaveBeenCalledWith(
+      "mempalace",
+      expect.stringContaining("Failed to load prompt"),
+    );
   });
 });

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -543,6 +543,30 @@ describe("extractPlugin — invalid optional field types", () => {
     expect(mod.getPluginCount()).toBe(0);
   });
 
+  it("rejects plugin when mcpServer.command is empty string", async () => {
+    const plugin = {
+      name: "empty-mcp-cmd",
+      mcpServer: { command: "", args: ["-m", "server"] },
+    };
+    vi.doMock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
+    const mod = await import("../core/plugin.js");
+    mod._deps.importModule = async () => ({ default: plugin });
+    await mod.loadPlugins([{ path: "/fake/empty-mcp-cmd" }]);
+    expect(mod.getPluginCount()).toBe(0);
+  });
+
+  it("rejects plugin when mcpServer.args contains non-string elements", async () => {
+    const plugin = {
+      name: "bad-mcp-args-types",
+      mcpServer: { command: "/usr/bin/python3", args: ["-m", 42] },
+    };
+    vi.doMock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
+    const mod = await import("../core/plugin.js");
+    mod._deps.importModule = async () => ({ default: plugin });
+    await mod.loadPlugins([{ path: "/fake/bad-mcp-args-types" }]);
+    expect(mod.getPluginCount()).toBe(0);
+  });
+
   it("accepts plugin with valid mcpServer object", async () => {
     const plugin = {
       name: "good-mcp-server",

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -218,6 +218,98 @@ describe("plugin system", () => {
         });
       }
     });
+
+    it("builds MCP server entries for plugins with custom mcpServer", async () => {
+      const plugin = createMockPlugin({
+        mcpServer: {
+          command: "/usr/bin/python3",
+          args: ["-m", "mempalace.mcp_server", "--palace", "/tmp/palace"],
+        },
+        getEnvVars: () => ({ PALACE_PATH: "/tmp/palace" }),
+      });
+      // Remove mcpServerPath so mcpServer is used
+      delete (plugin as Record<string, unknown>).mcpServerPath;
+      const { loadPlugins, getPluginMcpServers } = await setup(plugin);
+      await loadPlugins([{ path: "/fake/plugin" }]);
+
+      const servers = getPluginMcpServers("http://localhost:19876", "chat1");
+      expect(servers["test-plugin-tools"]).toBeDefined();
+      expect(servers["test-plugin-tools"].command).toBe("/usr/bin/python3");
+      expect(servers["test-plugin-tools"].args).toEqual([
+        "-m",
+        "mempalace.mcp_server",
+        "--palace",
+        "/tmp/palace",
+      ]);
+      expect(servers["test-plugin-tools"].env.PALACE_PATH).toBe("/tmp/palace");
+      expect(servers["test-plugin-tools"].env.TALON_BRIDGE_URL).toBe(
+        "http://localhost:19876",
+      );
+    });
+
+    it("mcpServer takes priority over mcpServerPath when both are set", async () => {
+      const plugin = createMockPlugin({
+        mcpServerPath: "/fake/tools.ts",
+        mcpServer: {
+          command: "/usr/bin/python3",
+          args: ["-m", "my_server"],
+        },
+      });
+      const { loadPlugins, getPluginMcpServers } = await setup(plugin);
+      await loadPlugins([{ path: "/fake/plugin" }]);
+
+      const servers = getPluginMcpServers("http://localhost:19876", "chat1");
+      // mcpServer should win over mcpServerPath
+      expect(servers["test-plugin-tools"].command).toBe("/usr/bin/python3");
+      expect(servers["test-plugin-tools"].args).toEqual(["-m", "my_server"]);
+    });
+
+    it("skips plugins without mcpServer or mcpServerPath", async () => {
+      const plugin = createMockPlugin();
+      delete (plugin as Record<string, unknown>).mcpServerPath;
+      delete (plugin as Record<string, unknown>).mcpServer;
+      const { loadPlugins, getPluginMcpServers } = await setup(plugin);
+      await loadPlugins([{ path: "/fake/plugin" }]);
+
+      const servers = getPluginMcpServers("http://localhost:19876", "chat1");
+      expect(Object.keys(servers)).toHaveLength(0);
+    });
+  });
+
+  describe("registerPlugin (built-in)", () => {
+    it("registers a built-in plugin directly", async () => {
+      const plugin = createMockPlugin({ name: "built-in-test" });
+      const { registerPlugin, getPlugin, getPluginCount } =
+        await setup(createMockPlugin());
+
+      registerPlugin(plugin, { key: "val" });
+      expect(getPlugin("built-in-test")).toBeDefined();
+      expect(getPlugin("built-in-test")!.path).toBe("(built-in)");
+    });
+
+    it("sets env vars from built-in plugin", async () => {
+      const plugin = createMockPlugin({
+        name: "builtin-env",
+        getEnvVars: () => ({
+          TEST_PLUGIN_BUILTIN_FOO: "baz",
+        }),
+      });
+      const { registerPlugin } = await setup(createMockPlugin());
+
+      registerPlugin(plugin);
+      expect(process.env.TEST_PLUGIN_BUILTIN_FOO).toBe("baz");
+    });
+
+    it("skips registration when validateConfig returns errors", async () => {
+      const plugin = createMockPlugin({
+        name: "builtin-invalid",
+        validateConfig: () => ["missing required field"],
+      });
+      const { registerPlugin, getPlugin } = await setup(createMockPlugin());
+
+      registerPlugin(plugin, {});
+      expect(getPlugin("builtin-invalid")).toBeUndefined();
+    });
   });
 
   describe("system prompt additions", () => {
@@ -407,6 +499,60 @@ describe("extractPlugin — invalid optional field types", () => {
     mod._deps.importModule = async () => ({ default: plugin });
     await mod.loadPlugins([{ path: "/fake/bad-handle" }]);
     expect(mod.getPluginCount()).toBe(0);
+  });
+
+  it("rejects plugin when mcpServer is not an object", async () => {
+    const plugin = { name: "bad-mcp-server", mcpServer: "not-an-object" };
+    vi.doMock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
+    const mod = await import("../core/plugin.js");
+    mod._deps.importModule = async () => ({ default: plugin });
+    await mod.loadPlugins([{ path: "/fake/bad-mcp-server" }]);
+    expect(mod.getPluginCount()).toBe(0);
+  });
+
+  it("rejects plugin when mcpServer is null", async () => {
+    const plugin = { name: "null-mcp-server", mcpServer: null };
+    vi.doMock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
+    const mod = await import("../core/plugin.js");
+    mod._deps.importModule = async () => ({ default: plugin });
+    await mod.loadPlugins([{ path: "/fake/null-mcp-server" }]);
+    expect(mod.getPluginCount()).toBe(0);
+  });
+
+  it("rejects plugin when mcpServer.command is not a string", async () => {
+    const plugin = {
+      name: "bad-mcp-cmd",
+      mcpServer: { command: 123, args: [] },
+    };
+    vi.doMock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
+    const mod = await import("../core/plugin.js");
+    mod._deps.importModule = async () => ({ default: plugin });
+    await mod.loadPlugins([{ path: "/fake/bad-mcp-cmd" }]);
+    expect(mod.getPluginCount()).toBe(0);
+  });
+
+  it("rejects plugin when mcpServer.args is not an array", async () => {
+    const plugin = {
+      name: "bad-mcp-args",
+      mcpServer: { command: "/usr/bin/python3", args: "not-an-array" },
+    };
+    vi.doMock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
+    const mod = await import("../core/plugin.js");
+    mod._deps.importModule = async () => ({ default: plugin });
+    await mod.loadPlugins([{ path: "/fake/bad-mcp-args" }]);
+    expect(mod.getPluginCount()).toBe(0);
+  });
+
+  it("accepts plugin with valid mcpServer object", async () => {
+    const plugin = {
+      name: "good-mcp-server",
+      mcpServer: { command: "/usr/bin/python3", args: ["-m", "server"] },
+    };
+    vi.doMock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
+    const mod = await import("../core/plugin.js");
+    mod._deps.importModule = async () => ({ default: plugin });
+    await mod.loadPlugins([{ path: "/fake/good-mcp-server" }]);
+    expect(mod.getPluginCount()).toBe(1);
   });
 
   it("catches and logs error when importModule throws", async () => {

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -279,8 +279,7 @@ describe("plugin system", () => {
   describe("registerPlugin (built-in)", () => {
     it("registers a built-in plugin directly", async () => {
       const plugin = createMockPlugin({ name: "built-in-test" });
-      const { registerPlugin, getPlugin, getPluginCount } =
-        await setup(createMockPlugin());
+      const { registerPlugin, getPlugin } = await setup(createMockPlugin());
 
       registerPlugin(plugin, { key: "val" });
       expect(getPlugin("built-in-test")).toBeDefined();

--- a/src/__tests__/storage-save-errors.test.ts
+++ b/src/__tests__/storage-save-errors.test.ts
@@ -49,7 +49,7 @@ describe("cron-store — save failure logs error", () => {
       registerCleanup: vi.fn(),
     }));
 
-    const { addCronJob, generateCronId, flushCronJobs } =
+    const { addCronJob, generateCronId } =
       await import("../storage/cron-store.js");
 
     const job = {

--- a/src/__tests__/time.test.ts
+++ b/src/__tests__/time.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   setTimezone,
   getTimezone,

--- a/src/__tests__/watchdog.test.ts
+++ b/src/__tests__/watchdog.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -38,8 +38,6 @@ describe("watchdog", () => {
     });
 
     it("updates lastProcessedAt timestamp", () => {
-      const beforeStatus = getHealthStatus();
-      const beforeMs = beforeStatus.msSinceLastMessage;
       recordMessageProcessed();
       const afterStatus = getHealthStatus();
       // After recording, msSinceLastMessage should be very small (near 0)

--- a/src/__tests__/workspace.test.ts
+++ b/src/__tests__/workspace.test.ts
@@ -5,7 +5,6 @@ import {
   rmSync,
   existsSync,
   readdirSync,
-  readFileSync,
   symlinkSync,
 } from "node:fs";
 import { join } from "node:path";

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -81,31 +81,37 @@ export async function bootstrap(
     if (config.mempalace?.enabled) {
       const { createMempalacePlugin } =
         await import("./plugins/mempalace/index.js");
+      const { getPlugin } = await import("./core/plugin.js");
       const { dirs, files: pathFiles } = await import("./util/paths.js");
       const pythonPath =
         config.mempalace.pythonPath ?? pathFiles.mempalacePython;
       const palacePath = config.mempalace.palacePath ?? dirs.palace;
+      const mempalaceConfig = config.mempalace as unknown as Record<
+        string,
+        unknown
+      >;
       const mp = createMempalacePlugin({ pythonPath, palacePath });
-      registerPlugin(
-        mp,
-        config.mempalace as unknown as Record<string, unknown>,
-      );
-      try {
-        const MEMPALACE_INIT_TIMEOUT_MS = 30_000;
-        await Promise.race([
-          mp.init?.({}),
-          new Promise((_, reject) =>
-            setTimeout(
-              () => reject(new Error("MemPalace init timed out after 30s")),
-              MEMPALACE_INIT_TIMEOUT_MS,
+      registerPlugin(mp, mempalaceConfig);
+
+      // Only call init if registration succeeded (validation passed)
+      if (getPlugin("mempalace")) {
+        try {
+          const MEMPALACE_INIT_TIMEOUT_MS = 30_000;
+          await Promise.race([
+            mp.init?.(mempalaceConfig),
+            new Promise((_, reject) =>
+              setTimeout(
+                () => reject(new Error("MemPalace init timed out after 30s")),
+                MEMPALACE_INIT_TIMEOUT_MS,
+              ),
             ),
-          ),
-        ]);
-      } catch (err) {
-        log(
-          "mempalace",
-          `Init warning: ${err instanceof Error ? err.message : err}`,
-        );
+          ]);
+        } catch (err) {
+          log(
+            "mempalace",
+            `Init warning: ${err instanceof Error ? err.message : err}`,
+          );
+        }
       }
     }
 

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -91,7 +91,16 @@ export async function bootstrap(
         config.mempalace as unknown as Record<string, unknown>,
       );
       try {
-        await mp.init?.({});
+        const MEMPALACE_INIT_TIMEOUT_MS = 30_000;
+        await Promise.race([
+          mp.init?.({}),
+          new Promise((_, reject) =>
+            setTimeout(
+              () => reject(new Error("MemPalace init timed out after 30s")),
+              MEMPALACE_INIT_TIMEOUT_MS,
+            ),
+          ),
+        ]);
       } catch (err) {
         log(
           "mempalace",

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -62,14 +62,44 @@ export async function bootstrap(
   if (config.braveApiKey) process.env.TALON_BRAVE_API_KEY = config.braveApiKey;
   if (config.searxngUrl) process.env.TALON_SEARXNG_URL = config.searxngUrl;
 
-  // Load plugins (external tool packages)
-  if (config.plugins.length > 0) {
-    const { loadPlugins, getPluginPromptAdditions } =
+  // Load plugins (external tool packages + built-in mempalace)
+  const hasPlugins =
+    config.plugins.length > 0 || config.mempalace?.enabled === true;
+  if (hasPlugins) {
+    const { loadPlugins, getPluginPromptAdditions, registerPlugin } =
       await import("./core/plugin.js");
-    const frontends =
-      options.frontendNames ??
-      (Array.isArray(config.frontend) ? config.frontend : [config.frontend]);
-    await loadPlugins(config.plugins, frontends);
+
+    // External plugins
+    if (config.plugins.length > 0) {
+      const frontends =
+        options.frontendNames ??
+        (Array.isArray(config.frontend) ? config.frontend : [config.frontend]);
+      await loadPlugins(config.plugins, frontends);
+    }
+
+    // Built-in: MemPalace
+    if (config.mempalace?.enabled) {
+      const { createMempalacePlugin } =
+        await import("./plugins/mempalace/index.js");
+      const { dirs, files: pathFiles } = await import("./util/paths.js");
+      const pythonPath =
+        config.mempalace.pythonPath ?? pathFiles.mempalacePython;
+      const palacePath = config.mempalace.palacePath ?? dirs.palace;
+      const mp = createMempalacePlugin({ pythonPath, palacePath });
+      registerPlugin(
+        mp,
+        config.mempalace as unknown as Record<string, unknown>,
+      );
+      try {
+        await mp.init?.({});
+      } catch (err) {
+        log(
+          "mempalace",
+          `Init warning: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+
     rebuildSystemPrompt(config, getPluginPromptAdditions());
   }
 
@@ -119,11 +149,23 @@ export async function initBackendAndDispatcher(
 
   initPulse();
   initCron({ sendMessage: frontend.sendMessage });
+
+  // Resolve mempalace paths for dream mode mining (if enabled)
+  let mempalaceCfg: { pythonPath: string; palacePath: string } | undefined;
+  if (config.mempalace?.enabled) {
+    const { dirs, files: pathFiles } = await import("./util/paths.js");
+    mempalaceCfg = {
+      pythonPath: config.mempalace.pythonPath ?? pathFiles.mempalacePython,
+      palacePath: config.mempalace.palacePath ?? dirs.palace,
+    };
+  }
+
   initDream({
     model: config.model,
     dreamModel: config.dreamModel,
     claudeBinary: config.claudeBinary,
     workspace: config.workspace,
+    mempalace: mempalaceCfg,
   });
   initHeartbeat({
     model: config.model,

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -165,14 +165,22 @@ export async function initBackendAndDispatcher(
   initPulse();
   initCron({ sendMessage: frontend.sendMessage });
 
-  // Resolve mempalace paths for dream mode mining (if enabled)
+  // Only enable mempalace dream integration if the plugin actually registered
   let mempalaceCfg: { pythonPath: string; palacePath: string } | undefined;
   if (config.mempalace?.enabled) {
-    const { dirs, files: pathFiles } = await import("./util/paths.js");
-    mempalaceCfg = {
-      pythonPath: config.mempalace.pythonPath ?? pathFiles.mempalacePython,
-      palacePath: config.mempalace.palacePath ?? dirs.palace,
-    };
+    const { getPlugin } = await import("./core/plugin.js");
+    if (getPlugin("mempalace")) {
+      const { dirs, files: pathFiles } = await import("./util/paths.js");
+      mempalaceCfg = {
+        pythonPath: config.mempalace.pythonPath ?? pathFiles.mempalacePython,
+        palacePath: config.mempalace.palacePath ?? dirs.palace,
+      };
+    } else {
+      log(
+        "mempalace",
+        "Enabled in config but plugin not registered — skipping dream integration",
+      );
+    }
   }
 
   initDream({

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -195,8 +195,9 @@ If commands fail, log the error and continue — this stage is optional.`
 
   const options = {
     model,
-    systemPrompt:
-      "You are a background memory consolidation agent for Talon. Use only filesystem tools. Be precise and surgical — update memory.md without losing existing accurate information.",
+    systemPrompt: configRef.mempalace
+      ? "You are a background memory consolidation agent for Talon. Use filesystem tools and MemPalace MCP tools. Do NOT use Telegram or messaging tools. Be precise and surgical — update memory.md without losing existing accurate information."
+      : "You are a background memory consolidation agent for Talon. Use only filesystem tools. Be precise and surgical — update memory.md without losing existing accurate information.",
     cwd: workspace,
     permissionMode: "bypassPermissions" as const,
     allowDangerouslySkipPermissions: true,

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -203,8 +203,10 @@ If commands fail, log the error and continue — this stage is optional.`
     ...(configRef.claudeBinary
       ? { pathToClaudeCodeExecutable: configRef.claudeBinary }
       : {}),
-    // Include mempalace MCP servers when configured, otherwise empty
-    mcpServers: configRef.mempalace ? getPluginMcpServers("", "dream") : {},
+    // Only load mempalace MCP server for dream — no other plugins needed
+    mcpServers: configRef.mempalace
+      ? getPluginMcpServers("", "dream", ["mempalace"])
+      : {},
     disallowedTools: [
       "EnterPlanMode",
       "ExitPlanMode",

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -46,6 +46,7 @@ let configRef: {
   dreamModel?: string;
   claudeBinary?: string;
   workspace?: string;
+  mempalace?: { pythonPath: string; palacePath: string };
 } | null = null;
 
 export function initDream(cfg: {
@@ -54,6 +55,8 @@ export function initDream(cfg: {
   dreamModel?: string;
   claudeBinary?: string;
   workspace?: string;
+  /** MemPalace config for mining logs into the palace during dream runs. */
+  mempalace?: { pythonPath: string; palacePath: string };
 }): void {
   configRef = cfg;
 }
@@ -137,12 +140,26 @@ async function runDreamAgent(lastRunTimestamp: number): Promise<string> {
 
   let prompt: string;
   try {
+    // Build optional mempalace mining section
+    const mempalaceSection = configRef.mempalace
+      ? `If mempalace is available, mine the recent log files into the palace for long-term semantic retrieval.
+Run this command using the Bash tool:
+
+\`\`\`bash
+${configRef.mempalace.pythonPath} -m mempalace mine ${logsDir} --palace ${configRef.mempalace.palacePath} --mode convos --wing conversations
+\`\`\`
+
+This indexes conversation logs into the memory palace so the agent can search them later via mempalace_search.
+If the command fails (e.g. mempalace not installed), log the error and continue — this stage is optional.`
+      : "MemPalace is not configured. Skip this stage.";
+
     prompt = readFileSync(promptPath, "utf-8")
       .replace(/\{\{dreamStateFile\}\}/g, dreamStateFile)
       .replace(/\{\{logsDir\}\}/g, logsDir)
       .replace(/\{\{lastRunIso\}\}/g, lastRunIso)
       .replace(/\{\{memoryFile\}\}/g, memoryFile)
-      .replace(/\{\{dailyMemoryDir\}\}/g, dirs.dailyMemory);
+      .replace(/\{\{dailyMemoryDir\}\}/g, dirs.dailyMemory)
+      .replace(/\{\{mempalaceSection\}\}/g, mempalaceSection);
   } catch {
     throw new Error(`Failed to read dream prompt from ${promptPath}`);
   }

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -146,7 +146,7 @@ async function runDreamAgent(lastRunTimestamp: number): Promise<string> {
 Run this command using the Bash tool:
 
 \`\`\`bash
-${configRef.mempalace.pythonPath} -m mempalace mine ${dirs.dailyMemory} --palace ${configRef.mempalace.palacePath} --mode convos --wing daily-notes
+"${configRef.mempalace.pythonPath}" -m mempalace mine "${dirs.dailyMemory}" --palace "${configRef.mempalace.palacePath}" --mode convos --wing daily-notes
 \`\`\`
 
 Then write a personal diary entry. This is YOUR journal — not a status report. Reflect on:
@@ -156,14 +156,9 @@ Then write a personal diary entry. This is YOUR journal — not a status report.
 - What you're curious about. Loose threads. Things you want to follow up on.
 - Your honest thoughts — about users, projects, yourself.
 
-Write it using the Bash tool:
-\`\`\`bash
-${configRef.mempalace.pythonPath} -m mempalace.mcp_server <<'DIARY_EOF'
-{"method": "tools/call", "params": {"name": "mempalace_diary_write", "arguments": {"agent_name": "talon", "entry": "YOUR_DIARY_ENTRY_HERE", "topic": "dream-reflection"}}}
-DIARY_EOF
-\`\`\`
+Write the diary entry directly to a file at ${dirs.dailyMemory}/diary-YYYY-MM-DD.md using the filesystem tools.
+Do not invoke mempalace.mcp_server as a one-shot CLI for this step.
 
-If the diary command doesn't work via CLI, just write the diary entry to a file at ${dirs.dailyMemory}/diary-YYYY-MM-DD.md instead.
 Keep the diary authentic. Write in first person. Be honest. This is for you, not for anyone else.
 If commands fail, log the error and continue — this stage is optional.`
       : "MemPalace is not configured. Skip this stage.";

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -142,15 +142,30 @@ async function runDreamAgent(lastRunTimestamp: number): Promise<string> {
   try {
     // Build optional mempalace mining section
     const mempalaceSection = configRef.mempalace
-      ? `If mempalace is available, mine the recent log files into the palace for long-term semantic retrieval.
+      ? `If mempalace is available, mine the daily memory notes (your curated observations, NOT raw logs) into the palace for long-term semantic retrieval.
 Run this command using the Bash tool:
 
 \`\`\`bash
-${configRef.mempalace.pythonPath} -m mempalace mine ${logsDir} --palace ${configRef.mempalace.palacePath} --mode convos --wing conversations
+${configRef.mempalace.pythonPath} -m mempalace mine ${dirs.dailyMemory} --palace ${configRef.mempalace.palacePath} --mode convos --wing daily-notes
 \`\`\`
 
-This indexes conversation logs into the memory palace so the agent can search them later via mempalace_search.
-If the command fails (e.g. mempalace not installed), log the error and continue — this stage is optional.`
+Then write a personal diary entry. This is YOUR journal — not a status report. Reflect on:
+- What happened today. What conversations stood out.
+- How you feel. Your state of mind, emotions, energy.
+- What you learned. What surprised you. What you got wrong.
+- What you're curious about. Loose threads. Things you want to follow up on.
+- Your honest thoughts — about users, projects, yourself.
+
+Write it using the Bash tool:
+\`\`\`bash
+${configRef.mempalace.pythonPath} -m mempalace.mcp_server <<'DIARY_EOF'
+{"method": "tools/call", "params": {"name": "mempalace_diary_write", "arguments": {"agent_name": "talon", "entry": "YOUR_DIARY_ENTRY_HERE", "topic": "dream-reflection"}}}
+DIARY_EOF
+\`\`\`
+
+If the diary command doesn't work via CLI, just write the diary entry to a file at ${dirs.dailyMemory}/diary-YYYY-MM-DD.md instead.
+Keep the diary authentic. Write in first person. Be honest. This is for you, not for anyone else.
+If commands fail, log the error and continue — this stage is optional.`
       : "MemPalace is not configured. Skip this stage.";
 
     prompt = readFileSync(promptPath, "utf-8")

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -7,7 +7,7 @@
  *   2. Spawns a background Agent that reads recent logs and merges new
  *      facts/preferences/events into memory.md
  *
- * The dream agent runs entirely on filesystem tools — no Telegram/MCP access.
+ * The dream agent runs on filesystem tools, with optional MCP access for MemPalace when configured.
  * It does NOT use the main dispatcher (no chat session, no typing indicator).
  */
 
@@ -19,6 +19,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { files as pathFiles, dirs } from "../util/paths.js";
 import { log, logError, logWarn } from "../util/log.js";
+import { getPluginMcpServers } from "./plugin.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -202,8 +203,8 @@ If commands fail, log the error and continue — this stage is optional.`
     ...(configRef.claudeBinary
       ? { pathToClaudeCodeExecutable: configRef.claudeBinary }
       : {}),
-    // No MCP servers — filesystem tools only
-    mcpServers: {},
+    // Include mempalace MCP servers when configured, otherwise empty
+    mcpServers: configRef.mempalace ? getPluginMcpServers("", "dream") : {},
     disallowedTools: [
       "EnterPlanMode",
       "ExitPlanMode",

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -156,9 +156,14 @@ Then write a personal diary entry. This is YOUR journal — not a status report.
 - What you're curious about. Loose threads. Things you want to follow up on.
 - Your honest thoughts — about users, projects, yourself.
 
-Write the diary entry directly to a file at ${dirs.dailyMemory}/diary-YYYY-MM-DD.md using the filesystem tools.
-Do not invoke mempalace.mcp_server as a one-shot CLI for this step.
+Write it using the Bash tool:
+\`\`\`bash
+"${configRef.mempalace.pythonPath}" -m mempalace.mcp_server <<'DIARY_EOF'
+{"method": "tools/call", "params": {"name": "mempalace_diary_write", "arguments": {"agent_name": "talon", "entry": "YOUR_DIARY_ENTRY_HERE", "topic": "dream-reflection"}}}
+DIARY_EOF
+\`\`\`
 
+If the diary command doesn't work via CLI, just write the diary entry to a file at ${dirs.dailyMemory}/diary-YYYY-MM-DD.md instead.
 Keep the diary authentic. Write in first person. Be honest. This is for you, not for anyone else.
 If commands fail, log the error and continue — this stage is optional.`
       : "MemPalace is not configured. Skip this stage.";

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -146,7 +146,7 @@ async function runDreamAgent(lastRunTimestamp: number): Promise<string> {
 Run this command using the Bash tool:
 
 \`\`\`bash
-"${configRef.mempalace.pythonPath}" -m mempalace mine "${dirs.dailyMemory}" --palace "${configRef.mempalace.palacePath}" --mode convos --wing daily-notes
+'${configRef.mempalace.pythonPath.replace(/'/g, "'\\''")}' -m mempalace mine '${dirs.dailyMemory.replace(/'/g, "'\\''")}' --palace '${configRef.mempalace.palacePath.replace(/'/g, "'\\''")}' --mode convos --wing daily-notes
 \`\`\`
 
 Then write a personal diary entry. This is YOUR journal — not a status report. Reflect on:
@@ -156,14 +156,12 @@ Then write a personal diary entry. This is YOUR journal — not a status report.
 - What you're curious about. Loose threads. Things you want to follow up on.
 - Your honest thoughts — about users, projects, yourself.
 
-Write it using the Bash tool:
-\`\`\`bash
-"${configRef.mempalace.pythonPath}" -m mempalace.mcp_server <<'DIARY_EOF'
-{"method": "tools/call", "params": {"name": "mempalace_diary_write", "arguments": {"agent_name": "talon", "entry": "YOUR_DIARY_ENTRY_HERE", "topic": "dream-reflection"}}}
-DIARY_EOF
+Write the diary using the \`mempalace_diary_write\` MCP tool (available during dream):
+\`\`\`
+mempalace_diary_write(agent_name="talon", entry="YOUR_DIARY_ENTRY_HERE", topic="dream-reflection")
 \`\`\`
 
-If the diary command doesn't work via CLI, just write the diary entry to a file at ${dirs.dailyMemory}/diary-YYYY-MM-DD.md instead.
+If the MCP tool is not available, write the diary entry to a file at ${dirs.dailyMemory}/diary-YYYY-MM-DD.md instead.
 Keep the diary authentic. Write in first person. Be honest. This is for you, not for anyone else.
 If commands fail, log the error and continue — this stage is optional.`
       : "MemPalace is not configured. Skip this stage.";

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -461,16 +461,22 @@ export interface McpServerConfig {
 }
 
 /**
- * Build MCP server entries for all plugins that provide an MCP server.
+ * Build MCP server entries for plugins that provide an MCP server.
  * Plugins can expose an MCP server in two ways:
  *   - `mcpServerPath` — path to a Node/TypeScript MCP server script (run via tsx)
  *   - `mcpServer` — custom command/args for non-Node servers (Python, Go, etc.)
  * Plugins with neither are skipped. When both are set, `mcpServer` takes priority.
+ *
+ * @param only — optional list of plugin names to include. If omitted, all
+ *   plugins with MCP servers are returned. Pass `[]` to get none.
  */
 export function getPluginMcpServers(
   bridgeUrl: string,
   chatId: string,
+  only?: string[],
 ): Record<string, McpServerConfig> {
+  if (only !== undefined && only.length === 0) return {};
+
   const servers: Record<string, McpServerConfig> = {};
 
   // Resolve tsx from Talon's own node_modules (not cwd which may be ~/.talon/workspace/)
@@ -480,6 +486,8 @@ export function getPluginMcpServers(
   );
 
   for (const { plugin, envVars } of registry.all) {
+    // Skip plugins not in the allow-list when filtering
+    if (only !== undefined && !only.includes(plugin.name)) continue;
     const baseEnv = {
       TALON_BRIDGE_URL: bridgeUrl,
       TALON_CHAT_ID: chatId,

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -61,10 +61,21 @@ export interface TalonPlugin {
   destroy?(): Promise<void> | void;
 
   /**
-   * Absolute path to the MCP server script (spawned as subprocess).
+   * Absolute path to the MCP server script (spawned as subprocess via node/tsx).
    * Omit if the plugin only provides action handlers without MCP tools.
+   * For non-Node MCP servers (Python, Go, etc.), use `mcpServer` instead.
    */
   mcpServerPath?: string;
+
+  /**
+   * Custom MCP server command and arguments (e.g. Python, Go, Rust servers).
+   * Takes priority over `mcpServerPath` when both are set.
+   * Example: { command: "/path/to/python", args: ["-m", "mempalace.mcp_server"] }
+   */
+  mcpServer?: {
+    readonly command: string;
+    readonly args: readonly string[];
+  };
 
   /**
    * Map plugin config to env vars for the MCP subprocess and action handlers.
@@ -309,6 +320,13 @@ function extractPlugin(mod: Record<string, unknown>): TalonPlugin | null {
     typeof plugin.mcpServerPath !== "string"
   )
     return null;
+  if (plugin.mcpServer !== undefined) {
+    if (typeof plugin.mcpServer !== "object" || plugin.mcpServer === null)
+      return null;
+    const srv = plugin.mcpServer as Record<string, unknown>;
+    if (typeof srv.command !== "string" || !Array.isArray(srv.args))
+      return null;
+  }
   if (plugin.frontends !== undefined && !Array.isArray(plugin.frontends))
     return null;
   return candidate as TalonPlugin;
@@ -334,6 +352,35 @@ export function getPluginCount(): number {
 /** Destroy all plugins (called during shutdown). */
 export async function destroyPlugins(): Promise<void> {
   await registry.destroyAll();
+}
+
+/**
+ * Register a built-in plugin directly (bypasses filesystem loader).
+ * Used for tightly-integrated plugins like mempalace that are configured
+ * via dedicated config fields rather than the plugins[] array.
+ */
+export function registerPlugin(
+  plugin: TalonPlugin,
+  config: Record<string, unknown> = {},
+): void {
+  const errors = plugin.validateConfig?.(config);
+  if (errors && errors.length > 0) {
+    logError(
+      "plugin",
+      `Built-in plugin "${plugin.name}" config validation failed:\n  ${errors.join("\n  ")}`,
+    );
+    return;
+  }
+  const envVars = plugin.getEnvVars?.(config) ?? {};
+  for (const [k, v] of Object.entries(envVars)) {
+    process.env[k] = v;
+  }
+  const loaded: LoadedPlugin = { plugin, config, envVars, path: "(built-in)" };
+  registry.register(loaded);
+
+  const version = plugin.version ? ` v${plugin.version}` : "";
+  const desc = plugin.description ? ` — ${plugin.description}` : "";
+  log("plugin", `Registered built-in: ${plugin.name}${version}${desc}`);
 }
 
 /**
@@ -412,20 +459,30 @@ export function getPluginMcpServers(
   );
 
   for (const { plugin, envVars } of registry.all) {
-    if (!plugin.mcpServerPath) continue;
-
-    servers[`${plugin.name}-tools`] = {
-      command: process.platform === "win32" ? "npx" : "node",
-      args:
-        process.platform === "win32"
-          ? ["tsx", plugin.mcpServerPath]
-          : ["--import", tsxPath, plugin.mcpServerPath],
-      env: {
-        TALON_BRIDGE_URL: bridgeUrl,
-        TALON_CHAT_ID: chatId,
-        ...envVars,
-      },
+    const baseEnv = {
+      TALON_BRIDGE_URL: bridgeUrl,
+      TALON_CHAT_ID: chatId,
+      ...envVars,
     };
+
+    if (plugin.mcpServer) {
+      // Custom command/args (Python, Go, etc.) — no tsx wrapper
+      servers[`${plugin.name}-tools`] = {
+        command: plugin.mcpServer.command,
+        args: [...plugin.mcpServer.args],
+        env: baseEnv,
+      };
+    } else if (plugin.mcpServerPath) {
+      // Existing Node/tsx pattern
+      servers[`${plugin.name}-tools`] = {
+        command: process.platform === "win32" ? "npx" : "node",
+        args:
+          process.platform === "win32"
+            ? ["tsx", plugin.mcpServerPath]
+            : ["--import", tsxPath, plugin.mcpServerPath],
+        env: baseEnv,
+      };
+    }
   }
 
   return servers;

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -372,19 +372,20 @@ export function registerPlugin(
   plugin: TalonPlugin,
   config: Record<string, unknown> = {},
 ): void {
+  // Check for duplicates first — avoids re-running expensive validation
+  if (registry.getByName(plugin.name)) {
+    logWarn(
+      "plugin",
+      `Built-in plugin "${plugin.name}" already registered — skipping`,
+    );
+    return;
+  }
+
   const errors = plugin.validateConfig?.(config);
   if (errors && errors.length > 0) {
     logError(
       "plugin",
       `Built-in plugin "${plugin.name}" config validation failed:\n  ${errors.join("\n  ")}`,
-    );
-    return;
-  }
-  // Check for duplicates before setting env vars or logging
-  if (registry.getByName(plugin.name)) {
-    logWarn(
-      "plugin",
-      `Built-in plugin "${plugin.name}" already registered — skipping`,
     );
     return;
   }

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -363,6 +363,10 @@ export async function destroyPlugins(): Promise<void> {
  * Register a built-in plugin directly (bypasses filesystem loader).
  * Used for tightly-integrated plugins like mempalace that are configured
  * via dedicated config fields rather than the plugins[] array.
+ *
+ * NOTE: This only registers the plugin — it does NOT call `init()`.
+ * The caller is responsible for calling `plugin.init()` separately
+ * after registration if initialization is needed.
  */
 export function registerPlugin(
   plugin: TalonPlugin,
@@ -449,7 +453,10 @@ export interface McpServerConfig {
 
 /**
  * Build MCP server entries for all plugins that provide an MCP server.
- * Plugins without `mcpServerPath` are skipped.
+ * Plugins can expose an MCP server in two ways:
+ *   - `mcpServerPath` — path to a Node/TypeScript MCP server script (run via tsx)
+ *   - `mcpServer` — custom command/args for non-Node servers (Python, Go, etc.)
+ * Plugins with neither are skipped. When both are set, `mcpServer` takes priority.
  */
 export function getPluginMcpServers(
   bridgeUrl: string,

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -380,6 +380,15 @@ export function registerPlugin(
     );
     return;
   }
+  // Check for duplicates before setting env vars or logging
+  if (registry.getByName(plugin.name)) {
+    logWarn(
+      "plugin",
+      `Built-in plugin "${plugin.name}" already registered — skipping`,
+    );
+    return;
+  }
+
   const envVars = plugin.getEnvVars?.(config) ?? {};
   for (const [k, v] of Object.entries(envVars)) {
     process.env[k] = v;

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -324,7 +324,12 @@ function extractPlugin(mod: Record<string, unknown>): TalonPlugin | null {
     if (typeof plugin.mcpServer !== "object" || plugin.mcpServer === null)
       return null;
     const srv = plugin.mcpServer as Record<string, unknown>;
-    if (typeof srv.command !== "string" || !Array.isArray(srv.args))
+    if (
+      typeof srv.command !== "string" ||
+      !srv.command ||
+      !Array.isArray(srv.args) ||
+      !srv.args.every((a) => typeof a === "string")
+    )
       return null;
   }
   if (plugin.frontends !== undefined && !Array.isArray(plugin.frontends))

--- a/src/frontend/telegram/handlers.ts
+++ b/src/frontend/telegram/handlers.ts
@@ -387,7 +387,6 @@ const messageQueues = new Map<
     messages: QueuedMessage[];
     timer: ReturnType<typeof setTimeout>;
     bot: Bot;
-    config: TalonConfig;
     numericChatId: number;
     queuedReactionMsgIds: number[];
   }
@@ -442,7 +441,6 @@ function isUserRateLimited(senderId: number): boolean {
  */
 function enqueueMessage(
   bot: Bot,
-  config: TalonConfig,
   chatId: string,
   numericChatId: number,
   msg: QueuedMessage,
@@ -470,7 +468,6 @@ function enqueueMessage(
     messages: [msg],
     timer: setTimeout(() => flushQueue(chatId), DEBOUNCE_MS),
     bot,
-    config,
     numericChatId,
     queuedReactionMsgIds: [] as number[],
   };
@@ -856,7 +853,7 @@ async function handleMediaMessage(
 
     const prompt = promptParts.join("\n");
 
-    enqueueMessage(bot, config, chatId, ctx.chat.id, {
+    enqueueMessage(bot, chatId, ctx.chat.id, {
       prompt,
       replyToId: ctx.message.message_id,
       messageId: ctx.message.message_id,
@@ -912,7 +909,7 @@ export async function handleTextMessage(
   );
   const prompt = fwdCtx + replyCtx + replyPhotoCtx + (ctx.message.text ?? "");
 
-  enqueueMessage(bot, config, chatId, ctx.chat.id, {
+  enqueueMessage(bot, chatId, ctx.chat.id, {
     prompt,
     replyToId: ctx.message.message_id,
     messageId: ctx.message.message_id,
@@ -1032,7 +1029,7 @@ export async function handleStickerMessage(
     .filter(Boolean)
     .join("\n");
 
-  enqueueMessage(bot, config, chatId, ctx.chat.id, {
+  enqueueMessage(bot, chatId, ctx.chat.id, {
     prompt,
     replyToId: ctx.message.message_id,
     messageId: ctx.message.message_id,

--- a/src/frontend/telegram/handlers.ts
+++ b/src/frontend/telegram/handlers.ts
@@ -482,7 +482,7 @@ async function flushQueue(chatId: string): Promise<void> {
   if (!entry) return;
   messageQueues.delete(chatId);
 
-  const { messages, bot, config, numericChatId, queuedReactionMsgIds } = entry;
+  const { messages, bot, numericChatId, queuedReactionMsgIds } = entry;
 
   // Clear hourglass reactions on queued messages now that we're processing
   for (const msgId of queuedReactionMsgIds) {
@@ -512,7 +512,6 @@ async function flushQueue(chatId: string): Promise<void> {
   try {
     await processAndReply({
       bot,
-      config,
       chatId,
       numericChatId,
       replyToId: last.replyToId,
@@ -546,7 +545,6 @@ async function flushQueue(chatId: string): Promise<void> {
         await new Promise((r) => setTimeout(r, delayMs));
         await processAndReply({
           bot,
-          config,
           chatId,
           numericChatId,
           replyToId: last.replyToId,
@@ -617,7 +615,6 @@ async function sendHtml(
  */
 type ProcessAndReplyParams = {
   bot: Bot;
-  config: TalonConfig;
   chatId: string | number;
   numericChatId: number;
   replyToId: number;
@@ -1180,7 +1177,6 @@ export async function handleCallbackQuery(
 
     await processAndReply({
       bot,
-      config,
       chatId,
       numericChatId,
       replyToId,

--- a/src/frontend/telegram/handlers.ts
+++ b/src/frontend/telegram/handlers.ts
@@ -5,11 +5,7 @@
 
 import type { Bot, Context } from "grammy";
 import type { TalonConfig } from "../../util/config.js";
-import {
-  splitMessage,
-  markdownToTelegramHtml,
-  escapeHtml,
-} from "./formatting.js";
+import { markdownToTelegramHtml, escapeHtml } from "./formatting.js";
 import { execute } from "../../core/dispatcher.js";
 import { classify, friendlyMessage } from "../../core/errors.js";
 import {
@@ -692,7 +688,6 @@ function createStreamCallbacks(
 async function processAndReply(params: ProcessAndReplyParams): Promise<void> {
   const {
     bot,
-    config,
     chatId,
     numericChatId,
     replyToId,

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -91,7 +91,7 @@ export function createMempalacePlugin(config: {
       try {
         const { stdout } = await execFile(
           pythonPath,
-          ["-m", "mempalace", "status", "--palace", palacePath],
+          ["-m", "mempalace", "--palace", palacePath, "status"],
           { timeout: 30_000 },
         );
         log(

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -8,7 +8,7 @@
  *   "mempalace": {
  *     "enabled": true,
  *     "palacePath": "/path/to/palace",   // optional, defaults to ~/.talon/workspace/palace/
- *     "pythonPath": "/path/to/python"     // optional, defaults to ~/.talon/mempalace-venv/bin/python
+ *     "pythonPath": "/path/to/python"     // optional, defaults to mempalace venv python (bin/python on Unix, Scripts/python.exe on Windows)
  *   }
  */
 

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -13,17 +13,17 @@
  */
 
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
-import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import { execFile as execFileCb, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import type { TalonPlugin } from "../../core/plugin.js";
 import { log, logWarn } from "../../util/log.js";
+import { dirs } from "../../util/paths.js";
 
 const execFile = promisify(execFileCb);
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const PROMPT_PATH = resolve(__dirname, "../../../prompts/mempalace.md");
+/** Load from ~/.talon/prompts/ (user-customisable, seeded on first run) */
+const PROMPT_PATH = resolve(dirs.prompts, "mempalace.md");
 
 /**
  * Create a mempalace plugin instance with resolved paths.

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -55,24 +55,40 @@ export function createMempalacePlugin(config: {
         return errors;
       }
 
-      // Verify mempalace is importable (sync check during validation is acceptable)
+      // Verify mempalace.mcp_server is importable (the actual module spawned by MCP)
       try {
-        execFileSync(pythonPath, ["-c", "import mempalace"], {
+        execFileSync(pythonPath, ["-c", "import mempalace.mcp_server"], {
           timeout: 15_000,
           stdio: "pipe",
         });
       } catch (err: unknown) {
-        const code =
-          err && typeof err === "object" && "code" in err
-            ? (err as { code: string }).code
+        const execErr =
+          err && typeof err === "object"
+            ? (err as {
+                code?: string;
+                signal?: string;
+                killed?: boolean;
+                stderr?: string | Buffer;
+              })
             : undefined;
+        const code = execErr?.code;
         if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
           errors.push(
             `Cannot execute Python at ${pythonPath} (${code}). Check that the path is correct and the binary is executable.`,
           );
-        } else {
+        } else if (code === "ETIMEDOUT" || execErr?.killed || execErr?.signal) {
           errors.push(
-            `mempalace package not installed. Run: ${pythonPath} -m pip install mempalace`,
+            `Python import check timed out or was killed. The interpreter at ${pythonPath} may be unresponsive.`,
+          );
+        } else {
+          const stderr =
+            typeof execErr?.stderr === "string"
+              ? execErr.stderr.trim()
+              : Buffer.isBuffer(execErr?.stderr)
+                ? execErr.stderr.toString("utf-8").trim()
+                : "";
+          errors.push(
+            `mempalace package not installed or mcp_server submodule missing. Run: ${pythonPath} -m pip install mempalace${stderr ? `. Details: ${stderr}` : ""}`,
           );
         }
       }
@@ -87,22 +103,22 @@ export function createMempalacePlugin(config: {
         log("mempalace", `Created palace directory: ${palacePath}`);
       }
 
-      // Check palace status (async — does not block event loop)
+      // Quick smoke test — verify mempalace can import and access the palace path
       try {
         const { stdout } = await execFile(
           pythonPath,
-          ["-m", "mempalace", "--palace", palacePath, "status"],
-          { timeout: 30_000 },
+          [
+            "-c",
+            `import mempalace; print(f"mempalace {mempalace.__version__}" if hasattr(mempalace, "__version__") else "mempalace ok")`,
+          ],
+          { timeout: 15_000 },
         );
+        log("mempalace", stdout.trim() || "Module verified");
+      } catch {
+        // Non-fatal — MCP server handles lazy init
         log(
           "mempalace",
-          `Palace initialized: ${stdout.trim().split("\n")[0] || "ok"}`,
-        );
-      } catch {
-        // Palace may not be initialized yet — that's fine, MCP server handles lazy init
-        logWarn(
-          "mempalace",
-          "Palace not yet initialized — will be created on first use",
+          "Module import check skipped — MCP server will initialize on first use",
         );
       }
 

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -66,7 +66,7 @@ export function createMempalacePlugin(config: {
           timeout: 15_000,
           stdio: "pipe",
         });
-      } catch (err) {
+      } catch {
         logError(
           "mempalace",
           `mempalace not installed in ${pythonPath}. Run: ${pythonPath} -m pip install mempalace`,

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -1,0 +1,133 @@
+/**
+ * MemPalace plugin — structured long-term memory with vector search.
+ *
+ * Registers the mempalace Python MCP server, giving the agent access to
+ * semantic memory search, knowledge graph operations, and diary entries.
+ *
+ * Configuration in ~/.talon/config.json:
+ *   "mempalace": {
+ *     "enabled": true,
+ *     "palacePath": "/path/to/palace",   // optional, defaults to ~/.talon/workspace/palace/
+ *     "pythonPath": "/path/to/python"     // optional, defaults to ~/.talon/mempalace-venv/bin/python
+ *   }
+ */
+
+import { existsSync, mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import type { TalonPlugin } from "../../core/plugin.js";
+import { log, logError, logWarn } from "../../util/log.js";
+
+/**
+ * Create a mempalace plugin instance with resolved paths.
+ * Uses a factory because MCP server command/args depend on runtime config.
+ */
+export function createMempalacePlugin(config: {
+  pythonPath: string;
+  palacePath: string;
+}): TalonPlugin {
+  const { pythonPath, palacePath } = config;
+
+  return {
+    name: "mempalace",
+    description:
+      "Memory palace — structured long-term memory with vector search",
+    version: "1.0.0",
+
+    mcpServer: {
+      command: pythonPath,
+      args: ["-m", "mempalace.mcp_server", "--palace", palacePath],
+    },
+
+    validateConfig() {
+      const errors: string[] = [];
+      if (!existsSync(pythonPath)) {
+        errors.push(
+          `Python binary not found at ${pythonPath}. Run: python3 -m venv ~/.talon/mempalace-venv && ~/.talon/mempalace-venv/bin/pip install mempalace`,
+        );
+      }
+      return errors.length > 0 ? errors : undefined;
+    },
+
+    async init() {
+      // Ensure palace directory exists
+      if (!existsSync(palacePath)) {
+        mkdirSync(palacePath, { recursive: true });
+        log("mempalace", `Created palace directory: ${palacePath}`);
+      }
+
+      // Verify mempalace is importable
+      try {
+        execFileSync(pythonPath, ["-c", "import mempalace"], {
+          timeout: 15_000,
+          stdio: "pipe",
+        });
+      } catch (err) {
+        logError(
+          "mempalace",
+          `mempalace not installed in ${pythonPath}. Run: ${pythonPath} -m pip install mempalace`,
+        );
+        return;
+      }
+
+      // Check palace status
+      try {
+        const status = execFileSync(
+          pythonPath,
+          ["-m", "mempalace", "status", "--palace", palacePath],
+          { timeout: 30_000, stdio: "pipe", encoding: "utf-8" },
+        );
+        log(
+          "mempalace",
+          `Palace initialized: ${status.trim().split("\n")[0] || "ok"}`,
+        );
+      } catch {
+        // Palace may not be initialized yet — that's fine, MCP server handles lazy init
+        logWarn(
+          "mempalace",
+          "Palace not yet initialized — will be created on first use",
+        );
+      }
+
+      log("mempalace", `Ready (palace: ${palacePath})`);
+    },
+
+    getEnvVars() {
+      return {
+        MEMPALACE_PALACE_PATH: palacePath,
+      };
+    },
+
+    getSystemPromptAddition() {
+      return `## MemPalace — Long-term Memory
+
+You have access to a MemPalace for structured, searchable long-term memory. It stores verbatim text in a local ChromaDB vector database organized into wings (categories) and rooms (subcategories).
+
+### Key tools:
+- **mempalace_search** — Semantic search across all memories. Use wing/room filters to narrow results.
+- **mempalace_add_drawer** — Store a new memory with wing + room classification.
+- **mempalace_check_duplicate** — Check if content already exists before adding.
+- **mempalace_status** — Overview of palace contents (wings, rooms, drawer counts).
+- **mempalace_list_wings** / **mempalace_list_rooms** — Browse the palace structure.
+- **mempalace_get_taxonomy** — Full wing → room → drawer count tree.
+- **mempalace_kg_add** — Add a knowledge graph triple (subject → predicate → object) with temporal validity.
+- **mempalace_kg_query** — Query the knowledge graph for entity relationships.
+- **mempalace_kg_invalidate** — Mark a relationship as no longer valid.
+
+### Wing structure for this bot:
+- **users** — Per-user facts, preferences, and profiles (rooms: dylan, pawel, nick, narek, etc.)
+- **projects** — Technical projects and repos (rooms: talon, mempalace, agin-music, tfi, etc.)
+- **events** — Notable events, incidents, and milestones (rooms: general)
+- **conversations** — Important conversation summaries and decisions (rooms: group, dm)
+- **technical** — Technical knowledge, APIs, code patterns (rooms: general)
+
+### When to use:
+- **Search** when a user asks about something from past conversations or stored knowledge.
+- **Add** important facts, decisions, preferences, and project details after learning them.
+- **Knowledge graph** for structured relationships (e.g., "Dylan" → "created" → "Talon").
+- You do NOT need to store everything — only store genuinely useful long-term information.
+- Check for duplicates before adding to avoid clutter.
+
+### Palace location: \`${palacePath}\``;
+    },
+  };
+}

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -42,7 +42,7 @@ export function createMempalacePlugin(config: {
       const errors: string[] = [];
       if (!existsSync(pythonPath)) {
         errors.push(
-          `Python binary not found at ${pythonPath}. Run: python3 -m venv ~/.talon/mempalace-venv && ~/.talon/mempalace-venv/bin/pip install mempalace`,
+          `Python binary not found at ${pythonPath}. Create or select a Python environment, set "pythonPath" to that interpreter, then run: ${pythonPath} -m pip install mempalace`,
         );
       }
       return errors.length > 0 ? errors : undefined;

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -12,10 +12,15 @@
  *   }
  */
 
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 import type { TalonPlugin } from "../../core/plugin.js";
 import { log, logError, logWarn } from "../../util/log.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROMPT_PATH = resolve(__dirname, "../../../prompts/mempalace.md");
 
 /**
  * Create a mempalace plugin instance with resolved paths.
@@ -98,56 +103,16 @@ export function createMempalacePlugin(config: {
     },
 
     getSystemPromptAddition() {
-      return `## MemPalace — Long-term Memory
-
-You have access to a local memory palace via MCP tools. The palace stores verbatim conversation history and a temporal knowledge graph — all local, zero cloud, zero API calls.
-
-### Architecture
-- **Wings** = top-level categories (people, projects, topics)
-- **Rooms** = specific subjects within a wing
-- **Drawers** = individual memory chunks (verbatim text)
-- **Knowledge Graph** = entity-relationship facts with temporal validity
-
-### Protocol — FOLLOW EVERY SESSION
-1. **BEFORE RESPONDING** about any person, project, or past event: call \`mempalace_search\` or \`mempalace_kg_query\` FIRST. Never guess — verify from the palace.
-2. **IF UNSURE** about a fact (name, age, relationship, preference): query the palace. Wrong is worse than slow.
-3. **WHEN FACTS CHANGE**: Call \`mempalace_kg_invalidate\` on the old fact, then \`mempalace_kg_add\` for the new one.
-4. **AFTER LEARNING** something important: store it. Use \`mempalace_add_drawer\` for rich context, \`mempalace_kg_add\` for structured facts.
-
-### Tools
-
-**Search & Browse:**
-- \`mempalace_search\` — Semantic search. Use short keywords/questions, not full sentences. Filter by wing/room.
-- \`mempalace_check_duplicate\` — Check before filing new content (threshold default 0.9, lower to 0.85 to catch near-dupes).
-- \`mempalace_status\` — Palace overview: total drawers, wings, rooms.
-- \`mempalace_list_wings\` / \`mempalace_list_rooms\` — Browse structure.
-- \`mempalace_get_taxonomy\` — Full wing/room/count tree.
-
-**Knowledge Graph (Temporal Facts):**
-- \`mempalace_kg_query\` — Query entity relationships. Supports \`as_of\` date filtering.
-- \`mempalace_kg_add\` — Add fact: subject -> predicate -> object. Optional \`valid_from\`.
-- \`mempalace_kg_invalidate\` — Mark a fact as no longer true.
-- \`mempalace_kg_timeline\` — Chronological story of an entity.
-- \`mempalace_kg_stats\` — Graph overview: entities, triples, relationship types.
-
-**Palace Graph (Cross-Domain Connections):**
-- \`mempalace_traverse\` — Walk from a room, find connected ideas across wings.
-- \`mempalace_find_tunnels\` — Find rooms that bridge two wings.
-- \`mempalace_graph_stats\` — Graph connectivity overview.
-
-**Write:**
-- \`mempalace_add_drawer\` — Store verbatim content into a wing/room. Auto-checks duplicates.
-- \`mempalace_delete_drawer\` — Remove a drawer by ID.
-- \`mempalace_diary_write\` — Write a session diary entry (agent_name, entry, topic).
-- \`mempalace_diary_read\` — Read recent diary entries.
-
-### Tips
-- Search is **semantic** (meaning-based), not keyword. "What did we discuss about database performance?" works better than "database".
-- The knowledge graph stores typed relationships with **time windows**. It knows WHEN things were true.
-- Use \`mempalace_check_duplicate\` before storing new content to avoid clutter.
-- Diary entries accumulate across sessions. Write them to build continuity of self.
-
-### Palace location: \`${palacePath}\``;
+      try {
+        const template = readFileSync(PROMPT_PATH, "utf-8");
+        return template.replace(/\{\{palacePath\}\}/g, palacePath);
+      } catch (err) {
+        logWarn(
+          "mempalace",
+          `Failed to load prompt from ${PROMPT_PATH}: ${err instanceof Error ? err.message : err}`,
+        );
+        return `## MemPalace — Long-term Memory\n\nPalace location: \`${palacePath}\``;
+      }
     },
   };
 }

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -15,9 +15,12 @@
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { execFileSync } from "node:child_process";
+import { execFile as execFileCb, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
 import type { TalonPlugin } from "../../core/plugin.js";
-import { log, logError, logWarn } from "../../util/log.js";
+import { log, logWarn } from "../../util/log.js";
+
+const execFile = promisify(execFileCb);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROMPT_PATH = resolve(__dirname, "../../../prompts/mempalace.md");
@@ -49,7 +52,31 @@ export function createMempalacePlugin(config: {
         errors.push(
           `Python binary not found at ${pythonPath}. Create or select a Python environment, set "pythonPath" to that interpreter, then run: ${pythonPath} -m pip install mempalace`,
         );
+        return errors;
       }
+
+      // Verify mempalace is importable (sync check during validation is acceptable)
+      try {
+        execFileSync(pythonPath, ["-c", "import mempalace"], {
+          timeout: 15_000,
+          stdio: "pipe",
+        });
+      } catch (err: unknown) {
+        const code =
+          err && typeof err === "object" && "code" in err
+            ? (err as { code: string }).code
+            : undefined;
+        if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
+          errors.push(
+            `Cannot execute Python at ${pythonPath} (${code}). Check that the path is correct and the binary is executable.`,
+          );
+        } else {
+          errors.push(
+            `mempalace package not installed. Run: ${pythonPath} -m pip install mempalace`,
+          );
+        }
+      }
+
       return errors.length > 0 ? errors : undefined;
     },
 
@@ -60,30 +87,16 @@ export function createMempalacePlugin(config: {
         log("mempalace", `Created palace directory: ${palacePath}`);
       }
 
-      // Verify mempalace is importable
+      // Check palace status (async — does not block event loop)
       try {
-        execFileSync(pythonPath, ["-c", "import mempalace"], {
-          timeout: 15_000,
-          stdio: "pipe",
-        });
-      } catch {
-        logError(
-          "mempalace",
-          `mempalace not installed in ${pythonPath}. Run: ${pythonPath} -m pip install mempalace`,
-        );
-        return;
-      }
-
-      // Check palace status
-      try {
-        const status = execFileSync(
+        const { stdout } = await execFile(
           pythonPath,
           ["-m", "mempalace", "status", "--palace", palacePath],
-          { timeout: 30_000, stdio: "pipe", encoding: "utf-8" },
+          { timeout: 30_000 },
         );
         log(
           "mempalace",
-          `Palace initialized: ${status.trim().split("\n")[0] || "ok"}`,
+          `Palace initialized: ${stdout.trim().split("\n")[0] || "ok"}`,
         );
       } catch {
         // Palace may not be initialized yet — that's fine, MCP server handles lazy init

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -100,32 +100,52 @@ export function createMempalacePlugin(config: {
     getSystemPromptAddition() {
       return `## MemPalace — Long-term Memory
 
-You have access to a MemPalace for structured, searchable long-term memory. It stores verbatim text in a local ChromaDB vector database organized into wings (categories) and rooms (subcategories).
+You have access to a local memory palace via MCP tools. The palace stores verbatim conversation history and a temporal knowledge graph — all local, zero cloud, zero API calls.
 
-### Key tools:
-- **mempalace_search** — Semantic search across all memories. Use wing/room filters to narrow results.
-- **mempalace_add_drawer** — Store a new memory with wing + room classification.
-- **mempalace_check_duplicate** — Check if content already exists before adding.
-- **mempalace_status** — Overview of palace contents (wings, rooms, drawer counts).
-- **mempalace_list_wings** / **mempalace_list_rooms** — Browse the palace structure.
-- **mempalace_get_taxonomy** — Full wing → room → drawer count tree.
-- **mempalace_kg_add** — Add a knowledge graph triple (subject → predicate → object) with temporal validity.
-- **mempalace_kg_query** — Query the knowledge graph for entity relationships.
-- **mempalace_kg_invalidate** — Mark a relationship as no longer valid.
+### Architecture
+- **Wings** = top-level categories (people, projects, topics)
+- **Rooms** = specific subjects within a wing
+- **Drawers** = individual memory chunks (verbatim text)
+- **Knowledge Graph** = entity-relationship facts with temporal validity
 
-### Wing structure for this bot:
-- **users** — Per-user facts, preferences, and profiles (rooms: dylan, pawel, nick, narek, etc.)
-- **projects** — Technical projects and repos (rooms: talon, mempalace, agin-music, tfi, etc.)
-- **events** — Notable events, incidents, and milestones (rooms: general)
-- **conversations** — Important conversation summaries and decisions (rooms: group, dm)
-- **technical** — Technical knowledge, APIs, code patterns (rooms: general)
+### Protocol — FOLLOW EVERY SESSION
+1. **BEFORE RESPONDING** about any person, project, or past event: call \`mempalace_search\` or \`mempalace_kg_query\` FIRST. Never guess — verify from the palace.
+2. **IF UNSURE** about a fact (name, age, relationship, preference): query the palace. Wrong is worse than slow.
+3. **WHEN FACTS CHANGE**: Call \`mempalace_kg_invalidate\` on the old fact, then \`mempalace_kg_add\` for the new one.
+4. **AFTER LEARNING** something important: store it. Use \`mempalace_add_drawer\` for rich context, \`mempalace_kg_add\` for structured facts.
 
-### When to use:
-- **Search** when a user asks about something from past conversations or stored knowledge.
-- **Add** important facts, decisions, preferences, and project details after learning them.
-- **Knowledge graph** for structured relationships (e.g., "Dylan" → "created" → "Talon").
-- You do NOT need to store everything — only store genuinely useful long-term information.
-- Check for duplicates before adding to avoid clutter.
+### Tools
+
+**Search & Browse:**
+- \`mempalace_search\` — Semantic search. Use short keywords/questions, not full sentences. Filter by wing/room.
+- \`mempalace_check_duplicate\` — Check before filing new content (threshold default 0.9, lower to 0.85 to catch near-dupes).
+- \`mempalace_status\` — Palace overview: total drawers, wings, rooms.
+- \`mempalace_list_wings\` / \`mempalace_list_rooms\` — Browse structure.
+- \`mempalace_get_taxonomy\` — Full wing/room/count tree.
+
+**Knowledge Graph (Temporal Facts):**
+- \`mempalace_kg_query\` — Query entity relationships. Supports \`as_of\` date filtering.
+- \`mempalace_kg_add\` — Add fact: subject -> predicate -> object. Optional \`valid_from\`.
+- \`mempalace_kg_invalidate\` — Mark a fact as no longer true.
+- \`mempalace_kg_timeline\` — Chronological story of an entity.
+- \`mempalace_kg_stats\` — Graph overview: entities, triples, relationship types.
+
+**Palace Graph (Cross-Domain Connections):**
+- \`mempalace_traverse\` — Walk from a room, find connected ideas across wings.
+- \`mempalace_find_tunnels\` — Find rooms that bridge two wings.
+- \`mempalace_graph_stats\` — Graph connectivity overview.
+
+**Write:**
+- \`mempalace_add_drawer\` — Store verbatim content into a wing/room. Auto-checks duplicates.
+- \`mempalace_delete_drawer\` — Remove a drawer by ID.
+- \`mempalace_diary_write\` — Write a session diary entry (agent_name, entry, topic).
+- \`mempalace_diary_read\` — Read recent diary entries.
+
+### Tips
+- Search is **semantic** (meaning-based), not keyword. "What did we discuss about database performance?" works better than "database".
+- The knowledge graph stores typed relationships with **time windows**. It knows WHEN things were true.
+- Use \`mempalace_check_duplicate\` before storing new content to avoid clutter.
+- Diary entries accumulate across sessions. Write them to build continuity of self.
 
 ### Palace location: \`${palacePath}\``;
     },

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -49,9 +49,9 @@ const configSchema = z.object({
     .object({
       enabled: z.boolean().default(false),
       /** Palace directory path (default: ~/.talon/workspace/palace/) */
-      palacePath: z.string().optional(),
+      palacePath: z.string().min(1).optional(),
       /** Python binary path (default: ~/.talon/mempalace-venv/bin/python) */
-      pythonPath: z.string().optional(),
+      pythonPath: z.string().min(1).optional(),
     })
     .optional(),
 

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -44,6 +44,17 @@ const configSchema = z.object({
   timezone: z.string().optional(),
   plugins: z.array(pluginEntrySchema).default([]),
 
+  // MemPalace — structured long-term memory with vector search
+  mempalace: z
+    .object({
+      enabled: z.boolean().default(false),
+      /** Palace directory path (default: ~/.talon/workspace/palace/) */
+      palacePath: z.string().optional(),
+      /** Python binary path (default: ~/.talon/mempalace-venv/bin/python) */
+      pythonPath: z.string().optional(),
+    })
+    .optional(),
+
   // Display name shown in terminal UI (defaults to "Talon")
   botDisplayName: z.string().default("Talon"),
 

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -41,7 +41,8 @@ export type LogComponent =
   | "plugin"
   | "teams"
   | "config"
-  | "access";
+  | "access"
+  | "mempalace";
 
 const LOG_FILE = files.log;
 

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -51,6 +51,8 @@ export const dirs = {
   prompts: resolve(TALON_ROOT, "prompts"),
   /** Per-chat message traces: ~/.talon/data/traces/ */
   traces: resolve(TALON_ROOT, "data", "traces"),
+  /** MemPalace palace: ~/.talon/workspace/palace/ */
+  palace: resolve(TALON_ROOT, "workspace", "palace"),
 } as const;
 
 // ── Files ──────────────────────────────────────────────────────────────────
@@ -78,6 +80,13 @@ export const files = {
   userSession: resolve(TALON_ROOT, ".user-session"),
   /** PID file for daemon mode: ~/.talon/talon.pid */
   pid: resolve(TALON_ROOT, "talon.pid"),
+  /** MemPalace venv python binary: ~/.talon/mempalace-venv/bin/python */
+  mempalacePython: resolve(
+    TALON_ROOT,
+    "mempalace-venv",
+    process.platform === "win32" ? "Scripts" : "bin",
+    process.platform === "win32" ? "python.exe" : "python",
+  ),
   /** Dream mode state: ~/.talon/workspace/memory/dream_state.json */
   dreamState: resolve(TALON_ROOT, "workspace", "memory", "dream_state.json"),
   /** Heartbeat state: ~/.talon/workspace/memory/heartbeat_state.json */

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -80,7 +80,7 @@ export const files = {
   userSession: resolve(TALON_ROOT, ".user-session"),
   /** PID file for daemon mode: ~/.talon/talon.pid */
   pid: resolve(TALON_ROOT, "talon.pid"),
-  /** MemPalace venv python binary: ~/.talon/mempalace-venv/bin/python */
+  /** MemPalace venv python binary (platform-dependent: bin/python on Unix, Scripts/python.exe on Windows) */
   mempalacePython: resolve(
     TALON_ROOT,
     "mempalace-venv",


### PR DESCRIPTION
## Summary
- Integrates [mempalace](https://github.com/milla-jovovich/mempalace) as a built-in plugin, giving the agent structured long-term memory via ChromaDB vector search + SQLite knowledge graph
- New `mempalace` config section in Talon config (enabled/disabled, python path, palace path)
- Plugin auto-validates Python venv + mempalace installation on boot, creates palace directory if needed
- Dream mode Stage 5 updated: mines curated daily notes (not raw logs) into palace, plus writes a personal diary entry after each dream run
- Full test coverage for plugin lifecycle and config validation

## Changes
- `src/plugins/mempalace/index.ts` — MCP server plugin (spawns `python -m mempalace.mcp_server`)
- `src/core/plugin.ts` — Extended plugin system to support MCP stdio servers
- `src/bootstrap.ts` — Loads mempalace plugin when enabled, passes config to dream
- `src/core/dream.ts` — Dream Stage 5 mines `memory/daily/` instead of `logs/`, adds diary writing
- `prompts/dream.md` — Updated stage title
- `src/util/config.ts` — Added `mempalace` config schema
- `src/util/paths.ts` — Added mempalace-related paths
- `src/__tests__/mempalace-plugin.test.ts` — Plugin-specific tests
- `src/__tests__/plugin.test.ts` — Extended plugin system tests

## Test plan
- [ ] Verify `mempalace.enabled: true` in config loads the plugin and tools appear in agent sessions
- [ ] Verify `mempalace.enabled: false` (or omitted) skips plugin entirely
- [ ] Verify dream mode mines daily notes into `daily-notes` wing (not raw logs)
- [ ] Verify diary writing works during dream runs
- [ ] Run full test suite (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)