### PR TITLE
feat: add GitHub and Playwright built-in plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -259,6 +259,29 @@
       "integrity": "sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==",
       "license": "GPL-3.0-or-later"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -2483,7 +2506,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -3491,7 +3513,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3762,9 +3783,9 @@
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3869,7 +3890,6 @@
       "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.42.0.tgz",
       "integrity": "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@grammyjs/types": "3.26.0",
         "abort-controller": "^3.0.0",
@@ -3925,7 +3945,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5193,20 +5212,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -6066,7 +6071,6 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -6079,6 +6083,20 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/type": {
@@ -6187,7 +6205,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6260,13 +6277,27 @@
         }
       }
     },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/vitest": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -6512,7 +6543,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@grammyjs/transformer-throttler": "^1.2.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opencode-ai/sdk": "^1.4.0",
+        "@playwright/mcp": "^0.0.70",
         "big-integer": "^1.6.52",
         "cheerio": "^1.2.0",
         "croner": "^10.0.1",
@@ -257,31 +258,6 @@
       "resolved": "https://registry.npmjs.org/@cryptography/aes/-/aes-0.1.1.tgz",
       "integrity": "sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==",
       "license": "GPL-3.0-or-later"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -2157,6 +2133,22 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/mcp": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/@playwright/mcp/-/mcp-0.0.70.tgz",
+      "integrity": "sha512-Kl0a6l9VL8rvT1oBou3hS5yArjwWV9UlwAkq+0skfK1YVg8XfmmNaAmwZhMeNx/ZhGiWXfCllo6rD/jvZz+WuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0-alpha-1774999321000",
+        "playwright-core": "1.60.0-alpha-1774999321000"
+      },
+      "bin": {
+        "playwright-mcp": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
@@ -5169,6 +5161,50 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0-alpha-1774999321000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1774999321000.tgz",
+      "integrity": "sha512-Bd5DkzYKG+2g1jLO6NeTXmGLbBYSFffJIOsR4l4hUBkJvzvGGdLZ7jZb2tOtb0WIoWXQKdQj3Ap6WthV4DBS8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0-alpha-1774999321000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0-alpha-1774999321000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1774999321000.tgz",
+      "integrity": "sha512-ams3Zo4VXxeOg5ZTTh16GkE8g48Bmxo/9pg9gXl9SVKlVohCU7Jaog7XntY8yFuzENA6dJc1Fz7Z/NNTm9nGEw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "^1.4.0",
+    "@playwright/mcp": "^0.0.70",
     "big-integer": "^1.6.52",
     "cheerio": "^1.2.0",
     "croner": "^10.0.1",

--- a/src/backend/claude-sdk/index.ts
+++ b/src/backend/claude-sdk/index.ts
@@ -9,7 +9,6 @@ import {
   setSessionName,
 } from "../../storage/sessions.js";
 import { getChatSettings, setChatModel } from "../../storage/chat-settings.js";
-import { getRecentHistory } from "../../storage/history.js";
 import { resolve } from "node:path";
 import { classify } from "../../core/errors.js";
 import {
@@ -19,7 +18,7 @@ import {
 import { rebuildSystemPrompt } from "../../util/config.js";
 import { log, logError, logWarn } from "../../util/log.js";
 import { traceMessage } from "../../util/trace.js";
-import { formatSmartTimestamp, formatFullDatetime } from "../../util/time.js";
+import { formatFullDatetime } from "../../util/time.js";
 
 import type { QueryParams, QueryResult } from "../../core/types.js";
 
@@ -185,25 +184,9 @@ export async function handleMessage(
   const msgIdHint = params.messageId ? ` [msg_id:${params.messageId}]` : "";
   const nowTag = `[${formatFullDatetime()}]`;
 
-  // Session continuity: when resuming a session that has history but no active
-  // SDK session (after restart or /resume), prepend recent messages for context.
-  let continuityPrefix = "";
-  if (!session.sessionId && session.turns > 0) {
-    const recentMsgs = getRecentHistory(chatId, 10);
-    if (recentMsgs.length > 0) {
-      const contextLines = recentMsgs
-        .map((m) => {
-          const time = formatSmartTimestamp(m.timestamp);
-          return `[${time}] ${m.senderName}: ${m.text.slice(0, 300)}`;
-        })
-        .join("\n");
-      continuityPrefix = `[Session resumed — recent conversation context:\n${contextLines}]\n\n`;
-    }
-  }
-
   const prompt = isGroup
-    ? `${continuityPrefix}${nowTag} [${senderName}]${msgIdHint}: ${text}`
-    : `${continuityPrefix}${nowTag}${msgIdHint} ${text}`;
+    ? `${nowTag} [${senderName}]${msgIdHint}: ${text}`
+    : `${nowTag}${msgIdHint} ${text}`;
   log("agent", `[${chatId}] <- (${text.length} chars)`);
   traceMessage(chatId, "in", text, { senderName, isGroup });
 

--- a/src/backend/opencode/index.ts
+++ b/src/backend/opencode/index.ts
@@ -17,7 +17,6 @@ import {
   resetSession,
 } from "../../storage/sessions.js";
 import { getChatSettings } from "../../storage/chat-settings.js";
-import { getRecentHistory } from "../../storage/history.js";
 import { classify } from "../../core/errors.js";
 import { log, logError, logWarn } from "../../util/log.js";
 import { traceMessage } from "../../util/trace.js";
@@ -150,24 +149,9 @@ export async function handleMessage(
 
   // Build prompt with group context
   const msgIdHint = params.messageId ? ` [msg_id:${params.messageId}]` : "";
-  let continuityPrefix = "";
-  const session = getSession(chatId);
-  if (!session.sessionId && session.turns > 0) {
-    const recent = getRecentHistory(chatId, 3);
-    if (recent.length > 0) {
-      const ctx = recent
-        .map(
-          (m) =>
-            `[${new Date(m.timestamp).toISOString().slice(11, 16)}] ${m.senderName}: ${m.text.slice(0, 300)}`,
-        )
-        .join("\n");
-      continuityPrefix = `[Session resumed — recent context:\n${ctx}]\n\n`;
-    }
-  }
-
   const prompt = isGroup
-    ? `${continuityPrefix}[${senderName}]${msgIdHint}: ${text}`
-    : `${continuityPrefix}${text}${msgIdHint}`;
+    ? `[${senderName}]${msgIdHint}: ${text}`
+    : `${text}${msgIdHint}`;
 
   log("agent", `[${chatId}] <- (${text.length} chars)`);
   traceMessage(chatId, "in", text, { senderName, isGroup });
@@ -212,7 +196,7 @@ export async function handleMessage(
       model: activeModel,
     });
 
-    if (session.turns === 0 && text) {
+    if (getSession(chatId).turns === 0 && text) {
       const cleanText = text
         .replace(/^\[.*?\]\s*/g, "")
         .replace(/\[msg_id:\d+\]\s*/g, "")

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -78,8 +78,7 @@ export async function bootstrap(
 
     // Built-in: GitHub
     if (config.github?.enabled) {
-      const { createGitHubPlugin } =
-        await import("./plugins/github/index.js");
+      const { createGitHubPlugin } = await import("./plugins/github/index.js");
       const { getPlugin } = await import("./core/plugin.js");
       const githubConfig = config.github as unknown as Record<string, unknown>;
       const gh = createGitHubPlugin({ token: config.github.token });

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -58,9 +58,12 @@ export async function bootstrap(
 ): Promise<BootstrapResult> {
   const config = loadConfig();
 
-  // Load plugins (external tool packages + built-in mempalace)
+  // Load plugins (external tool packages + built-in GitHub, MemPalace)
   const hasPlugins =
-    config.plugins.length > 0 || config.mempalace?.enabled === true;
+    config.plugins.length > 0 ||
+    config.github?.enabled === true ||
+    config.mempalace?.enabled === true ||
+    config.playwright?.enabled === true;
   if (hasPlugins) {
     const { loadPlugins, getPluginPromptAdditions, registerPlugin } =
       await import("./core/plugin.js");
@@ -71,6 +74,36 @@ export async function bootstrap(
         options.frontendNames ??
         (Array.isArray(config.frontend) ? config.frontend : [config.frontend]);
       await loadPlugins(config.plugins, frontends);
+    }
+
+    // Built-in: GitHub
+    if (config.github?.enabled) {
+      const { createGitHubPlugin } =
+        await import("./plugins/github/index.js");
+      const { getPlugin } = await import("./core/plugin.js");
+      const githubConfig = config.github as unknown as Record<string, unknown>;
+      const gh = createGitHubPlugin({ token: config.github.token });
+      registerPlugin(gh, githubConfig);
+
+      if (getPlugin("github")) {
+        try {
+          const GITHUB_INIT_TIMEOUT_MS = 15_000;
+          await Promise.race([
+            gh.init?.(githubConfig),
+            new Promise((_, reject) =>
+              setTimeout(
+                () => reject(new Error("GitHub init timed out after 15s")),
+                GITHUB_INIT_TIMEOUT_MS,
+              ),
+            ),
+          ]);
+        } catch (err) {
+          log(
+            "github",
+            `Init warning: ${err instanceof Error ? err.message : err}`,
+          );
+        }
+      }
     }
 
     // Built-in: MemPalace
@@ -105,6 +138,42 @@ export async function bootstrap(
         } catch (err) {
           log(
             "mempalace",
+            `Init warning: ${err instanceof Error ? err.message : err}`,
+          );
+        }
+      }
+    }
+
+    // Built-in: Playwright
+    if (config.playwright?.enabled) {
+      const { createPlaywrightPlugin } =
+        await import("./plugins/playwright/index.js");
+      const { getPlugin } = await import("./core/plugin.js");
+      const playwrightConfig = config.playwright as unknown as Record<
+        string,
+        unknown
+      >;
+      const pw = createPlaywrightPlugin({
+        browser: config.playwright.browser,
+        headless: config.playwright.headless,
+      });
+      registerPlugin(pw, playwrightConfig);
+
+      if (getPlugin("playwright")) {
+        try {
+          const PW_INIT_TIMEOUT_MS = 15_000;
+          await Promise.race([
+            pw.init?.(playwrightConfig),
+            new Promise((_, reject) =>
+              setTimeout(
+                () => reject(new Error("Playwright init timed out after 15s")),
+                PW_INIT_TIMEOUT_MS,
+              ),
+            ),
+          ]);
+        } catch (err) {
+          log(
+            "playwright",
             `Init warning: ${err instanceof Error ? err.message : err}`,
           );
         }

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -58,7 +58,7 @@ export async function bootstrap(
 ): Promise<BootstrapResult> {
   const config = loadConfig();
 
-  // Load plugins (external tool packages + built-in GitHub, MemPalace)
+  // Load plugins (external tool packages + built-in GitHub, MemPalace, Playwright)
   const hasPlugins =
     config.plugins.length > 0 ||
     config.github?.enabled === true ||

--- a/src/frontend/telegram/actions.ts
+++ b/src/frontend/telegram/actions.ts
@@ -278,7 +278,10 @@ export function createTelegramActionHandler(
       case "send_voice":
       case "send_audio": {
         const filePath = String(body.file_path ?? "");
-        const caption = body.caption ? String(body.caption) : undefined;
+        const caption = body.caption
+          ? markdownToTelegramHtml(String(body.caption))
+          : undefined;
+        const captionParseMode = caption ? ("HTML" as const) : undefined;
         gateway.incrementMessages(chatId);
         if (action === "send_file") {
           const stat = statSync(filePath);
@@ -294,6 +297,7 @@ export function createTelegramActionHandler(
             sent = await withRetry(() =>
               bot.api.sendDocument(chatId, file, {
                 caption,
+                parse_mode: captionParseMode,
                 reply_parameters: rp,
               }),
             );
@@ -302,6 +306,7 @@ export function createTelegramActionHandler(
             sent = await withRetry(() =>
               bot.api.sendPhoto(chatId, file, {
                 caption,
+                parse_mode: captionParseMode,
                 reply_parameters: rp,
               }),
             );
@@ -310,6 +315,7 @@ export function createTelegramActionHandler(
             sent = await withRetry(() =>
               bot.api.sendVideo(chatId, file, {
                 caption,
+                parse_mode: captionParseMode,
                 reply_parameters: rp,
               }),
             );
@@ -318,6 +324,7 @@ export function createTelegramActionHandler(
             sent = await withRetry(() =>
               bot.api.sendAnimation(chatId, file, {
                 caption,
+                parse_mode: captionParseMode,
                 reply_parameters: rp,
               }),
             );
@@ -326,6 +333,7 @@ export function createTelegramActionHandler(
             sent = await withRetry(() =>
               bot.api.sendAudio(chatId, file, {
                 caption,
+                parse_mode: captionParseMode,
                 reply_parameters: rp,
                 title: body.title as string | undefined,
                 performer: body.performer as string | undefined,
@@ -336,6 +344,7 @@ export function createTelegramActionHandler(
             sent = await withRetry(() =>
               bot.api.sendVoice(chatId, file, {
                 caption,
+                parse_mode: captionParseMode,
                 reply_parameters: rp,
               }),
             );

--- a/src/plugins/github/index.ts
+++ b/src/plugins/github/index.ts
@@ -20,7 +20,8 @@ import { log, logWarn } from "../../util/log.js";
  * Priority: explicit config > `gh auth token` CLI.
  */
 function resolveToken(configToken?: string): string | undefined {
-  if (configToken) return configToken;
+  const trimmed = configToken?.trim();
+  if (trimmed) return trimmed;
   try {
     return execFileSync("gh", ["auth", "token"], {
       timeout: 5_000,

--- a/src/plugins/github/index.ts
+++ b/src/plugins/github/index.ts
@@ -33,9 +33,7 @@ function resolveToken(configToken?: string): string | undefined {
   }
 }
 
-export function createGitHubPlugin(config: {
-  token?: string;
-}): TalonPlugin {
+export function createGitHubPlugin(config: { token?: string }): TalonPlugin {
   const token = resolveToken(config.token);
 
   return {
@@ -100,9 +98,7 @@ export function createGitHubPlugin(config: {
 
     getEnvVars() {
       return {
-        ...(token
-          ? { GITHUB_PERSONAL_ACCESS_TOKEN: token }
-          : {}),
+        ...(token ? { GITHUB_PERSONAL_ACCESS_TOKEN: token } : {}),
       };
     },
   };

--- a/src/plugins/github/index.ts
+++ b/src/plugins/github/index.ts
@@ -1,0 +1,109 @@
+/**
+ * GitHub plugin — GitHub API access via the official GitHub MCP server.
+ *
+ * Registers the GitHub MCP server (Docker image: ghcr.io/github/github-mcp-server),
+ * giving the agent access to repository management, issues, PRs, code search, etc.
+ *
+ * Configuration in ~/.talon/config.json:
+ *   "github": {
+ *     "enabled": true,
+ *     "token": "ghp_..."      // optional, defaults to `gh auth token` output
+ *   }
+ */
+
+import { execFileSync } from "node:child_process";
+import type { TalonPlugin } from "../../core/plugin.js";
+import { log, logWarn } from "../../util/log.js";
+
+/**
+ * Resolve a GitHub personal access token.
+ * Priority: explicit config > `gh auth token` CLI.
+ */
+function resolveToken(configToken?: string): string | undefined {
+  if (configToken) return configToken;
+  try {
+    return execFileSync("gh", ["auth", "token"], {
+      timeout: 5_000,
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+      .toString("utf-8")
+      .trim();
+  } catch {
+    return undefined;
+  }
+}
+
+export function createGitHubPlugin(config: {
+  token?: string;
+}): TalonPlugin {
+  const token = resolveToken(config.token);
+
+  return {
+    name: "github",
+    description: "GitHub API access via the official GitHub MCP server",
+    version: "1.0.0",
+
+    mcpServer: {
+      command: "docker",
+      args: [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        `GITHUB_PERSONAL_ACCESS_TOKEN=${token ?? ""}`,
+        "ghcr.io/github/github-mcp-server",
+      ],
+    },
+
+    validateConfig() {
+      const errors: string[] = [];
+
+      if (!token) {
+        errors.push(
+          'No GitHub token found. Set "token" in github config or run `gh auth login`.',
+        );
+      }
+
+      // Check Docker is available
+      try {
+        execFileSync("docker", ["info"], {
+          timeout: 10_000,
+          stdio: "pipe",
+        });
+      } catch {
+        errors.push(
+          "Docker is not available or not running. The GitHub MCP server requires Docker.",
+        );
+      }
+
+      return errors.length > 0 ? errors : undefined;
+    },
+
+    async init() {
+      // Verify the Docker image exists locally
+      try {
+        execFileSync(
+          "docker",
+          ["image", "inspect", "ghcr.io/github/github-mcp-server"],
+          { timeout: 10_000, stdio: "pipe" },
+        );
+        log("github", "Docker image verified");
+      } catch {
+        logWarn(
+          "github",
+          "Docker image not found locally — will pull on first use (may be slow)",
+        );
+      }
+
+      log("github", "Ready");
+    },
+
+    getEnvVars() {
+      return {
+        ...(token
+          ? { GITHUB_PERSONAL_ACCESS_TOKEN: token }
+          : {}),
+      };
+    },
+  };
+}

--- a/src/plugins/github/index.ts
+++ b/src/plugins/github/index.ts
@@ -48,7 +48,7 @@ export function createGitHubPlugin(config: { token?: string }): TalonPlugin {
         "--rm",
         "-i",
         "-e",
-        `GITHUB_PERSONAL_ACCESS_TOKEN=${token ?? ""}`,
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
         "ghcr.io/github/github-mcp-server",
       ],
     },

--- a/src/plugins/playwright/index.ts
+++ b/src/plugins/playwright/index.ts
@@ -1,0 +1,76 @@
+/**
+ * Playwright plugin — browser automation via the official Playwright MCP server.
+ *
+ * Gives the agent headless Chromium for web scraping, screenshots, PDF generation,
+ * and general browser automation.
+ *
+ * Configuration in ~/.talon/config.json:
+ *   "playwright": {
+ *     "enabled": true,
+ *     "browser": "chromium",     // optional, default "chromium"
+ *     "headless": true           // optional, default true
+ *   }
+ */
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import type { TalonPlugin } from "../../core/plugin.js";
+import { log, logWarn } from "../../util/log.js";
+
+export function createPlaywrightPlugin(config: {
+  browser?: string;
+  headless?: boolean;
+}): TalonPlugin {
+  const browser = config.browser ?? "chromium";
+  const headless = config.headless !== false; // default true
+
+  // Resolve npx path from Talon's node_modules
+  const mcpBin = resolve(
+    import.meta.dirname,
+    "../../../node_modules/@playwright/mcp/cli.js",
+  );
+
+  const args = ["--headless", "--no-sandbox"];
+
+  if (browser !== "chromium") {
+    args.push("--browser", browser);
+  }
+
+  return {
+    name: "playwright",
+    description: "Browser automation via Playwright MCP (headless Chromium)",
+    version: "1.0.0",
+
+    mcpServer: {
+      command: "node",
+      args: [mcpBin, ...args],
+    },
+
+    validateConfig() {
+      const errors: string[] = [];
+
+      const validBrowsers = ["chromium", "chrome", "firefox", "webkit", "msedge"];
+      if (!validBrowsers.includes(browser)) {
+        errors.push(
+          `Invalid browser "${browser}". Valid options: ${validBrowsers.join(", ")}`,
+        );
+      }
+
+      return errors.length > 0 ? errors : undefined;
+    },
+
+    async init() {
+      // Verify the MCP server script exists
+      const { existsSync } = await import("node:fs");
+      if (!existsSync(mcpBin)) {
+        logWarn(
+          "playwright",
+          `MCP server not found at ${mcpBin} — run "npm install @playwright/mcp"`,
+        );
+        return;
+      }
+
+      log("playwright", `Ready (${browser}, headless=${headless})`);
+    },
+  };
+}

--- a/src/plugins/playwright/index.ts
+++ b/src/plugins/playwright/index.ts
@@ -49,7 +49,13 @@ export function createPlaywrightPlugin(config: {
     validateConfig() {
       const errors: string[] = [];
 
-      const validBrowsers = ["chromium", "chrome", "firefox", "webkit", "msedge"];
+      const validBrowsers = [
+        "chromium",
+        "chrome",
+        "firefox",
+        "webkit",
+        "msedge",
+      ];
       if (!validBrowsers.includes(browser)) {
         errors.push(
           `Invalid browser "${browser}". Valid options: ${validBrowsers.join(", ")}`,

--- a/src/plugins/playwright/index.ts
+++ b/src/plugins/playwright/index.ts
@@ -12,10 +12,10 @@
  *   }
  */
 
-import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import type { TalonPlugin } from "../../core/plugin.js";
-import { log, logWarn } from "../../util/log.js";
+import { log } from "../../util/log.js";
 
 export function createPlaywrightPlugin(config: {
   browser?: string;
@@ -24,13 +24,17 @@ export function createPlaywrightPlugin(config: {
   const browser = config.browser ?? "chromium";
   const headless = config.headless !== false; // default true
 
-  // Resolve npx path from Talon's node_modules
+  // Resolve path from Talon's node_modules
   const mcpBin = resolve(
-    import.meta.dirname,
+    import.meta.dirname ?? ".",
     "../../../node_modules/@playwright/mcp/cli.js",
   );
 
-  const args = ["--headless", "--no-sandbox"];
+  const args = ["--no-sandbox"];
+
+  if (headless) {
+    args.push("--headless");
+  }
 
   if (browser !== "chromium") {
     args.push("--browser", browser);
@@ -62,20 +66,16 @@ export function createPlaywrightPlugin(config: {
         );
       }
 
+      if (!existsSync(mcpBin)) {
+        errors.push(
+          `@playwright/mcp not found at ${mcpBin} — run "npm install @playwright/mcp"`,
+        );
+      }
+
       return errors.length > 0 ? errors : undefined;
     },
 
     async init() {
-      // Verify the MCP server script exists
-      const { existsSync } = await import("node:fs");
-      if (!existsSync(mcpBin)) {
-        logWarn(
-          "playwright",
-          `MCP server not found at ${mcpBin} — run "npm install @playwright/mcp"`,
-        );
-        return;
-      }
-
       log("playwright", `Ready (${browser}, headless=${headless})`);
     },
   };

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -82,16 +82,6 @@ export function loadSessions(): void {
     );
     store = {};
   }
-  // SDK sessions don't survive process restarts — the embedded Claude Code
-  // subprocess is gone.  Clear stale session IDs so we don't try to resume
-  // a dead session (which causes the SDK to hang silently on Windows).
-  // Keep turns/usage intact — they're historical data used by /resume.
-  for (const session of Object.values(store)) {
-    if (session.sessionId) {
-      session.sessionId = undefined;
-      dirty = true;
-    }
-  }
 }
 
 function saveSessions(): void {

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -43,6 +43,15 @@ const configSchema = z.object({
   timezone: z.string().optional(),
   plugins: z.array(pluginEntrySchema).default([]),
 
+  // GitHub — GitHub API access via official MCP server
+  github: z
+    .object({
+      enabled: z.boolean().default(false),
+      /** GitHub personal access token (default: from `gh auth token`) */
+      token: z.string().min(1).optional(),
+    })
+    .optional(),
+
   // MemPalace — structured long-term memory with vector search
   mempalace: z
     .object({
@@ -51,6 +60,17 @@ const configSchema = z.object({
       palacePath: z.string().min(1).optional(),
       /** Python binary path (default: ~/.talon/mempalace-venv/bin/python) */
       pythonPath: z.string().min(1).optional(),
+    })
+    .optional(),
+
+  // Playwright — headless browser automation via MCP
+  playwright: z
+    .object({
+      enabled: z.boolean().default(false),
+      /** Browser engine: chromium (default), chrome, firefox, webkit, msedge */
+      browser: z.string().optional(),
+      /** Run headless (default: true) */
+      headless: z.boolean().default(true),
     })
     .optional(),
 

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -42,7 +42,9 @@ export type LogComponent =
   | "teams"
   | "config"
   | "access"
-  | "mempalace";
+  | "github"
+  | "mempalace"
+  | "playwright";
 
 const LOG_FILE = files.log;
 


### PR DESCRIPTION
## Summary
- **GitHub plugin** (`src/plugins/github/`): Registers the official GitHub MCP server (Docker image) as a built-in plugin with dedicated config section. Resolves PAT from config or `gh auth token` CLI.
- **Playwright plugin** (`src/plugins/playwright/`): Registers `@playwright/mcp` as a built-in plugin for headless browser automation (Chromium, `--no-sandbox` for server env). Configurable browser engine and headless mode.
- **Session resume fix**: Removed session ID wipe on startup — SDK sessions persist as `.jsonl` files and resume correctly across restarts. Also removed the redundant session continuity context injection that prepended truncated recent messages to the first user turn (broke caching, hid content behind arbitrary 300-char limits).
- **Caption formatting fix**: Media captions now go through `markdownToTelegramHtml()` with `parse_mode: HTML`, matching text message behavior.

## Test plan
- [x] GitHub tools: `get_me` returns authenticated user
- [x] Playwright tools: navigate to fast.com, screenshot, send as photo
- [x] Session persistence: restart Talon, verify context retained
- [ ] Verify validation rejects invalid browser names
- [ ] Verify graceful handling when Docker/Chromium unavailable