### PR TITLE
feat: add model registry middleware and dynamic model pickers

### DIFF
--- a/src/__tests__/chat-settings.test.ts
+++ b/src/__tests__/chat-settings.test.ts
@@ -31,8 +31,12 @@ const {
   loadChatSettings,
   resolveModelName,
   EFFORT_LEVELS,
-  MODEL_ALIASES,
 } = await import("../storage/chat-settings.js");
+
+// Register Claude models so alias resolution works in tests
+const { registerClaudeModels } =
+  await import("../backend/claude-sdk/models.js");
+registerClaudeModels();
 
 describe("chat-settings", () => {
   describe("getChatSettings", () => {
@@ -166,12 +170,21 @@ describe("chat-settings", () => {
     });
   });
 
-  describe("MODEL_ALIASES", () => {
-    it("contains all expected aliases", () => {
-      expect(Object.keys(MODEL_ALIASES).length).toBeGreaterThanOrEqual(9);
-      expect(MODEL_ALIASES.sonnet).toBe("claude-sonnet-4-6");
-      expect(MODEL_ALIASES.opus).toBe("claude-opus-4-6");
-      expect(MODEL_ALIASES.haiku).toBe("claude-haiku-4-5");
+  describe("model alias resolution (via registry)", () => {
+    it("resolves short aliases to full model IDs", () => {
+      expect(resolveModelName("sonnet")).toBe("claude-sonnet-4-6");
+      expect(resolveModelName("opus")).toBe("claude-opus-4-6");
+      expect(resolveModelName("haiku")).toBe("claude-haiku-4-5");
+    });
+
+    it("resolves versioned aliases", () => {
+      expect(resolveModelName("sonnet-4-6")).toBe("claude-sonnet-4-6");
+      expect(resolveModelName("opus-4.6")).toBe("claude-opus-4-6");
+      expect(resolveModelName("haiku-4.5")).toBe("claude-haiku-4-5");
+    });
+
+    it("passes through unknown names unchanged", () => {
+      expect(resolveModelName("gpt-4o")).toBe("gpt-4o");
     });
   });
 

--- a/src/__tests__/chat-settings.test.ts
+++ b/src/__tests__/chat-settings.test.ts
@@ -33,10 +33,10 @@ const {
   EFFORT_LEVELS,
 } = await import("../storage/chat-settings.js");
 
-// Register Claude models so alias resolution works in tests
-const { registerClaudeModels } =
+// Register Claude models (static — no SDK subprocess in tests)
+const { registerClaudeModelsStatic, CLAUDE_MODELS_STATIC } =
   await import("../backend/claude-sdk/models.js");
-registerClaudeModels();
+registerClaudeModelsStatic(CLAUDE_MODELS_STATIC);
 
 describe("chat-settings", () => {
   describe("getChatSettings", () => {

--- a/src/__tests__/fuzz.test.ts
+++ b/src/__tests__/fuzz.test.ts
@@ -49,6 +49,9 @@ const { classify, TalonError } = await import("../core/errors.js");
 await import("../storage/cron-store.js");
 const { handleSharedAction } = await import("../core/gateway-actions.js");
 const { resolveModelName } = await import("../storage/chat-settings.js");
+const { registerClaudeModels } =
+  await import("../backend/claude-sdk/models.js");
+registerClaudeModels();
 const { Cron } = await import("croner");
 
 // ── Configuration ───────────────────────────────────────────────────────────

--- a/src/__tests__/fuzz.test.ts
+++ b/src/__tests__/fuzz.test.ts
@@ -49,9 +49,9 @@ const { classify, TalonError } = await import("../core/errors.js");
 await import("../storage/cron-store.js");
 const { handleSharedAction } = await import("../core/gateway-actions.js");
 const { resolveModelName } = await import("../storage/chat-settings.js");
-const { registerClaudeModels } =
+const { registerClaudeModelsStatic, CLAUDE_MODELS_STATIC } =
   await import("../backend/claude-sdk/models.js");
-registerClaudeModels();
+registerClaudeModelsStatic(CLAUDE_MODELS_STATIC);
 const { Cron } = await import("croner");
 
 // ── Configuration ───────────────────────────────────────────────────────────

--- a/src/__tests__/reload-plugins.test.ts
+++ b/src/__tests__/reload-plugins.test.ts
@@ -75,12 +75,14 @@ vi.mock("../util/config.js", () => ({
     ),
 }));
 
-vi.mock("../backend/claude-sdk/index.js", () => ({
+// Backend mock — passed as 3rd arg to handleSharedAction
+const mockBackend = {
+  query: vi.fn(),
   updateSystemPrompt: (...args: unknown[]) =>
     mockUpdateSystemPrompt(
       ...(args as Parameters<typeof mockUpdateSystemPrompt>),
     ),
-}));
+};
 
 // ── Import after mocks ────────────────────────────────────────────────────
 
@@ -105,6 +107,7 @@ describe("reload_plugins gateway action", () => {
     const result = await handleSharedAction(
       { action: "reload_plugins" },
       12345,
+      mockBackend,
     );
     expect(result).not.toBeNull();
     expect(result!.ok).toBe(true);
@@ -115,19 +118,19 @@ describe("reload_plugins gateway action", () => {
   });
 
   it("calls reloadPlugins without explicit frontends (derived from config)", async () => {
-    await handleSharedAction({ action: "reload_plugins" }, 12345);
+    await handleSharedAction({ action: "reload_plugins" }, 12345, mockBackend);
     // Gateway no longer passes frontends — reloadPlugins derives them from config
     expect(mockReloadPlugins).toHaveBeenCalledWith();
   });
 
   it("rebuilds system prompt after reloading", async () => {
-    await handleSharedAction({ action: "reload_plugins" }, 12345);
+    await handleSharedAction({ action: "reload_plugins" }, 12345, mockBackend);
     expect(mockRebuildSystemPrompt).toHaveBeenCalledTimes(1);
     expect(mockGetPluginPromptAdditions).toHaveBeenCalledTimes(1);
   });
 
   it("updates backend system prompt after rebuild", async () => {
-    await handleSharedAction({ action: "reload_plugins" }, 12345);
+    await handleSharedAction({ action: "reload_plugins" }, 12345, mockBackend);
     expect(mockUpdateSystemPrompt).toHaveBeenCalledTimes(1);
   });
 
@@ -138,6 +141,7 @@ describe("reload_plugins gateway action", () => {
     const result = await handleSharedAction(
       { action: "reload_plugins" },
       12345,
+      mockBackend,
     );
     expect(result).not.toBeNull();
     expect(result!.ok).toBe(false);
@@ -151,6 +155,7 @@ describe("reload_plugins gateway action", () => {
     const result = await handleSharedAction(
       { action: "reload_plugins" },
       12345,
+      mockBackend,
     );
     expect(result!.ok).toBe(false);
     expect(result!.error).toContain("Invalid JSON in config");
@@ -164,6 +169,7 @@ describe("reload_plugins gateway action", () => {
     const result = await handleSharedAction(
       { action: "reload_plugins" },
       12345,
+      mockBackend,
     );
     expect(result!.ok).toBe(true);
     expect(result!.text).toContain("(0)");

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -17,6 +17,7 @@ import {
 } from "../../storage/sessions.js";
 import { getChatSettings, setChatModel } from "../../storage/chat-settings.js";
 import { classify } from "../../core/errors.js";
+import { getFallbackModel } from "../../core/models.js";
 import { rebuildSystemPrompt } from "../../util/config.js";
 import { getPluginPromptAdditions } from "../../core/plugin.js";
 import { log, logError, logWarn } from "../../util/log.js";
@@ -148,21 +149,17 @@ export async function handleMessage(
       return handleMessage(params, true);
     }
 
-    // Model fallback: if overloaded/timeout, retry with a faster model
+    // Model fallback: if overloaded/timeout, retry with the next-tier model
     if (!_retried && classified.retryable) {
-      const fallbackModel = activeModel.includes("opus")
-        ? "claude-sonnet-4-6"
-        : activeModel.includes("sonnet")
-          ? "claude-haiku-4-5"
-          : null;
-      if (fallbackModel) {
+      const fallback = getFallbackModel(activeModel);
+      if (fallback) {
         logWarn(
           "agent",
-          `[${chatId}] ${classified.reason}, falling back to ${fallbackModel.replace("claude-", "")}`,
+          `[${chatId}] ${classified.reason}, falling back to ${fallback.replace("claude-", "")}`,
         );
         resetSession(chatId);
         const originalModel = getChatSettings(chatId).model;
-        setChatModel(chatId, fallbackModel);
+        setChatModel(chatId, fallback);
         try {
           return await handleMessage(params, true);
         } finally {

--- a/src/backend/claude-sdk/models.ts
+++ b/src/backend/claude-sdk/models.ts
@@ -1,14 +1,24 @@
 /**
- * Anthropic model definitions for the Claude SDK backend.
+ * Claude model discovery — queries the SDK for available models.
  *
- * This is the single source of truth for Claude model metadata —
- * display names, aliases, capabilities, tiers, and fallback chains.
+ * On init, registers a static fallback set immediately (so the registry
+ * is never empty), then spawns a background SDK query to discover the
+ * actual model list and upgrades the registry with live data.
  */
 
+import { query } from "@anthropic-ai/claude-agent-sdk";
 import { registerModels } from "../../core/models.js";
 import type { ModelInfo } from "../../core/models.js";
+import { log, logWarn } from "../../util/log.js";
 
-export const CLAUDE_MODELS: ModelInfo[] = [
+// ── Static fallback models ──────────────────────────────────────────────────
+
+/**
+ * Minimal static set registered synchronously so the registry is usable
+ * before the async SDK discovery completes. These are overwritten once
+ * live data arrives.
+ */
+const FALLBACK_MODELS: ModelInfo[] = [
   {
     id: "claude-opus-4-6",
     displayName: "Opus 4.6",
@@ -40,7 +50,160 @@ export const CLAUDE_MODELS: ModelInfo[] = [
   },
 ];
 
-/** Register all Claude models in the global registry. */
-export function registerClaudeModels(): void {
-  registerModels(CLAUDE_MODELS);
+// ── Tier / fallback inference ───────────────────────────────────────────────
+
+/** Infer tier from model ID — used when the SDK doesn't provide it. */
+function inferTier(modelId: string): ModelInfo["tier"] {
+  if (modelId.includes("opus")) return "premium";
+  if (modelId.includes("haiku")) return "economy";
+  return "balanced";
+}
+
+/** Build short aliases from a model ID like "claude-sonnet-4-6". */
+function buildAliases(modelId: string): string[] {
+  const aliases: string[] = [];
+  // Extract family name (opus, sonnet, haiku, etc.)
+  const match = modelId.match(/claude-(\w+)-(.+)/);
+  if (match) {
+    const family = match[1]; // "sonnet"
+    const version = match[2]; // "4-6"
+    aliases.push(family); // "sonnet"
+    aliases.push(`${family}-${version}`); // "sonnet-4-6"
+    aliases.push(`${family}-${version.replace(/-/g, ".")}`); // "sonnet-4.6"
+  }
+  return aliases;
+}
+
+// ── SDK model discovery ─────────────────────────────────────────────────────
+
+/**
+ * Convert SDK ModelInfo to our registry ModelInfo format.
+ * Sorts models by tier and sets up fallback chains automatically.
+ */
+function convertSdkModels(
+  sdkModels: Array<{
+    value: string;
+    displayName: string;
+    description: string;
+  }>,
+): ModelInfo[] {
+  // Build registry entries from SDK data
+  const models: ModelInfo[] = sdkModels.map((m) => ({
+    id: m.value,
+    displayName: m.displayName,
+    description: m.description,
+    aliases: buildAliases(m.value),
+    provider: "anthropic",
+    capabilities: {
+      // Haiku models don't support 1M context
+      supports1mContext: !m.value.includes("haiku"),
+    },
+    tier: inferTier(m.value),
+  }));
+
+  // Sort by tier: premium first, then balanced, then economy
+  const tierOrder = { premium: 0, balanced: 1, economy: 2 };
+  models.sort((a, b) => tierOrder[a.tier] - tierOrder[b.tier]);
+
+  // Set up fallback chain: each model falls back to the next tier down
+  for (let i = 0; i < models.length - 1; i++) {
+    if (!models[i].fallback) {
+      models[i].fallback = models[i + 1].id;
+    }
+  }
+
+  return models;
+}
+
+/**
+ * Discover models from the SDK by spawning a throwaway query and calling
+ * supportedModels(). Fire-and-forget — non-blocking, non-fatal.
+ */
+async function discoverModelsFromSdk(
+  sdkOptions: Record<string, unknown>,
+): Promise<void> {
+  const abort = new AbortController();
+  try {
+    const neverYield = async function* (): AsyncGenerator<never> {
+      await new Promise<never>((_, reject) => {
+        abort.signal.addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
+      });
+    };
+
+    const q = query({
+      prompt: neverYield(),
+      options: {
+        ...sdkOptions,
+        abortController: abort,
+      } as Parameters<typeof query>[0]["options"],
+    });
+
+    // Drain stream in background to prevent backpressure
+    const drainPromise = (async () => {
+      try {
+        for await (const _ of q) {
+          /* discard */
+        }
+      } catch {
+        /* expected on abort */
+      }
+    })();
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error("model discovery timed out")),
+        15_000,
+      );
+    });
+
+    let sdkModels: Array<{
+      value: string;
+      displayName: string;
+      description: string;
+    }>;
+    try {
+      sdkModels = await Promise.race([q.supportedModels(), timeout]);
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
+
+    if (sdkModels.length > 0) {
+      const models = convertSdkModels(sdkModels);
+      registerModels(models);
+      log(
+        "agent",
+        `Discovered ${models.length} models from SDK: ${models.map((m) => m.id).join(", ")}`,
+      );
+    }
+
+    abort.abort();
+    await drainPromise;
+  } catch (err) {
+    abort.abort();
+    logWarn(
+      "agent",
+      `Model discovery failed (using static fallback): ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Register static fallback models immediately, then kick off async
+ * SDK discovery to upgrade with live data.
+ */
+export function registerClaudeModels(
+  sdkOptions?: Record<string, unknown>,
+): void {
+  // Register static models synchronously — always available
+  registerModels(FALLBACK_MODELS);
+
+  // If SDK options are provided, discover live models in the background
+  if (sdkOptions) {
+    discoverModelsFromSdk(sdkOptions).catch(() => {});
+  }
 }

--- a/src/backend/claude-sdk/models.ts
+++ b/src/backend/claude-sdk/models.ts
@@ -8,7 +8,7 @@
  */
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import { registerModels, clearModels } from "../../core/models.js";
+import { registerModels, clearModelsByProvider } from "../../core/models.js";
 import type { ModelInfo } from "../../core/models.js";
 import { log, logError } from "../../util/log.js";
 
@@ -153,7 +153,7 @@ export async function registerClaudeModels(sdkOptions: {
     }
 
     const models = convertSdkModels(sdkModels);
-    clearModels();
+    clearModelsByProvider("anthropic");
     registerModels(models);
     log(
       "agent",

--- a/src/backend/claude-sdk/models.ts
+++ b/src/backend/claude-sdk/models.ts
@@ -71,11 +71,13 @@ function convertSdkModels(
   const tierOrder = { premium: 0, balanced: 1, economy: 2 };
   models.sort((a, b) => tierOrder[a.tier] - tierOrder[b.tier]);
 
-  // Fallback chain: each model falls back to the next tier down
-  for (let i = 0; i < models.length - 1; i++) {
-    if (!models[i].fallback) {
-      models[i].fallback = models[i + 1].id;
-    }
+  // Fallback chain: each model falls back to the first model in the next lower tier
+  for (const model of models) {
+    if (model.fallback) continue;
+    const nextTier = models.find(
+      (m) => tierOrder[m.tier] > tierOrder[model.tier],
+    );
+    if (nextTier) model.fallback = nextTier.id;
   }
 
   return models;

--- a/src/backend/claude-sdk/models.ts
+++ b/src/backend/claude-sdk/models.ts
@@ -1,0 +1,46 @@
+/**
+ * Anthropic model definitions for the Claude SDK backend.
+ *
+ * This is the single source of truth for Claude model metadata —
+ * display names, aliases, capabilities, tiers, and fallback chains.
+ */
+
+import { registerModels } from "../../core/models.js";
+import type { ModelInfo } from "../../core/models.js";
+
+export const CLAUDE_MODELS: ModelInfo[] = [
+  {
+    id: "claude-opus-4-6",
+    displayName: "Opus 4.6",
+    description: "smartest",
+    aliases: ["opus", "opus-4.6", "opus-4-6"],
+    provider: "anthropic",
+    capabilities: { supports1mContext: true },
+    tier: "premium",
+    fallback: "claude-sonnet-4-6",
+  },
+  {
+    id: "claude-sonnet-4-6",
+    displayName: "Sonnet 4.6",
+    description: "fast, balanced",
+    aliases: ["sonnet", "sonnet-4.6", "sonnet-4-6"],
+    provider: "anthropic",
+    capabilities: { supports1mContext: true },
+    tier: "balanced",
+    fallback: "claude-haiku-4-5",
+  },
+  {
+    id: "claude-haiku-4-5",
+    displayName: "Haiku 4.5",
+    description: "fastest, cheapest",
+    aliases: ["haiku", "haiku-4.5", "haiku-4-5"],
+    provider: "anthropic",
+    capabilities: { supports1mContext: false },
+    tier: "economy",
+  },
+];
+
+/** Register all Claude models in the global registry. */
+export function registerClaudeModels(): void {
+  registerModels(CLAUDE_MODELS);
+}

--- a/src/backend/claude-sdk/models.ts
+++ b/src/backend/claude-sdk/models.ts
@@ -48,7 +48,15 @@ function convertSdkModels(
     description: string;
   }>,
 ): ModelInfo[] {
-  const models: ModelInfo[] = sdkModels.map((m) => ({
+  // Filter out SDK artifacts:
+  // - [1m] variants: we add this suffix ourselves in options.ts
+  // - "default" pseudo-model: not a real model, just an alias for the default
+  // - any model that doesn't start with "claude-": not an Anthropic model
+  const filtered = sdkModels.filter(
+    (m) => m.value.startsWith("claude-") && !m.value.includes("["),
+  );
+
+  const models: ModelInfo[] = filtered.map((m) => ({
     id: m.value,
     displayName: m.displayName,
     description: m.description,

--- a/src/backend/claude-sdk/models.ts
+++ b/src/backend/claude-sdk/models.ts
@@ -1,24 +1,179 @@
 /**
  * Claude model discovery — queries the SDK for available models.
  *
- * On init, registers a static fallback set immediately (so the registry
- * is never empty), then spawns a background SDK query to discover the
- * actual model list and upgrades the registry with live data.
+ * Spawns a throwaway SDK subprocess, calls supportedModels(), and
+ * registers the results in the global model registry. This is the
+ * only source of truth for available Claude models — if the SDK
+ * fails to provide models, initialization is aborted.
  */
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import { registerModels } from "../../core/models.js";
+import { registerModels, clearModels } from "../../core/models.js";
 import type { ModelInfo } from "../../core/models.js";
-import { log, logWarn } from "../../util/log.js";
+import { log, logError } from "../../util/log.js";
 
-// ── Static fallback models ──────────────────────────────────────────────────
+// ── Tier / fallback inference ───────────────────────────────────────────────
+
+/** Infer tier from model ID. */
+function inferTier(modelId: string): ModelInfo["tier"] {
+  if (modelId.includes("opus")) return "premium";
+  if (modelId.includes("haiku")) return "economy";
+  return "balanced";
+}
+
+/** Build short aliases from a model ID like "claude-sonnet-4-6". */
+function buildAliases(modelId: string): string[] {
+  const aliases: string[] = [];
+  const match = modelId.match(/claude-(\w+)-(.+)/);
+  if (match) {
+    const family = match[1];
+    const version = match[2];
+    aliases.push(family);
+    aliases.push(`${family}-${version}`);
+    aliases.push(`${family}-${version.replace(/-/g, ".")}`);
+  }
+  return aliases;
+}
+
+// ── SDK → registry conversion ───────────────────────────────────────────────
 
 /**
- * Minimal static set registered synchronously so the registry is usable
- * before the async SDK discovery completes. These are overwritten once
- * live data arrives.
+ * Convert SDK ModelInfo to our registry format.
+ * Sorts by tier and builds fallback chains automatically.
  */
-const FALLBACK_MODELS: ModelInfo[] = [
+function convertSdkModels(
+  sdkModels: Array<{
+    value: string;
+    displayName: string;
+    description: string;
+  }>,
+): ModelInfo[] {
+  const models: ModelInfo[] = sdkModels.map((m) => ({
+    id: m.value,
+    displayName: m.displayName,
+    description: m.description,
+    aliases: buildAliases(m.value),
+    provider: "anthropic",
+    capabilities: {
+      supports1mContext: !m.value.includes("haiku"),
+    },
+    tier: inferTier(m.value),
+  }));
+
+  const tierOrder = { premium: 0, balanced: 1, economy: 2 };
+  models.sort((a, b) => tierOrder[a.tier] - tierOrder[b.tier]);
+
+  // Fallback chain: each model falls back to the next tier down
+  for (let i = 0; i < models.length - 1; i++) {
+    if (!models[i].fallback) {
+      models[i].fallback = models[i + 1].id;
+    }
+  }
+
+  return models;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Discover available models from the Claude Agent SDK and register them.
+ *
+ * Spawns a throwaway SDK subprocess, calls supportedModels(), converts the
+ * results to our registry format, and registers them. Throws on failure —
+ * if the SDK can't provide models, Talon cannot function.
+ */
+export async function registerClaudeModels(sdkOptions: {
+  model: string;
+  cwd?: string;
+  permissionMode?: string;
+  allowDangerouslySkipPermissions?: boolean;
+  pathToClaudeCodeExecutable?: string;
+}): Promise<void> {
+  const abort = new AbortController();
+  let drainPromise: Promise<void> | undefined;
+
+  try {
+    const neverYield = async function* (): AsyncGenerator<never> {
+      await new Promise<never>((_, reject) => {
+        abort.signal.addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
+      });
+    };
+
+    const q = query({
+      prompt: neverYield(),
+      options: {
+        ...sdkOptions,
+        abortController: abort,
+      } as Parameters<typeof query>[0]["options"],
+    });
+
+    drainPromise = (async () => {
+      try {
+        for await (const _ of q) {
+          /* discard */
+        }
+      } catch {
+        /* expected on abort */
+      }
+    })();
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error("model discovery timed out after 15s")),
+        15_000,
+      );
+    });
+
+    let sdkModels: Array<{
+      value: string;
+      displayName: string;
+      description: string;
+    }>;
+    try {
+      sdkModels = await Promise.race([q.supportedModels(), timeout]);
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
+
+    if (sdkModels.length === 0) {
+      throw new Error("SDK returned empty model list");
+    }
+
+    const models = convertSdkModels(sdkModels);
+    clearModels();
+    registerModels(models);
+    log(
+      "agent",
+      `Discovered ${models.length} models from SDK: ${models.map((m) => m.id).join(", ")}`,
+    );
+
+    abort.abort();
+    await drainPromise;
+  } catch (err) {
+    abort.abort();
+    if (drainPromise) await drainPromise.catch(() => {});
+    const msg = err instanceof Error ? err.message : String(err);
+    logError("agent", `Fatal: model discovery failed — ${msg}`);
+    throw new Error(
+      `Claude SDK model discovery failed: ${msg}. ` +
+        `Check that Claude Code is installed and your API key is valid.`,
+    );
+  }
+}
+
+/**
+ * Register models from a static list. For use in tests and the CLI setup
+ * wizard where the SDK subprocess is not available.
+ */
+export function registerClaudeModelsStatic(models: ModelInfo[]): void {
+  registerModels(models);
+}
+
+/** Default model definitions for CLI setup wizard and tests. */
+export const CLAUDE_MODELS_STATIC: ModelInfo[] = [
   {
     id: "claude-opus-4-6",
     displayName: "Opus 4.6",
@@ -49,161 +204,3 @@ const FALLBACK_MODELS: ModelInfo[] = [
     tier: "economy",
   },
 ];
-
-// ── Tier / fallback inference ───────────────────────────────────────────────
-
-/** Infer tier from model ID — used when the SDK doesn't provide it. */
-function inferTier(modelId: string): ModelInfo["tier"] {
-  if (modelId.includes("opus")) return "premium";
-  if (modelId.includes("haiku")) return "economy";
-  return "balanced";
-}
-
-/** Build short aliases from a model ID like "claude-sonnet-4-6". */
-function buildAliases(modelId: string): string[] {
-  const aliases: string[] = [];
-  // Extract family name (opus, sonnet, haiku, etc.)
-  const match = modelId.match(/claude-(\w+)-(.+)/);
-  if (match) {
-    const family = match[1]; // "sonnet"
-    const version = match[2]; // "4-6"
-    aliases.push(family); // "sonnet"
-    aliases.push(`${family}-${version}`); // "sonnet-4-6"
-    aliases.push(`${family}-${version.replace(/-/g, ".")}`); // "sonnet-4.6"
-  }
-  return aliases;
-}
-
-// ── SDK model discovery ─────────────────────────────────────────────────────
-
-/**
- * Convert SDK ModelInfo to our registry ModelInfo format.
- * Sorts models by tier and sets up fallback chains automatically.
- */
-function convertSdkModels(
-  sdkModels: Array<{
-    value: string;
-    displayName: string;
-    description: string;
-  }>,
-): ModelInfo[] {
-  // Build registry entries from SDK data
-  const models: ModelInfo[] = sdkModels.map((m) => ({
-    id: m.value,
-    displayName: m.displayName,
-    description: m.description,
-    aliases: buildAliases(m.value),
-    provider: "anthropic",
-    capabilities: {
-      // Haiku models don't support 1M context
-      supports1mContext: !m.value.includes("haiku"),
-    },
-    tier: inferTier(m.value),
-  }));
-
-  // Sort by tier: premium first, then balanced, then economy
-  const tierOrder = { premium: 0, balanced: 1, economy: 2 };
-  models.sort((a, b) => tierOrder[a.tier] - tierOrder[b.tier]);
-
-  // Set up fallback chain: each model falls back to the next tier down
-  for (let i = 0; i < models.length - 1; i++) {
-    if (!models[i].fallback) {
-      models[i].fallback = models[i + 1].id;
-    }
-  }
-
-  return models;
-}
-
-/**
- * Discover models from the SDK by spawning a throwaway query and calling
- * supportedModels(). Fire-and-forget — non-blocking, non-fatal.
- */
-async function discoverModelsFromSdk(
-  sdkOptions: Record<string, unknown>,
-): Promise<void> {
-  const abort = new AbortController();
-  try {
-    const neverYield = async function* (): AsyncGenerator<never> {
-      await new Promise<never>((_, reject) => {
-        abort.signal.addEventListener("abort", () =>
-          reject(new Error("aborted")),
-        );
-      });
-    };
-
-    const q = query({
-      prompt: neverYield(),
-      options: {
-        ...sdkOptions,
-        abortController: abort,
-      } as Parameters<typeof query>[0]["options"],
-    });
-
-    // Drain stream in background to prevent backpressure
-    const drainPromise = (async () => {
-      try {
-        for await (const _ of q) {
-          /* discard */
-        }
-      } catch {
-        /* expected on abort */
-      }
-    })();
-
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(
-        () => reject(new Error("model discovery timed out")),
-        15_000,
-      );
-    });
-
-    let sdkModels: Array<{
-      value: string;
-      displayName: string;
-      description: string;
-    }>;
-    try {
-      sdkModels = await Promise.race([q.supportedModels(), timeout]);
-    } finally {
-      if (timeoutId !== undefined) clearTimeout(timeoutId);
-    }
-
-    if (sdkModels.length > 0) {
-      const models = convertSdkModels(sdkModels);
-      registerModels(models);
-      log(
-        "agent",
-        `Discovered ${models.length} models from SDK: ${models.map((m) => m.id).join(", ")}`,
-      );
-    }
-
-    abort.abort();
-    await drainPromise;
-  } catch (err) {
-    abort.abort();
-    logWarn(
-      "agent",
-      `Model discovery failed (using static fallback): ${err instanceof Error ? err.message : err}`,
-    );
-  }
-}
-
-// ── Public API ──────────────────────────────────────────────────────────────
-
-/**
- * Register static fallback models immediately, then kick off async
- * SDK discovery to upgrade with live data.
- */
-export function registerClaudeModels(
-  sdkOptions?: Record<string, unknown>,
-): void {
-  // Register static models synchronously — always available
-  registerModels(FALLBACK_MODELS);
-
-  // If SDK options are provided, discover live models in the background
-  if (sdkOptions) {
-    discoverModelsFromSdk(sdkOptions).catch(() => {});
-  }
-}

--- a/src/backend/claude-sdk/options.ts
+++ b/src/backend/claude-sdk/options.ts
@@ -10,6 +10,7 @@ import type { Options } from "@anthropic-ai/claude-agent-sdk";
 import { getSession } from "../../storage/sessions.js";
 import { getChatSettings } from "../../storage/chat-settings.js";
 import { getPluginMcpServers } from "../../core/plugin.js";
+import { supports1mContext } from "../../core/models.js";
 import { getConfig, getBridgePort } from "./state.js";
 import { DISALLOWED_TOOLS_CHAT, EFFORT_MAP } from "./constants.js";
 
@@ -100,9 +101,9 @@ export function buildSdkOptions(chatId: string): BuildSdkOptionsResult {
     thinking: { type: "adaptive" as const },
   };
 
-  const supports1m =
-    !activeModel.includes("haiku") && !activeModel.includes("[1m]");
-  const sdkModel = supports1m ? `${activeModel}[1m]` : activeModel;
+  const canUse1m =
+    supports1mContext(activeModel) && !activeModel.includes("[1m]");
+  const sdkModel = canUse1m ? `${activeModel}[1m]` : activeModel;
 
   const session = getSession(chatId);
 

--- a/src/backend/claude-sdk/state.ts
+++ b/src/backend/claude-sdk/state.ts
@@ -15,29 +15,29 @@ let bridgePortFn: () => number = () => 19876;
 
 // ── Public API (re-exported from barrel) ────────────────────────────────────
 
-export function initAgent(
+export async function initAgent(
   cfg: TalonConfig,
   getBridgePort?: () => number,
-): void {
+): Promise<void> {
   config = cfg;
   if (getBridgePort) bridgePortFn = getBridgePort;
-
-  // Register static models immediately, then discover live models from SDK
-  registerClaudeModels({
-    model: cfg.model,
-    cwd: cfg.workspace,
-    permissionMode: "bypassPermissions" as const,
-    allowDangerouslySkipPermissions: true,
-    ...(cfg.claudeBinary
-      ? { pathToClaudeCodeExecutable: cfg.claudeBinary }
-      : {}),
-  });
 
   // The Agent SDK spawns an embedded Claude Code subprocess.
   // If CLAUDECODE is set (e.g. running from a Claude Code terminal),
   // the subprocess refuses to start with a nested-session error that
   // gets swallowed — causing an infinite hang on Windows.
   delete process.env.CLAUDECODE;
+
+  // Discover available models from the SDK — fatal if this fails
+  await registerClaudeModels({
+    model: cfg.model,
+    cwd: cfg.workspace,
+    permissionMode: "bypassPermissions",
+    allowDangerouslySkipPermissions: true,
+    ...(cfg.claudeBinary
+      ? { pathToClaudeCodeExecutable: cfg.claudeBinary }
+      : {}),
+  });
 }
 
 /** Update the system prompt on the live config. Used by plugin hot-reload

--- a/src/backend/claude-sdk/state.ts
+++ b/src/backend/claude-sdk/state.ts
@@ -21,7 +21,17 @@ export function initAgent(
 ): void {
   config = cfg;
   if (getBridgePort) bridgePortFn = getBridgePort;
-  registerClaudeModels();
+
+  // Register static models immediately, then discover live models from SDK
+  registerClaudeModels({
+    model: cfg.model,
+    cwd: cfg.workspace,
+    permissionMode: "bypassPermissions" as const,
+    allowDangerouslySkipPermissions: true,
+    ...(cfg.claudeBinary
+      ? { pathToClaudeCodeExecutable: cfg.claudeBinary }
+      : {}),
+  });
 
   // The Agent SDK spawns an embedded Claude Code subprocess.
   // If CLAUDECODE is set (e.g. running from a Claude Code terminal),

--- a/src/backend/claude-sdk/state.ts
+++ b/src/backend/claude-sdk/state.ts
@@ -6,6 +6,7 @@
  */
 
 import type { TalonConfig } from "../../util/config.js";
+import { registerClaudeModels } from "./models.js";
 
 // ── State ────────────────────────────────────────────────────────────────────
 
@@ -20,6 +21,7 @@ export function initAgent(
 ): void {
   config = cfg;
   if (getBridgePort) bridgePortFn = getBridgePort;
+  registerClaudeModels();
 
   // The Agent SDK spawns an embedded Claude Code subprocess.
   // If CLAUDECODE is set (e.g. running from a Claude Code terminal),

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -47,6 +47,10 @@ export type BootstrapResult = {
   config: TalonConfig;
 };
 
+export type BackendAndDispatcherResult = {
+  backend: QueryBackend;
+};
+
 // ── Bootstrap: config, env, plugins, workspace, storage ──────────────────────
 
 /**
@@ -102,7 +106,7 @@ export async function bootstrap(
 export async function initBackendAndDispatcher(
   config: TalonConfig,
   frontend: Frontend,
-): Promise<void> {
+): Promise<BackendAndDispatcherResult> {
   let backend: QueryBackend;
 
   if (config.backend === "opencode") {
@@ -112,10 +116,18 @@ export async function initBackendAndDispatcher(
     backend = { query: (params) => opencodeHandleMessage(params) };
     log("bot", "Backend: OpenCode");
   } else {
-    const { initAgent: initClaudeAgent, handleMessage: claudeHandleMessage } =
-      await import("./backend/claude-sdk/index.js");
+    const {
+      initAgent: initClaudeAgent,
+      handleMessage: claudeHandleMessage,
+      warmSession: claudeWarmSession,
+      updateSystemPrompt: claudeUpdateSystemPrompt,
+    } = await import("./backend/claude-sdk/index.js");
     initClaudeAgent(config, frontend.getBridgePort);
-    backend = { query: (params) => claudeHandleMessage(params) };
+    backend = {
+      query: (params) => claudeHandleMessage(params),
+      warmSession: (chatId) => claudeWarmSession(chatId),
+      updateSystemPrompt: (prompt) => claudeUpdateSystemPrompt(prompt),
+    };
     log("bot", "Backend: Claude SDK");
   }
 
@@ -160,4 +172,6 @@ export async function initBackendAndDispatcher(
     claudeBinary: config.claudeBinary,
     workspace: config.workspace,
   });
+
+  return { backend };
 }

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -122,7 +122,7 @@ export async function initBackendAndDispatcher(
       warmSession: claudeWarmSession,
       updateSystemPrompt: claudeUpdateSystemPrompt,
     } = await import("./backend/claude-sdk/index.js");
-    initClaudeAgent(config, frontend.getBridgePort);
+    await initClaudeAgent(config, frontend.getBridgePort);
     backend = {
       query: (params) => claudeHandleMessage(params),
       warmSession: (chatId) => claudeWarmSession(chatId),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -282,10 +282,27 @@ async function runSetup(): Promise<void> {
     if (botName) teamsBotDisplayName = botName;
   }
 
-  // Register Claude models so the picker is populated from the registry
-  const { registerClaudeModels } =
-    await import("./backend/claude-sdk/models.js");
-  registerClaudeModels();
+  // Discover models from SDK; fall back to static list if SDK isn't available
+  const {
+    registerClaudeModels,
+    registerClaudeModelsStatic,
+    CLAUDE_MODELS_STATIC,
+  } = await import("./backend/claude-sdk/models.js");
+  try {
+    const { dirs } = await import("./util/paths.js");
+    await registerClaudeModels({
+      model: config.model,
+      cwd: dirs.workspace,
+      permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+      ...(config.claudeBinary
+        ? { pathToClaudeCodeExecutable: config.claudeBinary }
+        : {}),
+    });
+  } catch {
+    // Setup wizard may run before Claude Code is installed — use static list
+    registerClaudeModelsStatic(CLAUDE_MODELS_STATIC);
+  }
   const { getModels } = await import("./core/models.js");
   const registeredModels = getModels();
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -282,23 +282,20 @@ async function runSetup(): Promise<void> {
     if (botName) teamsBotDisplayName = botName;
   }
 
+  // Register Claude models so the picker is populated from the registry
+  const { registerClaudeModels } =
+    await import("./backend/claude-sdk/models.js");
+  registerClaudeModels();
+  const { getModels } = await import("./core/models.js");
+  const registeredModels = getModels();
+
   const model = await p.select({
     message: "Default model",
     initialValue: config.model,
-    options: [
-      {
-        value: "claude-sonnet-4-6",
-        label: `Sonnet 4.6  ${pc.dim("\u2014 fast, balanced")}`,
-      },
-      {
-        value: "claude-opus-4-6",
-        label: `Opus 4.6    ${pc.dim("\u2014 smartest")}`,
-      },
-      {
-        value: "claude-haiku-4-5",
-        label: `Haiku 4.5   ${pc.dim("\u2014 fastest, cheapest")}`,
-      },
-    ],
+    options: registeredModels.map((m) => ({
+      value: m.id,
+      label: `${m.displayName.padEnd(12)}${m.description ? pc.dim(`\u2014 ${m.description}`) : ""}`,
+    })),
   });
   if (p.isCancel(model)) {
     p.cancel("Cancelled.");
@@ -652,7 +649,8 @@ async function startChat(): Promise<void> {
   const gateway = new Gateway();
   const frontend = createTerminalFrontend(config, gateway);
   await frontend.init();
-  await initBackendAndDispatcher(config, frontend);
+  const { backend } = await initBackendAndDispatcher(config, frontend);
+  gateway.backend = backend;
 
   process.on("SIGINT", () => {
     flushSessions();

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -21,6 +21,7 @@ import { files as pathFiles, dirs } from "../util/paths.js";
 import { log, logError, logWarn } from "../util/log.js";
 import { getPluginMcpServers } from "./plugin.js";
 import { DISALLOWED_TOOLS_BACKGROUND } from "../backend/claude-sdk/constants.js";
+import { getDefaultModel } from "./models.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -179,7 +180,8 @@ If commands fail, log the error and continue — this stage is optional.`
     throw new Error(`Failed to read dream prompt from ${promptPath}`);
   }
 
-  const model = configRef.dreamModel ?? configRef.model ?? "claude-sonnet-4-6";
+  const model =
+    configRef.dreamModel ?? configRef.model ?? getDefaultModel("balanced");
   const workspace = configRef.workspace ?? dirs.workspace;
 
   // Set up dream log file

--- a/src/core/gateway-actions.ts
+++ b/src/core/gateway-actions.ts
@@ -27,7 +27,7 @@ import {
   type CronJobType,
 } from "../storage/cron-store.js";
 import { log } from "../util/log.js";
-import type { ActionResult } from "./types.js";
+import type { ActionResult, QueryBackend } from "./types.js";
 
 /** Extract readable text from HTML using cheerio (proper DOM parser). */
 function extractText(html: string, maxLength = 8000): string {
@@ -42,6 +42,7 @@ function extractText(html: string, maxLength = 8000): string {
 export async function handleSharedAction(
   body: Record<string, unknown>,
   chatId: number,
+  backend?: QueryBackend | null,
 ): Promise<ActionResult | null> {
   const action = body.action as string;
 
@@ -324,17 +325,7 @@ export async function handleSharedAction(
         // Rebuild system prompt on the freshConfig, then update the backend's
         // live config reference so subsequent messages use the new prompt
         rebuildSystemPrompt(freshConfig, getPluginPromptAdditions());
-        try {
-          const { updateSystemPrompt } =
-            await import("../backend/claude-sdk/index.js");
-          updateSystemPrompt(freshConfig.systemPrompt);
-        } catch (err) {
-          // Non-fatal — OpenCode backend doesn't expose updateSystemPrompt
-          log(
-            "gateway",
-            `reload_plugins: could not update backend prompt: ${err instanceof Error ? err.message : err}`,
-          );
-        }
+        backend?.updateSystemPrompt?.(freshConfig.systemPrompt);
 
         log("gateway", `reload_plugins: ${names.length} plugins loaded`);
         return {

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -21,7 +21,7 @@ import { getActiveSessionCount } from "../storage/sessions.js";
 import { log, logError, logDebug } from "../util/log.js";
 import { handleSharedAction } from "./gateway-actions.js";
 import { handlePluginAction } from "./plugin.js";
-import type { FrontendActionHandler } from "./types.js";
+import type { FrontendActionHandler, QueryBackend } from "./types.js";
 
 // ── Per-chat context state ───────────────────────────────────────────────────
 
@@ -79,6 +79,9 @@ export class Gateway {
   private frontendHandler: FrontendActionHandler | null = null;
   private server: ReturnType<typeof createServer> | null = null;
   private port = 0;
+
+  /** The active backend — set by bootstrap after initialization. */
+  backend: QueryBackend | null = null;
 
   // ── Frontend handler registration ────────────────────────────────────────
 
@@ -195,7 +198,7 @@ export class Gateway {
       }
 
       // Shared actions last — provides in-memory fallbacks for history, cron, etc.
-      const shared = await handleSharedAction(body, chatId);
+      const shared = await handleSharedAction(body, chatId, this.backend);
       if (shared) {
         logDebug(
           "gateway",

--- a/src/core/heartbeat.ts
+++ b/src/core/heartbeat.ts
@@ -19,6 +19,7 @@ import { log, logError, logWarn } from "../util/log.js";
 import { toYMD } from "../util/time.js";
 import { getPluginMcpServers } from "./plugin.js";
 import { DISALLOWED_TOOLS_BACKGROUND } from "../backend/claude-sdk/constants.js";
+import { getDefaultModel } from "./models.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -264,7 +265,7 @@ async function runHeartbeatAgent(
   }
 
   const model =
-    configRef.heartbeatModel ?? configRef.model ?? "claude-sonnet-4-6";
+    configRef.heartbeatModel ?? configRef.model ?? getDefaultModel("balanced");
 
   // Set up heartbeat log file
   const heartbeatLogFile = await createHeartbeatLogFile();

--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -53,6 +53,14 @@ const aliasIndex = new Map<string, string>();
 /** Register one or more models. Idempotent — re-registration overwrites. */
 export function registerModels(infos: ModelInfo[]): void {
   for (const info of infos) {
+    // Clear stale aliases from any previous registration of this model ID
+    const prev = models.get(info.id);
+    if (prev) {
+      aliasIndex.delete(prev.id.toLowerCase());
+      for (const alias of prev.aliases) {
+        aliasIndex.delete(alias.toLowerCase());
+      }
+    }
     models.set(info.id, info);
     // Index the canonical ID itself as an alias
     aliasIndex.set(info.id.toLowerCase(), info.id);

--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -1,0 +1,129 @@
+/**
+ * Model registry — single source of truth for available models.
+ *
+ * Backends register their models during initialization. Frontends read
+ * from the registry to build dynamic model pickers, resolve aliases,
+ * and query capabilities. No model names are hardcoded outside this
+ * system and the backend-specific model definition files.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type ModelTier = "premium" | "balanced" | "economy";
+
+export type ModelCapabilities = {
+  /** Whether the model supports the 1M token context window. */
+  supports1mContext: boolean;
+};
+
+export type ModelInfo = {
+  /** Canonical model ID (e.g. "claude-sonnet-4-6"). */
+  id: string;
+  /** Human-readable display name for UIs (e.g. "Sonnet 4.6"). */
+  displayName: string;
+  /** Short description for setup wizard (e.g. "fast, balanced"). */
+  description?: string;
+  /** Aliases that resolve to this model (e.g. ["sonnet", "sonnet-4.6"]). */
+  aliases: string[];
+  /** Provider identifier (e.g. "anthropic", "openai"). */
+  provider: string;
+  /** Model capabilities used for backend configuration. */
+  capabilities: ModelCapabilities;
+  /** Tier for UI grouping and fallback ordering. */
+  tier: ModelTier;
+  /** Model to fall back to on overload/timeout. */
+  fallback?: string;
+};
+
+// ── Tier sort order ─────────────────────────────────────────────────────────
+
+const TIER_ORDER: Record<ModelTier, number> = {
+  premium: 0,
+  balanced: 1,
+  economy: 2,
+};
+
+// ── Registry state ──────────────────────────────────────────────────────────
+
+const models = new Map<string, ModelInfo>();
+const aliasIndex = new Map<string, string>();
+
+// ── Registration ────────────────────────────────────────────────────────────
+
+/** Register one or more models. Idempotent — re-registration overwrites. */
+export function registerModels(infos: ModelInfo[]): void {
+  for (const info of infos) {
+    models.set(info.id, info);
+    // Index the canonical ID itself as an alias
+    aliasIndex.set(info.id.toLowerCase(), info.id);
+    for (const alias of info.aliases) {
+      aliasIndex.set(alias.toLowerCase(), info.id);
+    }
+  }
+}
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+/** Get a model by canonical ID. */
+export function getModel(id: string): ModelInfo | undefined {
+  return models.get(id);
+}
+
+/** List all registered models, optionally filtered by provider. Sorted by tier. */
+export function getModels(provider?: string): ModelInfo[] {
+  let result = [...models.values()];
+  if (provider) {
+    result = result.filter((m) => m.provider === provider);
+  }
+  return result.sort((a, b) => TIER_ORDER[a.tier] - TIER_ORDER[b.tier]);
+}
+
+/**
+ * Resolve a user input (alias or full ID) to the canonical model ID.
+ * Returns the input unchanged if no match is found (passthrough for
+ * unknown/custom model names).
+ */
+export function resolveModelId(input: string): string {
+  const lower = input.trim().toLowerCase();
+  return aliasIndex.get(lower) ?? input.trim();
+}
+
+/**
+ * Resolve a user input to the full ModelInfo, or undefined if not found.
+ */
+export function resolveModel(input: string): ModelInfo | undefined {
+  const id = resolveModelId(input);
+  return models.get(id);
+}
+
+/** Get the fallback model ID for a given model, or null if none configured. */
+export function getFallbackModel(modelId: string): string | null {
+  return models.get(modelId)?.fallback ?? null;
+}
+
+/** Check whether a model supports the 1M token context window. */
+export function supports1mContext(modelId: string): boolean {
+  const info = models.get(modelId);
+  // Default to true for unknown models (don't restrict capabilities we can't check)
+  return info?.capabilities.supports1mContext ?? true;
+}
+
+/**
+ * Get the default model for a given tier. Returns the first registered model
+ * matching the tier, or the first model overall, or the hardcoded fallback.
+ */
+export function getDefaultModel(tier: ModelTier = "balanced"): string {
+  const byTier = [...models.values()].find((m) => m.tier === tier);
+  if (byTier) return byTier.id;
+  const first = models.values().next();
+  if (!first.done) return first.value.id;
+  return "claude-sonnet-4-6"; // ultimate fallback if registry is empty
+}
+
+// ── Test support ────────────────────────────────────────────────────────────
+
+/** Clear the registry. For tests only. */
+export function clearModels(): void {
+  models.clear();
+  aliasIndex.clear();
+}

--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -128,9 +128,21 @@ export function getDefaultModel(tier: ModelTier = "balanced"): string {
   return "claude-sonnet-4-6"; // ultimate fallback if registry is empty
 }
 
-// ── Test support ────────────────────────────────────────────────────────────
+// ── Provider-scoped clearing ────────────────────────────────────────────────
 
-/** Clear the registry. For tests only. */
+/** Remove all models for a specific provider (and their aliases). */
+export function clearModelsByProvider(provider: string): void {
+  for (const [id, info] of models) {
+    if (info.provider !== provider) continue;
+    aliasIndex.delete(id.toLowerCase());
+    for (const alias of info.aliases) {
+      aliasIndex.delete(alias.toLowerCase());
+    }
+    models.delete(id);
+  }
+}
+
+/** Clear the entire registry. For tests only. */
 export function clearModels(): void {
   models.clear();
   aliasIndex.clear();

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -33,6 +33,10 @@ export type QueryResult = {
 /** Backend interface — any AI provider implements this. */
 export interface QueryBackend {
   query(params: QueryParams): Promise<QueryResult>;
+  /** Pre-warm a session (cold-start optimization). Optional — not all backends support this. */
+  warmSession?(chatId: string): Promise<void>;
+  /** Update the system prompt on the live backend config. Optional — used by plugin hot-reload. */
+  updateSystemPrompt?(prompt: string): void;
 }
 
 // ── Execution context ───────────────────────────────────────────────────────

--- a/src/frontend/teams/index.ts
+++ b/src/frontend/teams/index.ts
@@ -217,9 +217,7 @@ export function createTeamsFrontend(
               resetSession(talonChatId);
               clearHistory(talonChatId);
               log("teams", `Session reset by ${msg.senderName}`);
-              const { warmSession } =
-                await import("../../backend/claude-sdk/index.js");
-              await warmSession(talonChatId);
+              await gateway.backend?.warmSession?.(talonChatId);
               const card = buildAdaptiveCard("Session cleared.");
               await proxyFetch(webhookUrl, {
                 method: "POST",

--- a/src/frontend/telegram/callbacks.ts
+++ b/src/frontend/telegram/callbacks.ts
@@ -22,6 +22,7 @@ import {
 import { handleCallbackQuery } from "./handlers.js";
 import { escapeHtml } from "./formatting.js";
 import { renderSettingsText, renderSettingsKeyboard } from "./helpers.js";
+import { getModels } from "../../core/models.js";
 
 export function registerCallbacks(bot: Bot, config: TalonConfig): void {
   // ── Callback query handler ──────────────────────────────────────────────────
@@ -214,36 +215,23 @@ export function registerCallbacks(bot: Bot, config: TalonConfig): void {
         });
       }
       const current = getChatSettings(cid).model ?? config.model;
-      const isModel = (id: string) => current.includes(id);
+      // Build model buttons dynamically from the registry
+      const models = getModels();
+      const modelButtons = models.map((m) => ({
+        text: current.includes(m.id)
+          ? `\u2713 ${m.displayName}`
+          : m.displayName,
+        callback_data: `model:${m.aliases[0] ?? m.id}`,
+      }));
+      const rows: Array<Array<{ text: string; callback_data: string }>> = [];
+      for (let i = 0; i < modelButtons.length; i += 2) {
+        rows.push(modelButtons.slice(i, i + 2));
+      }
+      rows.push([{ text: "Reset to default", callback_data: "model:reset" }]);
       try {
         await ctx.editMessageText(
           `<b>Model:</b> <code>${escapeHtml(current)}</code>`,
-          {
-            parse_mode: "HTML",
-            reply_markup: {
-              inline_keyboard: [
-                [
-                  {
-                    text: isModel("sonnet")
-                      ? "\u2713 Sonnet 4.6"
-                      : "Sonnet 4.6",
-                    callback_data: "model:sonnet",
-                  },
-                  {
-                    text: isModel("opus") ? "\u2713 Opus 4.6" : "Opus 4.6",
-                    callback_data: "model:opus",
-                  },
-                ],
-                [
-                  {
-                    text: isModel("haiku") ? "\u2713 Haiku 4.5" : "Haiku 4.5",
-                    callback_data: "model:haiku",
-                  },
-                  { text: "Reset to default", callback_data: "model:reset" },
-                ],
-              ],
-            },
-          },
+          { parse_mode: "HTML", reply_markup: { inline_keyboard: rows } },
         );
       } catch {
         /* message unchanged */

--- a/src/frontend/telegram/commands.ts
+++ b/src/frontend/telegram/commands.ts
@@ -38,7 +38,7 @@ import { appendDailyLog } from "../../storage/daily-log.js";
 import { escapeHtml } from "./formatting.js";
 import { handleAdminCommand } from "./admin.js";
 import { getLoadedPlugins } from "../../core/plugin.js";
-import { warmSession } from "../../backend/claude-sdk/index.js";
+import { getModels } from "../../core/models.js";
 import {
   formatDuration,
   formatTokenCount,
@@ -56,7 +56,11 @@ export function setAdminUserId(id: number | undefined): void {
   ADMIN_USER_ID = id ?? 0;
 }
 
-export function registerCommands(bot: Bot, config: TalonConfig): void {
+export function registerCommands(
+  bot: Bot,
+  config: TalonConfig,
+  gateway?: { backend: import("../../core/types.js").QueryBackend | null },
+): void {
   bot.command("start", (ctx) =>
     ctx.reply(
       [
@@ -142,7 +146,7 @@ export function registerCommands(bot: Bot, config: TalonConfig): void {
     clearHistory(cid);
     resetPulseCheckpoint(cid);
     // Warm up the new session so /status has context data immediately
-    await warmSession(cid);
+    await gateway?.backend?.warmSession?.(cid);
     await ctx.reply("Session cleared.");
   });
 
@@ -179,33 +183,24 @@ export function registerCommands(bot: Bot, config: TalonConfig): void {
 
     if (!arg) {
       const current = settings.model ?? config.model;
-      const isModel = (id: string) => current.includes(id);
+      // Build model buttons dynamically from the registry
+      const models = getModels();
+      const modelButtons = models.map((m) => ({
+        text: current.includes(m.id)
+          ? `\u2713 ${m.displayName}`
+          : m.displayName,
+        callback_data: `model:${m.aliases[0] ?? m.id}`,
+      }));
+      // Two models per row, plus a reset button on the last row
+      const rows: Array<Array<{ text: string; callback_data: string }>> = [];
+      for (let i = 0; i < modelButtons.length; i += 2) {
+        rows.push(modelButtons.slice(i, i + 2));
+      }
+      rows.push([{ text: "Reset to default", callback_data: "model:reset" }]);
+
       await ctx.reply(
         `<b>Model:</b> <code>${escapeHtml(current)}</code>\nSelect a model:`,
-        {
-          parse_mode: "HTML",
-          reply_markup: {
-            inline_keyboard: [
-              [
-                {
-                  text: isModel("sonnet") ? "\u2713 Sonnet 4.6" : "Sonnet 4.6",
-                  callback_data: "model:sonnet",
-                },
-                {
-                  text: isModel("opus") ? "\u2713 Opus 4.6" : "Opus 4.6",
-                  callback_data: "model:opus",
-                },
-              ],
-              [
-                {
-                  text: isModel("haiku") ? "\u2713 Haiku 4.5" : "Haiku 4.5",
-                  callback_data: "model:haiku",
-                },
-                { text: "Reset to default", callback_data: "model:reset" },
-              ],
-            ],
-          },
-        },
+        { parse_mode: "HTML", reply_markup: { inline_keyboard: rows } },
       );
       return;
     }

--- a/src/frontend/telegram/helpers.ts
+++ b/src/frontend/telegram/helpers.ts
@@ -3,6 +3,7 @@
  */
 
 import { escapeHtml } from "./formatting.js";
+import { getModels } from "../../core/models.js";
 const DEFAULT_PULSE_INTERVAL_MS = 5 * 60 * 1000;
 
 /** Parse a duration string like "30m", "2h", "1h30m" into milliseconds. */
@@ -60,22 +61,15 @@ export function renderSettingsKeyboard(
   effort: string,
   proactive: boolean,
 ): Array<Array<{ text: string; callback_data: string }>> {
-  const isModel = (id: string) => model.includes(id);
+  // Build model row dynamically from the registry
+  const modelRow = getModels().map((m) => ({
+    text: model.includes(m.id)
+      ? `\u2713 ${m.displayName.split(" ")[0]}`
+      : m.displayName.split(" ")[0],
+    callback_data: `settings:model:${m.aliases[0] ?? m.id}`,
+  }));
   return [
-    [
-      {
-        text: isModel("sonnet") ? "\u2713 Sonnet" : "Sonnet",
-        callback_data: "settings:model:sonnet",
-      },
-      {
-        text: isModel("opus") ? "\u2713 Opus" : "Opus",
-        callback_data: "settings:model:opus",
-      },
-      {
-        text: isModel("haiku") ? "\u2713 Haiku" : "Haiku",
-        callback_data: "settings:model:haiku",
-      },
-    ],
+    modelRow,
     [
       {
         text: effort === "low" ? "\u2713 Low" : "Low",

--- a/src/frontend/telegram/helpers.ts
+++ b/src/frontend/telegram/helpers.ts
@@ -61,15 +61,19 @@ export function renderSettingsKeyboard(
   effort: string,
   proactive: boolean,
 ): Array<Array<{ text: string; callback_data: string }>> {
-  // Build model row dynamically from the registry
-  const modelRow = getModels().map((m) => ({
+  // Build model buttons dynamically from the registry, chunked into rows of 3
+  const modelButtons = getModels().map((m) => ({
     text: model.includes(m.id)
       ? `\u2713 ${m.displayName.split(" ")[0]}`
       : m.displayName.split(" ")[0],
     callback_data: `settings:model:${m.aliases[0] ?? m.id}`,
   }));
+  const modelRows: Array<Array<{ text: string; callback_data: string }>> = [];
+  for (let i = 0; i < modelButtons.length; i += 3) {
+    modelRows.push(modelButtons.slice(i, i + 3));
+  }
   return [
-    modelRow,
+    ...modelRows,
     [
       {
         text: effort === "low" ? "\u2713 Low" : "Low",

--- a/src/frontend/telegram/index.ts
+++ b/src/frontend/telegram/index.ts
@@ -75,7 +75,7 @@ export function createTelegramFrontend(
         adminUserId: config.adminUserId,
       });
 
-      registerCommands(bot, config);
+      registerCommands(bot, config, gateway);
       registerMiddleware(bot, config);
       registerCallbacks(bot, config);
 

--- a/src/frontend/terminal/commands.ts
+++ b/src/frontend/terminal/commands.ts
@@ -90,14 +90,17 @@ export function registerBuiltinCommands(): void {
   registerCommand({
     name: "model",
     argHint: "[name]",
-    description: "Switch model (opus, sonnet, haiku)",
+    description: "Switch model",
     async handler(args, ctx) {
       const { getChatSettings, setChatModel, resolveModelName } =
         await import("../../storage/chat-settings.js");
       if (!args) {
-        ctx.renderer.writeSystem(
-          `Model: ${getChatSettings(ctx.chatId()).model ?? ctx.config.model}`,
-        );
+        const { getModels } = await import("../../core/models.js");
+        const current = getChatSettings(ctx.chatId()).model ?? ctx.config.model;
+        const names = getModels()
+          .map((m) => m.aliases[0] ?? m.id)
+          .join(", ");
+        ctx.renderer.writeSystem(`Model: ${current} (available: ${names})`);
       } else {
         setChatModel(ctx.chatId(), resolveModelName(args));
         ctx.renderer.writeSystem(`Model → ${resolveModelName(args)}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,8 @@ if (selectedFrontend === "terminal") {
 
 // ── Create backend + wire dispatcher ─────────────────────────────────────────
 
-await initBackendAndDispatcher(config, frontend);
+const { backend } = await initBackendAndDispatcher(config, frontend);
+gateway.backend = backend;
 
 // ── Graceful shutdown ────────────────────────────────────────────────────────
 

--- a/src/storage/chat-settings.ts
+++ b/src/storage/chat-settings.ts
@@ -220,22 +220,8 @@ export const EFFORT_LEVELS: EffortLevel[] = [
   "max",
 ];
 
-/** Known model aliases. */
-export const MODEL_ALIASES: Record<string, string> = {
-  sonnet: "claude-sonnet-4-6",
-  opus: "claude-opus-4-6",
-  haiku: "claude-haiku-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "opus-4.6": "claude-opus-4-6",
-  "haiku-4.5": "claude-haiku-4-5",
-  "sonnet-4-6": "claude-sonnet-4-6",
-  "opus-4-6": "claude-opus-4-6",
-  "haiku-4-5": "claude-haiku-4-5",
-};
-
-export function resolveModelName(input: string): string {
-  const lower = input.trim().toLowerCase();
-  return Object.hasOwn(MODEL_ALIASES, lower)
-    ? MODEL_ALIASES[lower]
-    : input.trim();
-}
+/**
+ * Resolve a user-provided model name (alias or full ID) to the canonical model ID.
+ * Delegates to the model registry; falls through unknown names unchanged.
+ */
+export { resolveModelId as resolveModelName } from "../core/models.js";


### PR DESCRIPTION
## Summary
- **Model registry** (`src/core/models.ts`) — backends register models with metadata (display names, aliases, capabilities, tiers, fallback chains). Single source of truth replacing 11+ hardcoded locations.
- **Extended `QueryBackend` interface** — adds optional `warmSession()` and `updateSystemPrompt()` methods, eliminating direct imports of backend-specific modules from frontends and core
- **Dynamic model pickers** — Telegram `/model`, `/settings`, Terminal `/model`, and CLI setup wizard all build UI from the registry instead of hardcoding 3 buttons
- **Registry-driven fallback** — `opus->sonnet->haiku` chain reads from model metadata via `getFallbackModel()` instead of string matching
- **Registry-driven capabilities** — 1M context check uses `supports1mContext()` instead of `!model.includes("haiku")`

### New files
- `src/core/models.ts` — registry types and API (`registerModels`, `getModels`, `resolveModelId`, `getFallbackModel`, `supports1mContext`, `getDefaultModel`)
- `src/backend/claude-sdk/models.ts` — Anthropic model definitions with full metadata

### Architecture changes
- `gateway-actions.ts` uses `backend.updateSystemPrompt?.()` via interface instead of `import("../backend/claude-sdk/index.js")`
- `telegram/commands.ts` and `teams/index.ts` use `backend.warmSession?.()` instead of direct claude-sdk import
- `chat-settings.ts` delegates `resolveModelName()` to registry's `resolveModelId()`
- `dream.ts` and `heartbeat.ts` use `getDefaultModel("balanced")` instead of hardcoded `"claude-sonnet-4-6"`

## Test plan
- [x] `npx tsc --noEmit` — typecheck passes clean
- [x] `npx vitest run` — all 1322 tests pass (1 pre-existing Windows symlink failure)
- [x] `npx prettier --check` — formatted
- [x] Updated tests: `chat-settings.test.ts` (alias tests use registry), `fuzz.test.ts` (register models), `reload-plugins.test.ts` (pass mock backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)