### PR TITLE
refactor: remove backend-specific references from frontend and core

### DIFF
--- a/src/__tests__/chat-settings.test.ts
+++ b/src/__tests__/chat-settings.test.ts
@@ -38,9 +38,13 @@ const { registerClaudeModelsStatic, CLAUDE_MODELS_STATIC } =
   await import("../backend/claude-sdk/models.js");
 registerClaudeModelsStatic(CLAUDE_MODELS_STATIC);
 
+// convertSdkModels collapses base + 1M variants into a single canonical ID
+// per family+version, preferring the 1M variant (and "default" when the SDK
+// marks one canonical). So sonnet/sonnet[1m] → "default", opus/opus[1m] →
+// "opus[1m]", and plain "haiku" stays.
 const SDK_MODEL_IDS = {
   sonnet: "default",
-  opus: "opus",
+  opus: "opus[1m]",
   haiku: "haiku",
 } as const;
 

--- a/src/__tests__/claude-sdk-models.test.ts
+++ b/src/__tests__/claude-sdk-models.test.ts
@@ -58,7 +58,7 @@ describe("registerClaudeModels", () => {
     clearModels();
   });
 
-  it("keeps SDK IDs/display names and collapses duplicates", async () => {
+  it("derives clean display names (Sonnet 4.6) and collapses duplicates", async () => {
     const { registerClaudeModels } =
       await import("../backend/claude-sdk/models.js");
     const { getModels, resolveModelId } = await import("../core/models.js");
@@ -76,10 +76,16 @@ describe("registerClaudeModels", () => {
 
     expect(
       anthropicModels.find((model) => model.id === "default")?.displayName,
-    ).toBe("Default (recommended)");
+    ).toBe("Sonnet 4.6");
     expect(
       anthropicModels.find((model) => model.id === "sonnet[1m]")?.displayName,
-    ).toBe("Sonnet (1M context)");
+    ).toBe("Sonnet 4.6 [1M]");
+    expect(
+      anthropicModels.find((model) => model.id === "opus[1m]")?.displayName,
+    ).toBe("Opus 4.6 [1M]");
+    expect(
+      anthropicModels.find((model) => model.id === "haiku")?.displayName,
+    ).toBe("Haiku 4.5");
     // claude-sonnet-4-6 collapsed into "default" as alias
     expect(
       anthropicModels.some((model) => model.id === "claude-sonnet-4-6"),

--- a/src/__tests__/claude-sdk-models.test.ts
+++ b/src/__tests__/claude-sdk-models.test.ts
@@ -58,18 +58,20 @@ describe("registerClaudeModels", () => {
     clearModels();
   });
 
-  it("derives clean display names (Sonnet 4.6) and collapses duplicates", async () => {
+  it("collapses family+version duplicates (base + 1M + claude-*) into a single canonical entry", async () => {
     const { registerClaudeModels } =
       await import("../backend/claude-sdk/models.js");
     const { getModels, resolveModelId } = await import("../core/models.js");
 
     await registerClaudeModels({ model: "default" });
 
+    // sonnet, sonnet[1m], claude-sonnet-4-6 all share family+version and
+    // collapse into "default" (the SDK's recommended canonical). opus/opus[1m]
+    // collapse into opus[1m] (1M-preferred since no "default" exists for that
+    // family). haiku stands alone.
     const anthropicModels = getModels("anthropic");
     expect(anthropicModels.map((model) => model.id)).toEqual([
       "default",
-      "sonnet[1m]",
-      "opus",
       "opus[1m]",
       "haiku",
     ]);
@@ -78,22 +80,18 @@ describe("registerClaudeModels", () => {
       anthropicModels.find((model) => model.id === "default")?.displayName,
     ).toBe("Sonnet 4.6");
     expect(
-      anthropicModels.find((model) => model.id === "sonnet[1m]")?.displayName,
-    ).toBe("Sonnet 4.6 [1M]");
-    expect(
       anthropicModels.find((model) => model.id === "opus[1m]")?.displayName,
-    ).toBe("Opus 4.6 [1M]");
+    ).toBe("Opus 4.6");
     expect(
       anthropicModels.find((model) => model.id === "haiku")?.displayName,
     ).toBe("Haiku 4.5");
-    // claude-sonnet-4-6 collapsed into "default" as alias
-    expect(
-      anthropicModels.some((model) => model.id === "claude-sonnet-4-6"),
-    ).toBe(false);
 
+    expect(resolveModelId("sonnet")).toBe("default");
+    expect(resolveModelId("sonnet[1m]")).toBe("default");
     expect(resolveModelId("claude-sonnet-4-6")).toBe("default");
-    expect(resolveModelId("claude-sonnet-4-6[1m]")).toBe("sonnet[1m]");
-    expect(resolveModelId("claude-opus-4-6")).toBe("opus");
+    expect(resolveModelId("claude-sonnet-4-6[1m]")).toBe("default");
+    expect(resolveModelId("opus")).toBe("opus[1m]");
+    expect(resolveModelId("claude-opus-4-6")).toBe("opus[1m]");
   });
 
   it("derives compatibility aliases from SDK metadata instead of hardcoded versions", async () => {
@@ -140,8 +138,8 @@ describe("registerClaudeModels", () => {
 
     expect(resolveModelId("claude-sonnet-5-0")).toBe("default");
     expect(resolveModelId("claude-sonnet-4-6")).toBe("default");
-    expect(resolveModelId("claude-opus-5-0")).toBe("opus");
-    expect(resolveModelId("claude-opus-4-6")).toBe("opus");
+    expect(resolveModelId("claude-opus-5-0")).toBe("opus[1m]");
+    expect(resolveModelId("claude-opus-4-6")).toBe("opus[1m]");
     expect(resolveModelId("claude-haiku-5-0")).toBe("haiku");
     expect(resolveModelId("claude-haiku-4-5")).toBe("haiku");
   });

--- a/src/__tests__/fuzz.test.ts
+++ b/src/__tests__/fuzz.test.ts
@@ -327,13 +327,13 @@ describe("fuzz: resolveModelName()", () => {
   it("known aliases resolve to the expected SDK model IDs", () => {
     const aliasMappings = [
       ["sonnet", "default"],
-      ["opus", "opus"],
+      ["opus", "opus[1m]"],
       ["haiku", "haiku"],
       ["sonnet-4.6", "default"],
-      ["opus-4.6", "opus"],
+      ["opus-4.6", "opus[1m]"],
       ["haiku-4.5", "haiku"],
       ["sonnet-4-6", "default"],
-      ["opus-4-6", "opus"],
+      ["opus-4-6", "opus[1m]"],
       ["haiku-4-5", "haiku"],
     ] as const;
     fc.assert(

--- a/src/__tests__/telegram-helpers.test.ts
+++ b/src/__tests__/telegram-helpers.test.ts
@@ -17,7 +17,7 @@ describe("telegram helpers", () => {
     registerModels([
       {
         id: "default",
-        displayName: "Default (recommended)",
+        displayName: "Sonnet 4.6",
         description: "Sonnet 4.6 · Best for everyday tasks",
         aliases: ["sonnet", "claude-sonnet-4-6"],
         provider: "anthropic",
@@ -25,7 +25,7 @@ describe("telegram helpers", () => {
       },
       {
         id: "sonnet[1m]",
-        displayName: "Sonnet (1M context)",
+        displayName: "Sonnet 4.6 [1M]",
         description:
           "Sonnet 4.6 with 1M context · Billed as extra usage · $3/$15 per Mtok",
         aliases: ["claude-sonnet-4-6[1m]"],
@@ -34,7 +34,7 @@ describe("telegram helpers", () => {
       },
       {
         id: "opus",
-        displayName: "Opus",
+        displayName: "Opus 4.6",
         description: "Opus 4.6 · Most capable for complex work",
         aliases: ["claude-opus-4-6"],
         provider: "anthropic",
@@ -42,7 +42,7 @@ describe("telegram helpers", () => {
       },
       {
         id: "opus[1m]",
-        displayName: "Opus (1M context)",
+        displayName: "Opus 4.6 [1M]",
         description:
           "Opus 4.6 with 1M context · Billed as extra usage · $5/$25 per Mtok",
         aliases: ["claude-opus-4-6[1m]"],
@@ -51,7 +51,7 @@ describe("telegram helpers", () => {
       },
       {
         id: "haiku",
-        displayName: "Haiku",
+        displayName: "Haiku 4.5",
         description: "Haiku 4.5 · Fastest for quick answers",
         aliases: ["claude-haiku-4-5"],
         provider: "anthropic",
@@ -65,14 +65,14 @@ describe("telegram helpers", () => {
   });
 
   it("formats labels using backend-registered displayName", () => {
-    expect(formatModelLabel("default")).toBe("Default (recommended)");
-    expect(formatModelLabel("claude-sonnet-4-6")).toBe("Default (recommended)");
-    expect(formatModelLabel("sonnet[1m]")).toBe("Sonnet (1M context)");
+    expect(formatModelLabel("default")).toBe("Sonnet 4.6");
+    expect(formatModelLabel("claude-sonnet-4-6")).toBe("Sonnet 4.6");
+    expect(formatModelLabel("sonnet[1m]")).toBe("Sonnet 4.6 [1M]");
     expect(formatModelOptionLabel(getTelegramModelOptions()[0]!)).toBe(
-      "Default (recommended)",
+      "Sonnet 4.6",
     );
     expect(formatCompactModelLabel(getTelegramModelOptions()[1]!)).toBe(
-      "Sonnet (1M context)",
+      "Sonnet 4.6 [1M]",
     );
   });
 
@@ -95,7 +95,7 @@ describe("telegram helpers", () => {
       .flat()
       .map((button) => button.text);
 
-    expect(buttons).toContain("\u2713 Default (recommended)");
+    expect(buttons).toContain("\u2713 Sonnet 4.6");
   });
 });
 

--- a/src/__tests__/telegram-helpers.test.ts
+++ b/src/__tests__/telegram-helpers.test.ts
@@ -14,38 +14,28 @@ import {
 describe("telegram helpers", () => {
   beforeEach(() => {
     clearModels();
+    // Post-merge state: convertSdkModels collapses base/1M/claude-* variants
+    // of the same family+version into a single canonical entry. This fixture
+    // is what the registry looks like after that merge.
     registerModels([
       {
         id: "default",
         displayName: "Sonnet 4.6",
         description: "Sonnet 4.6 · Best for everyday tasks",
-        aliases: ["sonnet", "claude-sonnet-4-6"],
+        aliases: [
+          "sonnet",
+          "sonnet[1m]",
+          "claude-sonnet-4-6",
+          "claude-sonnet-4-6[1m]",
+        ],
         provider: "anthropic",
         fallback: "haiku",
-      },
-      {
-        id: "sonnet[1m]",
-        displayName: "Sonnet 4.6 [1M]",
-        description:
-          "Sonnet 4.6 with 1M context · Billed as extra usage · $3/$15 per Mtok",
-        aliases: ["claude-sonnet-4-6[1m]"],
-        provider: "anthropic",
-        fallback: "haiku",
-      },
-      {
-        id: "opus",
-        displayName: "Opus 4.6",
-        description: "Opus 4.6 · Most capable for complex work",
-        aliases: ["claude-opus-4-6"],
-        provider: "anthropic",
-        fallback: "default",
       },
       {
         id: "opus[1m]",
-        displayName: "Opus 4.6 [1M]",
-        description:
-          "Opus 4.6 with 1M context · Billed as extra usage · $5/$25 per Mtok",
-        aliases: ["claude-opus-4-6[1m]"],
+        displayName: "Opus 4.6",
+        description: "Opus 4.6 with 1M context · Large context window",
+        aliases: ["opus", "claude-opus-4-6", "claude-opus-4-6[1m]"],
         provider: "anthropic",
         fallback: "default",
       },
@@ -59,28 +49,32 @@ describe("telegram helpers", () => {
     ]);
   });
 
-  it("matches legacy aliases to the canonical selected model", () => {
+  it("matches legacy aliases and 1M variants to the canonical selected model", () => {
     expect(isSelectedModel("claude-sonnet-4-6", "default")).toBe(true);
+    // sonnet[1m] is merged into "default" — same canonical model.
+    expect(isSelectedModel("sonnet[1m]", "default")).toBe(true);
+    expect(isSelectedModel("claude-sonnet-4-6[1m]", "default")).toBe(true);
     expect(isSelectedModel("claude-sonnet-4-6", "haiku")).toBe(false);
   });
 
   it("formats labels using backend-registered displayName", () => {
     expect(formatModelLabel("default")).toBe("Sonnet 4.6");
     expect(formatModelLabel("claude-sonnet-4-6")).toBe("Sonnet 4.6");
-    expect(formatModelLabel("sonnet[1m]")).toBe("Sonnet 4.6 [1M]");
+    // 1M variants collapse into the same entry — same clean label.
+    expect(formatModelLabel("sonnet[1m]")).toBe("Sonnet 4.6");
+    expect(formatModelLabel("opus[1m]")).toBe("Opus 4.6");
+    expect(formatModelLabel("claude-opus-4-6")).toBe("Opus 4.6");
     expect(formatModelOptionLabel(getTelegramModelOptions()[0]!)).toBe(
       "Sonnet 4.6",
     );
     expect(formatCompactModelLabel(getTelegramModelOptions()[1]!)).toBe(
-      "Sonnet 4.6 [1M]",
+      "Opus 4.6",
     );
   });
 
-  it("shows one option per unique displayName", () => {
+  it("shows one option per family+version (base/1M variants merged)", () => {
     expect(getTelegramModelOptions().map((model) => model.id)).toEqual([
       "default",
-      "sonnet[1m]",
-      "opus",
       "opus[1m]",
       "haiku",
     ]);

--- a/src/__tests__/telegram-helpers.test.ts
+++ b/src/__tests__/telegram-helpers.test.ts
@@ -61,26 +61,27 @@ describe("telegram helpers", () => {
 
   it("matches legacy aliases to the canonical selected model", () => {
     expect(isSelectedModel("claude-sonnet-4-6", "default")).toBe(true);
-    expect(isSelectedModel("sonnet[1m]", "default")).toBe(true);
     expect(isSelectedModel("claude-sonnet-4-6", "haiku")).toBe(false);
   });
 
-  it("formats clean model labels for telegram users", () => {
-    expect(formatModelLabel("default")).toBe("Sonnet 4.6");
-    expect(formatModelLabel("claude-sonnet-4-6")).toBe("Sonnet 4.6");
-    expect(formatModelLabel("sonnet[1m]")).toBe("Sonnet 4.6");
+  it("formats labels using backend-registered displayName", () => {
+    expect(formatModelLabel("default")).toBe("Default (recommended)");
+    expect(formatModelLabel("claude-sonnet-4-6")).toBe("Default (recommended)");
+    expect(formatModelLabel("sonnet[1m]")).toBe("Sonnet (1M context)");
     expect(formatModelOptionLabel(getTelegramModelOptions()[0]!)).toBe(
-      "Sonnet 4.6",
+      "Default (recommended)",
     );
     expect(formatCompactModelLabel(getTelegramModelOptions()[1]!)).toBe(
-      "Opus 4.6",
+      "Sonnet (1M context)",
     );
   });
 
-  it("shows a single clean option per model family", () => {
+  it("shows one option per unique displayName", () => {
     expect(getTelegramModelOptions().map((model) => model.id)).toEqual([
       "default",
+      "sonnet[1m]",
       "opus",
+      "opus[1m]",
       "haiku",
     ]);
   });
@@ -94,7 +95,7 @@ describe("telegram helpers", () => {
       .flat()
       .map((button) => button.text);
 
-    expect(buttons).toContain("\u2713 Sonnet 4.6");
+    expect(buttons).toContain("\u2713 Default (recommended)");
   });
 });
 

--- a/src/__tests__/terminal-commands.test.ts
+++ b/src/__tests__/terminal-commands.test.ts
@@ -90,48 +90,6 @@ vi.mock("../core/plugin.js", () => ({
   getLoadedPlugins: () => mockGetLoadedPlugins(),
 }));
 
-const mockGetOpenCodeModelCatalog = vi.fn(async () => ({
-  generatedAt: Date.now(),
-  providers: [],
-  models: [],
-  connectedProviders: [],
-  loginProviders: [],
-  connectedModels: [],
-  connectedFreeModels: [],
-}));
-const mockGetOpenCodeModelInfo = vi.fn<
-  (modelId: string) => Promise<Record<string, unknown> | undefined>
->(async (_modelId: string) => undefined);
-const mockGetOpenCodeQuickPickModels = vi.fn<
-  (catalog: unknown, currentModelId?: string) => Array<unknown>
->(() => []);
-const mockResolveOpenCodeModelInput = vi.fn<
-  (query: string, catalog: unknown) => Record<string, unknown>
->((_query: string) => ({
-  kind: "missing",
-  matches: [],
-}));
-const mockGetOpenCodeSessionSnapshot = vi.fn<
-  (sessionId: string) => Promise<Record<string, unknown> | undefined>
->(async (_sessionId: string) => undefined);
-const mockGetOpenCodeModelSelectionValue = vi.fn<
-  (model: Record<string, unknown>, catalog: unknown) => string
->((model: Record<string, unknown>) => String(model.id ?? ""));
-vi.mock("../backend/opencode/index.js", () => ({
-  getOpenCodeModelCatalog: () => mockGetOpenCodeModelCatalog(),
-  getOpenCodeModelInfo: (modelId: string) => mockGetOpenCodeModelInfo(modelId),
-  getOpenCodeModelSelectionValue: (
-    model: Record<string, unknown>,
-    catalog: unknown,
-  ) => mockGetOpenCodeModelSelectionValue(model, catalog),
-  getOpenCodeQuickPickModels: (catalog: unknown, currentModelId?: string) =>
-    mockGetOpenCodeQuickPickModels(catalog, currentModelId),
-  resolveOpenCodeModelInput: (query: string, catalog: unknown) =>
-    mockResolveOpenCodeModelInput(query, catalog),
-  getOpenCodeSessionSnapshot: (sessionId: string) =>
-    mockGetOpenCodeSessionSnapshot(sessionId),
-}));
-
 import {
   registerCommand,
   tryRunCommand,
@@ -257,9 +215,6 @@ describe("built-in commands", () => {
     clearCommands();
     registerBuiltinCommands();
     vi.clearAllMocks();
-    mockGetOpenCodeModelSelectionValue.mockImplementation(
-      (model: Record<string, unknown>) => String(model.id ?? ""),
-    );
   });
 
   it("registers all expected commands", () => {

--- a/src/__tests__/terminal-commands.test.ts
+++ b/src/__tests__/terminal-commands.test.ts
@@ -328,35 +328,25 @@ describe("built-in commands", () => {
       );
     });
 
-    it("stores provider-qualified OpenCode model selections when needed", async () => {
-      mockGetOpenCodeModelCatalog.mockResolvedValueOnce({
-        generatedAt: Date.now(),
-        providers: [],
-        models: [],
-        connectedProviders: [],
-        loginProviders: [],
-        connectedModels: [],
-        connectedFreeModels: [],
-      });
-      mockResolveOpenCodeModelInput.mockReturnValueOnce({
-        kind: "exact",
-        model: {
-          id: "gpt-5",
-          providerID: "github-copilot",
-          providerName: "GitHub Copilot",
-          free: false,
-          selectable: true,
-          loginRequired: false,
-          envRequired: false,
-          authMethods: [],
-        },
-      });
-      mockGetOpenCodeModelSelectionValue.mockReturnValueOnce(
-        "github-copilot/gpt-5",
-      );
-
+    it("stores provider-qualified model selections via backend.resolveModel", async () => {
       const ctx = makeMockContext({
-        config: { model: "nemotron-3-super-free", backend: "opencode" } as any,
+        config: { model: "nemotron-3-super-free" } as any,
+        backend: {
+          query: vi.fn() as any,
+          resolveModel: vi.fn().mockResolvedValue({
+            kind: "exact",
+            model: {
+              id: "gpt-5",
+              displayName: "GPT-5",
+              provider: "github-copilot",
+              providerName: "GitHub Copilot",
+              free: false,
+              selectable: true,
+            },
+            storedValue: "github-copilot/gpt-5",
+          }),
+          formatModelError: vi.fn(),
+        },
       });
 
       await tryRunCommand("/model github-copilot/gpt-5", ctx);
@@ -366,7 +356,7 @@ describe("built-in commands", () => {
         "github-copilot/gpt-5",
       );
       expect(ctx.renderer.writeSystem).toHaveBeenCalledWith(
-        expect.stringContaining("github-copilot/gpt-5"),
+        expect.stringContaining("GPT-5"),
       );
     });
   });
@@ -593,7 +583,7 @@ describe("/status command", () => {
     expect(calls.join(" ")).toContain("actions only");
   });
 
-  it("/status uses live OpenCode usage totals when backend is opencode", async () => {
+  it("/status uses live backend usage totals via getSessionSnapshot", async () => {
     mockGetSessionInfo.mockReturnValueOnce({
       turns: 14,
       sessionId: "ses_live",
@@ -612,58 +602,31 @@ describe("/status command", () => {
       },
     });
     mockGetChatSettings.mockReturnValueOnce({ model: "big-pickle" });
-    mockGetOpenCodeModelInfo.mockResolvedValueOnce({
-      id: "big-pickle",
-      name: "Big Pickle",
-      providerID: "opencode",
-      providerName: "OpenCode Zen",
-      providerSource: "builtin",
-      connected: true,
-      selectable: true,
-      loginRequired: false,
-      envRequired: false,
-      authMethods: [],
-      free: true,
-      status: "active",
-      contextWindow: 204800,
-      outputWindow: 128000,
-      reasoning: true,
-      attachment: false,
-      toolcall: true,
-      costInput: 0,
-      costOutput: 0,
-      costCacheRead: 0,
-      costCacheWrite: 0,
-    });
-    mockGetOpenCodeSessionSnapshot.mockResolvedValueOnce({
-      sessionId: "ses_live",
-      assistant: {
-        modelID: "big-pickle",
-        providerID: "opencode",
-        inputTokens: 42200,
-        outputTokens: 20,
-        reasoningTokens: 10,
-        cacheRead: 0,
-        cacheWrite: 0,
-        costUsd: 0,
-        totalTokens: 42220,
-      },
-      usage: {
-        assistantMessages: 42,
-        totalInputTokens: 1389045,
-        totalOutputTokens: 3675,
-        totalReasoningTokens: 4717,
-        totalCacheRead: 0,
-        totalCacheWrite: 0,
-        totalCostUsd: 0,
-      },
-    });
 
     const ctx = makeMockContext({
       config: {
         model: "big-pickle",
-        backend: "opencode",
       } as CommandContext["config"],
+      backend: {
+        query: vi.fn() as any,
+        getModelInfo: vi.fn().mockResolvedValue({
+          id: "big-pickle",
+          displayName: "Big Pickle",
+          provider: "opencode",
+          providerName: "OpenCode Zen",
+          free: true,
+          contextWindow: 204800,
+          selectable: true,
+        }),
+        getSessionSnapshot: vi.fn().mockResolvedValue({
+          inputTokens: 1389045,
+          outputTokens: 3675,
+          cacheRead: 0,
+          cacheWrite: 0,
+          contextModelId: "big-pickle",
+        }),
+        backendLabel: "OpenCode",
+      },
     });
     await tryRunCommand("/status", ctx);
 

--- a/src/backend/claude-sdk/constants.ts
+++ b/src/backend/claude-sdk/constants.ts
@@ -1,44 +1,23 @@
 /**
- * Shared constants for Claude SDK backend and background agents.
+ * Claude SDK backend constants — thinking effort, streaming, and
+ * chat-specific tool restrictions.
  *
- * Single source of truth for disallowed tool lists, thinking effort
- * configuration, and streaming parameters.
+ * Core disallowed-tool lists live in core/constants.ts (backend-agnostic).
  */
 
-// ── Disallowed tool lists ──────────────────────────────────────────────────
+import {
+  DISALLOWED_TOOLS_CORE,
+  DISALLOWED_TOOLS_BACKGROUND,
+} from "../../core/constants.js";
 
-/**
- * Core tools disallowed in all SDK query contexts (chat, heartbeat, dream).
- * These are interactive or planning-only tools that make no sense in a
- * headless agent context.
- */
-export const DISALLOWED_TOOLS_CORE = [
-  "EnterPlanMode",
-  "ExitPlanMode",
-  "EnterWorktree",
-  "ExitWorktree",
-  "TodoWrite",
-  "TodoRead",
-  "TaskCreate",
-  "TaskUpdate",
-  "TaskGet",
-  "TaskList",
-  "TaskOutput",
-  "TaskStop",
-  "AskUserQuestion",
-] as const;
+// Re-export so existing backend imports keep working
+export { DISALLOWED_TOOLS_CORE, DISALLOWED_TOOLS_BACKGROUND };
 
 /** Disallowed tools for the main chat handler (core + web tools replaced by Brave MCP). */
 export const DISALLOWED_TOOLS_CHAT = [
   ...DISALLOWED_TOOLS_CORE,
   "WebSearch",
   "WebFetch",
-] as const;
-
-/** Disallowed tools for background agents — heartbeat and dream (core + Agent). */
-export const DISALLOWED_TOOLS_BACKGROUND = [
-  ...DISALLOWED_TOOLS_CORE,
-  "Agent",
 ] as const;
 
 // ── Thinking / effort configuration ────────────────────────────────────────

--- a/src/backend/claude-sdk/model-provider.ts
+++ b/src/backend/claude-sdk/model-provider.ts
@@ -189,6 +189,18 @@ export async function getProviderModels(
   };
 }
 
+export async function listModels(
+  filter?: "free" | "all",
+): Promise<{ models: UnifiedModelInfo[]; total: number }> {
+  // Claude SDK models are all paid/connected — "free" filter returns none
+  const all = getModels(PROVIDER_ID).map(toUnified);
+  if (filter === "free") {
+    const free = all.filter((m) => m.free);
+    return { models: free, total: free.length };
+  }
+  return { models: all, total: all.length };
+}
+
 export function formatModelError(
   query: string,
   resolution: UnifiedModelResolution,

--- a/src/backend/claude-sdk/model-provider.ts
+++ b/src/backend/claude-sdk/model-provider.ts
@@ -25,55 +25,23 @@ import type {
 const PROVIDER_ID = "anthropic";
 const PROVIDER_NAME = "Anthropic";
 
-const FAMILY_VERSION_PATTERN = /\b([A-Za-z][A-Za-z-]*)\s+(\d+(?:\.\d+)*)\b/;
-
-function toDisplayFamilyName(family: string): string {
-  return family
-    .split("-")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-function formatResolvedModelLabel(model: ModelInfo): string {
-  const isOneMillion =
-    model.id.endsWith("[1m]") || model.aliases.some((a) => a.endsWith("[1m]"));
-  const match = `${model.displayName} ${model.description ?? ""}`.match(
-    FAMILY_VERSION_PATTERN,
-  );
-  let label: string;
-  if (match) {
-    label = `${toDisplayFamilyName(match[1])} ${match[2]}`;
-  } else {
-    const familyAlias = model.aliases.find(
-      (alias) =>
-        !alias.startsWith("claude-") &&
-        !alias.endsWith("[1m]") &&
-        !/[-.]\d/.test(alias),
-    );
-    label = familyAlias
-      ? toDisplayFamilyName(familyAlias)
-      : model.displayName.replace(/\s*\([^)]*\)/g, "").trim();
-  }
-  return isOneMillion ? `${label} [1M]` : label;
-}
-
 function toUnified(model: ModelInfo): UnifiedModelInfo {
   return {
     id: model.id,
-    displayName: formatResolvedModelLabel(model),
+    displayName: model.displayName,
     provider: PROVIDER_ID,
     providerName: PROVIDER_NAME,
     selectable: true,
   };
 }
 
-/** De-duplicate models by their resolved display label (same logic as getTelegramModelOptions). */
+/** De-duplicate models by displayName (1M variants share a label with their base). */
 function getUniqueModels(): ModelInfo[] {
   const options: ModelInfo[] = [];
   const seenKeys = new Set<string>();
 
   for (const model of getModels(PROVIDER_ID)) {
-    const key = formatResolvedModelLabel(model).toLowerCase();
+    const key = model.displayName.toLowerCase();
     if (seenKeys.has(key)) continue;
     seenKeys.add(key);
     options.push(model);
@@ -87,8 +55,7 @@ function isSelectedModel(currentModel: string, candidateId: string): boolean {
   const candidate = coreResolveModel(candidateId);
   if (current && candidate) {
     return (
-      formatResolvedModelLabel(current).toLowerCase() ===
-      formatResolvedModelLabel(candidate).toLowerCase()
+      current.displayName.toLowerCase() === candidate.displayName.toLowerCase()
     );
   }
   return resolveModelId(currentModel) === candidateId;
@@ -149,10 +116,9 @@ export async function getSettingsPresentation(
   const options = getUniqueModels();
 
   const modelButtons: ModelButton[] = options.map((m) => {
-    const label = formatResolvedModelLabel(m);
     const selected = isSelectedModel(activeModel, m.id);
     return {
-      text: selected ? `\u2713 ${label}` : label,
+      text: selected ? `\u2713 ${m.displayName}` : m.displayName,
       callback_data: `${callbackPrefix}${m.id}`,
     };
   });
@@ -192,12 +158,9 @@ export async function getProviderModels(
 export async function listModels(
   filter?: "free" | "all",
 ): Promise<{ models: UnifiedModelInfo[]; total: number }> {
-  // Claude SDK models are all paid/connected — "free" filter returns none
+  // Claude SDK models are all paid — the "free" filter returns nothing.
+  if (filter === "free") return { models: [], total: 0 };
   const all = getModels(PROVIDER_ID).map(toUnified);
-  if (filter === "free") {
-    const free = all.filter((m) => m.free);
-    return { models: free, total: free.length };
-  }
   return { models: all, total: all.length };
 }
 

--- a/src/backend/claude-sdk/models.ts
+++ b/src/backend/claude-sdk/models.ts
@@ -45,6 +45,25 @@ function normalizeFamilyName(family: string): string {
   return family.trim().toLowerCase().replace(/\s+/g, "-");
 }
 
+function toDisplayFamilyName(family: string): string {
+  return family
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+/** Synthesize a clean label like "Sonnet 4.6" or "Sonnet 4.6 [1M]" from parsed identity. */
+function deriveDisplayName(
+  identity: ParsedModelIdentity,
+  fallback: string,
+): string {
+  if (!identity.family) return fallback;
+  const family = toDisplayFamilyName(identity.family);
+  const version = identity.version ? ` ${identity.version}` : "";
+  const million = identity.isOneMillion ? " [1M]" : "";
+  return `${family}${version}${million}`;
+}
+
 function stripOneMillionSuffix(value: string): string {
   return value.endsWith("[1m]") ? value.slice(0, -4) : value;
 }
@@ -303,7 +322,7 @@ function convertSdkModels(sdkModels: SdkModelInfo[]): ModelInfo[] {
 
     models.push({
       id: record.value,
-      displayName: record.displayName,
+      displayName: deriveDisplayName(record.identity, record.displayName),
       description: record.description,
       aliases,
       provider: "anthropic",
@@ -443,26 +462,26 @@ export const CLAUDE_MODELS_STATIC: ModelInfo[] = convertSdkModels([
   {
     value: "default",
     displayName: "Default (recommended)",
-    description: "Sonnet · Best for everyday tasks",
+    description: "Sonnet 4.6 · Best for everyday tasks",
   },
   {
     value: "sonnet[1m]",
     displayName: "Sonnet (1M context)",
-    description: "Sonnet with 1M context · Large context window",
+    description: "Sonnet 4.6 with 1M context · Large context window",
   },
   {
     value: "opus",
     displayName: "Opus",
-    description: "Opus · Most capable for complex work",
+    description: "Opus 4.6 · Most capable for complex work",
   },
   {
     value: "opus[1m]",
     displayName: "Opus (1M context)",
-    description: "Opus with 1M context · Large context window",
+    description: "Opus 4.6 with 1M context · Large context window",
   },
   {
     value: "haiku",
     displayName: "Haiku",
-    description: "Haiku · Fastest for quick answers",
+    description: "Haiku 4.5 · Fastest for quick answers",
   },
 ]);

--- a/src/backend/claude-sdk/models.ts
+++ b/src/backend/claude-sdk/models.ts
@@ -52,7 +52,11 @@ function toDisplayFamilyName(family: string): string {
     .join(" ");
 }
 
-/** Synthesize a clean label like "Sonnet 4.6" or "Sonnet 4.6 [1M]" from parsed identity. */
+/**
+ * Synthesize a clean label like "Sonnet 4.6" from parsed identity. Base and
+ * 1M variants share a label because the variant-merge step hides the base
+ * behind the 1M one — what we surface is effectively the 1M model.
+ */
 function deriveDisplayName(
   identity: ParsedModelIdentity,
   fallback: string,
@@ -60,8 +64,7 @@ function deriveDisplayName(
   if (!identity.family) return fallback;
   const family = toDisplayFamilyName(identity.family);
   const version = identity.version ? ` ${identity.version}` : "";
-  const million = identity.isOneMillion ? " [1M]" : "";
-  return `${family}${version}${million}`;
+  return `${family}${version}`;
 }
 
 function stripOneMillionSuffix(value: string): string {
@@ -148,11 +151,13 @@ function buildFamilyKey(identity: ParsedModelIdentity): string | null {
     : null;
 }
 
+/**
+ * Variant key collapses base and 1M variants of the same family+version into
+ * a single bucket. The priority function picks the 1M entry as canonical, so
+ * users see one "Sonnet 4.6" option (backed by sonnet[1m]) rather than two.
+ */
 function buildVariantKey(identity: ParsedModelIdentity): string | null {
-  const familyKey = buildFamilyKey(identity);
-  return familyKey
-    ? `${familyKey}:${identity.isOneMillion ? "1m" : "base"}`
-    : null;
+  return buildFamilyKey(identity);
 }
 
 function appendOneMillionSuffix(alias: string, isOneMillion: boolean): string {
@@ -188,10 +193,20 @@ function buildGeneratedAliases(identity: ParsedModelIdentity): string[] {
   return aliases;
 }
 
-function getPreferredModelPriority(value: string): number {
-  if (value === "default") return 0;
-  if (!value.startsWith("claude-")) return 1;
-  return 2;
+/**
+ * Lower number = higher priority when picking a canonical ID among variants
+ * sharing a family+version:
+ *   0 — "default"                      (SDK-recommended canonical)
+ *   1 — 1M variant, non-claude-prefix  (e.g. sonnet[1m])
+ *   2 — base variant, non-claude       (e.g. sonnet)
+ *   3 — claude-prefixed (legacy)       (e.g. claude-sonnet-4-6[1m])
+ */
+function getPreferredModelPriority(record: SdkModelRecord): number {
+  if (record.value === "default") return 0;
+  const isClaudePrefixed = record.value.startsWith("claude-");
+  if (record.identity.isOneMillion && !isClaudePrefixed) return 1;
+  if (!isClaudePrefixed) return 2;
+  return 3;
 }
 
 function buildSdkModelRecords(sdkModels: SdkModelInfo[]): SdkModelRecord[] {
@@ -223,8 +238,7 @@ function buildPreferredCanonicalIds(
   for (const [variantKey, variants] of grouped) {
     const canonical = [...variants].sort((left, right) => {
       const priorityDelta =
-        getPreferredModelPriority(left.value) -
-        getPreferredModelPriority(right.value);
+        getPreferredModelPriority(left) - getPreferredModelPriority(right);
       if (priorityDelta !== 0) return priorityDelta;
       return left.index - right.index;
     })[0];

--- a/src/backend/opencode/model-provider.ts
+++ b/src/backend/opencode/model-provider.ts
@@ -141,6 +141,18 @@ export async function getProviderModels(
   };
 }
 
+export async function listModels(
+  filter?: "free" | "all",
+): Promise<{ models: UnifiedModelInfo[]; total: number }> {
+  const catalog = await getOpenCodeModelCatalog();
+  const source =
+    filter === "free" ? catalog.connectedFreeModels : catalog.connectedModels;
+  return {
+    models: source.map(toUnifiedModelInfo),
+    total: source.length,
+  };
+}
+
 export function formatModelError(
   query: string,
   resolution: UnifiedModelResolution,

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -126,6 +126,8 @@ export async function initBackendAndDispatcher(
       getProviderModels: (p, pg, ps) =>
         ocModelProvider.getProviderModels(p, pg, ps),
       formatModelError: (q, r) => ocModelProvider.formatModelError(q, r),
+      listModels: (f) => ocModelProvider.listModels(f),
+      backendLabel: "OpenCode",
       getSessionSnapshot: async (sessionId) => {
         const { getOpenCodeSessionSnapshot } =
           await import("./backend/opencode/index.js");
@@ -166,6 +168,8 @@ export async function initBackendAndDispatcher(
       getProviderModels: (p, pg, ps) =>
         claudeModelProvider.getProviderModels(p, pg, ps),
       formatModelError: (q, r) => claudeModelProvider.formatModelError(q, r),
+      listModels: (f) => claudeModelProvider.listModels(f),
+      backendLabel: "Anthropic",
       refreshMcpServers: async (chatId) => {
         const qi = getActiveQuery(chatId);
         if (!qi) return null;

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared constants for background agents (dream, heartbeat).
+ *
+ * These tool restriction lists are backend-agnostic — they describe
+ * interactive or planning-only tools that make no sense in a headless
+ * agent context, regardless of which AI backend is active.
+ */
+
+/** Interactive/planning tools disallowed in all headless agent contexts. */
+export const DISALLOWED_TOOLS_CORE = [
+  "EnterPlanMode",
+  "ExitPlanMode",
+  "EnterWorktree",
+  "ExitWorktree",
+  "TodoWrite",
+  "TodoRead",
+  "TaskCreate",
+  "TaskUpdate",
+  "TaskGet",
+  "TaskList",
+  "TaskOutput",
+  "TaskStop",
+  "AskUserQuestion",
+] as const;
+
+/** Disallowed tools for background agents — dream and heartbeat (core + Agent). */
+export const DISALLOWED_TOOLS_BACKGROUND = [
+  ...DISALLOWED_TOOLS_CORE,
+  "Agent",
+] as const;

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -20,7 +20,7 @@ import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { files as pathFiles, dirs } from "../util/paths.js";
 import { log, logError, logWarn } from "../util/log.js";
 import { getPluginMcpServers } from "./plugin.js";
-import { DISALLOWED_TOOLS_BACKGROUND } from "../backend/claude-sdk/constants.js";
+import { DISALLOWED_TOOLS_BACKGROUND } from "./constants.js";
 import { getDefaultModel } from "./models.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -54,7 +54,7 @@ let configRef: {
 
 export function initDream(cfg: {
   model?: string;
-  /** Override model used specifically for dream consolidation (e.g. haiku for cost savings). Falls back to main model. */
+  /** Override model for dream consolidation (e.g. a cheaper model). Falls back to main model. */
   dreamModel?: string;
   claudeBinary?: string;
   workspace?: string;

--- a/src/core/heartbeat.ts
+++ b/src/core/heartbeat.ts
@@ -18,7 +18,7 @@ import { files as pathFiles, dirs } from "../util/paths.js";
 import { log, logError, logWarn } from "../util/log.js";
 import { toYMD } from "../util/time.js";
 import { getPluginMcpServers } from "./plugin.js";
-import { DISALLOWED_TOOLS_BACKGROUND } from "../backend/claude-sdk/constants.js";
+import { DISALLOWED_TOOLS_BACKGROUND } from "./constants.js";
 import { getDefaultModel } from "./models.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -59,7 +59,7 @@ let configRef: {
 
 export function initHeartbeat(cfg: {
   model?: string;
-  /** Override model used specifically for heartbeat (e.g. haiku for cost savings). Falls back to main model. */
+  /** Override model for heartbeat (e.g. a cheaper model). Falls back to main model. */
   heartbeatModel?: string;
   claudeBinary?: string;
   workspace?: string;

--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -10,13 +10,13 @@
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export type ModelInfo = {
-  /** Canonical SDK model ID (e.g. "default", "opus", "sonnet[1m]"). */
+  /** Canonical model ID as registered by the backend. */
   id: string;
   /** Human-readable display name for UIs (e.g. "Sonnet 4.6"). */
   displayName: string;
   /** Short description for setup wizard (e.g. "fast, balanced"). */
   description?: string;
-  /** Aliases that resolve to this model (e.g. ["sonnet", "sonnet-4.6"]). */
+  /** Aliases that resolve to this model. */
   aliases: string[];
   /** Provider identifier (e.g. "anthropic", "openai"). */
   provider: string;
@@ -31,7 +31,7 @@ const aliasIndex = new Map<string, string>();
 const providerPrefixes: string[] = [];
 
 /**
- * Register a provider-specific prefix (e.g. "claude-") that the fuzzy
+ * Register a provider-specific prefix that the fuzzy
  * alias resolver will strip when matching family names. Backends call
  * this during initialization so core stays provider-agnostic.
  */
@@ -46,8 +46,7 @@ function resolveGenericFamilyAlias(input: string): string | null {
   const trimmed = input.trim().toLowerCase();
   if (!trimmed) return null;
 
-  const isOneMillion = trimmed.endsWith("[1m]");
-  let base = isOneMillion ? trimmed.slice(0, -4) : trimmed;
+  let base = trimmed;
   for (const prefix of providerPrefixes) {
     if (base.startsWith(prefix)) {
       base = base.slice(prefix.length);
@@ -69,8 +68,7 @@ function resolveGenericFamilyAlias(input: string): string | null {
   );
   if (family.length === 0) return null;
 
-  const alias = family.join("-");
-  return isOneMillion ? `${alias}[1m]` : alias;
+  return family.join("-");
 }
 
 // ── Registration ────────────────────────────────────────────────────────────

--- a/src/core/tools/web.ts
+++ b/src/core/tools/web.ts
@@ -2,10 +2,8 @@
  * Web tools — URL fetching.
  *
  * Platform-agnostic, available on all frontends.
- * Web search is handled by the Brave Search MCP server (registered in
- * src/backend/claude-sdk/index.ts) when configured. URL fetching is provided here via
- * the `fetch_url` tool, so Claude Code's built-in WebSearch / WebFetch are
- * disabled in favor of these project-specific replacements.
+ * Web search is handled by the Brave Search MCP server when configured.
+ * URL fetching is provided here via the `fetch_url` tool.
  * These can be excluded via composeTools({ excludeTags: ["web"] }).
  */
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -76,7 +76,7 @@ export interface QueryBackend {
     removed: string[];
     errors: Record<string, string>;
   } | null>;
-  /** Resolve a user's model query (e.g. "opus", "gpt-5") to a concrete model. */
+  /** Resolve a user's model query to a concrete model. */
   resolveModel?(query: string): Promise<UnifiedModelResolution>;
   /** Get info for a model by its stored ID. */
   getModelInfo?(id: string): Promise<UnifiedModelInfo | undefined>;
@@ -109,6 +109,13 @@ export interface QueryBackend {
       }
     | undefined
   >;
+  /** List models matching a filter. Frontends use this for /model free|all|list. */
+  listModels?(filter?: "free" | "all"): Promise<{
+    models: UnifiedModelInfo[];
+    total: number;
+  }>;
+  /** Human-readable backend label for UIs (e.g. "Anthropic", "OpenCode"). */
+  backendLabel?: string;
 }
 
 // ── Execution context ───────────────────────────────────────────────────────

--- a/src/frontend/teams/index.ts
+++ b/src/frontend/teams/index.ts
@@ -244,9 +244,11 @@ export function createTeamsFrontend(
                   : 0;
               const { getChatSettings } =
                 await import("../../storage/chat-settings.js");
-              const model = (
-                getChatSettings(talonChatId).model ?? (config.model as string)
-              ).replace("claude-", "");
+              const { resolveModel: coreResolve } =
+                await import("../../core/models.js");
+              const rawModel =
+                getChatSettings(talonChatId).model ?? (config.model as string);
+              const model = coreResolve(rawModel)?.displayName ?? rawModel;
               const avgMs =
                 info.turns > 0 ? Math.round(u.totalResponseMs / info.turns) : 0;
               const ctxUsed = u.contextTokens || u.lastPromptTokens;
@@ -358,7 +360,7 @@ export function createTeamsFrontend(
             })
               .then(async (result) => {
                 // Only deliver messages sent via the send_message tool.
-                // Do NOT send fallback text — if Claude chose not to use send_message,
+                // Do NOT send fallback text — if the model chose not to use send_message,
                 // it's either choosing not to respond or outputting internal reasoning
                 // that shouldn't be shown to users.
                 if (result.bridgeMessageCount === 0 && result.text?.trim()) {

--- a/src/frontend/teams/index.ts
+++ b/src/frontend/teams/index.ts
@@ -13,6 +13,7 @@ import type { ContextManager } from "../../core/types.js";
 import type { Gateway } from "../../core/gateway.js";
 import { log, logError } from "../../util/log.js";
 import { deriveNumericChatId } from "../../util/chat-id.js";
+import { resolveModel } from "../../core/models.js";
 import { createTeamsActionHandler } from "./actions.js";
 import { splitTeamsMessage, buildAdaptiveCard } from "./formatting.js";
 import {
@@ -244,11 +245,9 @@ export function createTeamsFrontend(
                   : 0;
               const { getChatSettings } =
                 await import("../../storage/chat-settings.js");
-              const { resolveModel: coreResolve } =
-                await import("../../core/models.js");
               const rawModel =
                 getChatSettings(talonChatId).model ?? (config.model as string);
-              const model = coreResolve(rawModel)?.displayName ?? rawModel;
+              const model = resolveModel(rawModel)?.displayName ?? rawModel;
               const avgMs =
                 info.turns > 0 ? Math.round(u.totalResponseMs / info.turns) : 0;
               const ctxUsed = u.contextTokens || u.lastPromptTokens;

--- a/src/frontend/telegram/admin.ts
+++ b/src/frontend/telegram/admin.ts
@@ -17,7 +17,7 @@ import {
 import { getActiveCount } from "../../core/dispatcher.js";
 import { getPulseStatus } from "../../core/pulse.js";
 import { getHealthStatus, getRecentErrors } from "../../util/watchdog.js";
-import { formatDuration } from "./helpers.js";
+import { formatDuration, formatModelLabel } from "./helpers.js";
 
 export async function handleAdminCommand(
   ctx: Context,
@@ -64,9 +64,8 @@ export async function handleAdminCommand(
           ? `${Math.round((Date.now() - s.info.lastActive) / 60000)}m ago`
           : "?";
         const title = titles.get(s.chatId) ?? s.chatId;
-        const model = (getChatSettings(s.chatId).model ?? config.model).replace(
-          "claude-",
-          "",
+        const model = formatModelLabel(
+          getChatSettings(s.chatId).model ?? config.model,
         );
         return `<b>${escapeHtml(title)}</b> <code>${s.chatId}</code>\n  ${s.info.turns} turns | ${age} | ${model}`;
       });

--- a/src/frontend/telegram/callbacks.ts
+++ b/src/frontend/telegram/callbacks.ts
@@ -279,7 +279,7 @@ export function registerCallbacks(
       return;
     }
 
-    // Forward other callbacks to Claude
+    // Forward other callbacks to the AI backend
     handleCallbackQuery(ctx, bot, config);
   });
 }

--- a/src/frontend/telegram/commands.ts
+++ b/src/frontend/telegram/commands.ts
@@ -317,7 +317,7 @@ export function registerCommands(
     if (arg === "reset" || arg === "default" || arg === "adaptive") {
       setChatEffort(cid, undefined);
       await ctx.reply(
-        "Effort reset to <b>adaptive</b> (Claude decides when to think)",
+        "Effort reset to <b>adaptive</b> (model decides when to think)",
         { parse_mode: "HTML" },
       );
       return;
@@ -553,7 +553,7 @@ export function registerCommands(
       "",
       `<b>Session Stats</b>`,
       `  Response  last ${lastResponseMs ? formatDuration(lastResponseMs) : "\u2014"} \u00B7 avg ${avgResponseMs ? formatDuration(avgResponseMs) : "\u2014"} \u00B7 best ${fastestMs ? formatDuration(fastestMs) : "\u2014"}`,
-      `  Turns     ${info.turns}${turnsModelLabel ? ` (${turnsModelLabel.replace("claude-", "")})` : ""}`,
+      `  Turns     ${info.turns}${turnsModelLabel ? ` (${formatModelLabel(turnsModelLabel)})` : ""}`,
       "",
       `<b>Cache</b>     ${cacheHitPct}% hit`,
       `  Read ${formatTokenCount(displayCacheRead)}  Write ${formatTokenCount(displayCacheWrite)}`,

--- a/src/frontend/telegram/formatting.ts
+++ b/src/frontend/telegram/formatting.ts
@@ -35,7 +35,7 @@ export function escapeHtml(text: string): string {
 }
 
 /**
- * Convert Claude's Markdown output to Telegram-safe HTML.
+ * Convert Markdown output to Telegram-safe HTML.
  *
  * Handles: bold, italic, inline code, fenced code blocks, links.
  * Escapes HTML entities in non-formatted text.

--- a/src/frontend/telegram/handlers.ts
+++ b/src/frontend/telegram/handlers.ts
@@ -274,7 +274,7 @@ export function getReplyContext(
 
 /**
  * If the replied-to message contains a photo, download it and return a prompt
- * line pointing to the saved file so Claude can see it. Returns "" if no photo.
+ * line pointing to the saved file so the model can see it. Returns "" if no photo.
  */
 async function downloadReplyPhoto(
   replyMsg:
@@ -363,7 +363,7 @@ async function downloadTelegramFile(
     throw new Error("Downloaded file is empty (0 bytes)");
 
   // Validate image files — prevent saving HTML/garbage as .jpg/.png
-  // (corrupt "images" poison the Claude session permanently on resume)
+  // (corrupt "images" poison the session permanently on resume)
   const imageExts = [".jpg", ".jpeg", ".png", ".gif", ".webp"];
   const isImageExt = imageExts.some((ext) =>
     fileName.toLowerCase().endsWith(ext),
@@ -789,24 +789,10 @@ async function processAndReply(params: ProcessAndReplyParams): Promise<void> {
       !stream.sentTextBlock &&
       result.text?.trim()
     ) {
-      if (config.backend === "opencode") {
-        await sendHtml(
-          bot,
-          numericChatId,
-          markdownToTelegramHtml(result.text),
-          replyToId,
-        );
-        appendDailyLogResponse("Talon", result.text, { chatTitle });
-        log(
-          "bot",
-          `Delivered OpenCode fallback text (${result.text.length} chars)`,
-        );
-      } else {
-        log(
-          "bot",
-          `Suppressed fallback text (${result.text.length} chars) — no send tool used`,
-        );
-      }
+      log(
+        "bot",
+        `Suppressed fallback text (${result.text.length} chars) — no send tool used`,
+      );
     }
   } finally {
     clearTimeout(streamTimer);

--- a/src/frontend/telegram/helpers.ts
+++ b/src/frontend/telegram/helpers.ts
@@ -4,11 +4,7 @@
 
 import { escapeHtml } from "./formatting.js";
 import type { ModelInfo } from "../../core/models.js";
-import {
-  getModels,
-  resolveModel,
-  resolveModelId,
-} from "../../core/models.js";
+import { getModels, resolveModel, resolveModelId } from "../../core/models.js";
 const DEFAULT_PULSE_INTERVAL_MS = 5 * 60 * 1000;
 const DEFAULT_METRICS_MESSAGE_MAX = 3800;
 
@@ -215,8 +211,7 @@ export function isSelectedModel(
   const candidate = resolveModel(modelId);
   if (current && candidate) {
     return (
-      current.displayName.toLowerCase() ===
-      candidate.displayName.toLowerCase()
+      current.displayName.toLowerCase() === candidate.displayName.toLowerCase()
     );
   }
   return resolveModelId(currentModel) === modelId;

--- a/src/frontend/telegram/helpers.ts
+++ b/src/frontend/telegram/helpers.ts
@@ -4,9 +4,12 @@
 
 import { escapeHtml } from "./formatting.js";
 import type { ModelInfo } from "../../core/models.js";
-import { getModels, resolveModel, resolveModelId } from "../../core/models.js";
+import {
+  getModels,
+  resolveModel,
+  resolveModelId,
+} from "../../core/models.js";
 const DEFAULT_PULSE_INTERVAL_MS = 5 * 60 * 1000;
-const FAMILY_VERSION_PATTERN = /\b([A-Za-z][A-Za-z-]*)\s+(\d+(?:\.\d+)*)\b/;
 const DEFAULT_METRICS_MESSAGE_MAX = 3800;
 
 type MetricsSnapshot = {
@@ -51,44 +54,19 @@ export function formatBytes(bytes: number): string {
   return `${bytes} B`;
 }
 
-function toDisplayFamilyName(family: string): string {
-  return family
-    .split("-")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-function formatResolvedModelLabel(model: ModelInfo): string {
-  const match = `${model.displayName} ${model.description ?? ""}`.match(
-    FAMILY_VERSION_PATTERN,
-  );
-  if (match) {
-    return `${toDisplayFamilyName(match[1])} ${match[2]}`;
-  }
-
-  const familyAlias = model.aliases.find(
-    (alias) =>
-      !alias.startsWith("claude-") &&
-      !alias.endsWith("[1m]") &&
-      !/[-.]\d/.test(alias),
-  );
-  const baseName = familyAlias
-    ? toDisplayFamilyName(familyAlias)
-    : model.displayName.replace(/\s*\([^)]*\)/g, "").trim();
-  return baseName;
-}
-
+/** Resolve a model ID to its backend-registered display name. */
 export function formatModelLabel(modelId: string): string {
-  const model = resolveModel(modelId);
-  return model ? formatResolvedModelLabel(model) : modelId;
+  return resolveModel(modelId)?.displayName ?? modelId;
 }
 
+/** Display name for a known ModelInfo. */
 export function formatModelOptionLabel(model: ModelInfo): string {
-  return formatResolvedModelLabel(model);
+  return model.displayName;
 }
 
+/** Compact display name for a known ModelInfo. */
 export function formatCompactModelLabel(model: ModelInfo): string {
-  return formatResolvedModelLabel(model);
+  return model.displayName;
 }
 
 export function getTelegramModelOptions(): ModelInfo[] {
@@ -96,7 +74,7 @@ export function getTelegramModelOptions(): ModelInfo[] {
   const seenKeys = new Set<string>();
 
   for (const model of getModels()) {
-    const key = formatResolvedModelLabel(model).toLowerCase();
+    const key = model.displayName.toLowerCase();
     if (seenKeys.has(key)) continue;
     seenKeys.add(key);
     options.push(model);
@@ -237,8 +215,8 @@ export function isSelectedModel(
   const candidate = resolveModel(modelId);
   if (current && candidate) {
     return (
-      formatResolvedModelLabel(current).toLowerCase() ===
-      formatResolvedModelLabel(candidate).toLowerCase()
+      current.displayName.toLowerCase() ===
+      candidate.displayName.toLowerCase()
     );
   }
   return resolveModelId(currentModel) === modelId;

--- a/src/frontend/terminal/commands.ts
+++ b/src/frontend/terminal/commands.ts
@@ -7,9 +7,11 @@
 
 import pc from "picocolors";
 import type { TalonConfig } from "../../util/config.js";
+import type { QueryBackend } from "../../core/types.js";
 import type { Renderer } from "./renderer.js";
 import { formatTimeAgo } from "./renderer.js";
 import { isTerminalChatId } from "../../util/chat-id.js";
+import { resolveModel as coreResolveModel } from "../../core/models.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -23,6 +25,8 @@ export type CommandContext = {
   waitForInput: () => Promise<string>;
   /** Close the terminal (for /quit). */
   close: () => void;
+  /** AI backend (available after bootstrap). */
+  backend?: QueryBackend | null;
 };
 
 export type CommandHandler = (
@@ -96,203 +100,137 @@ export function registerBuiltinCommands(): void {
         await import("../../storage/chat-settings.js");
       const currentModel =
         getChatSettings(ctx.chatId()).model ?? ctx.config.model;
+      const be = ctx.backend;
 
-      if (ctx.config.backend === "opencode") {
-        const {
-          getOpenCodeModelCatalog,
-          getOpenCodeModelInfo,
-          getOpenCodeModelSelectionValue,
-          getOpenCodeQuickPickModels,
-          resolveOpenCodeModelInput,
-        } = await import("../../backend/opencode/index.js");
+      const trimmedArgs = args.trim();
+      const lowerArgs = trimmedArgs.toLowerCase();
 
-        const catalog = await getOpenCodeModelCatalog();
-        const trimmedArgs = args.trim();
-
-        const renderProviderLine = (providerName: string, details: string[]) =>
-          [providerName, ...details.filter(Boolean)].join(" · ");
-
-        if (!trimmedArgs) {
-          const currentInfo = await getOpenCodeModelInfo(currentModel);
-          const quickPicks = getOpenCodeQuickPickModels(catalog, currentModel);
-          const currentLabel = currentInfo
-            ? getOpenCodeModelSelectionValue(currentInfo, catalog)
-            : currentModel;
-          const details = currentInfo
-            ? [
-                currentInfo.providerName,
-                currentInfo.free ? "free" : "paid",
-                currentInfo.selectable
-                  ? "ready"
-                  : currentInfo.loginRequired
-                    ? "login required"
-                    : "not connected",
-              ]
-            : [];
-
-          ctx.renderer.writeSystem(
-            `Model: ${currentLabel}${details.length ? ` · ${renderProviderLine("", details).replace(/^ · /, "")}` : ""}`,
-          );
-
-          if (quickPicks.length > 0) {
-            ctx.renderer.writeln(
-              `  Free now: ${quickPicks
-                .map((model) => `${model.id}${model.free ? " (free)" : ""}`)
-                .join("  ·  ")}`,
-            );
-          }
-
-          if (catalog.loginProviders.length > 0) {
-            const loginSummary = catalog.loginProviders
-              .slice(0, 4)
-              .map(
-                (provider) =>
-                  `${provider.name} (${provider.authMethods.join(", ")})`,
-              )
-              .join("  ·  ");
-            ctx.renderer.writeln(`  Login required: ${loginSummary}`);
-          }
-
-          if (catalog.connectedProviders.length > 0) {
-            ctx.renderer.writeln(
-              `  Connected providers: ${catalog.connectedProviders
-                .map((provider) => `${provider.name} (${provider.modelCount})`)
-                .join(", ")}`,
-            );
-          }
-
-          if (currentInfo?.contextWindow) {
-            ctx.renderer.writeln(
-              `  Context window: ${currentInfo.contextWindow.toLocaleString()}`,
-            );
-          }
-
-          ctx.renderer.writeln(
-            `  Use /model free, /model all, /model providers, or /model <id>.`,
-          );
-          ctx.reprompt();
-          return;
-        }
-
-        const lowerArgs = trimmedArgs.toLowerCase();
-        if (lowerArgs === "reset" || lowerArgs === "default") {
-          setChatModel(ctx.chatId(), undefined);
-          ctx.renderer.writeSystem(`Model → ${ctx.config.model}`);
-          ctx.reprompt();
-          return;
-        }
-
-        if (
-          lowerArgs === "free" ||
-          lowerArgs === "list" ||
-          lowerArgs === "all"
-        ) {
-          const source =
-            lowerArgs === "free"
-              ? catalog.connectedFreeModels
-              : catalog.connectedModels;
-          const list = source.slice(0, 20);
-
-          ctx.renderer.writeSystem(
-            `${lowerArgs === "free" ? "Connected free" : "Connected"} models (${source.length})`,
-          );
-          for (const model of list) {
-            ctx.renderer.writeln(
-              `  ${getOpenCodeModelSelectionValue(model, catalog)}  ·  ${model.providerName}  ·  ${model.contextWindow.toLocaleString()} ctx${model.free ? "  ·  free" : ""}`,
-            );
-          }
-          if (source.length > list.length) {
-            ctx.renderer.writeln(`  …and ${source.length - list.length} more`);
-          }
-          ctx.reprompt();
-          return;
-        }
-
-        if (lowerArgs === "providers") {
-          ctx.renderer.writeSystem("OpenCode providers");
-          for (const provider of catalog.providers.slice(0, 20)) {
-            const detail = provider.connected
-              ? "connected"
-              : provider.loginRequired
-                ? `login: ${provider.authMethods.join(", ")}`
-                : provider.envRequired
-                  ? `env: ${provider.envKeys.join(", ")}`
-                  : provider.source;
-            ctx.renderer.writeln(
-              `  ${provider.id}  ·  ${provider.name}  ·  ${detail}  ·  ${provider.modelCount} models`,
-            );
-          }
-          ctx.reprompt();
-          return;
-        }
-
-        const resolution = resolveOpenCodeModelInput(trimmedArgs, catalog);
-        if (resolution.kind === "missing") {
-          ctx.renderer.writeError(
-            `No OpenCode model matched "${trimmedArgs}".`,
-          );
-          ctx.reprompt();
-          return;
-        }
-
-        if (resolution.kind === "ambiguous") {
-          const preview = resolution.matches
-            .map((model) => {
-              const providerLabel =
-                model.providerName === model.providerID
-                  ? model.providerName
-                  : `${model.providerName} / ${model.providerID}`;
-              const availability = model.selectable
+      if (!trimmedArgs) {
+        const modelInfo = await be?.getModelInfo?.(currentModel);
+        const displayName = modelInfo?.displayName ?? currentModel;
+        const details = modelInfo
+          ? [
+              modelInfo.providerName,
+              modelInfo.free ? "free" : undefined,
+              modelInfo.selectable
                 ? "ready"
-                : model.loginRequired
-                  ? "login required"
-                  : model.envRequired
-                    ? "credentials required"
-                    : "not connected";
-              return `${getOpenCodeModelSelectionValue(model, catalog)} — ${providerLabel} (${availability})`;
-            })
-            .join(", ");
-          ctx.renderer.writeError(
-            `Model query "${trimmedArgs}" is ambiguous: ${preview}`,
-          );
-          ctx.reprompt();
-          return;
-        }
-
-        const selectedModel = resolution.model;
-        if (!selectedModel.selectable) {
-          const detail = selectedModel.loginRequired
-            ? `Connect ${selectedModel.providerName} first (${selectedModel.authMethods.join(", ")}).`
-            : selectedModel.envRequired
-              ? `Set ${selectedModel.providerName} credentials (${selectedModel.providerID}).`
-              : `${selectedModel.providerName} is not connected.`;
-          ctx.renderer.writeError(detail);
-          ctx.reprompt();
-          return;
-        }
-
-        const storedModel = getOpenCodeModelSelectionValue(
-          selectedModel,
-          catalog,
-        );
-        setChatModel(ctx.chatId(), storedModel);
+                : (modelInfo.unavailableReason ?? "not connected"),
+            ].filter(Boolean)
+          : [];
         ctx.renderer.writeSystem(
-          `Model → ${storedModel} (${selectedModel.providerName}${selectedModel.free ? " · free" : ""})`,
+          `Model: ${displayName}${details.length ? ` · ${details.join(" · ")}` : ""}`,
+        );
+        if (modelInfo?.contextWindow) {
+          ctx.renderer.writeln(
+            `  Context window: ${modelInfo.contextWindow.toLocaleString()}`,
+          );
+        }
+        if (be?.getProviders) {
+          const providers = await be.getProviders();
+          const connected = providers.filter((p) => p.connected);
+          if (connected.length > 0) {
+            ctx.renderer.writeln(
+              `  Providers: ${connected.map((p) => `${p.name} (${p.modelCount})`).join(", ")}`,
+            );
+          }
+        }
+        ctx.renderer.writeln(
+          `  Use /model free, /model all, /model providers, or /model <name>.`,
         );
         ctx.reprompt();
         return;
       }
 
-      if (!args) {
-        const { getModels } = await import("../../core/models.js");
-        const current = getChatSettings(ctx.chatId()).model ?? ctx.config.model;
-        const names = getModels()
-          .map((m) => m.aliases[0] ?? m.id)
-          .join(", ");
-        ctx.renderer.writeSystem(`Model: ${current} (available: ${names})`);
+      if (lowerArgs === "reset" || lowerArgs === "default") {
+        setChatModel(ctx.chatId(), undefined);
+        ctx.renderer.writeSystem(`Model → ${ctx.config.model}`);
+        ctx.reprompt();
+        return;
+      }
+
+      if (
+        lowerArgs === "free" ||
+        lowerArgs === "list" ||
+        lowerArgs === "all"
+      ) {
+        if (be?.listModels) {
+          const filter = lowerArgs === "free" ? "free" : "all";
+          const { models, total } = await be.listModels(filter);
+          const list = models.slice(0, 20);
+          ctx.renderer.writeSystem(
+            `${filter === "free" ? "Free" : "Available"} models (${total})`,
+          );
+          for (const model of list) {
+            ctx.renderer.writeln(
+              `  ${model.displayName}  ·  ${model.providerName}${model.contextWindow ? `  ·  ${model.contextWindow.toLocaleString()} ctx` : ""}${model.free ? "  ·  free" : ""}`,
+            );
+          }
+          if (total > list.length) {
+            ctx.renderer.writeln(`  …and ${total - list.length} more`);
+          }
+        } else {
+          const { getModels } = await import("../../core/models.js");
+          const names = getModels()
+            .map((m) => m.aliases[0] ?? m.id)
+            .join(", ");
+          ctx.renderer.writeSystem(`Available: ${names}`);
+        }
+        ctx.reprompt();
+        return;
+      }
+
+      if (lowerArgs === "providers") {
+        if (be?.getProviders) {
+          const providers = await be.getProviders();
+          ctx.renderer.writeSystem(`Providers (${providers.length})`);
+          for (const p of providers.slice(0, 20)) {
+            ctx.renderer.writeln(
+              `  ${p.name}  ·  ${p.connected ? "connected" : "not connected"}  ·  ${p.modelCount} models`,
+            );
+          }
+        } else {
+          ctx.renderer.writeSystem("Provider listing not supported.");
+        }
+        ctx.reprompt();
+        return;
+      }
+
+      // Resolve model query via backend
+      if (be?.resolveModel) {
+        const resolution = await be.resolveModel(trimmedArgs);
+        if (resolution.kind === "missing") {
+          const msg =
+            be.formatModelError?.(trimmedArgs, resolution) ??
+            `No model matched "${trimmedArgs}".`;
+          ctx.renderer.writeError(msg);
+          ctx.reprompt();
+          return;
+        }
+        if (resolution.kind === "ambiguous") {
+          const preview = resolution.matches
+            .map((m) => `${m.displayName} (${m.providerName})`)
+            .join(", ");
+          ctx.renderer.writeError(
+            `Ambiguous: "${trimmedArgs}" matches ${preview}`,
+          );
+          ctx.reprompt();
+          return;
+        }
+        if (!resolution.model.selectable) {
+          ctx.renderer.writeError(
+            resolution.model.unavailableReason ??
+              `${resolution.model.providerName} is not connected.`,
+          );
+          ctx.reprompt();
+          return;
+        }
+        setChatModel(ctx.chatId(), resolution.storedValue);
+        ctx.renderer.writeSystem(
+          `Model → ${resolution.model.displayName} (${resolution.model.providerName}${resolution.model.free ? " · free" : ""})`,
+        );
       } else {
-        setChatModel(ctx.chatId(), resolveModelName(args));
-        ctx.renderer.writeSystem(`Model → ${resolveModelName(args)}`);
+        setChatModel(ctx.chatId(), resolveModelName(trimmedArgs));
+        ctx.renderer.writeSystem(`Model → ${resolveModelName(trimmedArgs)}`);
       }
       ctx.reprompt();
     },
@@ -332,49 +270,39 @@ export function registerBuiltinCommands(): void {
       const { getLoadedPlugins } = await import("../../core/plugin.js");
       const info = getSessionInfo(ctx.chatId());
       const u = info.usage;
+      const be = ctx.backend;
+      const activeModel =
+        getChatSettings(ctx.chatId()).model ?? ctx.config.model;
       let displayInputTokens = u.totalInputTokens;
       let displayOutputTokens = u.totalOutputTokens;
       let displayCacheRead = u.totalCacheRead;
       let displayCacheWrite = u.totalCacheWrite;
-      let openCodeModelLine = "";
-      let openCodeContextLine = "";
+      let backendModelLine = "";
+      let backendContextLine = "";
       ctx.renderer.writeln();
       const nameStr = info.sessionName ? `"${info.sessionName}"  ·  ` : "";
-      if (ctx.config.backend === "opencode") {
-        const activeModel =
-          getChatSettings(ctx.chatId()).model ?? ctx.config.model;
-        const { getOpenCodeModelInfo, getOpenCodeSessionSnapshot } =
-          await import("../../backend/opencode/index.js");
-        const modelInfo = await getOpenCodeModelInfo(activeModel).catch(
-          () => undefined,
-        );
-        const sessionSnapshot = info.sessionId
-          ? await getOpenCodeSessionSnapshot(info.sessionId).catch(
-              () => undefined,
-            )
-          : undefined;
-        const liveUsage = sessionSnapshot?.usage;
-        displayInputTokens = liveUsage?.totalInputTokens ?? displayInputTokens;
-        displayOutputTokens =
-          liveUsage?.totalOutputTokens ?? displayOutputTokens;
-        displayCacheRead = liveUsage?.totalCacheRead ?? displayCacheRead;
-        displayCacheWrite = liveUsage?.totalCacheWrite ?? displayCacheWrite;
 
-        const contextModelID =
-          sessionSnapshot?.assistant?.modelID ?? info.lastModel ?? activeModel;
-        const contextModelInfo =
-          contextModelID === activeModel
-            ? modelInfo
-            : await getOpenCodeModelInfo(contextModelID).catch(() => undefined);
-        const promptTokens = sessionSnapshot?.assistant
-          ? sessionSnapshot.assistant.inputTokens +
-            sessionSnapshot.assistant.cacheRead +
-            sessionSnapshot.assistant.cacheWrite
-          : u.lastPromptTokens;
+      // Enrich from backend when available
+      if (be?.getSessionSnapshot && info.sessionId) {
+        const snap = await be
+          .getSessionSnapshot(info.sessionId)
+          .catch(() => undefined);
+        if (snap) {
+          displayInputTokens = snap.inputTokens ?? displayInputTokens;
+          displayOutputTokens = snap.outputTokens ?? displayOutputTokens;
+          displayCacheRead = snap.cacheRead ?? displayCacheRead;
+          displayCacheWrite = snap.cacheWrite ?? displayCacheWrite;
+        }
+      }
 
-        openCodeModelLine = `  ${pc.bold("OpenCode")}  ${activeModel}${modelInfo ? `  ·  ${modelInfo.providerName}${modelInfo.free ? " · free" : ""}` : ""}`;
-        if (contextModelInfo?.contextWindow) {
-          openCodeContextLine = `  ${pc.dim(`context ${promptTokens.toLocaleString()} / ${contextModelInfo.contextWindow.toLocaleString()}  ·  cache ${displayCacheRead.toLocaleString()} / ${displayCacheWrite.toLocaleString()}`)}`;
+      if (be?.getModelInfo) {
+        const modelInfo = await be.getModelInfo(activeModel).catch(() => undefined);
+        const label = be.backendLabel ?? "Backend";
+        if (modelInfo) {
+          backendModelLine = `  ${pc.bold(label)}  ${modelInfo.displayName}  ·  ${modelInfo.providerName}${modelInfo.free ? " · free" : ""}`;
+          if (modelInfo.contextWindow) {
+            backendContextLine = `  ${pc.dim(`context window ${modelInfo.contextWindow.toLocaleString()}  ·  cache ${displayCacheRead.toLocaleString()} / ${displayCacheWrite.toLocaleString()}`)}`;
+          }
         }
       }
 
@@ -391,11 +319,11 @@ export function registerBuiltinCommands(): void {
       ctx.renderer.writeln(
         `  ${pc.dim(`in ${displayInputTokens.toLocaleString()}  ·  out ${displayOutputTokens.toLocaleString()} tokens`)}`,
       );
-      if (openCodeModelLine) {
+      if (backendModelLine) {
         ctx.renderer.writeln();
-        ctx.renderer.writeln(openCodeModelLine);
-        if (openCodeContextLine) {
-          ctx.renderer.writeln(openCodeContextLine);
+        ctx.renderer.writeln(backendModelLine);
+        if (backendContextLine) {
+          ctx.renderer.writeln(backendContextLine);
         }
       }
 
@@ -461,9 +389,7 @@ export function registerBuiltinCommands(): void {
         const turns = `${s.info.turns} turn${s.info.turns !== 1 ? "s" : ""}`;
         const ago = formatTimeAgo(s.info.lastActive);
         const model = s.info.lastModel
-          ? s.info.lastModel
-              .replace("claude-", "")
-              .replace(/-(\d+)-(\d+).*/, " $1.$2")
+          ? (coreResolveModel(s.info.lastModel)?.displayName ?? s.info.lastModel)
           : "";
         ctx.renderer.writeln(
           `  ${pc.green(String(i + 1))}. ${name}  ${pc.dim(`${turns}  ·  ${ago}${model ? `  ·  ${model}` : ""}`)}`,

--- a/src/frontend/terminal/commands.ts
+++ b/src/frontend/terminal/commands.ts
@@ -148,11 +148,7 @@ export function registerBuiltinCommands(): void {
         return;
       }
 
-      if (
-        lowerArgs === "free" ||
-        lowerArgs === "list" ||
-        lowerArgs === "all"
-      ) {
+      if (lowerArgs === "free" || lowerArgs === "list" || lowerArgs === "all") {
         if (be?.listModels) {
           const filter = lowerArgs === "free" ? "free" : "all";
           const { models, total } = await be.listModels(filter);
@@ -296,7 +292,9 @@ export function registerBuiltinCommands(): void {
       }
 
       if (be?.getModelInfo) {
-        const modelInfo = await be.getModelInfo(activeModel).catch(() => undefined);
+        const modelInfo = await be
+          .getModelInfo(activeModel)
+          .catch(() => undefined);
         const label = be.backendLabel ?? "Backend";
         if (modelInfo) {
           backendModelLine = `  ${pc.bold(label)}  ${modelInfo.displayName}  ·  ${modelInfo.providerName}${modelInfo.free ? " · free" : ""}`;
@@ -389,7 +387,8 @@ export function registerBuiltinCommands(): void {
         const turns = `${s.info.turns} turn${s.info.turns !== 1 ? "s" : ""}`;
         const ago = formatTimeAgo(s.info.lastActive);
         const model = s.info.lastModel
-          ? (coreResolveModel(s.info.lastModel)?.displayName ?? s.info.lastModel)
+          ? (coreResolveModel(s.info.lastModel)?.displayName ??
+            s.info.lastModel)
           : "";
         ctx.renderer.writeln(
           `  ${pc.green(String(i + 1))}. ${name}  ${pc.dim(`${turns}  ·  ${ago}${model ? `  ·  ${model}` : ""}`)}`,

--- a/src/frontend/terminal/index.ts
+++ b/src/frontend/terminal/index.ts
@@ -17,6 +17,7 @@ import {
   deriveNumericChatId,
   generateTerminalChatId,
 } from "../../util/chat-id.js";
+import { resolveModel } from "../../core/models.js";
 import { createRenderer } from "./renderer.js";
 import { createInput } from "./input.js";
 import {
@@ -145,10 +146,8 @@ export function createTerminalFrontend(
     async start() {
       initNewChat();
 
-      const { resolveModel: coreResolve } =
-        await import("../../core/models.js");
       const modelDisplay =
-        coreResolve(config.model)?.displayName ?? config.model;
+        resolveModel(config.model)?.displayName ?? config.model;
 
       renderer.writeln();
       renderer.writeln(

--- a/src/frontend/terminal/index.ts
+++ b/src/frontend/terminal/index.ts
@@ -145,8 +145,10 @@ export function createTerminalFrontend(
     async start() {
       initNewChat();
 
-      const { resolveModel: coreResolve } = await import("../../core/models.js");
-      const modelDisplay = coreResolve(config.model)?.displayName ?? config.model;
+      const { resolveModel: coreResolve } =
+        await import("../../core/models.js");
+      const modelDisplay =
+        coreResolve(config.model)?.displayName ?? config.model;
 
       renderer.writeln();
       renderer.writeln(

--- a/src/frontend/terminal/index.ts
+++ b/src/frontend/terminal/index.ts
@@ -145,13 +145,8 @@ export function createTerminalFrontend(
     async start() {
       initNewChat();
 
-      const modelDisplay = config.model
-        .replace("claude-", "")
-        .replace(
-          /^(\w+)-(\d+)-(\d+)/,
-          (_, name: string, maj: string, min: string) =>
-            `${name.charAt(0).toUpperCase() + name.slice(1)} ${maj}.${min}`,
-        );
+      const { resolveModel: coreResolve } = await import("../../core/models.js");
+      const modelDisplay = coreResolve(config.model)?.displayName ?? config.model;
 
       renderer.writeln();
       renderer.writeln(
@@ -189,6 +184,9 @@ export function createTerminalFrontend(
           renderer.writeln();
           input.close();
           process.exit(0);
+        },
+        get backend() {
+          return gateway.backend;
         },
       };
 


### PR DESCRIPTION
## Summary

- **Zero backend references in frontend**: No `config.backend` checks, no imports from `backend/claude-sdk` or `backend/opencode`, no hardcoded model names (claude, opus, sonnet, haiku, opencode) in any frontend file
- **Core stays provider-agnostic**: Moved shared constants to `core/constants.ts`, removed `[1m]` handling from core resolver (Claude-specific), cleaned provider-specific comments
- **Backends own display names**: `formatModelLabel` returns `model.displayName` directly — no more regex/alias scanning in frontend
- **Extended QueryBackend interface**: Added `listModels()` and `backendLabel` so frontends can browse models without knowing which backend is active

### Files changed (21)

| Area | Changes |
|------|---------|
| **core/** | New `constants.ts`, cleaned `models.ts` resolver, removed backend imports from `dream.ts`/`heartbeat.ts`, extended `types.ts` interface |
| **frontend/terminal/** | `/model` and `/status` use `ctx.backend` instead of OpenCode imports, model display via registry |
| **frontend/telegram/** | Removed `.replace("claude-", "")` calls, `config.backend` check, provider-specific alias filter, "Claude decides" string |
| **frontend/teams/** | Removed `.replace("claude-", "")`, use registry displayName |
| **backend/** | `constants.ts` re-exports from core, both model-providers implement `listModels()` |
| **tests** | Updated to mock via `ctx.backend` instead of backend module mocks |

## Test plan

- [x] `npx tsc --noEmit` — zero new type errors
- [x] `npx vitest run` — 1375/1375 tests pass
- [ ] Manual: `/model`, `/model free`, `/model all`, `/model providers` in terminal
- [ ] Manual: `/settings`, `/status` in telegram
- [ ] Manual: model switching in both backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)