### PR TITLE
feat(observability): structured logging, tracing, and debug tooling

### DIFF
--- a/src/__tests__/dispatcher.test.ts
+++ b/src/__tests__/dispatcher.test.ts
@@ -510,6 +510,7 @@ describe("typing indicator — interval error handling", () => {
   it("logs warning when sendTyping interval callback rejects", async () => {
     vi.useFakeTimers();
     vi.resetModules();
+    const childWarn = vi.fn();
     vi.doMock("../util/log.js", () => ({
       log: vi.fn(),
       logDebug: vi.fn(),
@@ -520,7 +521,7 @@ describe("typing indicator — interval error handling", () => {
         trace: vi.fn(),
         debug: vi.fn(),
         info: vi.fn(),
-        warn: vi.fn(),
+        warn: childWarn,
         error: vi.fn(),
         fatal: vi.fn(),
         child: vi.fn(),
@@ -530,9 +531,6 @@ describe("typing indicator — interval error handling", () => {
     vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
 
     const { initDispatcher, execute } = await import("../core/dispatcher.js");
-    const { logWarn } = (await import("../util/log.js")) as unknown as {
-      logWarn: ReturnType<typeof vi.fn>;
-    };
 
     let typingCallCount = 0;
     let resolveQuery!: (v: {
@@ -583,8 +581,7 @@ describe("typing indicator — interval error handling", () => {
     });
     await p;
 
-    expect(logWarn).toHaveBeenCalledWith(
-      "dispatcher",
+    expect(childWarn).toHaveBeenCalledWith(
       expect.stringContaining("interval failed"),
     );
 
@@ -595,6 +592,7 @@ describe("typing indicator — interval error handling", () => {
 describe("typing indicator — error handling", () => {
   it("logs warning when sendTyping rejects (initial call)", async () => {
     vi.resetModules();
+    const childWarn = vi.fn();
     vi.doMock("../util/log.js", () => ({
       log: vi.fn(),
       logDebug: vi.fn(),
@@ -605,7 +603,7 @@ describe("typing indicator — error handling", () => {
         trace: vi.fn(),
         debug: vi.fn(),
         info: vi.fn(),
-        warn: vi.fn(),
+        warn: childWarn,
         error: vi.fn(),
         fatal: vi.fn(),
         child: vi.fn(),
@@ -616,9 +614,6 @@ describe("typing indicator — error handling", () => {
     vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
 
     const { initDispatcher, execute } = await import("../core/dispatcher.js");
-    const logWarn = (await import("../util/log.js")).logWarn as ReturnType<
-      typeof vi.fn
-    >;
 
     const backend = {
       query: vi.fn(async () => ({
@@ -649,8 +644,7 @@ describe("typing indicator — error handling", () => {
       source: "message",
     });
 
-    expect(logWarn).toHaveBeenCalledWith(
-      "dispatcher",
+    expect(childWarn).toHaveBeenCalledWith(
       expect.stringContaining("sendTyping failed"),
     );
   });
@@ -659,6 +653,7 @@ describe("typing indicator — error handling", () => {
 describe("typing indicator — non-Error throws", () => {
   it("logs warning with String(err) when sendTyping throws a non-Error (initial call)", async () => {
     vi.resetModules();
+    const childWarn = vi.fn();
     vi.doMock("../util/log.js", () => ({
       log: vi.fn(),
       logDebug: vi.fn(),
@@ -669,7 +664,7 @@ describe("typing indicator — non-Error throws", () => {
         trace: vi.fn(),
         debug: vi.fn(),
         info: vi.fn(),
-        warn: vi.fn(),
+        warn: childWarn,
         error: vi.fn(),
         fatal: vi.fn(),
         child: vi.fn(),
@@ -679,9 +674,6 @@ describe("typing indicator — non-Error throws", () => {
     vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
 
     const { initDispatcher, execute } = await import("../core/dispatcher.js");
-    const logWarn = (await import("../util/log.js")).logWarn as ReturnType<
-      typeof vi.fn
-    >;
 
     initDispatcher({
       backend: {
@@ -711,8 +703,7 @@ describe("typing indicator — non-Error throws", () => {
       source: "message",
     });
 
-    expect(logWarn).toHaveBeenCalledWith(
-      "dispatcher",
+    expect(childWarn).toHaveBeenCalledWith(
       expect.stringContaining("plain string typing error"),
     );
   });
@@ -720,6 +711,7 @@ describe("typing indicator — non-Error throws", () => {
   it("logs warning with String(err) when sendTyping interval throws a non-Error", async () => {
     vi.useFakeTimers();
     vi.resetModules();
+    const childWarn = vi.fn();
     vi.doMock("../util/log.js", () => ({
       log: vi.fn(),
       logDebug: vi.fn(),
@@ -730,7 +722,7 @@ describe("typing indicator — non-Error throws", () => {
         trace: vi.fn(),
         debug: vi.fn(),
         info: vi.fn(),
-        warn: vi.fn(),
+        warn: childWarn,
         error: vi.fn(),
         fatal: vi.fn(),
         child: vi.fn(),
@@ -740,9 +732,6 @@ describe("typing indicator — non-Error throws", () => {
     vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
 
     const { initDispatcher, execute } = await import("../core/dispatcher.js");
-    const logWarn = (await import("../util/log.js")).logWarn as ReturnType<
-      typeof vi.fn
-    >;
 
     let callCount = 0;
     let resolveQuery!: (v: {
@@ -792,8 +781,7 @@ describe("typing indicator — non-Error throws", () => {
     });
     await p;
 
-    expect(logWarn).toHaveBeenCalledWith(
-      "dispatcher",
+    expect(childWarn).toHaveBeenCalledWith(
       expect.stringContaining("interval failed"),
     );
 

--- a/src/__tests__/dispatcher.test.ts
+++ b/src/__tests__/dispatcher.test.ts
@@ -515,6 +515,17 @@ describe("typing indicator — interval error handling", () => {
       logDebug: vi.fn(),
       logWarn: vi.fn(),
       logError: vi.fn(),
+      newRequestId: vi.fn(() => "testid01"),
+      childLogger: vi.fn(() => ({
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        child: vi.fn(),
+        bindings: vi.fn(() => ({ component: "dispatcher" })),
+      })),
     }));
     vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
 
@@ -589,6 +600,17 @@ describe("typing indicator — error handling", () => {
       logDebug: vi.fn(),
       logWarn: vi.fn(),
       logError: vi.fn(),
+      newRequestId: vi.fn(() => "testid01"),
+      childLogger: vi.fn(() => ({
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        child: vi.fn(),
+        bindings: vi.fn(() => ({ component: "dispatcher" })),
+      })),
     }));
     vi.doMock("./dream.js", () => ({ maybeStartDream: vi.fn() }));
     vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
@@ -642,6 +664,17 @@ describe("typing indicator — non-Error throws", () => {
       logDebug: vi.fn(),
       logWarn: vi.fn(),
       logError: vi.fn(),
+      newRequestId: vi.fn(() => "testid01"),
+      childLogger: vi.fn(() => ({
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        child: vi.fn(),
+        bindings: vi.fn(() => ({ component: "dispatcher" })),
+      })),
     }));
     vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
 
@@ -692,6 +725,17 @@ describe("typing indicator — non-Error throws", () => {
       logDebug: vi.fn(),
       logWarn: vi.fn(),
       logError: vi.fn(),
+      newRequestId: vi.fn(() => "testid01"),
+      childLogger: vi.fn(() => ({
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        child: vi.fn(),
+        bindings: vi.fn(() => ({ component: "dispatcher" })),
+      })),
     }));
     vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
 
@@ -765,6 +809,17 @@ describe("dispatcher — uninitialized guard", () => {
       logDebug: vi.fn(),
       logWarn: vi.fn(),
       logError: vi.fn(),
+      newRequestId: vi.fn(() => "testid01"),
+      childLogger: vi.fn(() => ({
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        child: vi.fn(),
+        bindings: vi.fn(() => ({ component: "dispatcher" })),
+      })),
     }));
     vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
 

--- a/src/__tests__/gateway-context.test.ts
+++ b/src/__tests__/gateway-context.test.ts
@@ -1,11 +1,23 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-vi.mock("../util/log.js", () => ({
-  log: vi.fn(),
-  logError: vi.fn(),
-  logWarn: vi.fn(),
-  logDebug: vi.fn(),
-}));
+// Gateway statically imports setLogLevel/getLogLevel/getRecentLogs from
+// log.js for the /debug/* routes. ESM resolution throws on any missing
+// export even when the test doesn't exercise that path, so expose them
+// defensively alongside the legacy wrappers.
+vi.mock("../util/log.js", () => {
+  let currentLevel = "trace";
+  return {
+    log: vi.fn(),
+    logError: vi.fn(),
+    logWarn: vi.fn(),
+    logDebug: vi.fn(),
+    setLogLevel: vi.fn((lvl: string) => {
+      currentLevel = lvl;
+    }),
+    getLogLevel: vi.fn(() => currentLevel),
+    getRecentLogs: vi.fn(() => []),
+  };
+});
 
 vi.mock("../core/gateway-actions.js", () => ({
   handleSharedAction: vi.fn(async () => null),

--- a/src/__tests__/gateway-http.test.ts
+++ b/src/__tests__/gateway-http.test.ts
@@ -592,6 +592,28 @@ describe("Gateway — debug endpoints", () => {
     expect(body.ok).toBe(false);
   });
 
+  it("413 path drains the body so the connection stays healthy", async () => {
+    // After the early 413 (rejected on Content-Length without reading the
+    // body), subsequent requests must succeed — i.e. the server didn't
+    // destroy the socket or leave req paused with unread data.
+    const huge = "x".repeat(10_000);
+    const tooBig = await fetch(`http://127.0.0.1:${port}/debug/log-level`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ level: "trace", pad: huge }),
+    });
+    expect(tooBig.status).toBe(413);
+    // Drain the response body so the connection can be returned to the pool.
+    await tooBig.text();
+    // Health-check the gateway with a tiny normal request.
+    const ok = await fetch(`http://127.0.0.1:${port}/debug/log-level`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ level: "trace" }),
+    });
+    expect(ok.status).toBe(200);
+  });
+
   it("GET /debug/nonsense returns 404", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/debug/nonsense`);
     expect(res.status).toBe(404);

--- a/src/__tests__/gateway-http.test.ts
+++ b/src/__tests__/gateway-http.test.ts
@@ -475,9 +475,7 @@ describe("Gateway — debug endpoints", () => {
   });
 
   it("GET /debug/logs rejects an invalid level with 400", async () => {
-    const res = await fetch(
-      `http://127.0.0.1:${port}/debug/logs?level=bogus`,
-    );
+    const res = await fetch(`http://127.0.0.1:${port}/debug/logs?level=bogus`);
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.ok).toBe(false);

--- a/src/__tests__/gateway-http.test.ts
+++ b/src/__tests__/gateway-http.test.ts
@@ -8,12 +8,20 @@ import {
   vi,
 } from "vitest";
 
-vi.mock("../util/log.js", () => ({
-  log: vi.fn(),
-  logError: vi.fn(),
-  logWarn: vi.fn(),
-  logDebug: vi.fn(),
-}));
+vi.mock("../util/log.js", () => {
+  let currentLevel = "trace";
+  return {
+    log: vi.fn(),
+    logError: vi.fn(),
+    logWarn: vi.fn(),
+    logDebug: vi.fn(),
+    setLogLevel: vi.fn((lvl: string) => {
+      currentLevel = lvl;
+    }),
+    getLogLevel: vi.fn(() => currentLevel),
+    getRecentLogs: vi.fn(() => []),
+  };
+});
 
 vi.mock("../core/plugin.js", () => ({
   handlePluginAction: vi.fn(async () => null),
@@ -26,6 +34,9 @@ vi.mock("../util/watchdog.js", () => ({
     recentErrorCount: 0,
     msSinceLastMessage: 0,
   })),
+  getRecentErrors: vi.fn(() => []),
+  getUptimeMs: vi.fn(() => 0),
+  getTotalMessagesProcessed: vi.fn(() => 0),
 }));
 
 vi.mock("../storage/sessions.js", () => ({
@@ -432,5 +443,99 @@ describe("gateway port retry — EADDRINUSE", () => {
         await new Promise<void>((resolve) => s.close(() => resolve()));
       }
     }
+  });
+});
+
+describe("Gateway — debug endpoints", () => {
+  it("GET /debug/state returns a JSON snapshot", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/debug/state`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.ts).toBe("string");
+    expect(body.process).toBeDefined();
+    expect(body.metrics).toBeDefined();
+    expect(body.logs).toBeDefined();
+  });
+
+  it("GET /debug/metrics returns counters + histograms", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/debug/metrics`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.counters).toBeDefined();
+    expect(body.histograms).toBeDefined();
+  });
+
+  it("GET /debug/spans clamps invalid limit to default", async () => {
+    const res = await fetch(
+      `http://127.0.0.1:${port}/debug/spans?limit=not-a-number`,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.spans)).toBe(true);
+  });
+
+  it("GET /debug/logs rejects an invalid level with 400", async () => {
+    const res = await fetch(
+      `http://127.0.0.1:${port}/debug/logs?level=bogus`,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(String(body.error)).toMatch(/level/i);
+  });
+
+  it("GET /debug/logs accepts a valid level", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/debug/logs?level=warn`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.level).toBe("string");
+    expect(Array.isArray(body.logs)).toBe(true);
+  });
+
+  it("GET /debug/log-level returns the current level", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/debug/log-level`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.level).toBe("string");
+  });
+
+  it("POST /debug/log-level sets the level and persists", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/debug/log-level`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ level: "warn" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.level).toBe("warn");
+
+    // Verify the GET now reflects it
+    const get = await fetch(`http://127.0.0.1:${port}/debug/log-level`);
+    const getBody = await get.json();
+    expect(getBody.level).toBe("warn");
+
+    // Restore trace for subsequent tests
+    await fetch(`http://127.0.0.1:${port}/debug/log-level`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ level: "trace" }),
+    });
+  });
+
+  it("POST /debug/log-level rejects a missing level with 400", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/debug/log-level`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
+
+  it("GET /debug/nonsense returns 404", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/debug/nonsense`);
+    expect(res.status).toBe(404);
   });
 });

--- a/src/__tests__/gateway-http.test.ts
+++ b/src/__tests__/gateway-http.test.ts
@@ -9,13 +9,25 @@ import {
 } from "vitest";
 
 vi.mock("../util/log.js", () => {
+  const VALID = new Set([
+    "trace",
+    "debug",
+    "info",
+    "warn",
+    "error",
+    "fatal",
+    "silent",
+  ]);
   let currentLevel = "trace";
   return {
     log: vi.fn(),
     logError: vi.fn(),
     logWarn: vi.fn(),
     logDebug: vi.fn(),
+    // Mirrors the real setLogLevel behavior: throws on unknown values so
+    // the gateway can translate that into a 400 without mutating state.
     setLogLevel: vi.fn((lvl: string) => {
+      if (!VALID.has(lvl)) throw new Error(`Invalid log level: ${lvl}`);
       currentLevel = lvl;
     }),
     getLogLevel: vi.fn(() => currentLevel),
@@ -528,6 +540,54 @@ describe("Gateway — debug endpoints", () => {
       body: JSON.stringify({}),
     });
     expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
+
+  it("POST /debug/log-level rejects an invalid level without mutating state", async () => {
+    // First, set a known level so we can verify it stays put.
+    await fetch(`http://127.0.0.1:${port}/debug/log-level`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ level: "warn" }),
+    });
+    const before = (await (
+      await fetch(`http://127.0.0.1:${port}/debug/log-level`)
+    ).json()) as { level: string };
+
+    // Attempt an invalid level — should 400, NOT change state.
+    const res = await fetch(`http://127.0.0.1:${port}/debug/log-level`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ level: "bogus" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/invalid/i);
+
+    // Verify the previous level is still in effect.
+    const after = (await (
+      await fetch(`http://127.0.0.1:${port}/debug/log-level`)
+    ).json()) as { level: string };
+    expect(after.level).toBe(before.level);
+
+    // Restore default for subsequent tests.
+    await fetch(`http://127.0.0.1:${port}/debug/log-level`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ level: "trace" }),
+    });
+  });
+
+  it("POST /debug/log-level rejects an oversized body with 413", async () => {
+    const huge = "x".repeat(10_000);
+    const res = await fetch(`http://127.0.0.1:${port}/debug/log-level`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ level: "trace", pad: huge }),
+    });
+    expect(res.status).toBe(413);
     const body = await res.json();
     expect(body.ok).toBe(false);
   });

--- a/src/__tests__/gateway-retry.test.ts
+++ b/src/__tests__/gateway-retry.test.ts
@@ -20,12 +20,24 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Mocks (before any dynamic import) ─────────────────────────────────────
 
-vi.mock("../util/log.js", () => ({
-  log: vi.fn(),
-  logError: vi.fn(),
-  logWarn: vi.fn(),
-  logDebug: vi.fn(),
-}));
+// Gateway imports these on top-level for the /debug/* routes. Test mocks
+// must expose them even though this file only exercises withRetry, because
+// ESM throws on any "module does not provide an export" lookup during
+// resolution.
+vi.mock("../util/log.js", () => {
+  let currentLevel = "trace";
+  return {
+    log: vi.fn(),
+    logError: vi.fn(),
+    logWarn: vi.fn(),
+    logDebug: vi.fn(),
+    setLogLevel: vi.fn((lvl: string) => {
+      currentLevel = lvl;
+    }),
+    getLogLevel: vi.fn(() => currentLevel),
+    getRecentLogs: vi.fn(() => []),
+  };
+});
 
 vi.mock("../core/dispatcher.js", () => ({
   getActiveCount: vi.fn(() => 0),
@@ -38,6 +50,9 @@ vi.mock("../util/watchdog.js", () => ({
     recentErrorCount: 0,
     msSinceLastMessage: 0,
   })),
+  getRecentErrors: vi.fn(() => []),
+  getUptimeMs: vi.fn(() => 0),
+  getTotalMessagesProcessed: vi.fn(() => 0),
 }));
 
 vi.mock("../storage/sessions.js", () => ({

--- a/src/__tests__/gateway-withRetry-extended.test.ts
+++ b/src/__tests__/gateway-withRetry-extended.test.ts
@@ -21,12 +21,23 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 // ── Mocks (must precede all imports) ─────────────────────────────────────────
 
-vi.mock("../util/log.js", () => ({
-  log: vi.fn(),
-  logError: vi.fn(),
-  logWarn: vi.fn(),
-  logDebug: vi.fn(),
-}));
+// Gateway statically imports setLogLevel/getLogLevel/getRecentLogs from
+// log.js for the /debug/* routes. ESM resolution throws on any missing
+// export even when the test doesn't exercise that path.
+vi.mock("../util/log.js", () => {
+  let currentLevel = "trace";
+  return {
+    log: vi.fn(),
+    logError: vi.fn(),
+    logWarn: vi.fn(),
+    logDebug: vi.fn(),
+    setLogLevel: vi.fn((lvl: string) => {
+      currentLevel = lvl;
+    }),
+    getLogLevel: vi.fn(() => currentLevel),
+    getRecentLogs: vi.fn(() => []),
+  };
+});
 
 vi.mock("../core/gateway-actions.js", () => ({
   handleSharedAction: vi.fn(async () => null),

--- a/src/__tests__/json-safe.test.ts
+++ b/src/__tests__/json-safe.test.ts
@@ -36,7 +36,9 @@ describe("toJsonSafe", () => {
     const safe = toJsonSafe(err) as Record<string, unknown>;
     expect(safe.name).toBe("Error");
     expect(safe.message).toBe("boom");
-    expect(typeof safe.stack === "string" || safe.stack === undefined).toBe(true);
+    expect(typeof safe.stack === "string" || safe.stack === undefined).toBe(
+      true,
+    );
   });
 
   it("converts Date to ISO string", () => {
@@ -53,7 +55,10 @@ describe("toJsonSafe", () => {
       ["a", 1],
       ["b", 2],
     ]);
-    const safe = toJsonSafe(m) as { __type: string; entries: [string, number][] };
+    const safe = toJsonSafe(m) as {
+      __type: string;
+      entries: [string, number][];
+    };
     expect(safe.__type).toBe("Map");
     expect(safe.entries).toEqual([
       ["a", 1],

--- a/src/__tests__/json-safe.test.ts
+++ b/src/__tests__/json-safe.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { toJsonSafe } from "../util/json-safe.js";
+
+describe("toJsonSafe", () => {
+  it("passes primitives through unchanged", () => {
+    expect(toJsonSafe(null)).toBeNull();
+    expect(toJsonSafe(true)).toBe(true);
+    expect(toJsonSafe(false)).toBe(false);
+    expect(toJsonSafe(42)).toBe(42);
+    expect(toJsonSafe("hi")).toBe("hi");
+  });
+
+  it("flattens undefined to null (JSON has no undefined)", () => {
+    expect(toJsonSafe(undefined)).toBeNull();
+  });
+
+  it("stringifies BigInt with trailing n marker", () => {
+    expect(toJsonSafe(123n)).toBe("123n");
+  });
+
+  it("flattens NaN and Infinity to strings (JSON would emit null)", () => {
+    expect(toJsonSafe(NaN)).toBe("NaN");
+    expect(toJsonSafe(Infinity)).toBe("Infinity");
+    expect(toJsonSafe(-Infinity)).toBe("-Infinity");
+  });
+
+  it("stringifies symbols and functions safely", () => {
+    expect(toJsonSafe(Symbol("hi"))).toBe("Symbol(hi)");
+    expect(toJsonSafe(function namedFn() {})).toBe("[Function namedFn]");
+    // Arrow function has empty .name when assigned inline.
+    expect(toJsonSafe(() => 0)).toMatch(/^\[Function/);
+  });
+
+  it("expands Errors into name/message/stack", () => {
+    const err = new Error("boom");
+    const safe = toJsonSafe(err) as Record<string, unknown>;
+    expect(safe.name).toBe("Error");
+    expect(safe.message).toBe("boom");
+    expect(typeof safe.stack === "string" || safe.stack === undefined).toBe(true);
+  });
+
+  it("converts Date to ISO string", () => {
+    const d = new Date("2026-04-18T00:00:00.000Z");
+    expect(toJsonSafe(d)).toBe("2026-04-18T00:00:00.000Z");
+  });
+
+  it("flags invalid Date", () => {
+    expect(toJsonSafe(new Date(NaN))).toBe("[Invalid Date]");
+  });
+
+  it("flattens Map into __type/entries shape", () => {
+    const m = new Map<string, number>([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    const safe = toJsonSafe(m) as { __type: string; entries: [string, number][] };
+    expect(safe.__type).toBe("Map");
+    expect(safe.entries).toEqual([
+      ["a", 1],
+      ["b", 2],
+    ]);
+  });
+
+  it("flattens Set into __type/values shape", () => {
+    const safe = toJsonSafe(new Set([1, 2, 3])) as {
+      __type: string;
+      values: unknown[];
+    };
+    expect(safe.__type).toBe("Set");
+    expect(safe.values).toEqual([1, 2, 3]);
+  });
+
+  it("breaks circular references with marker (does not throw)", () => {
+    const a: Record<string, unknown> = { name: "a" };
+    a.self = a;
+    const safe = toJsonSafe(a) as Record<string, unknown>;
+    expect(safe.name).toBe("a");
+    expect(safe.self).toBe("[circular]");
+    // Final form must be JSON-serializable — that's the whole point.
+    expect(() => JSON.stringify(safe)).not.toThrow();
+  });
+
+  it("caps deep recursion with [depth] marker", () => {
+    // 12 levels deep, max depth default = 8 → at depth 8 we get [depth].
+    const deep: Record<string, unknown> = { v: "leaf" };
+    let cur = deep;
+    for (let i = 0; i < 12; i++) {
+      const next: Record<string, unknown> = {};
+      cur.next = next;
+      cur = next;
+    }
+    const safe = toJsonSafe(deep);
+    const j = JSON.stringify(safe);
+    expect(j).toContain('"[depth]"');
+  });
+
+  it("truncates long strings with overflow marker", () => {
+    const big = "x".repeat(5000);
+    const safe = toJsonSafe(big, { maxString: 16 }) as string;
+    expect(safe.startsWith("xxxxxxxxxxxxxxxx")).toBe(true);
+    expect(safe).toContain("[+");
+  });
+
+  it("caps array length and marks remainder", () => {
+    const arr = Array.from({ length: 10 }, (_, i) => i);
+    const safe = toJsonSafe(arr, { maxItems: 4 }) as unknown[];
+    expect(safe.slice(0, 4)).toEqual([0, 1, 2, 3]);
+    expect(safe[4]).toMatch(/\+6 more/);
+  });
+
+  it("caps object key count and marks remainder", () => {
+    const obj: Record<string, number> = {};
+    for (let i = 0; i < 10; i++) obj[`k${i}`] = i;
+    const safe = toJsonSafe(obj, { maxItems: 3 }) as Record<string, unknown>;
+    expect(Object.keys(safe).length).toBe(4); // 3 keys + "…" overflow
+    expect(safe["…"]).toMatch(/\+7 more keys/);
+  });
+
+  it("survives a getter that throws", () => {
+    const obj = {
+      good: 1,
+      get bad(): number {
+        throw new Error("nope");
+      },
+    };
+    const safe = toJsonSafe(obj) as Record<string, unknown>;
+    expect(safe.good).toBe(1);
+    expect(safe.bad).toBe("[unserializable]");
+  });
+
+  it("describes typed arrays with byte-length preview, not full payload", () => {
+    const buf = Buffer.from("hello world");
+    const safe = toJsonSafe(buf) as string;
+    expect(safe).toMatch(/^\[Buffer .*bytes=11\]$/);
+  });
+
+  it("output is always JSON.stringify-safe (random nasty mix)", () => {
+    const messy: Record<string, unknown> = {
+      big: 9999999999999999999n,
+      sym: Symbol("x"),
+      fn: () => 0,
+      nan: NaN,
+      inf: Infinity,
+      err: new TypeError("nope"),
+      d: new Date("2026-01-01T00:00:00Z"),
+      m: new Map([["k", "v"]]),
+      s: new Set([1]),
+      bytes: new Uint8Array([1, 2, 3]),
+    };
+    messy.cycle = messy;
+    const safe = toJsonSafe(messy);
+    expect(() => JSON.stringify(safe)).not.toThrow();
+  });
+});

--- a/src/__tests__/log-extras.test.ts
+++ b/src/__tests__/log-extras.test.ts
@@ -108,4 +108,20 @@ describe("log extras", () => {
       expect(["error", "fatal"].includes(r.level)).toBe(true);
     }
   });
+
+  it("child logger lines reach the ring buffer with component bindings", () => {
+    const child = childLogger({ component: "dispatcher", reqId: "rid" });
+    child.info("child-info");
+    child.error("child-err", new Error("oops"));
+    const records = getRecentLogs(50);
+    const info = records.find(
+      (r) => r.msg === "child-info" && r.level === "info",
+    );
+    const err = records.find(
+      (r) => r.msg === "child-err" && r.level === "error",
+    );
+    expect(info?.component).toBe("dispatcher");
+    expect(err?.component).toBe("dispatcher");
+    expect(err?.err).toBe("oops");
+  });
 });

--- a/src/__tests__/log-extras.test.ts
+++ b/src/__tests__/log-extras.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 
+// Pin env before importing log.ts — log.ts resolves initial level and debug
+// namespaces at module-init time, so CI env bleeding would flake these tests.
+process.env.TALON_LOG_LEVEL = "trace";
+delete process.env.TALON_DEBUG;
+delete process.env.TALON_QUIET;
+
 const mockInfo = vi.fn();
 const mockError = vi.fn();
 const mockWarn = vi.fn();

--- a/src/__tests__/log-extras.test.ts
+++ b/src/__tests__/log-extras.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+
+const mockInfo = vi.fn();
+const mockError = vi.fn();
+const mockWarn = vi.fn();
+const mockDebug = vi.fn();
+const mockTrace = vi.fn();
+const mockFatal = vi.fn();
+const mockChild = vi.fn();
+
+vi.mock("pino", () => ({
+  default: () => {
+    const logger = {
+      level: "trace",
+      info: mockInfo,
+      error: mockError,
+      warn: mockWarn,
+      debug: mockDebug,
+      trace: mockTrace,
+      fatal: mockFatal,
+      child: mockChild,
+    };
+    mockChild.mockReturnValue(logger);
+    return logger;
+  },
+}));
+
+const {
+  newRequestId,
+  childLogger,
+  getLogLevel,
+  setLogLevel,
+  isLevelEnabled,
+  isDebugEnabled,
+  setDebugNamespaces,
+  getRecentLogs,
+  log,
+  logError,
+} = await import("../util/log.js");
+
+describe("log extras", () => {
+  it("newRequestId returns an 8-char hex string", () => {
+    const id = newRequestId();
+    expect(id).toMatch(/^[0-9a-f]{8}$/);
+    expect(newRequestId()).not.toBe(id);
+  });
+
+  it("childLogger creates a logger with bindings", () => {
+    const child = childLogger({ component: "bot", reqId: "abc123" });
+    expect(mockChild).toHaveBeenCalledWith(
+      expect.objectContaining({ component: "bot", reqId: "abc123" }),
+    );
+    expect(typeof child.info).toBe("function");
+    expect(typeof child.debug).toBe("function");
+    expect(typeof child.error).toBe("function");
+    expect(child.bindings().component).toBe("bot");
+  });
+
+  it("child.error preserves Error stack in the body", () => {
+    const child = childLogger({ component: "bot" });
+    const err = new Error("boom");
+    child.error("failed", err);
+    expect(mockError).toHaveBeenCalledWith(
+      expect.objectContaining({ err: "boom", stack: expect.any(String) }),
+      "failed",
+    );
+  });
+
+  it("setLogLevel updates current level", () => {
+    setLogLevel("warn");
+    expect(getLogLevel()).toBe("warn");
+    expect(isLevelEnabled("info")).toBe(false);
+    expect(isLevelEnabled("warn")).toBe(true);
+    expect(isLevelEnabled("error")).toBe(true);
+    setLogLevel("trace");
+  });
+
+  it("setLogLevel rejects invalid levels", () => {
+    expect(() => setLogLevel("boom" as never)).toThrow();
+  });
+
+  it("isDebugEnabled respects namespace filter", () => {
+    setDebugNamespaces([]);
+    expect(isDebugEnabled("gateway")).toBe(true);
+    setDebugNamespaces(["gateway", "dispat*"]);
+    expect(isDebugEnabled("gateway")).toBe(true);
+    expect(isDebugEnabled("dispatcher")).toBe(true);
+    expect(isDebugEnabled("teams")).toBe(false);
+    setDebugNamespaces([]);
+  });
+
+  it("getRecentLogs captures info/warn/error records", () => {
+    log("bot", "hello world");
+    logError("bot", "kaboom", new Error("nope"));
+    const records = getRecentLogs(10);
+    const messages = records.map((r) => r.msg);
+    expect(messages).toContain("hello world");
+    expect(messages).toContain("kaboom");
+    const err = records.find((r) => r.msg === "kaboom");
+    expect(err?.level).toBe("error");
+  });
+
+  it("getRecentLogs respects minLevel filter", () => {
+    log("bot", "info-only");
+    logError("bot", "serious");
+    const errs = getRecentLogs(10, "error");
+    for (const r of errs) {
+      expect(["error", "fatal"].includes(r.level)).toBe(true);
+    }
+  });
+});

--- a/src/__tests__/log-extras.test.ts
+++ b/src/__tests__/log-extras.test.ts
@@ -130,4 +130,37 @@ describe("log extras", () => {
     expect(err?.component).toBe("dispatcher");
     expect(err?.err).toBe("oops");
   });
+
+  it("captures falsy err values (0, '', false) instead of dropping them", () => {
+    const child = childLogger({ component: "dispatcher" });
+    child.error("zero-err", 0);
+    child.error("empty-err", "");
+    child.error("false-err", false);
+    const records = getRecentLogs(50);
+    expect(records.find((r) => r.msg === "zero-err")?.err).toBe("0");
+    expect(records.find((r) => r.msg === "empty-err")?.err).toBe("");
+    expect(records.find((r) => r.msg === "false-err")?.err).toBe("false");
+  });
+
+  it("normalizes circular extra so getRecentLogs is JSON-serializable", () => {
+    const child = childLogger({ component: "dispatcher" });
+    const cyclic: Record<string, unknown> = { name: "A" };
+    cyclic.self = cyclic;
+    child.info("cycle-info", cyclic);
+    const rec = getRecentLogs(50).find((r) => r.msg === "cycle-info");
+    expect(rec).toBeDefined();
+    // The whole snapshot must round-trip through JSON without throwing.
+    expect(() => JSON.stringify(rec)).not.toThrow();
+    const safeExtra = rec?.extra as Record<string, unknown>;
+    expect(safeExtra.name).toBe("A");
+    expect(safeExtra.self).toBe("[circular]");
+  });
+
+  it("normalizes BigInt in extra so getRecentLogs is JSON-serializable", () => {
+    const child = childLogger({ component: "dispatcher" });
+    child.info("bigint-info", { n: 9999999999999999999n });
+    const rec = getRecentLogs(50).find((r) => r.msg === "bigint-info");
+    expect(() => JSON.stringify(rec)).not.toThrow();
+    expect((rec?.extra as Record<string, unknown>).n).toMatch(/n$/);
+  });
 });

--- a/src/__tests__/log-init.test.ts
+++ b/src/__tests__/log-init.test.ts
@@ -29,6 +29,7 @@ describe("log.ts — module-level initialization branches", () => {
       dirs: { root: "/fake/.talon" },
       files: {
         log: "/fake/.talon/talon.log",
+        errorLog: "/fake/.talon/errors.log",
         config: "/fake/.talon/config.json",
       },
     }));
@@ -42,10 +43,22 @@ describe("log.ts — module-level initialization branches", () => {
     }));
     vi.doMock("pino", () => ({
       default: () => ({
+        level: "trace",
         info: mockLogFn,
         error: mockLogFn,
         warn: mockLogFn,
         debug: mockLogFn,
+        trace: mockLogFn,
+        fatal: mockLogFn,
+        child: vi.fn(() => ({
+          level: "trace",
+          info: mockLogFn,
+          error: mockLogFn,
+          warn: mockLogFn,
+          debug: mockLogFn,
+          trace: mockLogFn,
+          fatal: mockLogFn,
+        })),
       }),
     }));
 
@@ -62,6 +75,7 @@ describe("log.ts — module-level initialization branches", () => {
       dirs: { root: "/fake/.talon" },
       files: {
         log: "/fake/.talon/talon.log",
+        errorLog: "/fake/.talon/errors.log",
         config: "/fake/.talon/config.json",
       },
     }));
@@ -75,10 +89,22 @@ describe("log.ts — module-level initialization branches", () => {
     }));
     vi.doMock("pino", () => ({
       default: () => ({
+        level: "trace",
         info: mockLogFn,
         error: mockLogFn,
         warn: mockLogFn,
         debug: mockLogFn,
+        trace: mockLogFn,
+        fatal: mockLogFn,
+        child: vi.fn(() => ({
+          level: "trace",
+          info: mockLogFn,
+          error: mockLogFn,
+          warn: mockLogFn,
+          debug: mockLogFn,
+          trace: mockLogFn,
+          fatal: mockLogFn,
+        })),
       }),
     }));
 
@@ -97,6 +123,7 @@ describe("log.ts — module-level initialization branches", () => {
       dirs: { root: "/fake/.talon" },
       files: {
         log: "/fake/.talon/talon.log",
+        errorLog: "/fake/.talon/errors.log",
         config: "/fake/.talon/config.json",
       },
     }));
@@ -111,10 +138,22 @@ describe("log.ts — module-level initialization branches", () => {
     }));
     vi.doMock("pino", () => ({
       default: () => ({
+        level: "trace",
         info: mockLogFn,
         error: mockLogFn,
         warn: mockLogFn,
         debug: mockLogFn,
+        trace: mockLogFn,
+        fatal: mockLogFn,
+        child: vi.fn(() => ({
+          level: "trace",
+          info: mockLogFn,
+          error: mockLogFn,
+          warn: mockLogFn,
+          debug: mockLogFn,
+          trace: mockLogFn,
+          fatal: mockLogFn,
+        })),
       }),
     }));
 

--- a/src/__tests__/log.test.ts
+++ b/src/__tests__/log.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// Pin the logger's initial level + namespace filter to a known state BEFORE
+// importing log.ts. log.ts resolves both at module-init time from env vars,
+// so leaving them to the CI environment makes these assertions flaky (e.g.
+// TALON_LOG_LEVEL=warn would cause log()/logDebug() to silently no-op).
+process.env.TALON_LOG_LEVEL = "trace";
+delete process.env.TALON_DEBUG;
+delete process.env.TALON_QUIET;
+
 // Mock pino before importing log module
 const mockInfo = vi.fn();
 const mockError = vi.fn();

--- a/src/__tests__/log.test.ts
+++ b/src/__tests__/log.test.ts
@@ -8,10 +8,22 @@ const mockDebug = vi.fn();
 
 vi.mock("pino", () => ({
   default: () => ({
+    level: "trace",
     info: mockInfo,
     error: mockError,
     warn: mockWarn,
     debug: mockDebug,
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(() => ({
+      level: "trace",
+      info: mockInfo,
+      error: mockError,
+      warn: mockWarn,
+      debug: mockDebug,
+      trace: vi.fn(),
+      fatal: vi.fn(),
+    })),
   }),
 }));
 
@@ -78,6 +90,9 @@ describe("log", () => {
         { component: "bridge", err: "timeout", stack: err.stack },
         "request failed",
       );
+      // Stack trace is also captured for easier debugging.
+      const call = mockError.mock.calls[0];
+      expect((call[0] as { stack?: string }).stack).toBeDefined();
     });
 
     it("stringifies non-Error err values", () => {

--- a/src/__tests__/metrics.test.ts
+++ b/src/__tests__/metrics.test.ts
@@ -4,6 +4,7 @@ import {
   recordHistogram,
   getMetrics,
   resetMetrics,
+  sanitizeMetricLabel,
 } from "../util/metrics.js";
 
 describe("metrics", () => {
@@ -72,5 +73,28 @@ describe("metrics", () => {
     expect(Object.keys(getMetrics().histograms)).toHaveLength(500);
     recordHistogram("overflow_hist", 42);
     expect(getMetrics().histograms["overflow_hist"]).toBeUndefined();
+  });
+});
+
+describe("sanitizeMetricLabel", () => {
+  it("passes well-formed labels through (lowercased)", () => {
+    expect(sanitizeMetricLabel("send_message")).toBe("send_message");
+    expect(sanitizeMetricLabel("SendMessage")).toBe("sendmessage");
+  });
+
+  it("replaces unsafe characters with underscores", () => {
+    expect(sanitizeMetricLabel("foo.bar/baz")).toBe("foo_bar_baz");
+    expect(sanitizeMetricLabel("hello world!")).toBe("hello_world");
+  });
+
+  it("buckets empty / non-string / all-garbage input as 'unknown'", () => {
+    expect(sanitizeMetricLabel("")).toBe("unknown");
+    expect(sanitizeMetricLabel("!!!")).toBe("unknown");
+    expect(sanitizeMetricLabel(undefined as unknown as string)).toBe("unknown");
+  });
+
+  it("truncates long input to 40 chars", () => {
+    const result = sanitizeMetricLabel("a".repeat(200));
+    expect(result.length).toBeLessThanOrEqual(40);
   });
 });

--- a/src/__tests__/reload-plugins.test.ts
+++ b/src/__tests__/reload-plugins.test.ts
@@ -49,6 +49,7 @@ vi.mock("../core/models.js", () => ({
 }));
 vi.mock("../util/trace.js", () => ({
   traceMessage: vi.fn(),
+  currentSpan: vi.fn(() => undefined),
 }));
 vi.mock("../util/time.js", () => ({
   formatFullDatetime: vi.fn(() => ""),

--- a/src/__tests__/teams-frontend.test.ts
+++ b/src/__tests__/teams-frontend.test.ts
@@ -1,11 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("../util/log.js", () => ({
-  log: vi.fn(),
-  logError: vi.fn(),
-  logWarn: vi.fn(),
-  logDebug: vi.fn(),
-}));
+// Teams frontend transitively loads modules that import Gateway, which
+// statically pulls setLogLevel/getLogLevel/getRecentLogs from log.js.
+// Expose them defensively so ESM resolution doesn't trip on missing exports.
+vi.mock("../util/log.js", () => {
+  let currentLevel = "trace";
+  return {
+    log: vi.fn(),
+    logError: vi.fn(),
+    logWarn: vi.fn(),
+    logDebug: vi.fn(),
+    setLogLevel: vi.fn((lvl: string) => {
+      currentLevel = lvl;
+    }),
+    getLogLevel: vi.fn(() => currentLevel),
+    getRecentLogs: vi.fn(() => []),
+  };
+});
 
 vi.mock("../core/plugin.js", () => ({
   handlePluginAction: vi.fn(async () => null),

--- a/src/__tests__/trace-spans.test.ts
+++ b/src/__tests__/trace-spans.test.ts
@@ -11,6 +11,17 @@ vi.mock("node:fs", async () => {
   };
 });
 
+// Stub log.js so importing trace.js doesn't run module-level pino/file
+// transport initialization (which would touch the real user home).
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+  logTrace: vi.fn(),
+  logFatal: vi.fn(),
+}));
+
 const { startSpan, withSpan, currentSpan, getRecentSpans, resetSpans } =
   await import("../util/trace.js");
 

--- a/src/__tests__/trace-spans.test.ts
+++ b/src/__tests__/trace-spans.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Stub out filesystem writes — we only care about the in-memory ring buffer here.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    appendFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    existsSync: vi.fn(() => true),
+  };
+});
+
+const {
+  startSpan,
+  withSpan,
+  currentSpan,
+  getRecentSpans,
+  resetSpans,
+} = await import("../util/trace.js");
+
+describe("span tracing", () => {
+  beforeEach(() => {
+    resetSpans();
+  });
+
+  it("startSpan returns a span with trace + span ids", () => {
+    const span = startSpan("test.op", { key: "value" });
+    expect(span.traceId).toMatch(/^[0-9a-f]{16}$/);
+    expect(span.spanId).toMatch(/^[0-9a-f]{8}$/);
+    expect(span.name).toBe("test.op");
+    const rec = span.end();
+    expect(rec.name).toBe("test.op");
+    expect(rec.status).toBe("ok");
+    expect(rec.attrs.key).toBe("value");
+  });
+
+  it("withSpan wraps a function and records duration + status", async () => {
+    const rec = await withSpan("work", { kind: "test" }, async (span) => {
+      span.addEvent("mid");
+      span.setAttribute("answer", 42);
+      return "ok";
+    });
+    expect(rec).toBe("ok");
+    const [latest] = getRecentSpans(1);
+    expect(latest.name).toBe("work");
+    expect(latest.attrs.answer).toBe(42);
+    expect(latest.events.map((e) => e.name)).toContain("mid");
+    expect(latest.status).toBe("ok");
+  });
+
+  it("withSpan records errors and rethrows", async () => {
+    await expect(
+      withSpan("bad", undefined, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    const [latest] = getRecentSpans(1);
+    expect(latest.status).toBe("error");
+    expect(latest.err).toBe("boom");
+  });
+
+  it("nested spans share traceId and link parent", async () => {
+    let childTraceId = "";
+    let childParentId = "";
+    let parentSpanId = "";
+    await withSpan("outer", undefined, async (outer) => {
+      parentSpanId = outer.spanId;
+      await withSpan("inner", undefined, async () => {
+        const cur = currentSpan();
+        childTraceId = cur?.traceId ?? "";
+        // end() returns a record with parentSpanId
+      });
+      const spans = getRecentSpans(10);
+      const inner = spans.find((s) => s.name === "inner");
+      childParentId = inner?.parentSpanId ?? "";
+    });
+    const spans = getRecentSpans(10);
+    const outer = spans.find((s) => s.name === "outer");
+    expect(outer?.traceId).toBe(childTraceId);
+    expect(childParentId).toBe(parentSpanId);
+  });
+
+  it("getRecentSpans caps the returned slice", async () => {
+    for (let i = 0; i < 5; i++) {
+      await withSpan(`op-${i}`, undefined, async () => i);
+    }
+    const last3 = getRecentSpans(3);
+    expect(last3).toHaveLength(3);
+    expect(last3[2].name).toBe("op-4");
+  });
+});

--- a/src/__tests__/trace-spans.test.ts
+++ b/src/__tests__/trace-spans.test.ts
@@ -95,4 +95,28 @@ describe("span tracing", () => {
     expect(last3).toHaveLength(3);
     expect(last3[2].name).toBe("op-4");
   });
+
+  it("normalizes JSON-hostile attributes so /debug/spans is exportable", async () => {
+    const cyclic: Record<string, unknown> = { name: "node" };
+    cyclic.self = cyclic;
+    await withSpan("messy", undefined, (span) => {
+      span.setAttribute("cycle", cyclic);
+      span.setAttribute("big", 9999999999999999999n);
+      span.setAttribute("fn", () => 0);
+      span.addEvent("evt", { also_cyclic: cyclic });
+      return null;
+    });
+    const [rec] = getRecentSpans(1);
+    expect(rec.attrs.cycle).toEqual(
+      expect.objectContaining({ name: "node", self: "[circular]" }),
+    );
+    expect(rec.attrs.big).toMatch(/n$/);
+    expect(rec.attrs.fn).toMatch(/^\[Function/);
+    expect(rec.events[0]?.attrs?.also_cyclic).toEqual(
+      expect.objectContaining({ self: "[circular]" }),
+    );
+    // The whole record must round-trip through JSON.stringify, since that's
+    // what /debug/spans and the spans-YYYY-MM-DD.jsonl writer call on it.
+    expect(() => JSON.stringify(rec)).not.toThrow();
+  });
 });

--- a/src/__tests__/trace-spans.test.ts
+++ b/src/__tests__/trace-spans.test.ts
@@ -11,13 +11,8 @@ vi.mock("node:fs", async () => {
   };
 });
 
-const {
-  startSpan,
-  withSpan,
-  currentSpan,
-  getRecentSpans,
-  resetSpans,
-} = await import("../util/trace.js");
+const { startSpan, withSpan, currentSpan, getRecentSpans, resetSpans } =
+  await import("../util/trace.js");
 
 describe("span tracing", () => {
   beforeEach(() => {

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -21,7 +21,7 @@ import { getFallbackModel } from "../../core/models.js";
 import { rebuildSystemPrompt } from "../../util/config.js";
 import { getPluginPromptAdditions } from "../../core/plugin.js";
 import { log, logError, logWarn } from "../../util/log.js";
-import { traceMessage } from "../../util/trace.js";
+import { traceMessage, currentSpan } from "../../util/trace.js";
 import { incrementCounter, recordHistogram } from "../../util/metrics.js";
 import { formatFullDatetime } from "../../util/time.js";
 import { isTurnTerminator } from "../../core/tools/index.js";
@@ -90,6 +90,15 @@ export async function handleMessage(
     : `${nowTag}${msgIdHint} ${text}`;
   log("agent", `[${chatId}] <- (${text.length} chars)`);
   traceMessage(chatId, "in", text, { senderName, isGroup });
+
+  const span = currentSpan();
+  span?.setAttributes({
+    backend: "claude-sdk",
+    model: activeModel,
+    sessionTurn: session.turns,
+    inputChars: text.length,
+  });
+  span?.addEvent("query-start");
 
   const qi = query({ prompt, options });
   activeQueries.set(chatId, qi);
@@ -350,6 +359,12 @@ export async function handleMessage(
     toolCalls: state.toolCalls,
     model: activeModel,
   });
+  span?.setAttributes({
+    cacheHitPct,
+    toolCalls: state.toolCalls,
+    numApiCalls: state.numApiCalls,
+  });
+  span?.addEvent("query-end");
 
   return {
     text: state.allResponseText.trim(),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -554,7 +554,8 @@ async function tailFile(
   );
   const content = readFileSync(filePath, "utf-8");
   const lines = content.trim().split("\n");
-  for (const line of lines.slice(-initialLines)) console.log(formatLogLine(line));
+  for (const line of lines.slice(-initialLines))
+    console.log(formatLogLine(line));
   let lastSize = lines.length;
   watchFile(filePath, { interval: 500 }, () => {
     try {
@@ -621,7 +622,9 @@ async function debugDumpMetrics(): Promise<void> {
       }
     }
     console.log();
-    console.log(`  ${pc.bold("Histograms")} ${pc.dim("(p50 / p95 / p99 / avg, ms)")}`);
+    console.log(
+      `  ${pc.bold("Histograms")} ${pc.dim("(p50 / p95 / p99 / avg, ms)")}`,
+    );
     const histograms = Object.entries(data.histograms ?? {}).sort(([a], [b]) =>
       a.localeCompare(b),
     );
@@ -639,9 +642,7 @@ async function debugDumpMetrics(): Promise<void> {
     console.log(
       `  ${pc.red("✖")} Could not reach bot: ${err instanceof Error ? err.message : err}\n`,
     );
-    console.log(
-      `  Is Talon running?  Start with ${pc.cyan("talon start")}.\n`,
-    );
+    console.log(`  Is Talon running?  Start with ${pc.cyan("talon start")}.\n`);
   }
 }
 
@@ -703,7 +704,9 @@ async function debugSetLogLevel(level: string): Promise<void> {
       error?: string;
     };
     if (res.ok) {
-      console.log(`  ${pc.green("●")} Log level set to ${pc.bold(res.level ?? level)}\n`);
+      console.log(
+        `  ${pc.green("●")} Log level set to ${pc.bold(res.level ?? level)}\n`,
+      );
     } else {
       console.log(`  ${pc.red("✖")} ${res.error}\n`);
     }
@@ -772,9 +775,7 @@ async function runDebug(args: string[]): Promise<void> {
       console.log(
         `    ${pc.cyan("spans [N]")}           Last N spans (default 30)`,
       );
-      console.log(
-        `    ${pc.cyan("errors")}              Tail errors.log live`,
-      );
+      console.log(`    ${pc.cyan("errors")}              Tail errors.log live`);
       console.log(
         `    ${pc.cyan("log-level [lvl]")}     Get/set runtime log level`,
       );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -552,14 +552,20 @@ async function tailFile(
   console.log(
     `  ${pc.dim(`Tailing ${label}`)} ${pc.dim(filePath)}\n  ${pc.dim("Press Ctrl+C to stop")}\n`,
   );
-  const content = readFileSync(filePath, "utf-8");
-  const lines = content.trim().split("\n");
+  // An empty/whitespace-only file must yield 0 lines, not [""]. Otherwise
+  // lastSize starts at 1 and the first real appended line gets skipped.
+  const splitLines = (content: string): string[] => {
+    const trimmed = content.replace(/\n+$/, "");
+    return trimmed === "" ? [] : trimmed.split("\n");
+  };
+
+  const lines = splitLines(readFileSync(filePath, "utf-8"));
   for (const line of lines.slice(-initialLines))
     console.log(formatLogLine(line));
   let lastSize = lines.length;
   watchFile(filePath, { interval: 500 }, () => {
     try {
-      const nl = readFileSync(filePath, "utf-8").trim().split("\n");
+      const nl = splitLines(readFileSync(filePath, "utf-8"));
       for (let i = lastSize; i < nl.length; i++)
         console.log(formatLogLine(nl[i]));
       lastSize = nl.length;
@@ -739,9 +745,12 @@ async function runDebug(args: string[]): Promise<void> {
     case "metrics":
       await debugDumpMetrics();
       return;
-    case "spans":
-      await debugDumpSpans(parseInt(args[1] ?? "30", 10));
+    case "spans": {
+      const parsed = Number.parseInt(args[1] ?? "30", 10);
+      const limit = Number.isFinite(parsed) && parsed > 0 ? parsed : 30;
+      await debugDumpSpans(limit);
       return;
+    }
     case "errors":
       await tailErrors();
       return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -631,8 +631,12 @@ async function debugDumpMetrics(): Promise<void> {
       }
     }
     console.log();
+    // Histogram keys mix time (e.g. `span.x.ms`, `dispatcher.duration.ms`)
+    // with non-time metrics (e.g. `tokens.input`). Derive the unit per-key
+    // from the `.ms` suffix so the header isn't a lie and per-row labels
+    // are honest. Anything else is shown unitless.
     console.log(
-      `  ${pc.bold("Histograms")} ${pc.dim("(p50 / p95 / p99 / avg, ms)")}`,
+      `  ${pc.bold("Histograms")} ${pc.dim("(p50 / p95 / p99 / avg)")}`,
     );
     const histograms = Object.entries(data.histograms ?? {}).sort(([a], [b]) =>
       a.localeCompare(b),
@@ -641,8 +645,9 @@ async function debugDumpMetrics(): Promise<void> {
       console.log(`    ${pc.dim("(none)")}`);
     } else {
       for (const [k, h] of histograms) {
+        const unit = k.endsWith(".ms") ? pc.dim("ms") : "";
         console.log(
-          `    ${pc.dim(k.padEnd(40))} ${pc.cyan(`${h.p50}`.padStart(5))} / ${pc.cyan(`${h.p95}`.padStart(5))} / ${pc.cyan(`${h.p99}`.padStart(5))} / ${pc.cyan(`${h.avg}`.padStart(5))} ${pc.dim(`n=${h.count}`)}`,
+          `    ${pc.dim(k.padEnd(40))} ${pc.cyan(`${h.p50}`.padStart(5))} / ${pc.cyan(`${h.p95}`.padStart(5))} / ${pc.cyan(`${h.p99}`.padStart(5))} / ${pc.cyan(`${h.avg}`.padStart(5))}${unit ? " " + unit : ""} ${pc.dim(`n=${h.count}`)}`,
         );
       }
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -566,6 +566,9 @@ async function tailFile(
   watchFile(filePath, { interval: 500 }, () => {
     try {
       const nl = splitLines(readFileSync(filePath, "utf-8"));
+      // File shrank — rotated or truncated. Reset so we print everything that
+      // arrives after this point rather than silently halting forever.
+      if (nl.length < lastSize) lastSize = 0;
       for (let i = lastSize; i < nl.length; i++)
         console.log(formatLogLine(nl[i]));
       lastSize = nl.length;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,9 @@ import { dirs, files as pathFiles } from "./util/paths.js";
 const PKG_ROOT = resolve(import.meta.dirname ?? process.cwd(), "..");
 const CONFIG_FILE = pathFiles.config;
 const LOG_FILE = pathFiles.log;
-const HEALTH_URL = "http://127.0.0.1:19876/health";
+const ERROR_LOG_FILE = pathFiles.errorLog;
+const BASE_URL = "http://127.0.0.1:19876";
+const HEALTH_URL = `${BASE_URL}/health`;
 
 function printBanner(): void {
   console.log();
@@ -535,24 +537,28 @@ function formatLogLine(line: string): string {
   }
 }
 
-async function tailLogs(): Promise<void> {
+async function tailFile(
+  filePath: string,
+  label: string,
+  initialLines = 30,
+): Promise<void> {
   printBanner();
-  if (!existsSync(LOG_FILE)) {
+  if (!existsSync(filePath)) {
     console.log(
-      `  No log file. Start the bot first: ${pc.cyan("talon start")}\n`,
+      `  No ${label} file yet.  Start the bot first: ${pc.cyan("talon start")}\n`,
     );
     return;
   }
   console.log(
-    `  ${pc.dim("Tailing")} ${pc.dim(LOG_FILE)}\n  ${pc.dim("Press Ctrl+C to stop")}\n`,
+    `  ${pc.dim(`Tailing ${label}`)} ${pc.dim(filePath)}\n  ${pc.dim("Press Ctrl+C to stop")}\n`,
   );
-  const content = readFileSync(LOG_FILE, "utf-8");
+  const content = readFileSync(filePath, "utf-8");
   const lines = content.trim().split("\n");
-  for (const line of lines.slice(-30)) console.log(formatLogLine(line));
+  for (const line of lines.slice(-initialLines)) console.log(formatLogLine(line));
   let lastSize = lines.length;
-  watchFile(LOG_FILE, { interval: 500 }, () => {
+  watchFile(filePath, { interval: 500 }, () => {
     try {
-      const nl = readFileSync(LOG_FILE, "utf-8").trim().split("\n");
+      const nl = readFileSync(filePath, "utf-8").trim().split("\n");
       for (let i = lastSize; i < nl.length; i++)
         console.log(formatLogLine(nl[i]));
       lastSize = nl.length;
@@ -561,6 +567,219 @@ async function tailLogs(): Promise<void> {
     }
   });
   await new Promise(() => {});
+}
+
+async function tailLogs(): Promise<void> {
+  await tailFile(LOG_FILE, "log", 30);
+}
+
+async function tailErrors(): Promise<void> {
+  await tailFile(ERROR_LOG_FILE, "errors.log", 50);
+}
+
+// ── Debug ───────────────────────────────────────────────────────────────────
+
+async function fetchJson(url: string): Promise<unknown> {
+  const resp = await fetch(url, { signal: AbortSignal.timeout(5000) });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+async function postJson(url: string, body: unknown): Promise<unknown> {
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`HTTP ${resp.status}: ${text}`);
+  }
+  return resp.json();
+}
+
+async function debugDumpMetrics(): Promise<void> {
+  printBanner();
+  try {
+    const data = (await fetchJson(`${BASE_URL}/debug/metrics`)) as {
+      counters: Record<string, number>;
+      histograms: Record<
+        string,
+        { count: number; p50: number; p95: number; p99: number; avg: number }
+      >;
+    };
+    console.log(`  ${pc.bold("Counters")}`);
+    const counters = Object.entries(data.counters ?? {}).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    if (counters.length === 0) {
+      console.log(`    ${pc.dim("(none)")}`);
+    } else {
+      for (const [k, v] of counters) {
+        console.log(`    ${pc.dim(k.padEnd(40))} ${pc.cyan(String(v))}`);
+      }
+    }
+    console.log();
+    console.log(`  ${pc.bold("Histograms")} ${pc.dim("(p50 / p95 / p99 / avg, ms)")}`);
+    const histograms = Object.entries(data.histograms ?? {}).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    if (histograms.length === 0) {
+      console.log(`    ${pc.dim("(none)")}`);
+    } else {
+      for (const [k, h] of histograms) {
+        console.log(
+          `    ${pc.dim(k.padEnd(40))} ${pc.cyan(`${h.p50}`.padStart(5))} / ${pc.cyan(`${h.p95}`.padStart(5))} / ${pc.cyan(`${h.p99}`.padStart(5))} / ${pc.cyan(`${h.avg}`.padStart(5))} ${pc.dim(`n=${h.count}`)}`,
+        );
+      }
+    }
+    console.log();
+  } catch (err) {
+    console.log(
+      `  ${pc.red("✖")} Could not reach bot: ${err instanceof Error ? err.message : err}\n`,
+    );
+    console.log(
+      `  Is Talon running?  Start with ${pc.cyan("talon start")}.\n`,
+    );
+  }
+}
+
+async function debugDumpSpans(limit: number): Promise<void> {
+  printBanner();
+  try {
+    const data = (await fetchJson(
+      `${BASE_URL}/debug/spans?limit=${limit}`,
+    )) as {
+      spans: Array<{
+        name: string;
+        durationMs: number;
+        status: string;
+        attrs: Record<string, unknown>;
+        err?: string;
+        startMs: number;
+        traceId: string;
+      }>;
+    };
+    if (!data.spans?.length) {
+      console.log(`  ${pc.dim("(no spans)")}\n`);
+      return;
+    }
+    console.log(`  ${pc.bold(`Last ${data.spans.length} spans`)}\n`);
+    for (const s of data.spans) {
+      const ok = s.status === "ok" ? pc.green("✓") : pc.red("✗");
+      const when = pc.dim(new Date(s.startMs).toISOString().slice(11, 19));
+      const ms = pc.cyan(`${s.durationMs}ms`.padStart(8));
+      console.log(`  ${when} ${ok} ${ms} ${pc.bold(s.name)}`);
+      const keys = Object.keys(s.attrs).slice(0, 4);
+      if (keys.length) {
+        const summary = keys
+          .map((k) => `${pc.dim(k)}=${String(s.attrs[k]).slice(0, 40)}`)
+          .join(" ");
+        console.log(`            ${summary}`);
+      }
+      if (s.err) console.log(`            ${pc.red(s.err)}`);
+    }
+    console.log();
+  } catch (err) {
+    console.log(
+      `  ${pc.red("✖")} Could not reach bot: ${err instanceof Error ? err.message : err}\n`,
+    );
+  }
+}
+
+async function debugSetLogLevel(level: string): Promise<void> {
+  printBanner();
+  const valid = ["trace", "debug", "info", "warn", "error", "fatal", "silent"];
+  if (!valid.includes(level)) {
+    console.log(`  ${pc.red("✖")} Invalid level: ${level}`);
+    console.log(`  Valid: ${valid.join(", ")}\n`);
+    return;
+  }
+  try {
+    const res = (await postJson(`${BASE_URL}/debug/log-level`, { level })) as {
+      ok: boolean;
+      level?: string;
+      error?: string;
+    };
+    if (res.ok) {
+      console.log(`  ${pc.green("●")} Log level set to ${pc.bold(res.level ?? level)}\n`);
+    } else {
+      console.log(`  ${pc.red("✖")} ${res.error}\n`);
+    }
+  } catch (err) {
+    console.log(
+      `  ${pc.red("✖")} Could not reach bot: ${err instanceof Error ? err.message : err}\n`,
+    );
+  }
+}
+
+async function debugDumpState(): Promise<void> {
+  printBanner();
+  try {
+    const data = await fetchJson(`${BASE_URL}/debug/state`);
+    console.log(JSON.stringify(data, null, 2));
+    console.log();
+  } catch (err) {
+    console.log(
+      `  ${pc.red("✖")} Could not reach bot: ${err instanceof Error ? err.message : err}\n`,
+    );
+  }
+}
+
+async function runDebug(args: string[]): Promise<void> {
+  const sub = args[0];
+  switch (sub) {
+    case "state":
+      await debugDumpState();
+      return;
+    case "metrics":
+      await debugDumpMetrics();
+      return;
+    case "spans":
+      await debugDumpSpans(parseInt(args[1] ?? "30", 10));
+      return;
+    case "errors":
+      await tailErrors();
+      return;
+    case "log-level":
+      if (!args[1]) {
+        printBanner();
+        try {
+          const cur = (await fetchJson(`${BASE_URL}/debug/log-level`)) as {
+            level: string;
+          };
+          console.log(`  Current log level: ${pc.bold(cur.level)}\n`);
+        } catch (err) {
+          console.log(
+            `  ${pc.red("✖")} Could not reach bot: ${err instanceof Error ? err.message : err}\n`,
+          );
+        }
+        return;
+      }
+      await debugSetLogLevel(args[1]);
+      return;
+    default:
+      printBanner();
+      console.log("  Usage: talon debug <subcommand>\n");
+      console.log("  Subcommands:");
+      console.log(
+        `    ${pc.cyan("state")}               Full runtime snapshot (JSON)`,
+      );
+      console.log(
+        `    ${pc.cyan("metrics")}             Counters + histogram percentiles`,
+      );
+      console.log(
+        `    ${pc.cyan("spans [N]")}           Last N spans (default 30)`,
+      );
+      console.log(
+        `    ${pc.cyan("errors")}              Tail errors.log live`,
+      );
+      console.log(
+        `    ${pc.cyan("log-level [lvl]")}     Get/set runtime log level`,
+      );
+      console.log();
+  }
 }
 
 // ── Doctor ──────────────────────────────────────────────────────────────────
@@ -887,6 +1106,12 @@ switch (command) {
   case "logs":
     tailLogs();
     break;
+  case "errors":
+    tailErrors();
+    break;
+  case "debug":
+    runDebug(process.argv.slice(3));
+    break;
   case "start":
     printBanner();
     await daemonStart();
@@ -924,6 +1149,12 @@ switch (command) {
     console.log(`    ${pc.cyan("status")}     Show bot health`);
     console.log(`    ${pc.cyan("config")}     View/edit configuration`);
     console.log(`    ${pc.cyan("logs")}       Tail log file`);
+    console.log(
+      `    ${pc.cyan("errors")}     Tail errors-only log (errors.log)`,
+    );
+    console.log(
+      `    ${pc.cyan("debug")}      Runtime debug tools (state|metrics|spans|log-level|errors)`,
+    );
     console.log(`    ${pc.cyan("doctor")}     Validate environment`);
     console.log();
     console.log(

--- a/src/core/cron.ts
+++ b/src/core/cron.ts
@@ -17,6 +17,8 @@ import {
 } from "../storage/cron-store.js";
 import { appendDailyLog } from "../storage/daily-log.js";
 import { log, logError, logWarn } from "../util/log.js";
+import { withSpan } from "../util/trace.js";
+import { incrementCounter, recordHistogram } from "../util/metrics.js";
 
 // ── Dependencies (injected at startup) ──────────────────────────────────────
 
@@ -64,19 +66,37 @@ async function runCronTick(): Promise<void> {
     if (!isDue(job, now)) continue;
     if (getActiveCount() > 10) break;
 
+    const jobStart = Date.now();
     try {
       log(
         "cron",
         `Executing "${job.name}" [${job.id}] (${job.type}) in chat ${job.chatId}`,
       );
-      await executeJob(job);
+      await withSpan(
+        "cron.executeJob",
+        {
+          jobId: job.id,
+          jobName: job.name,
+          jobType: job.type,
+          chatId: job.chatId,
+          schedule: job.schedule,
+        },
+        () => executeJob(job),
+      );
       recordCronRun(job.id);
       appendDailyLog(
         "Cron",
         `Ran "${job.name}" (${job.type}) in chat ${job.chatId}`,
       );
-      log("cron", `Executed "${job.name}" [${job.id}] in chat ${job.chatId}`);
+      const ms = Date.now() - jobStart;
+      recordHistogram(`cron.${job.type}.ms`, ms);
+      incrementCounter(`cron.${job.type}.ok`);
+      log(
+        "cron",
+        `Executed "${job.name}" [${job.id}] in chat ${job.chatId} (${ms}ms)`,
+      );
     } catch (err) {
+      incrementCounter(`cron.${job.type}.error`);
       logError("cron", `Job "${job.name}" [${job.id}] failed`, err);
     }
   }

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -15,7 +15,13 @@ import type {
   ExecuteParams,
   ExecuteResult,
 } from "./types.js";
-import { log, logDebug, logWarn, newRequestId, childLogger } from "../util/log.js";
+import {
+  log,
+  logDebug,
+  logWarn,
+  newRequestId,
+  childLogger,
+} from "../util/log.js";
 import { withSpan } from "../util/trace.js";
 import { incrementCounter, recordHistogram } from "../util/metrics.js";
 import { maybeStartDream } from "./dream.js";

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -9,14 +9,15 @@
  * frontend/ or backend/.
  */
 
-import { randomBytes } from "node:crypto";
 import type {
   QueryBackend,
   ContextManager,
   ExecuteParams,
   ExecuteResult,
 } from "./types.js";
-import { log, logDebug, logWarn } from "../util/log.js";
+import { log, logDebug, logWarn, newRequestId, childLogger } from "../util/log.js";
+import { withSpan } from "../util/trace.js";
+import { incrementCounter, recordHistogram } from "../util/metrics.js";
 import { maybeStartDream } from "./dream.js";
 
 // ── Dependencies (injected at startup) ──────────────────────────────────────
@@ -87,58 +88,94 @@ async function run(params: ExecuteParams): Promise<ExecuteResult> {
 
 async function executeInner(params: ExecuteParams): Promise<ExecuteResult> {
   const { backend, context, sendTyping, onActivity } = deps!;
-  const reqId = randomBytes(4).toString("hex");
+  const reqId = newRequestId();
+  const logCtx = childLogger({
+    component: "dispatcher",
+    reqId,
+    chatId: params.chatId,
+    source: params.source,
+  });
 
   // Dream check — fire-and-forget background memory consolidation if due
   maybeStartDream();
 
-  logDebug(
-    "dispatcher",
-    `[${reqId}] ${params.source} chat=${params.chatId} started (active=${activeCount})`,
-  );
-  context.acquire(params.numericChatId, params.chatId);
-
-  let typingTimer: ReturnType<typeof setInterval> | undefined;
-  try {
-    await sendTyping(params.numericChatId).catch((err: unknown) => {
-      logWarn(
-        "dispatcher",
-        `sendTyping failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    });
-    typingTimer = setInterval(() => {
-      sendTyping(params.numericChatId).catch((err: unknown) => {
-        logWarn(
-          "dispatcher",
-          `sendTyping interval failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
-    }, 4000);
-
-    const result = await backend.query({
+  return withSpan(
+    "dispatcher.execute",
+    {
+      reqId,
       chatId: params.chatId,
-      text: params.prompt,
-      senderName: params.senderName,
-      isGroup: params.isGroup,
-      messageId: params.messageId,
-      onStreamDelta: params.onStreamDelta,
-      onTextBlock: params.onTextBlock,
-      onToolUse: params.onToolUse,
-    });
+      source: params.source,
+      numericChatId: params.numericChatId,
+    },
+    async (span) => {
+      logCtx.debug(
+        `${params.source} chat=${params.chatId} started (active=${activeCount})`,
+      );
+      incrementCounter("dispatcher.queries");
+      incrementCounter(`dispatcher.source.${params.source}`);
+      context.acquire(params.numericChatId, params.chatId);
 
-    onActivity();
+      let typingTimer: ReturnType<typeof setInterval> | undefined;
+      try {
+        await sendTyping(params.numericChatId).catch((err: unknown) => {
+          logWarn(
+            "dispatcher",
+            `sendTyping failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
+        typingTimer = setInterval(() => {
+          sendTyping(params.numericChatId).catch((err: unknown) => {
+            logWarn(
+              "dispatcher",
+              `sendTyping interval failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
+        }, 4000);
 
-    logDebug(
-      "dispatcher",
-      `[${reqId}] completed in ${result.durationMs}ms (in=${result.inputTokens} out=${result.outputTokens})`,
-    );
+        span.addEvent("backend-query-start");
+        const result = await backend.query({
+          chatId: params.chatId,
+          text: params.prompt,
+          senderName: params.senderName,
+          isGroup: params.isGroup,
+          messageId: params.messageId,
+          onStreamDelta: params.onStreamDelta,
+          onTextBlock: params.onTextBlock,
+          onToolUse: params.onToolUse,
+        });
+        span.addEvent("backend-query-end");
+        span.setAttributes({
+          durationMs: result.durationMs,
+          inputTokens: result.inputTokens,
+          outputTokens: result.outputTokens,
+          cacheRead: result.cacheRead,
+          cacheWrite: result.cacheWrite,
+        });
+        recordHistogram("dispatcher.duration.ms", result.durationMs);
+        if (result.inputTokens !== undefined)
+          recordHistogram("tokens.input", result.inputTokens);
+        if (result.outputTokens !== undefined)
+          recordHistogram("tokens.output", result.outputTokens);
 
-    return {
-      ...result,
-      bridgeMessageCount: context.getMessageCount(params.numericChatId),
-    };
-  } finally {
-    clearInterval(typingTimer);
-    context.release(params.numericChatId);
-  }
+        onActivity();
+
+        logCtx.debug(
+          `completed in ${result.durationMs}ms (in=${result.inputTokens} out=${result.outputTokens})`,
+        );
+        incrementCounter("dispatcher.queries.ok");
+
+        return {
+          ...result,
+          bridgeMessageCount: context.getMessageCount(params.numericChatId),
+        };
+      } catch (err) {
+        incrementCounter("dispatcher.queries.error");
+        logCtx.error(`query failed`, err);
+        throw err;
+      } finally {
+        clearInterval(typingTimer);
+        context.release(params.numericChatId);
+      }
+    },
+  );
 }

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -15,7 +15,7 @@ import type {
   ExecuteParams,
   ExecuteResult,
 } from "./types.js";
-import { log, logWarn, newRequestId, childLogger } from "../util/log.js";
+import { log, newRequestId, childLogger } from "../util/log.js";
 import { withSpan } from "../util/trace.js";
 import { incrementCounter, recordHistogram } from "../util/metrics.js";
 import { maybeStartDream } from "./dream.js";
@@ -118,15 +118,13 @@ async function executeInner(params: ExecuteParams): Promise<ExecuteResult> {
       let typingTimer: ReturnType<typeof setInterval> | undefined;
       try {
         await sendTyping(params.numericChatId).catch((err: unknown) => {
-          logWarn(
-            "dispatcher",
+          logCtx.warn(
             `sendTyping failed: ${err instanceof Error ? err.message : String(err)}`,
           );
         });
         typingTimer = setInterval(() => {
           sendTyping(params.numericChatId).catch((err: unknown) => {
-            logWarn(
-              "dispatcher",
+            logCtx.warn(
               `sendTyping interval failed: ${err instanceof Error ? err.message : String(err)}`,
             );
           });

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -15,13 +15,7 @@ import type {
   ExecuteParams,
   ExecuteResult,
 } from "./types.js";
-import {
-  log,
-  logDebug,
-  logWarn,
-  newRequestId,
-  childLogger,
-} from "../util/log.js";
+import { log, logWarn, newRequestId, childLogger } from "../util/log.js";
 import { withSpan } from "../util/trace.js";
 import { incrementCounter, recordHistogram } from "../util/metrics.js";
 import { maybeStartDream } from "./dream.js";

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -19,6 +19,8 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { files as pathFiles, dirs } from "../util/paths.js";
 import { log, logError, logWarn } from "../util/log.js";
+import { withSpan } from "../util/trace.js";
+import { incrementCounter } from "../util/metrics.js";
 import { getPluginMcpServers } from "./plugin.js";
 import { DISALLOWED_TOOLS_BACKGROUND } from "./constants.js";
 import { getDefaultModel } from "./models.js";
@@ -99,19 +101,26 @@ async function executeDream(trigger: "auto" | "forced"): Promise<void> {
 
   dreaming = true;
   writeDreamState({ last_run: now, status: "running" });
+  incrementCounter(`dream.${trigger}.started`);
   log(
     "dream",
     `${trigger === "forced" ? "Force-triggering" : "Triggering"} memory consolidation (last run: ${state?.last_run ? new Date(state.last_run).toISOString() : "never"})`,
   );
 
   try {
-    const dreamLogPath = await runDreamAgent(state?.last_run ?? 0);
+    const dreamLogPath = await withSpan(
+      "dream.run",
+      { trigger, lastRun: state?.last_run ?? 0 },
+      () => runDreamAgent(state?.last_run ?? 0),
+    );
     writeDreamState({ last_run: Date.now(), status: "idle" });
+    incrementCounter(`dream.${trigger}.ok`);
     log(
       "dream",
       `Memory consolidation complete (${trigger}), log: ${dreamLogPath}`,
     );
   } catch (err) {
+    incrementCounter(`dream.${trigger}.error`);
     logError("dream", `Memory consolidation failed (${trigger})`, err);
     writeDreamState({ last_run: Date.now(), status: "idle" });
     if (trigger === "forced") throw err;

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -341,9 +341,31 @@ export class Gateway {
     req: IncomingMessage,
     res: ServerResponse,
   ): Promise<void> {
+    // POST /debug/log-level bodies are tiny JSON — cap at 4KB so a local
+    // client can't push arbitrary data and exhaust memory before we parse.
+    const MAX_BODY_BYTES = 4096;
     try {
+      // Early-reject on a large advertised Content-Length.
+      const declared = Number.parseInt(req.headers["content-length"] ?? "", 10);
+      if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+        res.writeHead(413, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: "Payload too large" }));
+        return;
+      }
+
       const chunks: Buffer[] = [];
-      for await (const chunk of req) chunks.push(chunk as Buffer);
+      let total = 0;
+      for await (const chunk of req) {
+        const buf = chunk as Buffer;
+        total += buf.length;
+        if (total > MAX_BODY_BYTES) {
+          res.writeHead(413, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Payload too large" }));
+          return;
+        }
+        chunks.push(buf);
+      }
+
       const body = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as {
         level?: LogLevel;
       };
@@ -352,7 +374,23 @@ export class Gateway {
         res.end(JSON.stringify({ ok: false, error: "Missing level" }));
         return;
       }
-      setLogLevel(body.level);
+      try {
+        setLogLevel(body.level);
+      } catch (err) {
+        // Unknown level — setLogLevel throws. Surface as 400 without mutating
+        // current state so callers can distinguish "bad input" from "server
+        // error" and the level remains whatever it was.
+        res.writeHead(400, {
+          "Content-Type": "application/json",
+        });
+        res.end(
+          JSON.stringify({
+            ok: false,
+            error: err instanceof Error ? err.message : "Invalid level",
+          }),
+        );
+        return;
+      }
       log("gateway", `Log level changed to ${body.level}`);
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: true, level: body.level }));

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -343,13 +343,24 @@ export class Gateway {
   ): Promise<void> {
     // POST /debug/log-level bodies are tiny JSON — cap at 4KB so a local
     // client can't push arbitrary data and exhaust memory before we parse.
+    // Both the Content-Length header and the actual stream byte count are
+    // checked; the header is advisory (may be missing, lying, or absent for
+    // chunked transfers) so the stream-time check is what actually enforces.
     const MAX_BODY_BYTES = 4096;
+    const tooLarge = (): void => {
+      res.writeHead(413, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "Payload too large" }));
+    };
+
     try {
-      // Early-reject on a large advertised Content-Length.
-      const declared = Number.parseInt(req.headers["content-length"] ?? "", 10);
+      // Node's types for req.headers values are `string | string[] | undefined`
+      // depending on duplicate-header handling. Content-Length should only
+      // ever be a single value, but normalize defensively anyway.
+      const clRaw = req.headers["content-length"];
+      const clStr = Array.isArray(clRaw) ? (clRaw[0] ?? "") : (clRaw ?? "");
+      const declared = Number.parseInt(clStr, 10);
       if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
-        res.writeHead(413, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ ok: false, error: "Payload too large" }));
+        tooLarge();
         return;
       }
 
@@ -359,8 +370,12 @@ export class Gateway {
         const buf = chunk as Buffer;
         total += buf.length;
         if (total > MAX_BODY_BYTES) {
-          res.writeHead(413, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ ok: false, error: "Payload too large" }));
+          // Free anything we already buffered so the oversize body doesn't
+          // stay pinned while the response drains.
+          chunks.length = 0;
+          // Stop reading further chunks.
+          req.destroy();
+          tooLarge();
           return;
         }
         chunks.push(buf);

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -214,10 +214,7 @@ export class Gateway {
             span.setAttribute("durationMs", ms);
             recordHistogram(`gateway.${action}.ms`, ms);
             incrementCounter(`gateway.${action}.ok`);
-            logDebug(
-              "gateway",
-              `${action} chat=${chatId} ${ms}ms (plugin)`,
-            );
+            logDebug("gateway", `${action} chat=${chatId} ${ms}ms (plugin)`);
             return pluginResult;
           }
 
@@ -229,10 +226,7 @@ export class Gateway {
             span.setAttribute("durationMs", ms);
             recordHistogram(`gateway.${action}.ms`, ms);
             incrementCounter(`gateway.${action}.ok`);
-            logDebug(
-              "gateway",
-              `${action} chat=${chatId} ${ms}ms (shared)`,
-            );
+            logDebug("gateway", `${action} chat=${chatId} ${ms}ms (shared)`);
             return shared;
           }
 

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -18,9 +18,19 @@ import { classify } from "./errors.js";
 import { getActiveCount } from "./dispatcher.js";
 import { getHealthStatus } from "../util/watchdog.js";
 import { getActiveSessionCount } from "../storage/sessions.js";
-import { log, logError, logDebug } from "../util/log.js";
+import {
+  log,
+  logError,
+  logDebug,
+  setLogLevel,
+  getLogLevel,
+  type LogLevel,
+} from "../util/log.js";
 import { handleSharedAction } from "./gateway-actions.js";
 import { handlePluginAction } from "./plugin.js";
+import { withSpan } from "../util/trace.js";
+import { buildDebugSnapshot } from "../util/debug.js";
+import { incrementCounter, recordHistogram } from "../util/metrics.js";
 import type { FrontendActionHandler, QueryBackend } from "./types.js";
 
 // ── Per-chat context state ───────────────────────────────────────────────────
@@ -176,42 +186,150 @@ export class Gateway {
     if (!action) return { ok: false, error: "Missing action" };
     const t0 = Date.now();
 
-    try {
-      // Try frontend first — it has richer implementations (e.g. userbot history)
-      // and falls back to null when it can't handle the action.
-      if (this.frontendHandler) {
-        const result = await this.frontendHandler(body, chatId);
-        if (result) {
-          logDebug("gateway", `${action} chat=${chatId} ${Date.now() - t0}ms`);
-          return result;
+    return withSpan(
+      "gateway.action",
+      { action, chatId },
+      async (span): Promise<unknown> => {
+        try {
+          // Try frontend first — it has richer implementations (e.g. userbot history)
+          // and falls back to null when it can't handle the action.
+          if (this.frontendHandler) {
+            const result = await this.frontendHandler(body, chatId);
+            if (result) {
+              const ms = Date.now() - t0;
+              span.setAttribute("route", "frontend");
+              span.setAttribute("durationMs", ms);
+              recordHistogram(`gateway.${action}.ms`, ms);
+              incrementCounter(`gateway.${action}.ok`);
+              logDebug("gateway", `${action} chat=${chatId} ${ms}ms`);
+              return result;
+            }
+          }
+
+          // Try plugin actions (loaded from external plugin packages)
+          const pluginResult = await handlePluginAction(body, String(chatId));
+          if (pluginResult) {
+            const ms = Date.now() - t0;
+            span.setAttribute("route", "plugin");
+            span.setAttribute("durationMs", ms);
+            recordHistogram(`gateway.${action}.ms`, ms);
+            incrementCounter(`gateway.${action}.ok`);
+            logDebug(
+              "gateway",
+              `${action} chat=${chatId} ${ms}ms (plugin)`,
+            );
+            return pluginResult;
+          }
+
+          // Shared actions last — provides in-memory fallbacks for history, cron, etc.
+          const shared = await handleSharedAction(body, chatId, this.backend);
+          if (shared) {
+            const ms = Date.now() - t0;
+            span.setAttribute("route", "shared");
+            span.setAttribute("durationMs", ms);
+            recordHistogram(`gateway.${action}.ms`, ms);
+            incrementCounter(`gateway.${action}.ok`);
+            logDebug(
+              "gateway",
+              `${action} chat=${chatId} ${ms}ms (shared)`,
+            );
+            return shared;
+          }
+
+          incrementCounter(`gateway.${action}.unknown`);
+          span.setStatus("error", `Unknown action: ${action}`);
+          return { ok: false, error: `Unknown action: ${action}` };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          incrementCounter(`gateway.${action}.error`);
+          span.setStatus("error", err);
+          logError("gateway", `${action} chat=${chatId} failed: ${msg}`);
+          return { ok: false, error: `${action}: ${msg}` };
         }
-      }
+      },
+    );
+  }
 
-      // Try plugin actions (loaded from external plugin packages)
-      const pluginResult = await handlePluginAction(body, String(chatId));
-      if (pluginResult) {
-        logDebug(
-          "gateway",
-          `${action} chat=${chatId} ${Date.now() - t0}ms (plugin)`,
-        );
-        return pluginResult;
-      }
+  // ── Debug endpoints ──────────────────────────────────────────────────────
 
-      // Shared actions last — provides in-memory fallbacks for history, cron, etc.
-      const shared = await handleSharedAction(body, chatId, this.backend);
-      if (shared) {
-        logDebug(
-          "gateway",
-          `${action} chat=${chatId} ${Date.now() - t0}ms (shared)`,
-        );
-        return shared;
-      }
+  private async handleDebug(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<void> {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const route = url.pathname;
+    const writeJson = (status: number, body: unknown): void => {
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
 
-      return { ok: false, error: `Unknown action: ${action}` };
+    try {
+      const { getMetrics } = await import("../util/metrics.js");
+      const { getRecentSpans } = await import("../util/trace.js");
+      const { getRecentLogs } = await import("../util/log.js");
+      const { getRecentErrors } = await import("../util/watchdog.js");
+
+      if (route === "/debug/state") {
+        writeJson(200, buildDebugSnapshot());
+        return;
+      }
+      if (route === "/debug/metrics") {
+        writeJson(200, getMetrics());
+        return;
+      }
+      if (route === "/debug/spans") {
+        const limit = Number(url.searchParams.get("limit") ?? "100");
+        writeJson(200, { spans: getRecentSpans(limit) });
+        return;
+      }
+      if (route === "/debug/logs") {
+        const limit = Number(url.searchParams.get("limit") ?? "100");
+        const level = url.searchParams.get("level") as LogLevel | null;
+        writeJson(200, {
+          level: getLogLevel(),
+          logs: getRecentLogs(limit, level ?? undefined),
+        });
+        return;
+      }
+      if (route === "/debug/errors") {
+        const limit = Number(url.searchParams.get("limit") ?? "20");
+        writeJson(200, { errors: getRecentErrors(limit) });
+        return;
+      }
+      if (route === "/debug/log-level") {
+        writeJson(200, { level: getLogLevel() });
+        return;
+      }
+      writeJson(404, { ok: false, error: "Unknown debug route" });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      logError("gateway", `${action} chat=${chatId} failed: ${msg}`);
-      return { ok: false, error: `${action}: ${msg}` };
+      writeJson(500, { ok: false, error: msg });
+    }
+  }
+
+  private async handleSetLogLevel(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<void> {
+    try {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(chunk as Buffer);
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as {
+        level?: LogLevel;
+      };
+      if (!body.level) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: "Missing level" }));
+        return;
+      }
+      setLogLevel(body.level);
+      log("gateway", `Log level changed to ${body.level}`);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, level: body.level }));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: msg }));
     }
   }
 
@@ -241,6 +359,16 @@ export class Gateway {
                   : `${Math.round(w.msSinceLastMessage / 60000)}m ago`,
             }),
           );
+          return;
+        }
+
+        if (req.method === "GET" && req.url?.startsWith("/debug/")) {
+          await this.handleDebug(req, res);
+          return;
+        }
+
+        if (req.method === "POST" && req.url === "/debug/log-level") {
+          await this.handleSetLogLevel(req, res);
           return;
         }
 

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -16,7 +16,7 @@ import {
 import pRetry, { AbortError } from "p-retry";
 import { classify } from "./errors.js";
 import { getActiveCount } from "./dispatcher.js";
-import { getHealthStatus } from "../util/watchdog.js";
+import { getHealthStatus, getRecentErrors } from "../util/watchdog.js";
 import { getActiveSessionCount } from "../storage/sessions.js";
 import {
   log,
@@ -24,16 +24,18 @@ import {
   logDebug,
   setLogLevel,
   getLogLevel,
+  getRecentLogs,
   type LogLevel,
 } from "../util/log.js";
 import { handleSharedAction } from "./gateway-actions.js";
 import { handlePluginAction } from "./plugin.js";
-import { withSpan } from "../util/trace.js";
+import { withSpan, getRecentSpans } from "../util/trace.js";
 import { buildDebugSnapshot } from "../util/debug.js";
 import {
   incrementCounter,
   recordHistogram,
   sanitizeMetricLabel,
+  getMetrics,
 } from "../util/metrics.js";
 import type { FrontendActionHandler, QueryBackend } from "./types.js";
 
@@ -280,11 +282,6 @@ export class Gateway {
     };
 
     try {
-      const { getMetrics } = await import("../util/metrics.js");
-      const { getRecentSpans } = await import("../util/trace.js");
-      const { getRecentLogs } = await import("../util/log.js");
-      const { getRecentErrors } = await import("../util/watchdog.js");
-
       if (route === "/debug/state") {
         writeJson(200, buildDebugSnapshot());
         return;

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -373,9 +373,13 @@ export class Gateway {
           // Free anything we already buffered so the oversize body doesn't
           // stay pinned while the response drains.
           chunks.length = 0;
-          // Stop reading further chunks.
-          req.destroy();
+          // Send the 413 first, then drain-and-discard the remaining body
+          // without destroying the socket. `req.destroy()` would tear down
+          // the underlying TCP connection and the client would see ECONNRESET
+          // instead of our 413 JSON; `req.resume()` keeps the stream flowing
+          // in discard mode so HTTP can complete the response cleanly.
           tooLarge();
+          req.resume();
           return;
         }
         chunks.push(buf);

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -296,8 +296,8 @@ export class Gateway {
       }
       writeJson(404, { ok: false, error: "Unknown debug route" });
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      writeJson(500, { ok: false, error: msg });
+      logError("gateway", `Debug endpoint ${route} failed`, err);
+      writeJson(500, { ok: false, error: "Internal error" });
     }
   }
 
@@ -321,9 +321,9 @@ export class Gateway {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: true, level: body.level }));
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      logError("gateway", "Set log level failed", err);
       res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: false, error: msg }));
+      res.end(JSON.stringify({ ok: false, error: "Invalid request" }));
     }
   }
 

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -268,7 +268,11 @@ export class Gateway {
     // Clamp query-parsed limits to positive finite integers so malformed or
     // absurdly large values can't return the whole in-memory buffer or allocate
     // unbounded response arrays.
-    const parseLimit = (raw: string | null, def: number, max = 1000): number => {
+    const parseLimit = (
+      raw: string | null,
+      def: number,
+      max = 1000,
+    ): number => {
       if (raw === null) return def;
       const n = Number(raw);
       if (!Number.isFinite(n) || n <= 0) return def;

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -300,7 +300,24 @@ export class Gateway {
       }
       if (route === "/debug/logs") {
         const limit = parseLimit(url.searchParams.get("limit"), 100);
-        const level = url.searchParams.get("level") as LogLevel | null;
+        const levelRaw = url.searchParams.get("level");
+        const ALLOWED: LogLevel[] = [
+          "trace",
+          "debug",
+          "info",
+          "warn",
+          "error",
+          "fatal",
+          "silent",
+        ];
+        if (levelRaw !== null && !ALLOWED.includes(levelRaw as LogLevel)) {
+          writeJson(400, {
+            ok: false,
+            error: `Invalid level. Allowed: ${ALLOWED.join(", ")}`,
+          });
+          return;
+        }
+        const level = levelRaw as LogLevel | null;
         writeJson(200, {
           level: getLogLevel(),
           logs: getRecentLogs(limit, level ?? undefined),

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -30,7 +30,11 @@ import { handleSharedAction } from "./gateway-actions.js";
 import { handlePluginAction } from "./plugin.js";
 import { withSpan } from "../util/trace.js";
 import { buildDebugSnapshot } from "../util/debug.js";
-import { incrementCounter, recordHistogram } from "../util/metrics.js";
+import {
+  incrementCounter,
+  recordHistogram,
+  sanitizeMetricLabel,
+} from "../util/metrics.js";
 import type { FrontendActionHandler, QueryBackend } from "./types.js";
 
 // ── Per-chat context state ───────────────────────────────────────────────────
@@ -184,6 +188,10 @@ export class Gateway {
 
     const action = typeof body.action === "string" ? body.action : "";
     if (!action) return { ok: false, error: "Missing action" };
+    // Action names are bucketed for metric keys so untrusted/malformed input
+    // can't blow out the global MAX_METRIC_KEYS cap. The raw action is still
+    // logged and recorded as a span attribute for debugging.
+    const mAction = sanitizeMetricLabel(action);
     const t0 = Date.now();
 
     return withSpan(
@@ -199,8 +207,8 @@ export class Gateway {
               const ms = Date.now() - t0;
               span.setAttribute("route", "frontend");
               span.setAttribute("durationMs", ms);
-              recordHistogram(`gateway.${action}.ms`, ms);
-              incrementCounter(`gateway.${action}.ok`);
+              recordHistogram(`gateway.${mAction}.ms`, ms);
+              incrementCounter(`gateway.${mAction}.ok`);
               logDebug("gateway", `${action} chat=${chatId} ${ms}ms`);
               return result;
             }
@@ -212,8 +220,8 @@ export class Gateway {
             const ms = Date.now() - t0;
             span.setAttribute("route", "plugin");
             span.setAttribute("durationMs", ms);
-            recordHistogram(`gateway.${action}.ms`, ms);
-            incrementCounter(`gateway.${action}.ok`);
+            recordHistogram(`gateway.${mAction}.ms`, ms);
+            incrementCounter(`gateway.${mAction}.ok`);
             logDebug("gateway", `${action} chat=${chatId} ${ms}ms (plugin)`);
             return pluginResult;
           }
@@ -224,18 +232,18 @@ export class Gateway {
             const ms = Date.now() - t0;
             span.setAttribute("route", "shared");
             span.setAttribute("durationMs", ms);
-            recordHistogram(`gateway.${action}.ms`, ms);
-            incrementCounter(`gateway.${action}.ok`);
+            recordHistogram(`gateway.${mAction}.ms`, ms);
+            incrementCounter(`gateway.${mAction}.ok`);
             logDebug("gateway", `${action} chat=${chatId} ${ms}ms (shared)`);
             return shared;
           }
 
-          incrementCounter(`gateway.${action}.unknown`);
+          incrementCounter(`gateway.${mAction}.unknown`);
           span.setStatus("error", `Unknown action: ${action}`);
           return { ok: false, error: `Unknown action: ${action}` };
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          incrementCounter(`gateway.${action}.error`);
+          incrementCounter(`gateway.${mAction}.error`);
           span.setStatus("error", err);
           logError("gateway", `${action} chat=${chatId} failed: ${msg}`);
           return { ok: false, error: `${action}: ${msg}` };
@@ -257,6 +265,16 @@ export class Gateway {
       res.end(JSON.stringify(body));
     };
 
+    // Clamp query-parsed limits to positive finite integers so malformed or
+    // absurdly large values can't return the whole in-memory buffer or allocate
+    // unbounded response arrays.
+    const parseLimit = (raw: string | null, def: number, max = 1000): number => {
+      if (raw === null) return def;
+      const n = Number(raw);
+      if (!Number.isFinite(n) || n <= 0) return def;
+      return Math.min(Math.floor(n), max);
+    };
+
     try {
       const { getMetrics } = await import("../util/metrics.js");
       const { getRecentSpans } = await import("../util/trace.js");
@@ -272,12 +290,12 @@ export class Gateway {
         return;
       }
       if (route === "/debug/spans") {
-        const limit = Number(url.searchParams.get("limit") ?? "100");
+        const limit = parseLimit(url.searchParams.get("limit"), 100);
         writeJson(200, { spans: getRecentSpans(limit) });
         return;
       }
       if (route === "/debug/logs") {
-        const limit = Number(url.searchParams.get("limit") ?? "100");
+        const limit = parseLimit(url.searchParams.get("limit"), 100);
         const level = url.searchParams.get("level") as LogLevel | null;
         writeJson(200, {
           level: getLogLevel(),
@@ -286,7 +304,7 @@ export class Gateway {
         return;
       }
       if (route === "/debug/errors") {
-        const limit = Number(url.searchParams.get("limit") ?? "20");
+        const limit = parseLimit(url.searchParams.get("limit"), 20);
         writeJson(200, { errors: getRecentErrors(limit) });
         return;
       }

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -360,7 +360,12 @@ export class Gateway {
       const clStr = Array.isArray(clRaw) ? (clRaw[0] ?? "") : (clRaw ?? "");
       const declared = Number.parseInt(clStr, 10);
       if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+        // Same rationale as the streaming oversize path below: send the
+        // 413 and drain the body in discard mode. Without `req.resume()`
+        // the connection can be left paused with unread data, which is
+        // cheap but measurable backpressure if an attacker keeps dialling.
         tooLarge();
+        req.resume();
         return;
       }
 

--- a/src/core/heartbeat.ts
+++ b/src/core/heartbeat.ts
@@ -16,6 +16,8 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { files as pathFiles, dirs } from "../util/paths.js";
 import { log, logError, logWarn } from "../util/log.js";
+import { withSpan } from "../util/trace.js";
+import { incrementCounter } from "../util/metrics.js";
 import { toYMD } from "../util/time.js";
 import { getPluginMcpServers } from "./plugin.js";
 import { DISALLOWED_TOOLS_BACKGROUND } from "./constants.js";
@@ -188,9 +190,14 @@ async function executeHeartbeat(trigger: "auto" | "forced"): Promise<void> {
 
   const run = (async () => {
     try {
-      const heartbeatLogPath = await runHeartbeatAgent(
-        previousLastRun,
-        previousRunCount + 1,
+      const heartbeatLogPath = await withSpan(
+        "heartbeat.run",
+        {
+          trigger,
+          runNumber: previousRunCount + 1,
+          lastRun: previousLastRun,
+        },
+        () => runHeartbeatAgent(previousLastRun, previousRunCount + 1),
       );
       // Only update last_run and increment run_count on success
       writeHeartbeatState({
@@ -199,11 +206,13 @@ async function executeHeartbeat(trigger: "auto" | "forced"): Promise<void> {
         status: "idle",
         run_count: previousRunCount + 1,
       });
+      incrementCounter(`heartbeat.${trigger}.ok`);
       log(
         "heartbeat",
         `Heartbeat #${previousRunCount + 1} complete (${trigger}), log: ${heartbeatLogPath}`,
       );
     } catch (err) {
+      incrementCounter(`heartbeat.${trigger}.error`);
       logError(
         "heartbeat",
         `Heartbeat #${previousRunCount + 1} failed (${trigger})`,

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -695,23 +695,24 @@ export async function handlePluginAction(
   chatId: string,
 ): Promise<ActionResult | null> {
   const action = typeof body.action === "string" ? body.action : "unknown";
+  const { recordHistogram, incrementCounter, sanitizeMetricLabel } =
+    await import("../util/metrics.js");
+  // Bucket untrusted action names for metric keys so a rogue plugin or garbage
+  // input can't fill MAX_METRIC_KEYS. The raw action stays in log messages.
+  const mAction = sanitizeMetricLabel(action);
   for (const { plugin } of registry.all) {
     if (!plugin.handleAction) continue;
+    const mPluginName = sanitizeMetricLabel(plugin.name);
     const t0 = Date.now();
     try {
       const result = await plugin.handleAction(body, chatId);
       if (result) {
         const ms = Date.now() - t0;
-        (await import("../util/metrics.js")).recordHistogram(
-          `plugin.${plugin.name}.${action}.ms`,
-          ms,
-        );
+        recordHistogram(`plugin.${mPluginName}.${mAction}.ms`, ms);
         return result;
       }
     } catch (err) {
-      (await import("../util/metrics.js")).incrementCounter(
-        `plugin.${plugin.name}.${action}.error`,
-      );
+      incrementCounter(`plugin.${mPluginName}.${mAction}.error`);
       logError(
         "plugin",
         `${plugin.name} action error: ${err instanceof Error ? err.message : err}`,

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -264,23 +264,33 @@ export async function loadPlugins(
   pluginConfigs: PluginEntry[],
   activeFrontends?: string[],
 ): Promise<void> {
+  const t0 = Date.now();
+  let loaded = 0;
+  let failed = 0;
   for (const entry of pluginConfigs) {
     // Standalone MCP servers are registered for getPluginMcpServers, not loaded as modules
     if (isMcpPlugin(entry)) {
       if (registry.registerMcpEntry(entry)) {
         log("plugin", `Registered standalone MCP server: ${entry.name}`);
+        loaded++;
       }
       continue;
     }
     try {
       await loadSinglePlugin(entry, activeFrontends);
+      loaded++;
     } catch (err) {
+      failed++;
       logError(
         "plugin",
         `Failed to load plugin at ${entry.path}: ${err instanceof Error ? err.message : err}`,
       );
     }
   }
+  log(
+    "plugin",
+    `Plugin loading complete: ${loaded} loaded, ${failed} failed (${Date.now() - t0}ms)`,
+  );
 }
 
 function applyEnvVars(envVars: Record<string, string>): void {
@@ -684,12 +694,24 @@ export async function handlePluginAction(
   body: Record<string, unknown>,
   chatId: string,
 ): Promise<ActionResult | null> {
+  const action = typeof body.action === "string" ? body.action : "unknown";
   for (const { plugin } of registry.all) {
     if (!plugin.handleAction) continue;
+    const t0 = Date.now();
     try {
       const result = await plugin.handleAction(body, chatId);
-      if (result) return result;
+      if (result) {
+        const ms = Date.now() - t0;
+        (await import("../util/metrics.js")).recordHistogram(
+          `plugin.${plugin.name}.${action}.ms`,
+          ms,
+        );
+        return result;
+      }
     } catch (err) {
+      (await import("../util/metrics.js")).incrementCounter(
+        `plugin.${plugin.name}.${action}.error`,
+      );
       logError(
         "plugin",
         `${plugin.name} action error: ${err instanceof Error ? err.message : err}`,

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -18,6 +18,11 @@ import { resolve } from "node:path";
 import { existsSync } from "node:fs";
 import { log, logError, logWarn } from "../util/log.js";
 import { wrapMcpServer } from "../util/mcp-launcher.js";
+import {
+  recordHistogram,
+  incrementCounter,
+  sanitizeMetricLabel,
+} from "../util/metrics.js";
 import type { ActionResult } from "./types.js";
 import type { TalonConfig } from "../util/config.js";
 
@@ -695,8 +700,6 @@ export async function handlePluginAction(
   chatId: string,
 ): Promise<ActionResult | null> {
   const action = typeof body.action === "string" ? body.action : "unknown";
-  const { recordHistogram, incrementCounter, sanitizeMetricLabel } =
-    await import("../util/metrics.js");
   // Bucket untrusted action names for metric keys so a rogue plugin or garbage
   // input can't fill MAX_METRIC_KEYS. The raw action stays in log messages.
   const mAction = sanitizeMetricLabel(action);

--- a/src/util/debug.ts
+++ b/src/util/debug.ts
@@ -90,7 +90,8 @@ export function buildDebugSnapshot(
     logs: {
       level: safe(() => getLogLevel(), "info" as LogLevel),
       recent: safe(
-        () => getRecentLogs(opts.logLimit ?? 50) as Array<Record<string, unknown>>,
+        () =>
+          getRecentLogs(opts.logLimit ?? 50) as Array<Record<string, unknown>>,
         [],
       ),
       recentErrors: safe(() => getRecentErrors(20), []),

--- a/src/util/debug.ts
+++ b/src/util/debug.ts
@@ -1,8 +1,7 @@
 /**
  * Debug snapshot — aggregates runtime state from across Talon subsystems into
  * a single JSON dump suitable for /debug/state and the `talon debug state`
- * CLI command. Kept free of cyclic imports by using dynamic imports where
- * needed.
+ * CLI command.
  */
 
 import {

--- a/src/util/debug.ts
+++ b/src/util/debug.ts
@@ -1,0 +1,111 @@
+/**
+ * Debug snapshot — aggregates runtime state from across Talon subsystems into
+ * a single JSON dump suitable for /debug/state and the `talon debug state`
+ * CLI command. Kept free of cyclic imports by using dynamic imports where
+ * needed.
+ */
+
+import {
+  getTotalMessagesProcessed,
+  getUptimeMs,
+  getHealthStatus,
+  getRecentErrors,
+} from "./watchdog.js";
+import { getMetrics } from "./metrics.js";
+import { getRecentSpans, type SpanRecord } from "./trace.js";
+import { getRecentLogs, getLogLevel, type LogLevel } from "./log.js";
+import { getActiveCount } from "../core/dispatcher.js";
+import { getActiveSessionCount } from "../storage/sessions.js";
+
+export type DebugSnapshot = {
+  ts: string;
+  process: {
+    pid: number;
+    uptimeSec: number;
+    node: string;
+    memMb: number;
+    rssMb: number;
+    platform: string;
+  };
+  bot: {
+    uptimeMs: number;
+    totalMessagesProcessed: number;
+    recentErrorCount: number;
+    healthy: boolean;
+  };
+  dispatcher: {
+    activeQueries: number;
+  };
+  sessions: {
+    active: number;
+  };
+  logs: {
+    level: LogLevel;
+    recent: Array<Record<string, unknown>>;
+    recentErrors: Array<{ message: string; timestamp: number }>;
+  };
+  metrics: ReturnType<typeof getMetrics>;
+  spans: {
+    recent: SpanRecord[];
+  };
+};
+
+/** Build a best-effort snapshot. Individual sections swallow errors so that
+ * a single broken source never blocks the whole report. */
+export function buildDebugSnapshot(
+  opts: { logLimit?: number; spanLimit?: number } = {},
+): DebugSnapshot {
+  const mem = process.memoryUsage();
+  const health = safe(() => getHealthStatus(), {
+    healthy: true,
+    uptimeMs: 0,
+    totalMessagesProcessed: 0,
+    lastProcessedAt: 0,
+    msSinceLastMessage: 0,
+    recentErrorCount: 0,
+  });
+
+  return {
+    ts: new Date().toISOString(),
+    process: {
+      pid: process.pid,
+      uptimeSec: Math.round(process.uptime()),
+      node: process.versions.node,
+      memMb: Math.round(mem.heapUsed / 1024 / 1024),
+      rssMb: Math.round(mem.rss / 1024 / 1024),
+      platform: process.platform,
+    },
+    bot: {
+      uptimeMs: safe(() => getUptimeMs(), 0),
+      totalMessagesProcessed: safe(() => getTotalMessagesProcessed(), 0),
+      recentErrorCount: health.recentErrorCount,
+      healthy: health.healthy,
+    },
+    dispatcher: {
+      activeQueries: safe(() => getActiveCount(), 0),
+    },
+    sessions: {
+      active: safe(() => getActiveSessionCount(), 0),
+    },
+    logs: {
+      level: safe(() => getLogLevel(), "info" as LogLevel),
+      recent: safe(
+        () => getRecentLogs(opts.logLimit ?? 50) as Array<Record<string, unknown>>,
+        [],
+      ),
+      recentErrors: safe(() => getRecentErrors(20), []),
+    },
+    metrics: safe(() => getMetrics(), { counters: {}, histograms: {} }),
+    spans: {
+      recent: safe(() => getRecentSpans(opts.spanLimit ?? 100), []),
+    },
+  };
+}
+
+function safe<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}

--- a/src/util/json-safe.ts
+++ b/src/util/json-safe.ts
@@ -1,0 +1,172 @@
+/**
+ * JSON-safe normalization for untrusted structured values.
+ *
+ * Plugins, third-party libraries, and test doubles can hand log records or
+ * span attributes arbitrary shapes: circular references, BigInts, functions,
+ * symbols, Maps/Sets, and unbounded object graphs. Every one of those breaks
+ * `JSON.stringify` — which quietly bricks `/debug/logs`, `/debug/state`, and
+ * the spans-YYYY-MM-DD.jsonl persistence path when the debug endpoints or
+ * append hit a poisoned object.
+ *
+ * This module normalizes any `unknown` into something `JSON.stringify` can
+ * always emit. It also enforces a per-value size budget so a plugin can't
+ * accidentally pin megabytes of state in the in-memory ring buffers by
+ * passing a Big Fat Object through `childLogger.info(msg, extra)`.
+ *
+ * Cheap when the input is already primitive — the hot path is just a
+ * `typeof` switch on a string/number/boolean/null — so this is safe to call
+ * on every log and span.
+ */
+export type JsonSafeOptions = {
+  /** Max recursion depth; deeper branches become the string "[depth]". */
+  maxDepth?: number;
+  /** Max entries per array / keys per object; excess trimmed + marked. */
+  maxItems?: number;
+  /** Max characters per string value; excess truncated + marked. */
+  maxString?: number;
+};
+
+const DEFAULTS: Required<JsonSafeOptions> = {
+  maxDepth: 8,
+  maxItems: 100,
+  maxString: 4096,
+};
+
+/**
+ * Convert an unknown value into a JSON-safe tree.
+ *
+ * Primitives pass through. Objects/arrays are deep-copied with cycles
+ * replaced by a "[circular]" marker. BigInts, Dates, Errors, Maps, Sets,
+ * functions, and symbols are stringified. Anything that somehow still slips
+ * through becomes the string "[unserializable]" rather than throwing.
+ */
+export function toJsonSafe(value: unknown, opts: JsonSafeOptions = {}): unknown {
+  const o = { ...DEFAULTS, ...opts };
+  const seen = new WeakSet<object>();
+  return normalize(value, o, seen, 0);
+}
+
+function normalize(
+  value: unknown,
+  o: Required<JsonSafeOptions>,
+  seen: WeakSet<object>,
+  depth: number,
+): unknown {
+  // Primitives that JSON already handles.
+  if (value === null) return null;
+  const t = typeof value;
+  if (t === "string") {
+    const s = value as string;
+    return s.length > o.maxString
+      ? s.slice(0, o.maxString) + `…[+${s.length - o.maxString}ch]`
+      : s;
+  }
+  if (t === "number") {
+    const n = value as number;
+    // JSON can't represent ±Infinity or NaN — flatten to strings instead of
+    // letting `JSON.stringify` silently emit `null`.
+    if (!Number.isFinite(n)) return String(n);
+    return n;
+  }
+  if (t === "boolean") return value;
+  if (t === "undefined") return null;
+
+  // Non-JSON primitives.
+  if (t === "bigint") return `${String(value)}n`;
+  if (t === "symbol") return (value as symbol).toString();
+  if (t === "function") {
+    const name = (value as { name?: string }).name;
+    return `[Function${name ? " " + name : ""}]`;
+  }
+
+  // Objects from here on. Guard depth + cycles.
+  if (depth >= o.maxDepth) return "[depth]";
+  const obj = value as object;
+  if (seen.has(obj)) return "[circular]";
+  seen.add(obj);
+
+  // Error — expose message/name/stack explicitly, stack length-capped.
+  if (value instanceof Error) {
+    const stack =
+      typeof value.stack === "string"
+        ? value.stack.length > o.maxString
+          ? value.stack.slice(0, o.maxString) + "…"
+          : value.stack
+        : undefined;
+    return { name: value.name, message: value.message, stack };
+  }
+
+  // Date — ISO string is round-trippable and compact.
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? "[Invalid Date]" : value.toISOString();
+  }
+
+  // Map / Set — JSON has no native form; flatten to arrays.
+  if (value instanceof Map) {
+    const out: [unknown, unknown][] = [];
+    let i = 0;
+    for (const [k, v] of value) {
+      if (i++ >= o.maxItems) {
+        out.push([`…[+${value.size - o.maxItems} more]`, null]);
+        break;
+      }
+      out.push([
+        normalize(k, o, seen, depth + 1),
+        normalize(v, o, seen, depth + 1),
+      ]);
+    }
+    return { __type: "Map", entries: out };
+  }
+  if (value instanceof Set) {
+    const out: unknown[] = [];
+    let i = 0;
+    for (const v of value) {
+      if (i++ >= o.maxItems) {
+        out.push(`…[+${value.size - o.maxItems} more]`);
+        break;
+      }
+      out.push(normalize(v, o, seen, depth + 1));
+    }
+    return { __type: "Set", values: out };
+  }
+
+  // Array — length-capped copy.
+  if (Array.isArray(value)) {
+    const out: unknown[] = [];
+    const len = Math.min(value.length, o.maxItems);
+    for (let i = 0; i < len; i++) {
+      out.push(normalize(value[i], o, seen, depth + 1));
+    }
+    if (value.length > o.maxItems) {
+      out.push(`…[+${value.length - o.maxItems} more]`);
+    }
+    return out;
+  }
+
+  // Buffer / TypedArray — dump a short preview, not the whole payload.
+  if (ArrayBuffer.isView(value)) {
+    const anyView = value as ArrayBufferView & { length?: number };
+    return `[${(value as object).constructor.name} bytes=${
+      typeof anyView.length === "number" ? anyView.length : anyView.byteLength
+    }]`;
+  }
+
+  // Plain object — iterate own string keys, length-capped.
+  const out: Record<string, unknown> = {};
+  const keys = Object.keys(obj);
+  const kLen = Math.min(keys.length, o.maxItems);
+  for (let i = 0; i < kLen; i++) {
+    const k = keys[i]!;
+    try {
+      out[k] = normalize((obj as Record<string, unknown>)[k], o, seen, depth + 1);
+    } catch {
+      // Getter threw (e.g. proxy); swallow so one bad field doesn't kill the
+      // whole payload.
+      out[k] = "[unserializable]";
+    }
+  }
+  if (keys.length > o.maxItems) {
+    out["…"] = `[+${keys.length - o.maxItems} more keys]`;
+  }
+  return out;
+}

--- a/src/util/json-safe.ts
+++ b/src/util/json-safe.ts
@@ -40,7 +40,10 @@ const DEFAULTS: Required<JsonSafeOptions> = {
  * functions, and symbols are stringified. Anything that somehow still slips
  * through becomes the string "[unserializable]" rather than throwing.
  */
-export function toJsonSafe(value: unknown, opts: JsonSafeOptions = {}): unknown {
+export function toJsonSafe(
+  value: unknown,
+  opts: JsonSafeOptions = {},
+): unknown {
   const o = { ...DEFAULTS, ...opts };
   const seen = new WeakSet<object>();
   return normalize(value, o, seen, 0);
@@ -98,7 +101,9 @@ function normalize(
 
   // Date — ISO string is round-trippable and compact.
   if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? "[Invalid Date]" : value.toISOString();
+    return Number.isNaN(value.getTime())
+      ? "[Invalid Date]"
+      : value.toISOString();
   }
 
   // Map / Set — JSON has no native form; flatten to arrays.
@@ -158,7 +163,12 @@ function normalize(
   for (let i = 0; i < kLen; i++) {
     const k = keys[i]!;
     try {
-      out[k] = normalize((obj as Record<string, unknown>)[k], o, seen, depth + 1);
+      out[k] = normalize(
+        (obj as Record<string, unknown>)[k],
+        o,
+        seen,
+        depth + 1,
+      );
     } catch {
       // Getter threw (e.g. proxy); swallow so one bad field doesn't kill the
       // whole payload.

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -270,6 +270,7 @@ function errMsg(err: unknown): string | undefined {
 }
 
 export function log(component: LogComponent, message: string): void {
+  if (!isLevelEnabled("info")) return;
   logger.info({ component }, message);
   pushRecent({ ts: Date.now(), level: "info", component, msg: message });
 }
@@ -279,6 +280,7 @@ export function logError(
   message: string,
   err?: unknown,
 ): void {
+  if (!isLevelEnabled("error")) return;
   if (err instanceof Error) {
     // Capture both the concise message (for log consumers that look at `err`)
     // and the full stack (for diagnostics). pino-pretty renders the `stack`
@@ -299,6 +301,7 @@ export function logError(
 }
 
 export function logWarn(component: LogComponent, message: string): void {
+  if (!isLevelEnabled("warn")) return;
   logger.warn({ component }, message);
   pushRecent({ ts: Date.now(), level: "warn", component, msg: message });
 }
@@ -322,6 +325,7 @@ export function logFatal(
   message: string,
   err?: unknown,
 ): void {
+  if (!isLevelEnabled("fatal")) return;
   if (err instanceof Error) {
     logger.fatal({ component, err: err.message, stack: err.stack }, message);
   } else if (err !== undefined) {
@@ -391,14 +395,17 @@ function buildChild(bindings: Bindings): ChildLogger {
       capture("debug", msg, undefined, extra);
     },
     info: (msg, extra) => {
+      if (!isLevelEnabled("info")) return;
       pinoChild.info(extra ?? {}, msg);
       capture("info", msg, undefined, extra);
     },
     warn: (msg, extra) => {
+      if (!isLevelEnabled("warn")) return;
       pinoChild.warn(extra ?? {}, msg);
       capture("warn", msg, undefined, extra);
     },
     error: (msg, err, extra) => {
+      if (!isLevelEnabled("error")) return;
       const body: Record<string, unknown> = { ...(extra ?? {}) };
       if (err instanceof Error) {
         body.err = err.message;
@@ -410,6 +417,7 @@ function buildChild(bindings: Bindings): ChildLogger {
       capture("error", msg, err, extra);
     },
     fatal: (msg, err, extra) => {
+      if (!isLevelEnabled("fatal")) return;
       const body: Record<string, unknown> = { ...(extra ?? {}) };
       if (err instanceof Error) {
         body.err = err.message;

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -450,8 +450,11 @@ export function childLogger(bindings: Bindings): ChildLogger {
 }
 
 // ── Recent in-memory buffer ───────────────────────────────────────────────────
-// Small ring buffer of the most recent log records. Exposed by /debug/logs so
-// operators can peek at activity without tailing the file.
+// Fixed-size circular buffer of the most recent log records. Exposed by
+// /debug/logs so operators can peek at activity without tailing the file.
+//
+// Keyed on a write index + valid-count: inserts are O(1) with no Array#shift
+// cost, which matters at default level "trace" where this is on every log line.
 
 type LogRecord = {
   ts: number;
@@ -463,19 +466,34 @@ type LogRecord = {
 };
 
 const RECENT_BUFFER_SIZE = 500;
-const recentBuffer: LogRecord[] = [];
+const recentBuffer: (LogRecord | undefined)[] = new Array(RECENT_BUFFER_SIZE);
+let recentBufferHead = 0; // next write index
+let recentBufferSize = 0; // valid entries (≤ capacity)
 
 function pushRecent(rec: LogRecord): void {
-  recentBuffer.push(rec);
-  if (recentBuffer.length > RECENT_BUFFER_SIZE) recentBuffer.shift();
+  recentBuffer[recentBufferHead] = rec;
+  recentBufferHead = (recentBufferHead + 1) % RECENT_BUFFER_SIZE;
+  if (recentBufferSize < RECENT_BUFFER_SIZE) recentBufferSize++;
+}
+
+/** Snapshot of the ring in oldest-to-newest order. */
+function snapshotRecent(): LogRecord[] {
+  if (recentBufferSize === 0) return [];
+  if (recentBufferSize < RECENT_BUFFER_SIZE) {
+    return recentBuffer.slice(0, recentBufferSize) as LogRecord[];
+  }
+  // Full ring — head points at the oldest entry as well as the next slot.
+  return [
+    ...(recentBuffer.slice(recentBufferHead) as LogRecord[]),
+    ...(recentBuffer.slice(0, recentBufferHead) as LogRecord[]),
+  ];
 }
 
 export function getRecentLogs(limit = 100, minLevel?: LogLevel): LogRecord[] {
+  const ordered = snapshotRecent();
   const min = minLevel ? LEVEL_WEIGHTS[minLevel] : 0;
   const filtered =
-    min === 0
-      ? recentBuffer
-      : recentBuffer.filter((r) => LEVEL_WEIGHTS[r.level] >= min);
+    min === 0 ? ordered : ordered.filter((r) => LEVEL_WEIGHTS[r.level] >= min);
   return filtered.slice(-limit);
 }
 

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -1,10 +1,24 @@
 /**
  * Structured logging via pino — console + file output.
  *
- * Always runs at trace level (maximum verbosity) for debugging.
- * Logs to both:
- *   - stdout (pretty-printed for readability)
- *   - workspace/talon.log (JSON, append-only, for persistence)
+ * Targets:
+ *   - stdout (pretty-printed for readability; suppressed in quiet/binary mode)
+ *   - ~/.talon/talon.log      (JSON, all levels, rotated on startup at 10MB)
+ *   - ~/.talon/errors.log     (JSON, warn+ only, rotated on startup at 10MB)
+ *     — dedicated errors file that survives across restarts so subtle
+ *       long-running errors can be tracked without info-log dilution.
+ *
+ * Level control:
+ *   - Default level is "trace" (maximum verbosity)
+ *   - Override with TALON_LOG_LEVEL env var (trace|debug|info|warn|error|fatal)
+ *   - Namespace filter via TALON_DEBUG env var (comma list of components,
+ *     wildcard * accepted; e.g. "gateway,dispatcher" or "tele*")
+ *   - setLogLevel() flips the level at runtime (used by /debug/log-level)
+ *
+ * Correlation:
+ *   - childLogger({ component, reqId, chatId, ... }) returns a pino child with
+ *     bindings merged into every line. Use for per-request/per-chat logs.
+ *   - newRequestId() generates an 8-char hex id suitable for correlation.
  */
 
 import pino from "pino";
@@ -16,6 +30,7 @@ import {
   renameSync,
   unlinkSync,
 } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { dirs, files } from "./paths.js";
 
 export type LogComponent =
@@ -44,11 +59,25 @@ export type LogComponent =
   | "access"
   | "github"
   | "mempalace"
-  | "playwright";
+  | "playwright"
+  | "trace"
+  | "debug";
+
+export type LogLevel =
+  | "trace"
+  | "debug"
+  | "info"
+  | "warn"
+  | "error"
+  | "fatal"
+  | "silent";
 
 const LOG_FILE = files.log;
+const ERROR_LOG_FILE = files.errorLog;
+const MAX_LOG_SIZE = 10 * 1024 * 1024;
 
-// Ensure .talon dir exists for log file
+// ── Directory / rotation setup ────────────────────────────────────────────────
+
 if (!existsSync(dirs.root)) {
   try {
     mkdirSync(dirs.root, { recursive: true });
@@ -57,20 +86,41 @@ if (!existsSync(dirs.root)) {
   }
 }
 
-// Rotate log file on startup if it exceeds 10MB
-const MAX_LOG_SIZE = 10 * 1024 * 1024;
-try {
-  if (existsSync(LOG_FILE) && statSync(LOG_FILE).size > MAX_LOG_SIZE) {
-    const rotated = `${LOG_FILE}.old`;
-    try {
-      unlinkSync(rotated);
-    } catch {
-      /* ignore */
+function rotateIfOversized(path: string): void {
+  try {
+    if (existsSync(path) && statSync(path).size > MAX_LOG_SIZE) {
+      const rotated = `${path}.old`;
+      try {
+        unlinkSync(rotated);
+      } catch {
+        /* ignore */
+      }
+      renameSync(path, rotated);
     }
-    renameSync(LOG_FILE, rotated);
+  } catch {
+    /* ignore */
   }
-} catch {
-  /* ignore */
+}
+
+rotateIfOversized(LOG_FILE);
+rotateIfOversized(ERROR_LOG_FILE);
+
+// ── Level / quiet mode resolution ─────────────────────────────────────────────
+
+const VALID_LEVELS: LogLevel[] = [
+  "trace",
+  "debug",
+  "info",
+  "warn",
+  "error",
+  "fatal",
+  "silent",
+];
+
+function resolveInitialLevel(): LogLevel {
+  const env = (process.env.TALON_LOG_LEVEL ?? "").toLowerCase() as LogLevel;
+  if (VALID_LEVELS.includes(env)) return env;
+  return "trace";
 }
 
 // Suppress console output for terminal frontend (stdout belongs to the REPL)
@@ -87,8 +137,42 @@ if (!quiet) {
   }
 }
 
+// ── Namespace filter (TALON_DEBUG) ────────────────────────────────────────────
+// When set, only messages from matching components go to stdout and talon.log
+// at debug/trace levels. warn+ always passes through so errors are never lost.
+
+function parseNamespaces(raw: string | undefined): RegExp[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((pat) => {
+      const escaped = pat
+        .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+        .replace(/\*/g, ".*");
+      return new RegExp(`^${escaped}$`);
+    });
+}
+
+let debugNamespaces = parseNamespaces(process.env.TALON_DEBUG);
+
+export function setDebugNamespaces(patterns: string[]): void {
+  debugNamespaces = parseNamespaces(patterns.join(","));
+}
+
+export function isDebugEnabled(component: string): boolean {
+  if (debugNamespaces.length === 0) return true;
+  return debugNamespaces.some((re) => re.test(component));
+}
+
+// ── Pino construction ─────────────────────────────────────────────────────────
+
+const initialLevel = resolveInitialLevel();
+
 const logger = pino({
-  level: "trace",
+  level: "trace", // transport targets gate via their own level
+  base: { pid: process.pid, v: 1 },
   transport: {
     targets: [
       // Console output (disabled in quiet mode)
@@ -96,7 +180,7 @@ const logger = pino({
         ? [
             {
               target: "pino-pretty",
-              level: "trace" as const,
+              level: initialLevel as string,
               options: {
                 colorize: true,
                 ignore: "pid,hostname",
@@ -105,12 +189,21 @@ const logger = pino({
             },
           ]
         : []),
-      // JSON file output (always active)
+      // Full log file (all levels)
       {
         target: "pino/file",
-        level: "trace",
+        level: initialLevel as string,
         options: {
           destination: LOG_FILE,
+          mkdir: true,
+        },
+      },
+      // Error-only log file — preserved long-term for subtle error tracking
+      {
+        target: "pino/file",
+        level: "warn" as const,
+        options: {
+          destination: ERROR_LOG_FILE,
           mkdir: true,
         },
       },
@@ -118,7 +211,53 @@ const logger = pino({
   },
 });
 
+// Effective level — used by isLevelEnabled() when skipping expensive work
+let currentLevel: LogLevel = initialLevel;
+
+const LEVEL_WEIGHTS: Record<LogLevel, number> = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+  silent: 100,
+};
+
+export function getLogLevel(): LogLevel {
+  return currentLevel;
+}
+
+/** Runtime level change — affects pino and skip-expensive-work guards. */
+export function setLogLevel(level: LogLevel): void {
+  if (!VALID_LEVELS.includes(level)) {
+    throw new Error(`Invalid log level: ${level}`);
+  }
+  currentLevel = level;
+  logger.level = level === "silent" ? "silent" : level;
+}
+
+export function isLevelEnabled(level: LogLevel): boolean {
+  return LEVEL_WEIGHTS[level] >= LEVEL_WEIGHTS[currentLevel];
+}
+
+// ── Correlation IDs ───────────────────────────────────────────────────────────
+
+/** Generate an 8-character hex request id. */
+export function newRequestId(): string {
+  return randomBytes(4).toString("hex");
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+function shouldEmit(component: string, level: LogLevel): boolean {
+  // Warn+ always emitted (important errors are never filtered away).
+  if (LEVEL_WEIGHTS[level] >= LEVEL_WEIGHTS.warn) return true;
+  return isDebugEnabled(component);
+}
+
 export function log(component: LogComponent, message: string): void {
+  if (!shouldEmit(component, "info")) return;
   logger.info({ component }, message);
 }
 
@@ -144,10 +283,179 @@ export function logWarn(component: LogComponent, message: string): void {
 }
 
 export function logDebug(component: LogComponent, message: string): void {
+  if (!isLevelEnabled("debug")) return;
+  if (!shouldEmit(component, "debug")) return;
   logger.debug({ component }, message);
 }
 
-// Expose logger to plugins running in the same process
+export function logTrace(component: LogComponent, message: string): void {
+  if (!isLevelEnabled("trace")) return;
+  if (!shouldEmit(component, "trace")) return;
+  logger.trace({ component }, message);
+}
+
+export function logFatal(
+  component: LogComponent,
+  message: string,
+  err?: unknown,
+): void {
+  if (err instanceof Error) {
+    logger.fatal(
+      { component, err: err.message, stack: err.stack },
+      message,
+    );
+  } else if (err !== undefined) {
+    logger.fatal({ component, err: String(err) }, message);
+  } else {
+    logger.fatal({ component }, message);
+  }
+}
+
+// ── Child loggers with fixed bindings ─────────────────────────────────────────
+
+export type Bindings = {
+  component: LogComponent;
+  reqId?: string;
+  chatId?: string | number;
+  [key: string]: unknown;
+};
+
+export type ChildLogger = {
+  trace: (msg: string, extra?: Record<string, unknown>) => void;
+  debug: (msg: string, extra?: Record<string, unknown>) => void;
+  info: (msg: string, extra?: Record<string, unknown>) => void;
+  warn: (msg: string, extra?: Record<string, unknown>) => void;
+  error: (msg: string, err?: unknown, extra?: Record<string, unknown>) => void;
+  fatal: (msg: string, err?: unknown, extra?: Record<string, unknown>) => void;
+  child: (extra: Record<string, unknown>) => ChildLogger;
+  bindings: () => Bindings;
+};
+
+function buildChild(bindings: Bindings): ChildLogger {
+  const pinoChild = logger.child(bindings);
+  return {
+    trace: (msg, extra) => {
+      if (!isLevelEnabled("trace")) return;
+      if (!shouldEmit(bindings.component, "trace")) return;
+      pinoChild.trace(extra ?? {}, msg);
+    },
+    debug: (msg, extra) => {
+      if (!isLevelEnabled("debug")) return;
+      if (!shouldEmit(bindings.component, "debug")) return;
+      pinoChild.debug(extra ?? {}, msg);
+    },
+    info: (msg, extra) => {
+      if (!shouldEmit(bindings.component, "info")) return;
+      pinoChild.info(extra ?? {}, msg);
+    },
+    warn: (msg, extra) => {
+      pinoChild.warn(extra ?? {}, msg);
+    },
+    error: (msg, err, extra) => {
+      const body: Record<string, unknown> = { ...(extra ?? {}) };
+      if (err instanceof Error) {
+        body.err = err.message;
+        body.stack = err.stack;
+      } else if (err !== undefined) {
+        body.err = String(err);
+      }
+      pinoChild.error(body, msg);
+    },
+    fatal: (msg, err, extra) => {
+      const body: Record<string, unknown> = { ...(extra ?? {}) };
+      if (err instanceof Error) {
+        body.err = err.message;
+        body.stack = err.stack;
+      } else if (err !== undefined) {
+        body.err = String(err);
+      }
+      pinoChild.fatal(body, msg);
+    },
+    child: (extra) => buildChild({ ...bindings, ...extra } as Bindings),
+    bindings: () => bindings,
+  };
+}
+
+/**
+ * Create a child logger with pre-bound fields. Every line emitted through it
+ * is tagged with the bindings (component, reqId, chatId, etc.) — ideal for
+ * per-request or per-chat context that you don't want to repeat at every call.
+ */
+export function childLogger(bindings: Bindings): ChildLogger {
+  return buildChild(bindings);
+}
+
+// ── Recent in-memory buffer ───────────────────────────────────────────────────
+// Small ring buffer of the most recent log records. Exposed by /debug/logs so
+// operators can peek at activity without tailing the file.
+
+type LogRecord = {
+  ts: number;
+  level: LogLevel;
+  component: string;
+  msg: string;
+  err?: string;
+  extra?: Record<string, unknown>;
+};
+
+const RECENT_BUFFER_SIZE = 500;
+const recentBuffer: LogRecord[] = [];
+
+function pushRecent(rec: LogRecord): void {
+  recentBuffer.push(rec);
+  if (recentBuffer.length > RECENT_BUFFER_SIZE) recentBuffer.shift();
+}
+
+export function getRecentLogs(limit = 100, minLevel?: LogLevel): LogRecord[] {
+  const min = minLevel ? LEVEL_WEIGHTS[minLevel] : 0;
+  const filtered =
+    min === 0
+      ? recentBuffer
+      : recentBuffer.filter((r) => LEVEL_WEIGHTS[r.level] >= min);
+  return filtered.slice(-limit);
+}
+
+// Tap pino so recent records stay accessible in-process.
+const ORIG_INFO = logger.info.bind(logger);
+const ORIG_WARN = logger.warn.bind(logger);
+const ORIG_ERROR = logger.error.bind(logger);
+const ORIG_DEBUG = logger.debug.bind(logger);
+const ORIG_TRACE = logger.trace.bind(logger);
+const ORIG_FATAL = logger.fatal.bind(logger);
+
+type PinoCall = (obj: Record<string, unknown>, msg?: string) => void;
+
+function wrap(orig: PinoCall, level: LogLevel): PinoCall {
+  return (obj, msg) => {
+    orig(obj, msg);
+    const component =
+      typeof obj === "object" && obj && "component" in obj
+        ? String((obj as { component?: unknown }).component ?? "?")
+        : "?";
+    pushRecent({
+      ts: Date.now(),
+      level,
+      component,
+      msg: msg ?? "",
+      err:
+        typeof obj === "object" && obj && "err" in obj
+          ? String((obj as { err?: unknown }).err)
+          : undefined,
+    });
+  };
+}
+
+(logger as unknown as { info: PinoCall }).info = wrap(ORIG_INFO, "info");
+(logger as unknown as { warn: PinoCall }).warn = wrap(ORIG_WARN, "warn");
+(logger as unknown as { error: PinoCall }).error = wrap(ORIG_ERROR, "error");
+(logger as unknown as { debug: PinoCall }).debug = wrap(ORIG_DEBUG, "debug");
+(logger as unknown as { trace: PinoCall }).trace = wrap(ORIG_TRACE, "trace");
+(logger as unknown as { fatal: PinoCall }).fatal = wrap(ORIG_FATAL, "fatal");
+
+// ── Plugin access ─────────────────────────────────────────────────────────────
+
 (globalThis as Record<string, unknown>).__talonLog = log;
 (globalThis as Record<string, unknown>).__talonLogError = logError;
 (globalThis as Record<string, unknown>).__talonLogWarn = logWarn;
+(globalThis as Record<string, unknown>).__talonLogDebug = logDebug;
+(globalThis as Record<string, unknown>).__talonChildLogger = childLogger;

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -10,7 +10,8 @@
  *
  * Level control:
  *   - Default level is "trace" (maximum verbosity)
- *   - Override with TALON_LOG_LEVEL env var (trace|debug|info|warn|error|fatal)
+ *   - Override with TALON_LOG_LEVEL env var
+ *     (trace|debug|info|warn|error|fatal|silent)
  *   - Namespace filter via TALON_DEBUG env var (comma list of components,
  *     wildcard * accepted; e.g. "gateway,dispatcher" or "tele*")
  *   - setLogLevel() flips the level at runtime (used by /debug/log-level)
@@ -32,6 +33,7 @@ import {
 } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { dirs, files } from "./paths.js";
+import { toJsonSafe } from "./json-safe.js";
 
 export type LogComponent =
   | "bot"
@@ -384,8 +386,20 @@ function buildChild(bindings: Bindings): ChildLogger {
       level,
       component: String(bindings.component),
       msg,
-      err: err instanceof Error ? err.message : err ? String(err) : undefined,
-      extra,
+      // `err` can legitimately be any falsy non-undefined value (0, "", false)
+      // that a plugin mistakenly passed as the error argument — capture those
+      // as-is rather than dropping them silently.
+      err:
+        err instanceof Error
+          ? err.message
+          : err !== undefined
+            ? String(err)
+            : undefined,
+      // Normalize extra into a JSON-safe, size-bounded form so a plugin can't
+      // poison the ring with circular refs, BigInt, or megabyte payloads.
+      extra: extra
+        ? (toJsonSafe(extra) as Record<string, unknown>)
+        : undefined,
     });
   };
   return {

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -138,8 +138,9 @@ if (!quiet) {
 }
 
 // ── Namespace filter (TALON_DEBUG) ────────────────────────────────────────────
-// When set, only messages from matching components go to stdout and talon.log
-// at debug/trace levels. warn+ always passes through so errors are never lost.
+// When set, debug/trace messages are only emitted for matching components.
+// Info and warn+ always pass through so operational and error output is never
+// suppressed — this filter is purely for narrowing verbose debug output.
 
 function parseNamespaces(raw: string | undefined): RegExp[] {
   if (!raw) return [];
@@ -170,8 +171,13 @@ export function isDebugEnabled(component: string): boolean {
 
 const initialLevel = resolveInitialLevel();
 
+// Transport targets are intentionally open (level: "trace") so that the
+// logger-level gate (`logger.level`, updated at runtime by setLogLevel) is the
+// single source of truth. Errors.log is the one exception — it always filters
+// to warn+ regardless of the effective logger level, so the long-term error
+// record is never diluted when someone temporarily raises verbosity.
 const logger = pino({
-  level: "trace", // transport targets gate via their own level
+  level: initialLevel,
   base: { pid: process.pid, v: 1 },
   transport: {
     targets: [
@@ -180,7 +186,7 @@ const logger = pino({
         ? [
             {
               target: "pino-pretty",
-              level: initialLevel as string,
+              level: "trace" as const,
               options: {
                 colorize: true,
                 ignore: "pid,hostname",
@@ -189,16 +195,16 @@ const logger = pino({
             },
           ]
         : []),
-      // Full log file (all levels)
+      // Full log file — gated by logger.level
       {
         target: "pino/file",
-        level: initialLevel as string,
+        level: "trace" as const,
         options: {
           destination: LOG_FILE,
           mkdir: true,
         },
       },
-      // Error-only log file — preserved long-term for subtle error tracking
+      // Error-only log file — always warn+ for long-term retention
       {
         target: "pino/file",
         level: "warn" as const,
@@ -251,14 +257,21 @@ export function newRequestId(): string {
 // ── Public API ────────────────────────────────────────────────────────────────
 
 function shouldEmit(component: string, level: LogLevel): boolean {
-  // Warn+ always emitted (important errors are never filtered away).
-  if (LEVEL_WEIGHTS[level] >= LEVEL_WEIGHTS.warn) return true;
+  // Only debug/trace are subject to the namespace filter; info and warn+ always
+  // emit so operational signals and errors are never suppressed.
+  if (LEVEL_WEIGHTS[level] >= LEVEL_WEIGHTS.info) return true;
   return isDebugEnabled(component);
 }
 
+function errMsg(err: unknown): string | undefined {
+  if (err instanceof Error) return err.message;
+  if (err !== undefined) return String(err);
+  return undefined;
+}
+
 export function log(component: LogComponent, message: string): void {
-  if (!shouldEmit(component, "info")) return;
   logger.info({ component }, message);
+  pushRecent({ ts: Date.now(), level: "info", component, msg: message });
 }
 
 export function logError(
@@ -276,22 +289,32 @@ export function logError(
   } else {
     logger.error({ component }, message);
   }
+  pushRecent({
+    ts: Date.now(),
+    level: "error",
+    component,
+    msg: message,
+    err: errMsg(err),
+  });
 }
 
 export function logWarn(component: LogComponent, message: string): void {
   logger.warn({ component }, message);
+  pushRecent({ ts: Date.now(), level: "warn", component, msg: message });
 }
 
 export function logDebug(component: LogComponent, message: string): void {
   if (!isLevelEnabled("debug")) return;
   if (!shouldEmit(component, "debug")) return;
   logger.debug({ component }, message);
+  pushRecent({ ts: Date.now(), level: "debug", component, msg: message });
 }
 
 export function logTrace(component: LogComponent, message: string): void {
   if (!isLevelEnabled("trace")) return;
   if (!shouldEmit(component, "trace")) return;
   logger.trace({ component }, message);
+  pushRecent({ ts: Date.now(), level: "trace", component, msg: message });
 }
 
 export function logFatal(
@@ -306,6 +329,13 @@ export function logFatal(
   } else {
     logger.fatal({ component }, message);
   }
+  pushRecent({
+    ts: Date.now(),
+    level: "fatal",
+    component,
+    msg: message,
+    err: errMsg(err),
+  });
 }
 
 // ── Child loggers with fixed bindings ─────────────────────────────────────────
@@ -330,23 +360,43 @@ export type ChildLogger = {
 
 function buildChild(bindings: Bindings): ChildLogger {
   const pinoChild = logger.child(bindings);
+  // Child-logger lines don't pass through the root wrap (that only taps the
+  // root pino instance), so capture to the ring buffer directly here.
+  const capture = (
+    level: LogLevel,
+    msg: string,
+    err?: unknown,
+    extra?: Record<string, unknown>,
+  ): void => {
+    pushRecent({
+      ts: Date.now(),
+      level,
+      component: String(bindings.component),
+      msg,
+      err: err instanceof Error ? err.message : err ? String(err) : undefined,
+      extra,
+    });
+  };
   return {
     trace: (msg, extra) => {
       if (!isLevelEnabled("trace")) return;
       if (!shouldEmit(bindings.component, "trace")) return;
       pinoChild.trace(extra ?? {}, msg);
+      capture("trace", msg, undefined, extra);
     },
     debug: (msg, extra) => {
       if (!isLevelEnabled("debug")) return;
       if (!shouldEmit(bindings.component, "debug")) return;
       pinoChild.debug(extra ?? {}, msg);
+      capture("debug", msg, undefined, extra);
     },
     info: (msg, extra) => {
-      if (!shouldEmit(bindings.component, "info")) return;
       pinoChild.info(extra ?? {}, msg);
+      capture("info", msg, undefined, extra);
     },
     warn: (msg, extra) => {
       pinoChild.warn(extra ?? {}, msg);
+      capture("warn", msg, undefined, extra);
     },
     error: (msg, err, extra) => {
       const body: Record<string, unknown> = { ...(extra ?? {}) };
@@ -357,6 +407,7 @@ function buildChild(bindings: Bindings): ChildLogger {
         body.err = String(err);
       }
       pinoChild.error(body, msg);
+      capture("error", msg, err, extra);
     },
     fatal: (msg, err, extra) => {
       const body: Record<string, unknown> = { ...(extra ?? {}) };
@@ -367,6 +418,7 @@ function buildChild(bindings: Bindings): ChildLogger {
         body.err = String(err);
       }
       pinoChild.fatal(body, msg);
+      capture("fatal", msg, err, extra);
     },
     child: (extra) => buildChild({ ...bindings, ...extra } as Bindings),
     bindings: () => bindings,
@@ -412,42 +464,11 @@ export function getRecentLogs(limit = 100, minLevel?: LogLevel): LogRecord[] {
   return filtered.slice(-limit);
 }
 
-// Tap pino so recent records stay accessible in-process.
-const ORIG_INFO = logger.info.bind(logger);
-const ORIG_WARN = logger.warn.bind(logger);
-const ORIG_ERROR = logger.error.bind(logger);
-const ORIG_DEBUG = logger.debug.bind(logger);
-const ORIG_TRACE = logger.trace.bind(logger);
-const ORIG_FATAL = logger.fatal.bind(logger);
-
-type PinoCall = (obj: Record<string, unknown>, msg?: string) => void;
-
-function wrap(orig: PinoCall, level: LogLevel): PinoCall {
-  return (obj, msg) => {
-    orig(obj, msg);
-    const component =
-      typeof obj === "object" && obj && "component" in obj
-        ? String((obj as { component?: unknown }).component ?? "?")
-        : "?";
-    pushRecent({
-      ts: Date.now(),
-      level,
-      component,
-      msg: msg ?? "",
-      err:
-        typeof obj === "object" && obj && "err" in obj
-          ? String((obj as { err?: unknown }).err)
-          : undefined,
-    });
-  };
-}
-
-(logger as unknown as { info: PinoCall }).info = wrap(ORIG_INFO, "info");
-(logger as unknown as { warn: PinoCall }).warn = wrap(ORIG_WARN, "warn");
-(logger as unknown as { error: PinoCall }).error = wrap(ORIG_ERROR, "error");
-(logger as unknown as { debug: PinoCall }).debug = wrap(ORIG_DEBUG, "debug");
-(logger as unknown as { trace: PinoCall }).trace = wrap(ORIG_TRACE, "trace");
-(logger as unknown as { fatal: PinoCall }).fatal = wrap(ORIG_FATAL, "fatal");
+// Ring-buffer capture is done explicitly by the log*() helpers and by each
+// childLogger method. Calling pino directly (outside those helpers) will skip
+// the in-memory buffer — that's intentional, since pino targets a flat
+// transport write path and avoiding a post-emit wrap keeps hot-path overhead
+// at a single function call.
 
 // ── Plugin access ─────────────────────────────────────────────────────────────
 

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -397,9 +397,7 @@ function buildChild(bindings: Bindings): ChildLogger {
             : undefined,
       // Normalize extra into a JSON-safe, size-bounded form so a plugin can't
       // poison the ring with circular refs, BigInt, or megabyte payloads.
-      extra: extra
-        ? (toJsonSafe(extra) as Record<string, unknown>)
-        : undefined,
+      extra: extra ? (toJsonSafe(extra) as Record<string, unknown>) : undefined,
     });
   };
   return {

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -171,13 +171,14 @@ export function isDebugEnabled(component: string): boolean {
 
 const initialLevel = resolveInitialLevel();
 
-// Transport targets are intentionally open (level: "trace") so that the
-// logger-level gate (`logger.level`, updated at runtime by setLogLevel) is the
-// single source of truth. Errors.log is the one exception — it always filters
-// to warn+ regardless of the effective logger level, so the long-term error
-// record is never diluted when someone temporarily raises verbosity.
+// Transport targets are intentionally open (level: "trace") so warn+ always
+// reach the errors.log transport's own warn-level gate, regardless of the
+// user-facing level set via setLogLevel. User-facing filtering is applied in
+// the wrapper functions below: info/debug/trace wrappers gate on currentLevel,
+// while warn/error/fatal wrappers always emit so the long-term error record
+// is never diluted when someone temporarily raises the display level.
 const logger = pino({
-  level: initialLevel,
+  level: "trace",
   base: { pid: process.pid, v: 1 },
   transport: {
     targets: [
@@ -195,7 +196,7 @@ const logger = pino({
             },
           ]
         : []),
-      // Full log file — gated by logger.level
+      // Full log file — accepts every level the wrappers let through
       {
         target: "pino/file",
         level: "trace" as const,
@@ -234,13 +235,17 @@ export function getLogLevel(): LogLevel {
   return currentLevel;
 }
 
-/** Runtime level change — affects pino and skip-expensive-work guards. */
+/**
+ * Runtime level change — gates the info/debug/trace wrappers. Warn/error/fatal
+ * always pass through so errors.log keeps a complete record (see logger
+ * construction above). `logger.level` stays at "trace" so transport-level
+ * filtering (e.g. errors.log's warn gate) remains the source of truth.
+ */
 export function setLogLevel(level: LogLevel): void {
   if (!VALID_LEVELS.includes(level)) {
     throw new Error(`Invalid log level: ${level}`);
   }
   currentLevel = level;
-  logger.level = level === "silent" ? "silent" : level;
 }
 
 export function isLevelEnabled(level: LogLevel): boolean {
@@ -280,7 +285,6 @@ export function logError(
   message: string,
   err?: unknown,
 ): void {
-  if (!isLevelEnabled("error")) return;
   if (err instanceof Error) {
     // Capture both the concise message (for log consumers that look at `err`)
     // and the full stack (for diagnostics). pino-pretty renders the `stack`
@@ -301,7 +305,6 @@ export function logError(
 }
 
 export function logWarn(component: LogComponent, message: string): void {
-  if (!isLevelEnabled("warn")) return;
   logger.warn({ component }, message);
   pushRecent({ ts: Date.now(), level: "warn", component, msg: message });
 }
@@ -325,7 +328,6 @@ export function logFatal(
   message: string,
   err?: unknown,
 ): void {
-  if (!isLevelEnabled("fatal")) return;
   if (err instanceof Error) {
     logger.fatal({ component, err: err.message, stack: err.stack }, message);
   } else if (err !== undefined) {
@@ -400,12 +402,10 @@ function buildChild(bindings: Bindings): ChildLogger {
       capture("info", msg, undefined, extra);
     },
     warn: (msg, extra) => {
-      if (!isLevelEnabled("warn")) return;
       pinoChild.warn(extra ?? {}, msg);
       capture("warn", msg, undefined, extra);
     },
     error: (msg, err, extra) => {
-      if (!isLevelEnabled("error")) return;
       const body: Record<string, unknown> = { ...(extra ?? {}) };
       if (err instanceof Error) {
         body.err = err.message;
@@ -417,7 +417,6 @@ function buildChild(bindings: Bindings): ChildLogger {
       capture("error", msg, err, extra);
     },
     fatal: (msg, err, extra) => {
-      if (!isLevelEnabled("fatal")) return;
       const body: Record<string, unknown> = { ...(extra ?? {}) };
       if (err instanceof Error) {
         body.err = err.message;

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -176,7 +176,9 @@ const initialLevel = resolveInitialLevel();
 // user-facing level set via setLogLevel. User-facing filtering is applied in
 // the wrapper functions below: info/debug/trace wrappers gate on currentLevel,
 // while warn/error/fatal wrappers always emit so the long-term error record
-// is never diluted when someone temporarily raises the display level.
+// is never diluted when someone temporarily raises the display level. The one
+// exception is "silent", which short-circuits every wrapper so no output is
+// produced at all — the user explicitly asked for silence.
 const logger = pino({
   level: "trace",
   base: { pid: process.pid, v: 1 },
@@ -285,6 +287,7 @@ export function logError(
   message: string,
   err?: unknown,
 ): void {
+  if (currentLevel === "silent") return;
   if (err instanceof Error) {
     // Capture both the concise message (for log consumers that look at `err`)
     // and the full stack (for diagnostics). pino-pretty renders the `stack`
@@ -305,6 +308,7 @@ export function logError(
 }
 
 export function logWarn(component: LogComponent, message: string): void {
+  if (currentLevel === "silent") return;
   logger.warn({ component }, message);
   pushRecent({ ts: Date.now(), level: "warn", component, msg: message });
 }
@@ -328,6 +332,7 @@ export function logFatal(
   message: string,
   err?: unknown,
 ): void {
+  if (currentLevel === "silent") return;
   if (err instanceof Error) {
     logger.fatal({ component, err: err.message, stack: err.stack }, message);
   } else if (err !== undefined) {
@@ -402,10 +407,12 @@ function buildChild(bindings: Bindings): ChildLogger {
       capture("info", msg, undefined, extra);
     },
     warn: (msg, extra) => {
+      if (currentLevel === "silent") return;
       pinoChild.warn(extra ?? {}, msg);
       capture("warn", msg, undefined, extra);
     },
     error: (msg, err, extra) => {
+      if (currentLevel === "silent") return;
       const body: Record<string, unknown> = { ...(extra ?? {}) };
       if (err instanceof Error) {
         body.err = err.message;
@@ -417,6 +424,7 @@ function buildChild(bindings: Bindings): ChildLogger {
       capture("error", msg, err, extra);
     },
     fatal: (msg, err, extra) => {
+      if (currentLevel === "silent") return;
       const body: Record<string, unknown> = { ...(extra ?? {}) };
       if (err instanceof Error) {
         body.err = err.message;

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -300,10 +300,7 @@ export function logFatal(
   err?: unknown,
 ): void {
   if (err instanceof Error) {
-    logger.fatal(
-      { component, err: err.message, stack: err.stack },
-      message,
-    );
+    logger.fatal({ component, err: err.message, stack: err.stack }, message);
   } else if (err !== undefined) {
     logger.fatal({ component, err: String(err) }, message);
   } else {

--- a/src/util/metrics.ts
+++ b/src/util/metrics.ts
@@ -32,12 +32,15 @@ function ringValues(buf: RingBuffer): number[] {
 /**
  * Normalize an untrusted label (e.g. a request-provided action name) for safe
  * use inside a metric key. Collapses anything outside [A-Za-z0-9_] to "_",
- * lowercases, and truncates to 40 chars. Empty or absurdly-long (>200 char)
- * input is bucketed as "unknown". Together with MAX_METRIC_KEYS, this keeps
- * high-cardinality input from exhausting the key budget.
+ * lowercases, and truncates to 40 chars. Empty, non-string, or absurdly-long
+ * (>200 char) input is bucketed as "unknown". Together with MAX_METRIC_KEYS,
+ * this keeps high-cardinality input from exhausting the key budget.
+ *
+ * Typed as `unknown` so callers don't have to cast — the whole point is that
+ * the input is untrusted, which includes not being sure it's a string.
  */
-export function sanitizeMetricLabel(raw: string): string {
-  if (!raw || typeof raw !== "string") return "unknown";
+export function sanitizeMetricLabel(raw: unknown): string {
+  if (typeof raw !== "string" || raw.length === 0) return "unknown";
   if (raw.length > 200) return "unknown";
   const cleaned = raw
     .toLowerCase()

--- a/src/util/metrics.ts
+++ b/src/util/metrics.ts
@@ -32,11 +32,13 @@ function ringValues(buf: RingBuffer): number[] {
 /**
  * Normalize an untrusted label (e.g. a request-provided action name) for safe
  * use inside a metric key. Collapses anything outside [A-Za-z0-9_] to "_",
- * lowercases, truncates to 40 chars, and buckets empty / absurdly-long input
- * as "unknown" so high-cardinality input can't exhaust MAX_METRIC_KEYS.
+ * lowercases, and truncates to 40 chars. Empty or absurdly-long (>200 char)
+ * input is bucketed as "unknown". Together with MAX_METRIC_KEYS, this keeps
+ * high-cardinality input from exhausting the key budget.
  */
 export function sanitizeMetricLabel(raw: string): string {
   if (!raw || typeof raw !== "string") return "unknown";
+  if (raw.length > 200) return "unknown";
   const cleaned = raw
     .toLowerCase()
     .replace(/[^a-z0-9_]+/g, "_")

--- a/src/util/metrics.ts
+++ b/src/util/metrics.ts
@@ -37,7 +37,10 @@ function ringValues(buf: RingBuffer): number[] {
  */
 export function sanitizeMetricLabel(raw: string): string {
   if (!raw || typeof raw !== "string") return "unknown";
-  const cleaned = raw.toLowerCase().replace(/[^a-z0-9_]+/g, "_").slice(0, 40);
+  const cleaned = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .slice(0, 40);
   return cleaned.replace(/^_+|_+$/g, "") || "unknown";
 }
 

--- a/src/util/metrics.ts
+++ b/src/util/metrics.ts
@@ -29,6 +29,18 @@ function ringValues(buf: RingBuffer): number[] {
   return [...buf.data.slice(buf.head), ...buf.data.slice(0, buf.head)];
 }
 
+/**
+ * Normalize an untrusted label (e.g. a request-provided action name) for safe
+ * use inside a metric key. Collapses anything outside [A-Za-z0-9_] to "_",
+ * lowercases, truncates to 40 chars, and buckets empty / absurdly-long input
+ * as "unknown" so high-cardinality input can't exhaust MAX_METRIC_KEYS.
+ */
+export function sanitizeMetricLabel(raw: string): string {
+  if (!raw || typeof raw !== "string") return "unknown";
+  const cleaned = raw.toLowerCase().replace(/[^a-z0-9_]+/g, "_").slice(0, 40);
+  return cleaned.replace(/^_+|_+$/g, "") || "unknown";
+}
+
 export function incrementCounter(name: string, amount = 1): void {
   // Only allow new keys up to the cap — existing keys always pass
   if (!counters.has(name) && counters.size >= MAX_METRIC_KEYS) return;

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -62,6 +62,8 @@ export const files = {
   config: resolve(TALON_ROOT, "config.json"),
   /** Structured log: ~/.talon/talon.log */
   log: resolve(TALON_ROOT, "talon.log"),
+  /** Errors-only log (warn+), long-term retained: ~/.talon/errors.log */
+  errorLog: resolve(TALON_ROOT, "errors.log"),
   /** Session store: ~/.talon/data/sessions.json */
   sessions: resolve(TALON_ROOT, "data", "sessions.json"),
   /** Chat history: ~/.talon/data/history.json */

--- a/src/util/trace.ts
+++ b/src/util/trace.ts
@@ -18,6 +18,11 @@
  *
  *    AsyncLocalStorage propagates the current span across awaits so child
  *    spans link to their parent automatically.
+ *
+ *    Persistence (spans-YYYY-MM-DD.jsonl) is opt-in via TALON_TRACE_PERSIST=1
+ *    because every span.end() would otherwise issue a blocking appendFileSync
+ *    from hot code paths (dispatcher, gateway). The in-memory ring buffer and
+ *    auto-emitted metrics are always available.
  */
 
 import { appendFileSync, existsSync, mkdirSync } from "node:fs";
@@ -113,7 +118,10 @@ function currentLogFile(): string {
   return resolve(dirs.traces, `${SPAN_LOG_PREFIX}-${y}-${m}-${day}.jsonl`);
 }
 
+const persistEnabled = process.env.TALON_TRACE_PERSIST === "1";
+
 function persistSpan(rec: SpanRecord): void {
+  if (!persistEnabled) return;
   try {
     ensureDir();
     appendFileSync(currentLogFile(), JSON.stringify(rec) + "\n");

--- a/src/util/trace.ts
+++ b/src/util/trace.ts
@@ -1,15 +1,38 @@
 /**
- * Per-chat message trace — dumps full in/out messages to ~/.talon/data/traces/<chatId>.jsonl
- * for debugging. One JSON object per line, append-only.
+ * Tracing — two complementary tools for debugging Talon.
+ *
+ * 1. traceMessage(): per-chat message dump to ~/.talon/data/traces/<chatId>.jsonl
+ *    (unchanged historical API — used by the Claude handler)
+ *
+ * 2. Spans: lightweight, OpenTelemetry-inspired spans for tracking latency and
+ *    causality across async code. Spans are stored in an in-memory ring buffer
+ *    (exposed via /debug/spans) and appended to
+ *    ~/.talon/data/traces/spans-YYYY-MM-DD.jsonl for post-mortem analysis.
+ *
+ *    Usage:
+ *      await withSpan("dispatcher.run", { chatId }, async (span) => {
+ *        span.setAttribute("model", "sonnet");
+ *        span.addEvent("typing-started");
+ *        return doWork();
+ *      });
+ *
+ *    AsyncLocalStorage propagates the current span across awaits so child
+ *    spans link to their parent automatically.
  */
 
 import { appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomBytes } from "node:crypto";
 import { dirs } from "./paths.js";
+import { logError } from "./log.js";
+import { recordHistogram, incrementCounter } from "./metrics.js";
 
 function ensureDir(): void {
   if (!existsSync(dirs.traces)) mkdirSync(dirs.traces, { recursive: true });
 }
+
+// ── Legacy per-chat message trace (unchanged) ────────────────────────────────
 
 export function traceMessage(
   chatId: string,
@@ -34,4 +57,199 @@ export function traceMessage(
       `[trace] Trace write failed: ${err instanceof Error ? err.message : err}\n`,
     );
   }
+}
+
+// ── Span-based tracing ────────────────────────────────────────────────────────
+
+export type SpanStatus = "ok" | "error";
+
+export type SpanAttributes = Record<string, unknown>;
+
+export type SpanEvent = {
+  ts: number;
+  name: string;
+  attrs?: SpanAttributes;
+};
+
+export type SpanRecord = {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+  status: SpanStatus;
+  attrs: SpanAttributes;
+  events: SpanEvent[];
+  err?: string;
+};
+
+export type Span = {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly name: string;
+  setAttribute: (key: string, value: unknown) => void;
+  setAttributes: (attrs: SpanAttributes) => void;
+  addEvent: (name: string, attrs?: SpanAttributes) => void;
+  setStatus: (status: SpanStatus, err?: unknown) => void;
+  end: () => SpanRecord;
+};
+
+const SPAN_RING_SIZE = 1000;
+const recentSpans: SpanRecord[] = [];
+const SPAN_LOG_PREFIX = "spans";
+
+function pushSpan(rec: SpanRecord): void {
+  recentSpans.push(rec);
+  if (recentSpans.length > SPAN_RING_SIZE) recentSpans.shift();
+}
+
+function currentLogFile(): string {
+  const d = new Date();
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return resolve(dirs.traces, `${SPAN_LOG_PREFIX}-${y}-${m}-${day}.jsonl`);
+}
+
+function persistSpan(rec: SpanRecord): void {
+  try {
+    ensureDir();
+    appendFileSync(currentLogFile(), JSON.stringify(rec) + "\n");
+  } catch (err) {
+    // Surface to the logger but don't throw — tracing must never break the app.
+    logError("trace", "Span persist failed", err);
+  }
+}
+
+const als = new AsyncLocalStorage<Span>();
+
+function genTraceId(): string {
+  return randomBytes(8).toString("hex");
+}
+
+function genSpanId(): string {
+  return randomBytes(4).toString("hex");
+}
+
+function buildSpan(
+  name: string,
+  parent: Span | undefined,
+  attrs: SpanAttributes | undefined,
+): Span {
+  const traceId = parent?.traceId ?? genTraceId();
+  const spanId = genSpanId();
+  const startMs = Date.now();
+  const events: SpanEvent[] = [];
+  const attributes: SpanAttributes = { ...(attrs ?? {}) };
+  let status: SpanStatus = "ok";
+  let errMsg: string | undefined;
+  let ended = false;
+
+  return {
+    traceId,
+    spanId,
+    name,
+    setAttribute(key, value) {
+      attributes[key] = value;
+    },
+    setAttributes(a) {
+      Object.assign(attributes, a);
+    },
+    addEvent(evName, evAttrs) {
+      events.push({ ts: Date.now(), name: evName, attrs: evAttrs });
+    },
+    setStatus(s, err) {
+      status = s;
+      if (s === "error") {
+        if (err instanceof Error) errMsg = err.message;
+        else if (err !== undefined) errMsg = String(err);
+      }
+    },
+    end() {
+      if (ended) {
+        // Prevent double-end from emitting a second record.
+        return {
+          traceId,
+          spanId,
+          parentSpanId: parent?.spanId,
+          name,
+          startMs,
+          endMs: startMs,
+          durationMs: 0,
+          status,
+          attrs: attributes,
+          events,
+          err: errMsg,
+        };
+      }
+      ended = true;
+      const endMs = Date.now();
+      const rec: SpanRecord = {
+        traceId,
+        spanId,
+        parentSpanId: parent?.spanId,
+        name,
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+        status,
+        attrs: attributes,
+        events,
+        err: errMsg,
+      };
+      pushSpan(rec);
+      persistSpan(rec);
+      // Emit metrics so histograms show up without every caller opting in.
+      recordHistogram(`span.${name}.ms`, rec.durationMs);
+      incrementCounter(`span.${name}.${status}`);
+      return rec;
+    },
+  };
+}
+
+/** Start a new span. If a parent is active in AsyncLocalStorage, it's linked. */
+export function startSpan(name: string, attrs?: SpanAttributes): Span {
+  const parent = als.getStore();
+  return buildSpan(name, parent, attrs);
+}
+
+/**
+ * Run `fn` inside a span. The span is made the current context so nested
+ * calls to startSpan/withSpan link as children. Errors thrown by `fn` are
+ * recorded (status=error) and re-thrown.
+ */
+export async function withSpan<T>(
+  name: string,
+  attrs: SpanAttributes | undefined,
+  fn: (span: Span) => Promise<T> | T,
+): Promise<T> {
+  const span = startSpan(name, attrs);
+  return als.run(span, async () => {
+    try {
+      const out = await fn(span);
+      return out;
+    } catch (err) {
+      span.setStatus("error", err);
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/** The currently active span (from AsyncLocalStorage), or undefined. */
+export function currentSpan(): Span | undefined {
+  return als.getStore();
+}
+
+/** Snapshot of recent spans (most recent last). */
+export function getRecentSpans(limit = 100): SpanRecord[] {
+  return recentSpans.slice(-limit);
+}
+
+/** Clear the in-memory span ring buffer. Intended for tests. */
+export function resetSpans(): void {
+  recentSpans.length = 0;
 }

--- a/src/util/trace.ts
+++ b/src/util/trace.ts
@@ -36,6 +36,7 @@ import {
   incrementCounter,
   sanitizeMetricLabel,
 } from "./metrics.js";
+import { toJsonSafe } from "./json-safe.js";
 
 function ensureDir(): void {
   if (!existsSync(dirs.traces)) mkdirSync(dirs.traces, { recursive: true });
@@ -201,7 +202,20 @@ function buildSpan(
       ended = true;
       const endMs = Date.now();
       // Snapshot attributes/events so post-end() mutations can't touch the
-      // record stored in the ring buffer or persisted to disk.
+      // record stored in the ring buffer or persisted to disk. Also run both
+      // through toJsonSafe so the spans-YYYY-MM-DD.jsonl appendFileSync and
+      // /debug/spans JSON.stringify can't be poisoned by a BigInt, circular
+      // ref, function, or megabyte blob passed via span.setAttribute /
+      // addEvent (plugins are allowed to set arbitrary unknowns).
+      const safeAttrs = toJsonSafe({ ...attributes }) as SpanAttributes;
+      const safeEvents = events.map((e) => ({
+        ts: e.ts,
+        name: e.name,
+        attrs:
+          e.attrs === undefined
+            ? undefined
+            : (toJsonSafe(e.attrs) as SpanAttributes),
+      })) as SpanEvent[];
       const rec: SpanRecord = Object.freeze({
         traceId,
         spanId,
@@ -211,8 +225,8 @@ function buildSpan(
         endMs,
         durationMs: endMs - startMs,
         status,
-        attrs: Object.freeze({ ...attributes }) as SpanAttributes,
-        events: Object.freeze(events.slice()) as SpanEvent[],
+        attrs: Object.freeze(safeAttrs) as SpanAttributes,
+        events: Object.freeze(safeEvents) as SpanEvent[],
         err: errMsg,
       }) as SpanRecord;
       endedRec = rec;

--- a/src/util/trace.ts
+++ b/src/util/trace.ts
@@ -31,7 +31,11 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { randomBytes } from "node:crypto";
 import { dirs } from "./paths.js";
 import { logError } from "./log.js";
-import { recordHistogram, incrementCounter } from "./metrics.js";
+import {
+  recordHistogram,
+  incrementCounter,
+  sanitizeMetricLabel,
+} from "./metrics.js";
 
 function ensureDir(): void {
   if (!existsSync(dirs.traces)) mkdirSync(dirs.traces, { recursive: true });
@@ -103,7 +107,11 @@ export type Span = {
 
 const SPAN_RING_SIZE = 1000;
 // Fixed-size circular buffer — O(1) insert, no Array#shift cost under load.
-const recentSpans: SpanRecord[] = new Array<SpanRecord>(SPAN_RING_SIZE);
+// Slots start empty and can be explicitly cleared (resetSpans), so the slot
+// type is `SpanRecord | undefined` rather than a lie with casts.
+const recentSpans: (SpanRecord | undefined)[] = new Array<
+  SpanRecord | undefined
+>(SPAN_RING_SIZE);
 let recentSpansHead = 0; // next write position
 let recentSpansSize = 0; // valid entries (≤ capacity)
 const SPAN_LOG_PREFIX = "spans";
@@ -211,8 +219,12 @@ function buildSpan(
       pushSpan(rec);
       persistSpan(rec);
       // Emit metrics so histograms show up without every caller opting in.
-      recordHistogram(`span.${name}.ms`, rec.durationMs);
-      incrementCounter(`span.${name}.${status}`);
+      // Span names come from user code (including plugins) and can be
+      // dynamic; sanitize them so the per-span metric keys can't blow out
+      // MAX_METRIC_KEYS and crowd out more important metrics.
+      const mName = sanitizeMetricLabel(name);
+      recordHistogram(`span.${mName}.ms`, rec.durationMs);
+      incrementCounter(`span.${mName}.${status}`);
       return rec;
     },
   };
@@ -257,21 +269,24 @@ export function currentSpan(): Span | undefined {
 export function getRecentSpans(limit = 100): SpanRecord[] {
   if (recentSpansSize === 0) return [];
   // Build an ordered snapshot from the ring. Head points at the next slot to
-  // write — when the buffer is full, it's also the oldest entry.
-  const ordered: SpanRecord[] =
+  // write — when the buffer is full, it's also the oldest entry. Filter
+  // out any undefined holes defensively (shouldn't be any within the valid
+  // region, but the slot type allows undefined after resetSpans()).
+  const raw =
     recentSpansSize < SPAN_RING_SIZE
       ? recentSpans.slice(0, recentSpansSize)
       : [
           ...recentSpans.slice(recentSpansHead),
           ...recentSpans.slice(0, recentSpansHead),
         ];
+  const ordered = raw.filter((r): r is SpanRecord => r !== undefined);
   return ordered.slice(-limit);
 }
 
 /** Clear the in-memory span ring buffer. Intended for tests. */
 export function resetSpans(): void {
   for (let i = 0; i < recentSpans.length; i++) {
-    recentSpans[i] = undefined as unknown as SpanRecord;
+    recentSpans[i] = undefined;
   }
   recentSpansHead = 0;
   recentSpansSize = 0;

--- a/src/util/trace.ts
+++ b/src/util/trace.ts
@@ -102,12 +102,16 @@ export type Span = {
 };
 
 const SPAN_RING_SIZE = 1000;
-const recentSpans: SpanRecord[] = [];
+// Fixed-size circular buffer — O(1) insert, no Array#shift cost under load.
+const recentSpans: SpanRecord[] = new Array<SpanRecord>(SPAN_RING_SIZE);
+let recentSpansHead = 0; // next write position
+let recentSpansSize = 0; // valid entries (≤ capacity)
 const SPAN_LOG_PREFIX = "spans";
 
 function pushSpan(rec: SpanRecord): void {
-  recentSpans.push(rec);
-  if (recentSpans.length > SPAN_RING_SIZE) recentSpans.shift();
+  recentSpans[recentSpansHead] = rec;
+  recentSpansHead = (recentSpansHead + 1) % SPAN_RING_SIZE;
+  if (recentSpansSize < SPAN_RING_SIZE) recentSpansSize++;
 }
 
 function currentLogFile(): string {
@@ -254,10 +258,24 @@ export function currentSpan(): Span | undefined {
 
 /** Snapshot of recent spans (most recent last). */
 export function getRecentSpans(limit = 100): SpanRecord[] {
-  return recentSpans.slice(-limit);
+  if (recentSpansSize === 0) return [];
+  // Build an ordered snapshot from the ring. Head points at the next slot to
+  // write — when the buffer is full, it's also the oldest entry.
+  const ordered: SpanRecord[] =
+    recentSpansSize < SPAN_RING_SIZE
+      ? recentSpans.slice(0, recentSpansSize)
+      : [
+          ...recentSpans.slice(recentSpansHead),
+          ...recentSpans.slice(0, recentSpansHead),
+        ];
+  return ordered.slice(-limit);
 }
 
 /** Clear the in-memory span ring buffer. Intended for tests. */
 export function resetSpans(): void {
-  recentSpans.length = 0;
+  for (let i = 0; i < recentSpans.length; i++) {
+    recentSpans[i] = undefined as unknown as SpanRecord;
+  }
+  recentSpansHead = 0;
+  recentSpansSize = 0;
 }

--- a/src/util/trace.ts
+++ b/src/util/trace.ts
@@ -159,20 +159,29 @@ function buildSpan(
   let errMsg: string | undefined;
   let ended = false;
 
+  // Cached snapshot built at end() — returned on any further end() calls so
+  // the ring-buffer record cannot be mutated by late attribute/event writes
+  // from code that still holds a reference to the span.
+  let endedRec: SpanRecord | undefined;
+
   return {
     traceId,
     spanId,
     name,
     setAttribute(key, value) {
+      if (ended) return;
       attributes[key] = value;
     },
     setAttributes(a) {
+      if (ended) return;
       Object.assign(attributes, a);
     },
     addEvent(evName, evAttrs) {
+      if (ended) return;
       events.push({ ts: Date.now(), name: evName, attrs: evAttrs });
     },
     setStatus(s, err) {
+      if (ended) return;
       status = s;
       if (s === "error") {
         if (err instanceof Error) errMsg = err.message;
@@ -180,25 +189,12 @@ function buildSpan(
       }
     },
     end() {
-      if (ended) {
-        // Prevent double-end from emitting a second record.
-        return {
-          traceId,
-          spanId,
-          parentSpanId: parent?.spanId,
-          name,
-          startMs,
-          endMs: startMs,
-          durationMs: 0,
-          status,
-          attrs: attributes,
-          events,
-          err: errMsg,
-        };
-      }
+      if (ended && endedRec) return endedRec;
       ended = true;
       const endMs = Date.now();
-      const rec: SpanRecord = {
+      // Snapshot attributes/events so post-end() mutations can't touch the
+      // record stored in the ring buffer or persisted to disk.
+      const rec: SpanRecord = Object.freeze({
         traceId,
         spanId,
         parentSpanId: parent?.spanId,
@@ -207,10 +203,11 @@ function buildSpan(
         endMs,
         durationMs: endMs - startMs,
         status,
-        attrs: attributes,
-        events,
+        attrs: Object.freeze({ ...attributes }) as SpanAttributes,
+        events: Object.freeze(events.slice()) as SpanEvent[],
         err: errMsg,
-      };
+      }) as SpanRecord;
+      endedRec = rec;
       pushSpan(rec);
       persistSpan(rec);
       // Emit metrics so histograms show up without every caller opting in.


### PR DESCRIPTION
## Summary

- **Logging**: runtime log levels, child loggers with `reqId`/`chatId` bindings, namespace filter, in-memory ring buffer, and a dedicated `~/.talon/errors.log` (warn+) that isn't diluted by info logs.
- **Tracing**: OpenTelemetry-inspired spans with `AsyncLocalStorage` parent linking. Spans persist to `~/.talon/data/traces/spans-YYYY-MM-DD.jsonl` and auto-emit `span.<name>.ms` histograms + `span.<name>.<status>` counters.
- **Debug surface**: new `util/debug.ts` snapshot aggregator powering `/debug/{state,metrics,spans,logs,errors,log-level}` HTTP endpoints (with runtime `POST /debug/log-level`) and a `talon debug` CLI (`state|metrics|spans|errors|log-level`), plus `talon errors` to tail the new errors log.
- **Instrumentation** across `dispatcher`, `gateway`, `plugin`, `cron`, `dream`, `heartbeat`, and `backend/claude-sdk` — spans, per-action metrics, and span annotations for query metadata (model, tokens, cache hits, tool calls).

## Test plan

- [x] `npm test` (1387/1388 pass; 1 preexisting Windows symlink failure unrelated)
- [x] `npm run typecheck`
- [x] `npm run lint` (warnings only, none in new code)
- [ ] Manual: run the bot, hit `/debug/state` and `/debug/spans`, flip log level via `POST /debug/log-level`
- [ ] Manual: verify `~/.talon/errors.log` only contains warn+ records after normal traffic
- [ ] Manual: `talon debug spans 20` and `talon errors --tail 100`

🤖 Generated with [Claude Code](https://claude.com/claude-code)