### PR TITLE
fix(mempalace): require >= 3.3.2 for PID guard + HNSW crash fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ The token is optional --- defaults to the output of `gh auth token` if the GitHu
 
 Structured long-term memory with vector search. The agent can store, search, and retrieve memories semantically. Integrates with Dream mode for automatic memory consolidation and personal diary entries.
 
-**Requirements:** Python 3.10+ with the `mempalace` package.
+**Requirements:** Python 3.10+ with `mempalace >= 3.3.2`.
 
 ```bash
 # Set up a Python environment
 python -m venv ~/.talon/mempalace-venv
-~/.talon/mempalace-venv/bin/pip install mempalace    # Unix
-# or: ~/.talon/mempalace-venv/Scripts/pip install mempalace   # Windows
+~/.talon/mempalace-venv/bin/pip install 'mempalace>=3.3.2'    # Unix
+# or: ~/.talon/mempalace-venv/Scripts/pip install 'mempalace>=3.3.2'   # Windows
 ```
 
 ```json

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -9,7 +9,7 @@
  *     "enabled": true,
  *     "palacePath": "/path/to/palace",         // optional, defaults to ~/.talon/workspace/palace/
  *     "pythonPath": "/path/to/python",         // optional, defaults to mempalace venv python (bin/python on Unix, Scripts/python.exe on Windows)
- *     "entityLanguages": ["en", "ja"],         // optional, BCP 47 codes (mempalace >= 3.3)
+ *     "entityLanguages": ["en", "ja"],         // optional, BCP 47 codes (mempalace >= 3.3.2)
  *     "verbose": false                          // optional, enables MEMPAL_VERBOSE diagnostics
  *   }
  */
@@ -34,7 +34,7 @@ const PROMPT_PATH = resolve(dirs.prompts, "mempalace.md");
 export function createMempalacePlugin(config: {
   pythonPath: string;
   palacePath: string;
-  /** BCP 47 codes passed via MEMPALACE_ENTITY_LANGUAGES (mempalace >= 3.3). */
+  /** BCP 47 codes passed via MEMPALACE_ENTITY_LANGUAGES (mempalace >= 3.3.2). */
   entityLanguages?: readonly string[];
   /** When true, sets MEMPAL_VERBOSE=1 so the MCP server logs diagnostic diaries. */
   verbose?: boolean;
@@ -104,7 +104,7 @@ export function createMempalacePlugin(config: {
                 ? execErr.stderr.toString("utf-8").trim()
                 : "";
           errors.push(
-            `mempalace package not installed or mcp_server submodule missing. Run: ${pythonPath} -m pip install mempalace${stderr ? `. Details: ${stderr}` : ""}`,
+            `mempalace package not installed or mcp_server submodule missing. Run: ${pythonPath} -m pip install 'mempalace>=3.3.2'${stderr ? `. Details: ${stderr}` : ""}`,
           );
         }
       }

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -152,7 +152,7 @@ const configSchema = z.object({
       /** Python binary path (default: ~/.talon/mempalace-venv/bin/python) */
       pythonPath: z.string().min(1).optional(),
       /**
-       * BCP 47 language codes for entity detection (mempalace >= 3.3).
+       * BCP 47 language codes for entity detection (mempalace >= 3.3.2).
        * Supported: en, es, fr, de, ja, ko, zh-CN, zh-TW, pt-br, ru, it, hi, id.
        * Sets MEMPALACE_ENTITY_LANGUAGES for the MCP server.
        */


### PR DESCRIPTION
## Summary

Bumps mempalace minimum version from **3.3** to **3.3.2** across docstrings, config comments, and README install instructions.

Upstream [3.3.2](https://github.com/MemPalace/mempalace/releases/tag/v3.3.2) is a bug-fix release:

- **PID file guard** — prevents stacking mine processes ([#1023](https://github.com/MemPalace/mempalace/pull/1023))
- **Quarantine stale HNSW** — recovers from HNSW/sqlite drift, fixes SIGSEGV on palace load ([#1000](https://github.com/MemPalace/mempalace/pull/1000))
- **Windows Unicode** — replaces Unicode checkmark with ASCII for Windows encoding ([#681](https://github.com/MemPalace/mempalace/pull/681))

No code changes to the plugin itself — MCP server command/args are unchanged. Local venv on this VPS has already been bumped to 3.3.2 and is running fine.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npx vitest run` — 1361/1361 passing
- [x] Local venv upgraded to 3.3.2 and mempalace MCP tools verified working (palace status, search, kg queries)