### PR TITLE
feat(mempalace): automated onboarding + pinned version + multi-OS CI smoke

### DIFF
--- a/.github/workflows/mempalace-smoke.yml
+++ b/.github/workflows/mempalace-smoke.yml
@@ -1,0 +1,74 @@
+name: MemPalace Smoke
+
+# Functional smoke test for the MemPalace plugin on Linux, macOS, and Windows.
+# Verifies that:
+#   1. The Talon-pinned mempalace version installs cleanly from PyPI.
+#   2. The MCP server starts.
+#   3. The server responds to MCP initialize + tools/list over stdio.
+#   4. A representative tool (mempalace_status) returns valid JSON.
+#
+# Runs on PRs that touch mempalace code / config / this workflow, and nightly
+# against main to catch upstream regressions.
+
+on:
+  pull_request:
+    paths:
+      - "src/plugins/mempalace/**"
+      - "src/util/config.ts"
+      - ".github/workflows/mempalace-smoke.yml"
+      - "scripts/mempalace-smoke.mjs"
+  push:
+    branches: [main]
+    paths:
+      - "src/plugins/mempalace/**"
+      - ".github/workflows/mempalace-smoke.yml"
+      - "scripts/mempalace-smoke.mjs"
+  schedule:
+    # Every day at 05:30 UTC so we catch upstream PyPI/package breakage
+    - cron: "30 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: mempalace-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: ${{ matrix.os }} (py${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Show Talon-supported mempalace version
+        shell: bash
+        run: |
+          grep -E 'MEMPALACE_(INSTALL_TARGET|MIN_VERSION)' src/plugins/mempalace/install.ts
+
+      - name: npm ci
+        run: npm ci
+
+      - name: Create mempalace venv and install pinned version
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/mempalace-smoke.mjs install
+
+      - name: MCP server responsiveness smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/mempalace-smoke.mjs smoke

--- a/README.md
+++ b/README.md
@@ -104,13 +104,27 @@ The token is optional --- defaults to the output of `gh auth token` if the GitHu
 
 Structured long-term memory with vector search. The agent can store, search, and retrieve memories semantically. Integrates with Dream mode for automatic memory consolidation and personal diary entries.
 
-**Requirements:** Python 3.10+ with the `mempalace` package.
+**Requirements:** Python 3.10+ with `mempalace >= 3.3.2` (Talon pins install against **3.3.2**).
+
+#### Option A — automatic onboarding (recommended)
+
+Set `autoInstall: true` and Talon creates the venv + pip installs the supported mempalace release on first run.
+
+```json
+{
+  "mempalace": {
+    "enabled": true,
+    "autoInstall": true
+  }
+}
+```
+
+#### Option B — manual
 
 ```bash
-# Set up a Python environment
 python -m venv ~/.talon/mempalace-venv
-~/.talon/mempalace-venv/bin/pip install mempalace    # Unix
-# or: ~/.talon/mempalace-venv/Scripts/pip install mempalace   # Windows
+~/.talon/mempalace-venv/bin/pip install 'mempalace==3.3.2'    # Unix
+# or: ~/.talon/mempalace-venv/Scripts/pip install 'mempalace==3.3.2'   # Windows
 ```
 
 ```json
@@ -123,7 +137,7 @@ python -m venv ~/.talon/mempalace-venv
 }
 ```
 
-Both paths are optional --- defaults to `~/.talon/workspace/palace/` and the venv Python respectively.
+All paths are optional --- defaults to `~/.talon/workspace/palace/` and the venv Python respectively. At startup the plugin verifies the installed version meets the supported floor and logs the detected version.
 
 ### Playwright
 

--- a/scripts/mempalace-smoke.mjs
+++ b/scripts/mempalace-smoke.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+/**
+ * MemPalace functional smoke test — driven from CI across Linux/macOS/Windows.
+ *
+ * Subcommands:
+ *   install  — create venv, pip install the Talon-pinned mempalace release,
+ *              verify `import mempalace` and `import mempalace.mcp_server`.
+ *   smoke    — spawn the MCP server (stdio), run MCP `initialize` →
+ *              `tools/list` → `tools/call mempalace_status`, assert
+ *              responses are well-formed and include expected tools.
+ *
+ * Exits non-zero on any failure. Prints structured progress so CI logs are
+ * skimmable.
+ */
+
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const execFileP = promisify(execFile);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+const IS_WINDOWS = process.platform === "win32";
+const VENV_DIR = join(REPO_ROOT, ".smoke-mempalace-venv");
+const VENV_PY = IS_WINDOWS
+  ? join(VENV_DIR, "Scripts", "python.exe")
+  : join(VENV_DIR, "bin", "python");
+
+/** Read the pinned version from install.ts so source stays single-truth. */
+function pinnedVersion() {
+  const src = readFileSync(
+    join(REPO_ROOT, "src/plugins/mempalace/install.ts"),
+    "utf-8",
+  );
+  const match = /MEMPALACE_INSTALL_TARGET\s*=\s*"([^"]+)"/.exec(src);
+  if (!match) throw new Error("failed to parse MEMPALACE_INSTALL_TARGET");
+  return match[1];
+}
+
+function minVersion() {
+  const src = readFileSync(
+    join(REPO_ROOT, "src/plugins/mempalace/install.ts"),
+    "utf-8",
+  );
+  const match = /MEMPALACE_MIN_VERSION\s*=\s*"([^"]+)"/.exec(src);
+  if (!match) throw new Error("failed to parse MEMPALACE_MIN_VERSION");
+  return match[1];
+}
+
+function log(...args) {
+  console.log("[smoke]", ...args);
+}
+
+async function run(cmd, args, opts = {}) {
+  const label = `${cmd} ${args.join(" ")}`;
+  log(`$ ${label}`);
+  const { stdout, stderr } = await execFileP(cmd, args, {
+    maxBuffer: 50 * 1024 * 1024,
+    ...opts,
+  });
+  if (stdout.trim()) log(stdout.trim());
+  if (stderr.trim()) log(`stderr: ${stderr.trim()}`);
+  return { stdout, stderr };
+}
+
+// ── install ──────────────────────────────────────────────────────────────
+
+async function doInstall() {
+  const target = pinnedVersion();
+  log(`pinned mempalace version: ${target}`);
+
+  const pythonBootstrap = process.env.PYTHON ?? (IS_WINDOWS ? "python" : "python3");
+  log(`bootstrap python: ${pythonBootstrap}`);
+
+  if (!existsSync(VENV_PY)) {
+    await run(pythonBootstrap, ["-m", "venv", VENV_DIR]);
+  } else {
+    log(`reusing existing venv at ${VENV_DIR}`);
+  }
+
+  // Upgrade pip first — fresh venvs often ship stale pip that chokes on
+  // newer wheels. Ignore failures, not critical.
+  try {
+    await run(VENV_PY, ["-m", "pip", "install", "--upgrade", "pip"]);
+  } catch (err) {
+    log(`pip upgrade skipped: ${err.message}`);
+  }
+
+  await run(VENV_PY, [
+    "-m",
+    "pip",
+    "install",
+    "--upgrade",
+    `mempalace==${target}`,
+  ]);
+
+  // Use a two-step check: first verify mempalace importable (version via
+  // sys.stdout), then verify mempalace.mcp_server importable separately. The
+  // mcp_server import is noisy (banner on stderr) which can confuse callers
+  // that capture both streams.
+  const { stdout } = await run(VENV_PY, [
+    "-c",
+    "import mempalace, sys; sys.stdout.write(getattr(mempalace, '__version__', ''))",
+  ]);
+  const installed = stdout.trim();
+  log(`installed mempalace: ${installed}`);
+  if (installed !== target) {
+    throw new Error(
+      `installed version "${installed}" != pinned target ${target}`,
+    );
+  }
+
+  await run(VENV_PY, ["-c", "import mempalace.mcp_server"]);
+  log("install OK");
+}
+
+// ── smoke ────────────────────────────────────────────────────────────────
+
+/** Minimal MCP client — just enough to hit initialize → tools/list → call. */
+class StdioMcpClient {
+  constructor(child) {
+    this.child = child;
+    this.buffer = "";
+    this.pending = new Map();
+    this.nextId = 1;
+    this.child.stdout.setEncoding("utf-8");
+    this.child.stdout.on("data", (chunk) => this.onData(chunk));
+    this.child.stderr.setEncoding("utf-8");
+    this.child.stderr.on("data", (chunk) => {
+      process.stderr.write(`[mcp-stderr] ${chunk}`);
+    });
+    this.child.on("exit", (code, signal) => {
+      const err = new Error(`MCP server exited code=${code} signal=${signal}`);
+      for (const { reject } of this.pending.values()) reject(err);
+      this.pending.clear();
+    });
+  }
+
+  onData(chunk) {
+    this.buffer += chunk;
+    let nl;
+    while ((nl = this.buffer.indexOf("\n")) !== -1) {
+      const line = this.buffer.slice(0, nl).trim();
+      this.buffer = this.buffer.slice(nl + 1);
+      if (!line) continue;
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        log(`non-JSON line from server: ${line.slice(0, 200)}`);
+        continue;
+      }
+      if (msg.id !== undefined && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.error) reject(new Error(JSON.stringify(msg.error)));
+        else resolve(msg.result);
+      }
+    }
+  }
+
+  request(method, params, timeoutMs = 30_000) {
+    const id = this.nextId++;
+    const payload = { jsonrpc: "2.0", id, method, params };
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`request ${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (err) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      });
+      this.child.stdin.write(`${JSON.stringify(payload)}\n`);
+    });
+  }
+
+  notify(method, params) {
+    const payload = { jsonrpc: "2.0", method, params };
+    this.child.stdin.write(`${JSON.stringify(payload)}\n`);
+  }
+
+  async close() {
+    this.child.stdin.end();
+    await new Promise((resolve) => {
+      this.child.on("exit", () => resolve());
+    });
+  }
+}
+
+async function doSmoke() {
+  if (!existsSync(VENV_PY)) {
+    throw new Error(
+      `expected python at ${VENV_PY} — run 'node scripts/mempalace-smoke.mjs install' first`,
+    );
+  }
+
+  const palace = mkdtempSync(join(tmpdir(), "talon-smoke-palace-"));
+  log(`temp palace: ${palace}`);
+
+  const child = spawn(
+    VENV_PY,
+    ["-m", "mempalace.mcp_server", "--palace", palace],
+    {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, MEMPALACE_PALACE_PATH: palace },
+    },
+  );
+
+  const client = new StdioMcpClient(child);
+
+  try {
+    log("initialize…");
+    const init = await client.request("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "talon-smoke", version: "0.0.0" },
+    });
+    if (!init?.protocolVersion) {
+      throw new Error(
+        `initialize returned no protocolVersion: ${JSON.stringify(init)}`,
+      );
+    }
+    log(`server protocol: ${init.protocolVersion}`);
+    client.notify("notifications/initialized", {});
+
+    log("tools/list…");
+    const tools = await client.request("tools/list", {});
+    if (!Array.isArray(tools?.tools) || tools.tools.length === 0) {
+      throw new Error(
+        `tools/list returned no tools: ${JSON.stringify(tools)}`,
+      );
+    }
+    const toolNames = tools.tools.map((t) => t.name).sort();
+    log(`tools (${toolNames.length}): ${toolNames.slice(0, 10).join(", ")}${toolNames.length > 10 ? ", …" : ""}`);
+    const expected = ["mempalace_status", "mempalace_search"];
+    for (const name of expected) {
+      if (!toolNames.includes(name)) {
+        throw new Error(`expected tool "${name}" not found in tools/list`);
+      }
+    }
+
+    log("tools/call mempalace_status…");
+    const statusCall = await client.request("tools/call", {
+      name: "mempalace_status",
+      arguments: {},
+    });
+    if (!statusCall?.content || !Array.isArray(statusCall.content)) {
+      throw new Error(
+        `mempalace_status returned unexpected shape: ${JSON.stringify(statusCall).slice(0, 300)}`,
+      );
+    }
+    log("mempalace_status OK");
+  } finally {
+    await client.close().catch(() => {});
+  }
+
+  log(`smoke OK on ${process.platform} (python floor >= ${minVersion()})`);
+}
+
+// ── entrypoint ───────────────────────────────────────────────────────────
+
+async function main() {
+  const cmd = process.argv[2] ?? "smoke";
+  try {
+    if (cmd === "install") await doInstall();
+    else if (cmd === "smoke") await doSmoke();
+    else {
+      console.error(`unknown subcommand "${cmd}" — use install | smoke`);
+      process.exit(2);
+    }
+  } catch (err) {
+    console.error(`[smoke] FAILED: ${err.stack || err.message || err}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/__tests__/mempalace-install.test.ts
+++ b/src/__tests__/mempalace-install.test.ts
@@ -223,6 +223,58 @@ describe("ensureMempalaceInstalled", () => {
     );
   });
 
+  it("aligns to pinned target when autoInstall=true and current differs from target even if above floor", async () => {
+    const exec = makeExec([
+      { stdout: "3.4.0\n" }, // above floor but not equal to target (3.3.2)
+      { stdout: "" }, // pip install (realign/downgrade)
+      { stdout: "3.3.2\n" }, // re-detect
+    ]);
+    const status = await ensureMempalaceInstalled({
+      pythonPath: venvPython,
+      autoInstall: true,
+      installTarget: "3.3.2",
+      minVersion: "3.3.2",
+      existsSyncImpl: () => true,
+      isVenvImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(status.version).toBe("3.3.2");
+    expect(status.steps.some((s) => s.includes("aligning mempalace"))).toBe(
+      true,
+    );
+    expect(status.steps.some((s) => s.includes("was 3.4.0"))).toBe(true);
+  });
+
+  it("leaves off-target alone when autoInstall=false if above floor", async () => {
+    const exec = makeExec([{ stdout: "3.4.0\n" }]);
+    const status = await ensureMempalaceInstalled({
+      pythonPath: venvPython,
+      autoInstall: false,
+      installTarget: "3.3.2",
+      minVersion: "3.3.2",
+      existsSyncImpl: () => true,
+      isVenvImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(status.version).toBe("3.4.0");
+    expect(status.steps.some((s) => s.includes("aligning"))).toBe(false);
+  });
+
+  it("no-op when already at the exact target (single exec call)", async () => {
+    const exec = makeExec([{ stdout: "3.3.2\n" }]);
+    const status = await ensureMempalaceInstalled({
+      pythonPath: venvPython,
+      autoInstall: true,
+      existsSyncImpl: () => true,
+      isVenvImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
   it("returns actionable error when pip install fails", async () => {
     const exec = makeExec([
       { stdout: "" }, // first detect → null

--- a/src/__tests__/mempalace-install.test.ts
+++ b/src/__tests__/mempalace-install.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  MEMPALACE_INSTALL_TARGET,
+  MEMPALACE_MIN_VERSION,
+  compareSemVer,
+  detectMempalaceVersion,
+  ensureMempalaceInstalled,
+  isVersionSupported,
+  parseSemVer,
+} from "../plugins/mempalace/install.js";
+
+describe("parseSemVer", () => {
+  it("parses basic X.Y.Z", () => {
+    expect(parseSemVer("3.3.2")).toEqual({ major: 3, minor: 3, patch: 2 });
+  });
+
+  it("parses with trailing prerelease/whitespace", () => {
+    expect(parseSemVer("  3.3.2-rc.1 ")).toEqual({
+      major: 3,
+      minor: 3,
+      patch: 2,
+    });
+  });
+
+  it("returns null for non-semver", () => {
+    expect(parseSemVer("abc")).toBeNull();
+    expect(parseSemVer("3.3")).toBeNull();
+    expect(parseSemVer("")).toBeNull();
+  });
+});
+
+describe("compareSemVer", () => {
+  it("orders by major/minor/patch", () => {
+    expect(
+      compareSemVer(
+        { major: 3, minor: 3, patch: 2 },
+        { major: 3, minor: 3, patch: 1 },
+      ),
+    ).toBe(1);
+    expect(
+      compareSemVer(
+        { major: 3, minor: 3, patch: 1 },
+        { major: 3, minor: 3, patch: 2 },
+      ),
+    ).toBe(-1);
+    expect(
+      compareSemVer(
+        { major: 3, minor: 3, patch: 2 },
+        { major: 3, minor: 3, patch: 2 },
+      ),
+    ).toBe(0);
+    expect(
+      compareSemVer(
+        { major: 4, minor: 0, patch: 0 },
+        { major: 3, minor: 9, patch: 9 },
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("isVersionSupported", () => {
+  it("returns true at and above the floor", () => {
+    expect(isVersionSupported("3.3.2", "3.3.2")).toBe(true);
+    expect(isVersionSupported("3.3.3", "3.3.2")).toBe(true);
+    expect(isVersionSupported("3.4.0", "3.3.2")).toBe(true);
+    expect(isVersionSupported("4.0.0", "3.3.2")).toBe(true);
+  });
+
+  it("returns false below the floor", () => {
+    expect(isVersionSupported("3.3.1", "3.3.2")).toBe(false);
+    expect(isVersionSupported("3.2.0", "3.3.2")).toBe(false);
+  });
+
+  it("returns false for unparseable versions", () => {
+    expect(isVersionSupported("not-a-version", "3.3.2")).toBe(false);
+  });
+});
+
+describe("constants", () => {
+  it("MEMPALACE_MIN_VERSION is parseable semver", () => {
+    expect(parseSemVer(MEMPALACE_MIN_VERSION)).not.toBeNull();
+  });
+  it("MEMPALACE_INSTALL_TARGET is parseable semver", () => {
+    expect(parseSemVer(MEMPALACE_INSTALL_TARGET)).not.toBeNull();
+  });
+  it("install target is at or above the minimum", () => {
+    const target = parseSemVer(MEMPALACE_INSTALL_TARGET)!;
+    const floor = parseSemVer(MEMPALACE_MIN_VERSION)!;
+    expect(compareSemVer(target, floor)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("detectMempalaceVersion", () => {
+  it("returns trimmed stdout when import succeeds", async () => {
+    const fakeExec = vi.fn(async () => ({ stdout: "3.3.2\n", stderr: "" }));
+    const result = await detectMempalaceVersion(
+      "/fake/python",
+      fakeExec as unknown as never,
+    );
+    expect(result).toBe("3.3.2");
+    expect(fakeExec).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when import throws", async () => {
+    const fakeExec = vi.fn(async () => {
+      throw new Error("ModuleNotFoundError: mempalace");
+    });
+    const result = await detectMempalaceVersion(
+      "/fake/python",
+      fakeExec as unknown as never,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when stdout is empty", async () => {
+    const fakeExec = vi.fn(async () => ({ stdout: "   ", stderr: "" }));
+    const result = await detectMempalaceVersion(
+      "/fake/python",
+      fakeExec as unknown as never,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("ensureMempalaceInstalled", () => {
+  const venvPython = "/home/user/.talon/mempalace-venv/bin/python";
+
+  function makeExec(
+    responses: Array<{ stdout: string; stderr?: string } | Error>,
+  ): ReturnType<typeof vi.fn> & { calls: unknown[] } {
+    const calls: unknown[] = [];
+    const impl = async (cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+      const next = responses.shift();
+      if (next instanceof Error) throw next;
+      if (!next) throw new Error("unexpected exec call (no response queued)");
+      return next;
+    };
+    const fn = vi.fn(impl) as ReturnType<typeof vi.fn> & { calls: unknown[] };
+    fn.calls = calls;
+    return fn;
+  }
+
+  it("reports ok when python exists, venv, and version is supported", async () => {
+    const exec = makeExec([{ stdout: "3.3.2\n" }]);
+    const status = await ensureMempalaceInstalled({
+      pythonPath: venvPython,
+      autoInstall: false,
+      existsSyncImpl: () => true,
+      isVenvImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(status.version).toBe("3.3.2");
+    expect(status.error).toBeUndefined();
+  });
+
+  it("errors without installing when autoInstall=false and python is missing", async () => {
+    const exec = makeExec([]); // should never be called
+    const status = await ensureMempalaceInstalled({
+      pythonPath: venvPython,
+      autoInstall: false,
+      existsSyncImpl: () => false,
+      isVenvImpl: () => false,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("Python binary not found");
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("creates venv + installs when autoInstall=true and python is missing", async () => {
+    let pythonExistsAfterVenv = false;
+    const exec = makeExec([
+      { stdout: "" }, // python -m venv
+      { stdout: "" }, // import mempalace (detect, empty → null)
+      { stdout: "" }, // pip install
+      { stdout: "3.3.2\n" }, // re-detect
+    ]);
+    const existsSyncImpl = vi.fn((_path: string) => pythonExistsAfterVenv);
+    const status = await ensureMempalaceInstalled({
+      pythonPath: venvPython,
+      autoInstall: true,
+      existsSyncImpl,
+      isVenvImpl: () => true,
+      execFileImpl: (async (cmd: string, args: string[]) => {
+        const result = await (
+          exec as unknown as (
+            cmd: string,
+            args: string[],
+          ) => Promise<{ stdout: string; stderr?: string }>
+        )(cmd, args);
+        // After the venv step, the python binary "appears"
+        if (args.includes("venv")) pythonExistsAfterVenv = true;
+        return result;
+      }) as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(status.version).toBe("3.3.2");
+    expect(status.steps.some((s) => s.includes("creating venv"))).toBe(true);
+    expect(status.steps.some((s) => s.includes("installing mempalace"))).toBe(
+      true,
+    );
+  });
+
+  it("upgrades when current version is below the floor", async () => {
+    const exec = makeExec([
+      { stdout: "3.3.1\n" }, // first detect → below floor
+      { stdout: "" }, // pip install --upgrade
+      { stdout: "3.3.2\n" }, // re-detect
+    ]);
+    const status = await ensureMempalaceInstalled({
+      pythonPath: venvPython,
+      autoInstall: true,
+      existsSyncImpl: () => true,
+      isVenvImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(status.version).toBe("3.3.2");
+    expect(status.steps.some((s) => s.includes("upgrading mempalace"))).toBe(
+      true,
+    );
+  });
+
+  it("returns actionable error when pip install fails", async () => {
+    const exec = makeExec([
+      { stdout: "" }, // first detect → null
+      Object.assign(new Error("pip crash"), {
+        stderr: "ERROR: No matching distribution",
+      }),
+    ]);
+    const status = await ensureMempalaceInstalled({
+      pythonPath: venvPython,
+      autoInstall: true,
+      existsSyncImpl: () => true,
+      isVenvImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("pip install");
+    expect(status.error).toContain("No matching distribution");
+  });
+
+  it("errors when install succeeds but version still below floor", async () => {
+    const exec = makeExec([
+      { stdout: "3.3.1\n" }, // first detect
+      { stdout: "" }, // pip install (pretend it installed but wrong version)
+      { stdout: "3.3.1\n" }, // re-detect still old
+    ]);
+    const status = await ensureMempalaceInstalled({
+      pythonPath: venvPython,
+      autoInstall: true,
+      existsSyncImpl: () => true,
+      isVenvImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("below the supported minimum");
+  });
+
+  it("respects custom minVersion / installTarget", async () => {
+    const exec = makeExec([{ stdout: "4.0.0\n" }]);
+    const status = await ensureMempalaceInstalled({
+      pythonPath: venvPython,
+      autoInstall: false,
+      minVersion: "3.9.9",
+      installTarget: "3.9.9",
+      existsSyncImpl: () => true,
+      isVenvImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+  });
+
+  it("flags non-venv python in steps but still proceeds", async () => {
+    const exec = makeExec([{ stdout: "3.3.2\n" }]);
+    const status = await ensureMempalaceInstalled({
+      pythonPath: "/usr/bin/python3",
+      autoInstall: false,
+      existsSyncImpl: () => true,
+      isVenvImpl: () => false,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(status.steps.some((s) => s.includes("non-venv python"))).toBe(true);
+  });
+});

--- a/src/__tests__/mempalace-plugin.test.ts
+++ b/src/__tests__/mempalace-plugin.test.ts
@@ -128,10 +128,13 @@ describe("mempalace plugin", () => {
       palacePath: "/data/palace",
     });
 
+    // Install/import checks moved to async init() via ensureMempalaceInstalled.
+    // validateConfig now only fails synchronously for missing python binary
+    // (when autoInstall is off); mempalace-not-importable is surfaced at init
+    // as a logged error rather than a validation failure — so the MCP server
+    // can still try to come up and surface transient pip issues.
     const errors = plugin.validateConfig!({});
-    expect(errors).toBeDefined();
-    expect(errors!.length).toBeGreaterThan(0);
-    expect(errors![0]).toContain("mempalace package not installed");
+    expect(errors).toBeUndefined();
   });
 
   it("init creates palace directory if missing", async () => {
@@ -195,11 +198,12 @@ describe("mempalace plugin", () => {
       palacePath: "/data/palace",
     });
 
+    // Same as the previous test: import failures no longer surface through
+    // validateConfig; they're detected asynchronously in init(). This test
+    // now just confirms validateConfig doesn't spuriously block a python
+    // binary that exists.
     const errors = plugin.validateConfig!({});
-    expect(errors).toBeDefined();
-    expect(errors!.length).toBeGreaterThan(0);
-    expect(errors![0]).toContain("Cannot execute Python");
-    expect(errors![0]).toContain("ENOENT");
+    expect(errors).toBeUndefined();
   });
 
   it("getEnvVars returns MEMPALACE_PALACE_PATH", async () => {

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -530,6 +530,7 @@ export async function loadBuiltinPlugins(config: TalonConfig): Promise<void> {
         palacePath,
         entityLanguages: mempalace.entityLanguages,
         verbose: mempalace.verbose,
+        autoInstall: mempalace.autoInstall,
       });
       const mpConfig = mempalace as unknown as Record<string, unknown>;
       const loaded = registerPlugin(mp, mpConfig);

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -9,18 +9,28 @@
  *     "enabled": true,
  *     "palacePath": "/path/to/palace",         // optional, defaults to ~/.talon/workspace/palace/
  *     "pythonPath": "/path/to/python",         // optional, defaults to mempalace venv python (bin/python on Unix, Scripts/python.exe on Windows)
- *     "entityLanguages": ["en", "ja"],         // optional, BCP 47 codes (mempalace >= 3.3)
+ *     "entityLanguages": ["en", "ja"],         // optional, BCP 47 codes (mempalace >= 3.3.2)
+ *     "autoInstall": true,                      // optional, bootstrap venv + pip install on first run
  *     "verbose": false                          // optional, enables MEMPAL_VERBOSE diagnostics
  *   }
  */
 
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { execFile as execFileCb, execFileSync } from "node:child_process";
+import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import type { TalonPlugin } from "../../core/plugin.js";
-import { log, logWarn } from "../../util/log.js";
+import { log, logError, logWarn } from "../../util/log.js";
 import { dirs } from "../../util/paths.js";
+import {
+  MEMPALACE_INSTALL_TARGET,
+  MEMPALACE_MIN_VERSION,
+  detectMempalaceVersion,
+  ensureMempalaceInstalled,
+  isVersionSupported,
+} from "./install.js";
+
+export { MEMPALACE_INSTALL_TARGET, MEMPALACE_MIN_VERSION } from "./install.js";
 
 const execFile = promisify(execFileCb);
 
@@ -34,12 +44,20 @@ const PROMPT_PATH = resolve(dirs.prompts, "mempalace.md");
 export function createMempalacePlugin(config: {
   pythonPath: string;
   palacePath: string;
-  /** BCP 47 codes passed via MEMPALACE_ENTITY_LANGUAGES (mempalace >= 3.3). */
+  /** BCP 47 codes passed via MEMPALACE_ENTITY_LANGUAGES (mempalace >= 3.3.2). */
   entityLanguages?: readonly string[];
   /** When true, sets MEMPAL_VERBOSE=1 so the MCP server logs diagnostic diaries. */
   verbose?: boolean;
+  /**
+   * When true, `init()` will create the venv / install / upgrade mempalace
+   * to match {@link MEMPALACE_INSTALL_TARGET} if the current install is
+   * missing or below {@link MEMPALACE_MIN_VERSION}. Default false — we do
+   * not touch the user's environment without consent.
+   */
+  autoInstall?: boolean;
 }): TalonPlugin {
-  const { pythonPath, palacePath, entityLanguages, verbose } = config;
+  const { pythonPath, palacePath, entityLanguages, verbose, autoInstall } =
+    config;
 
   const envVars: Record<string, string> = {
     MEMPALACE_PALACE_PATH: palacePath,
@@ -63,53 +81,20 @@ export function createMempalacePlugin(config: {
     },
 
     validateConfig() {
+      // When autoInstall is on we defer every check to init() — we can't
+      // fail validation for "not installed" if the whole point of init()
+      // is to install it. Config is only invalid when paths are malformed,
+      // which zod handles upstream.
+      if (autoInstall) return undefined;
+
       const errors: string[] = [];
       if (!existsSync(pythonPath)) {
         errors.push(
-          `Python binary not found at ${pythonPath}. Create or select a Python environment, set "pythonPath" to that interpreter, then run: ${pythonPath} -m pip install mempalace`,
+          `Python binary not found at ${pythonPath}. Create or select a Python environment, set "pythonPath" to that interpreter, then run: ${pythonPath} -m pip install 'mempalace==${MEMPALACE_INSTALL_TARGET}' — or set mempalace.autoInstall=true to do it automatically.`,
         );
         return errors;
       }
-
-      // Verify mempalace.mcp_server is importable (the actual module spawned by MCP)
-      try {
-        execFileSync(pythonPath, ["-c", "import mempalace.mcp_server"], {
-          timeout: 15_000,
-          stdio: "pipe",
-        });
-      } catch (err: unknown) {
-        const execErr =
-          err && typeof err === "object"
-            ? (err as {
-                code?: string;
-                signal?: string;
-                killed?: boolean;
-                stderr?: string | Buffer;
-              })
-            : undefined;
-        const code = execErr?.code;
-        if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
-          errors.push(
-            `Cannot execute Python at ${pythonPath} (${code}). Check that the path is correct and the binary is executable.`,
-          );
-        } else if (code === "ETIMEDOUT" || execErr?.killed || execErr?.signal) {
-          errors.push(
-            `Python import check timed out or was killed. The interpreter at ${pythonPath} may be unresponsive.`,
-          );
-        } else {
-          const stderr =
-            typeof execErr?.stderr === "string"
-              ? execErr.stderr.trim()
-              : Buffer.isBuffer(execErr?.stderr)
-                ? execErr.stderr.toString("utf-8").trim()
-                : "";
-          errors.push(
-            `mempalace package not installed or mcp_server submodule missing. Run: ${pythonPath} -m pip install mempalace${stderr ? `. Details: ${stderr}` : ""}`,
-          );
-        }
-      }
-
-      return errors.length > 0 ? errors : undefined;
+      return undefined;
     },
 
     async init() {
@@ -119,30 +104,54 @@ export function createMempalacePlugin(config: {
         log("mempalace", `Created palace directory: ${palacePath}`);
       }
 
-      // Quick smoke test — verify mempalace can import and access the palace path
-      try {
-        const { stdout } = await execFile(
-          pythonPath,
-          [
-            "-c",
-            `import mempalace; print(f"mempalace {mempalace.__version__}" if hasattr(mempalace, "__version__") else "mempalace ok")`,
-          ],
-          { timeout: 15_000 },
-        );
-        log("mempalace", stdout.trim() || "Module verified");
-      } catch {
-        // Non-fatal — MCP server handles lazy init
-        log(
-          "mempalace",
-          "Module import check skipped — MCP server will initialize on first use",
-        );
+      // Onboarding check: install / upgrade (if autoInstall) + verify version.
+      // In non-autoInstall mode this is purely diagnostic — if install is
+      // missing or below the supported floor we log a clear error but
+      // don't block startup, so the MCP server can surface its own errors
+      // for transient issues (pip mirror down, etc).
+      const status = await ensureMempalaceInstalled({
+        pythonPath,
+        autoInstall: autoInstall === true,
+      });
+      for (const step of status.steps) log("mempalace", step);
+      if (!status.ok) {
+        if (autoInstall) {
+          logError(
+            "mempalace",
+            status.error ?? "mempalace ensureInstalled failed",
+          );
+        } else {
+          // Fall back to a soft smoke test so a missing version string
+          // doesn't spam errors on every startup — user opted out of auto.
+          const detected = await detectMempalaceVersion(pythonPath, execFile);
+          if (
+            detected &&
+            !isVersionSupported(detected, MEMPALACE_MIN_VERSION)
+          ) {
+            logWarn(
+              "mempalace",
+              `installed version ${detected} is below supported minimum ${MEMPALACE_MIN_VERSION}. Run: ${pythonPath} -m pip install --upgrade 'mempalace==${MEMPALACE_INSTALL_TARGET}'`,
+            );
+          } else if (!detected) {
+            logWarn(
+              "mempalace",
+              `mempalace import check failed — MCP server will try to initialize lazily, but expect errors. Install manually: ${pythonPath} -m pip install 'mempalace==${MEMPALACE_INSTALL_TARGET}'`,
+            );
+          }
+        }
       }
 
       const langSuffix =
         entityLanguages && entityLanguages.length > 0
           ? ` (languages: ${entityLanguages.join(",")})`
           : "";
-      log("mempalace", `Ready (palace: ${palacePath})${langSuffix}`);
+      const versionSuffix = status.version
+        ? ` [mempalace ${status.version}]`
+        : "";
+      log(
+        "mempalace",
+        `Ready (palace: ${palacePath})${langSuffix}${versionSuffix}`,
+      );
     },
 
     getEnvVars() {

--- a/src/plugins/mempalace/install.ts
+++ b/src/plugins/mempalace/install.ts
@@ -208,13 +208,27 @@ export async function ensureMempalaceInstalled(
     Math.min(timeoutMs, 20_000),
   );
 
-  // 3. Install / upgrade if needed
+  // 3. Install / upgrade if needed. Three trigger cases:
+  //   - missing          → install from scratch
+  //   - below floor      → upgrade (mandatory, regardless of autoInstall
+  //                        we can only surface an error in off-mode)
+  //   - off-target       → realign to the tested pin. Only actioned when
+  //                        autoInstall is on; in off-mode we let a
+  //                        user-chosen newer-patch stick if it satisfies
+  //                        the floor.
   const needsInstall = currentVersion === null;
   const needsUpgrade =
     currentVersion !== null && !isVersionSupported(currentVersion, minVersion);
+  const needsAlign =
+    currentVersion !== null &&
+    !needsUpgrade &&
+    currentVersion !== installTarget &&
+    autoInstall;
 
-  if (needsInstall || needsUpgrade) {
+  if (needsInstall || needsUpgrade || needsAlign) {
     if (!autoInstall) {
+      // needsAlign requires autoInstall=true, so here we only hit install
+      // or below-floor.
       return {
         ok: false,
         version: currentVersion,
@@ -224,8 +238,14 @@ export async function ensureMempalaceInstalled(
           : `mempalace ${currentVersion} is below the supported minimum ${minVersion}. Run: ${pythonPath} -m pip install --upgrade 'mempalace==${installTarget}' — or enable mempalace.autoInstall.`,
       };
     }
-    const verb = needsInstall ? "installing" : "upgrading";
-    steps.push(`${verb} mempalace==${installTarget}`);
+    const verb = needsInstall
+      ? "installing"
+      : needsUpgrade
+        ? "upgrading"
+        : "aligning";
+    steps.push(
+      `${verb} mempalace==${installTarget}${currentVersion ? ` (was ${currentVersion})` : ""}`,
+    );
     try {
       await execFileImpl(
         pythonPath,

--- a/src/plugins/mempalace/install.ts
+++ b/src/plugins/mempalace/install.ts
@@ -1,0 +1,277 @@
+/**
+ * MemPalace installation and sanity checks.
+ *
+ * Responsible for onboarding automation:
+ *   - Creating the Python venv if it's missing (optional)
+ *   - Installing mempalace at the Talon-supported version (optional)
+ *   - Verifying the installed version satisfies MEMPALACE_MIN_VERSION
+ *   - Surfacing actionable errors when any step fails
+ *
+ * The "pinned" install target is the version Talon ships against — we
+ * know its MCP server protocol, known tools, and bug profile. `MIN_VERSION`
+ * is the floor we refuse to start below.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+/**
+ * Exact mempalace release Talon ships and installs against when autoInstall
+ * is enabled. Bump this when the plugin is tested and verified against a
+ * newer release — not before.
+ */
+export const MEMPALACE_INSTALL_TARGET = "3.3.2";
+
+/**
+ * Minimum mempalace version Talon will accept. Anything below this is
+ * unsupported and will fail validateConfig so the user sees a clear error.
+ */
+export const MEMPALACE_MIN_VERSION = "3.3.2";
+
+/** Parsed semver triplet — non-semver releases fail the check. */
+export type SemVer = { major: number; minor: number; patch: number };
+
+/** Parse "X.Y.Z" into {major, minor, patch}. Returns null if invalid. */
+export function parseSemVer(raw: string): SemVer | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(raw.trim());
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+/**
+ * Compare two SemVer values. Returns -1 if a < b, 0 if equal, 1 if a > b.
+ */
+export function compareSemVer(a: SemVer, b: SemVer): -1 | 0 | 1 {
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+  if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1;
+  return 0;
+}
+
+/** True when `version` satisfies `>= minimum`. */
+export function isVersionSupported(version: string, minimum: string): boolean {
+  const parsed = parseSemVer(version);
+  const floor = parseSemVer(minimum);
+  if (!parsed || !floor) return false;
+  return compareSemVer(parsed, floor) >= 0;
+}
+
+export type InstallStatus = {
+  /** True when mempalace is importable at a supported version. */
+  ok: boolean;
+  /** Detected installed version, or null if import failed. */
+  version: string | null;
+  /** Human-readable steps taken during this ensure() call. */
+  steps: string[];
+  /** Populated when ok=false — actionable error for the user. */
+  error?: string;
+};
+
+export type EnsureOptions = {
+  /** Python binary path to probe and, if needed, install against. */
+  pythonPath: string;
+  /**
+   * If true, missing venv / missing package / outdated version triggers
+   * automatic remediation (create venv, pip install, upgrade). When false,
+   * the function only diagnoses and returns an error.
+   */
+  autoInstall: boolean;
+  /**
+   * When creating a fresh venv, which python executable to bootstrap with.
+   * Defaults to `python3` on POSIX, `python` on Windows.
+   */
+  bootstrapPython?: string;
+  /** Install target version. Defaults to {@link MEMPALACE_INSTALL_TARGET}. */
+  installTarget?: string;
+  /** Minimum acceptable version. Defaults to {@link MEMPALACE_MIN_VERSION}. */
+  minVersion?: string;
+  /** Timeout for each subprocess call, ms. Default 120s (pip can be slow). */
+  timeoutMs?: number;
+  /** Injected for tests — defaults to Node's promisified execFile. */
+  execFileImpl?: typeof execFile;
+  /** Injected for tests — defaults to fs.existsSync. */
+  existsSyncImpl?: (path: string) => boolean;
+  /** Injected for tests — defaults to checking for pyvenv.cfg near python. */
+  isVenvImpl?: (pythonPath: string) => boolean;
+};
+
+/** True when the directory containing `pythonPath` has a sibling `pyvenv.cfg`. */
+export function looksLikeVenv(pythonPath: string): boolean {
+  // Unix: venv/bin/python   → venv/pyvenv.cfg
+  // Windows: venv\Scripts\python.exe → venv\pyvenv.cfg
+  const binDir = dirname(pythonPath);
+  const venvRoot = dirname(binDir);
+  return existsSync(`${venvRoot}/pyvenv.cfg`);
+}
+
+/**
+ * Run `python -c "import mempalace; print(mempalace.__version__)"` and
+ * return the version string, or null if import fails for any reason.
+ */
+export async function detectMempalaceVersion(
+  pythonPath: string,
+  execFileImpl: typeof execFile = execFile,
+  timeoutMs = 20_000,
+): Promise<string | null> {
+  try {
+    const { stdout } = await execFileImpl(
+      pythonPath,
+      [
+        "-c",
+        "import mempalace, sys; sys.stdout.write(getattr(mempalace, '__version__', ''))",
+      ],
+      { timeout: timeoutMs },
+    );
+    const trimmed = stdout.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensure mempalace is installed at a supported version.
+ *
+ * When autoInstall=true this is self-healing: missing venv → created,
+ * missing package → pip install, outdated → pip install --upgrade.
+ * When autoInstall=false the function is purely diagnostic.
+ */
+export async function ensureMempalaceInstalled(
+  opts: EnsureOptions,
+): Promise<InstallStatus> {
+  const {
+    pythonPath,
+    autoInstall,
+    bootstrapPython = process.platform === "win32" ? "python" : "python3",
+    installTarget = MEMPALACE_INSTALL_TARGET,
+    minVersion = MEMPALACE_MIN_VERSION,
+    timeoutMs = 120_000,
+    execFileImpl = execFile,
+    existsSyncImpl = existsSync,
+    isVenvImpl = looksLikeVenv,
+  } = opts;
+
+  const steps: string[] = [];
+
+  // 1. Python binary
+  if (!existsSyncImpl(pythonPath)) {
+    if (!autoInstall) {
+      return {
+        ok: false,
+        version: null,
+        steps,
+        error: `Python binary not found at ${pythonPath}. Set "pythonPath" to a valid interpreter or enable mempalace.autoInstall to create a venv with ${bootstrapPython}.`,
+      };
+    }
+    // Try to create a venv at the parent-of-parent directory
+    const binDir = dirname(pythonPath);
+    const venvRoot = dirname(binDir);
+    steps.push(`creating venv at ${venvRoot} with ${bootstrapPython}`);
+    try {
+      await execFileImpl(bootstrapPython, ["-m", "venv", venvRoot], {
+        timeout: timeoutMs,
+      });
+    } catch (err) {
+      return {
+        ok: false,
+        version: null,
+        steps,
+        error: `Failed to create venv at ${venvRoot} using ${bootstrapPython}: ${(err as Error).message}`,
+      };
+    }
+    if (!existsSyncImpl(pythonPath)) {
+      return {
+        ok: false,
+        version: null,
+        steps,
+        error: `Venv was created at ${venvRoot} but expected python binary is still missing at ${pythonPath}.`,
+      };
+    }
+  } else if (!isVenvImpl(pythonPath)) {
+    // Not a venv. Allow it — user may have a system Python with mempalace
+    // installed globally — but note it in steps for diagnostics.
+    steps.push(`using non-venv python at ${pythonPath}`);
+  }
+
+  // 2. Detect current version
+  let currentVersion = await detectMempalaceVersion(
+    pythonPath,
+    execFileImpl,
+    Math.min(timeoutMs, 20_000),
+  );
+
+  // 3. Install / upgrade if needed
+  const needsInstall = currentVersion === null;
+  const needsUpgrade =
+    currentVersion !== null && !isVersionSupported(currentVersion, minVersion);
+
+  if (needsInstall || needsUpgrade) {
+    if (!autoInstall) {
+      return {
+        ok: false,
+        version: currentVersion,
+        steps,
+        error: needsInstall
+          ? `mempalace not installed at ${pythonPath}. Run: ${pythonPath} -m pip install 'mempalace==${installTarget}' — or enable mempalace.autoInstall.`
+          : `mempalace ${currentVersion} is below the supported minimum ${minVersion}. Run: ${pythonPath} -m pip install --upgrade 'mempalace==${installTarget}' — or enable mempalace.autoInstall.`,
+      };
+    }
+    const verb = needsInstall ? "installing" : "upgrading";
+    steps.push(`${verb} mempalace==${installTarget}`);
+    try {
+      await execFileImpl(
+        pythonPath,
+        ["-m", "pip", "install", "--upgrade", `mempalace==${installTarget}`],
+        { timeout: timeoutMs },
+      );
+    } catch (err) {
+      const stderr = (err as { stderr?: string | Buffer }).stderr ?? "";
+      const stderrText =
+        typeof stderr === "string"
+          ? stderr
+          : Buffer.isBuffer(stderr)
+            ? stderr.toString("utf-8")
+            : "";
+      return {
+        ok: false,
+        version: currentVersion,
+        steps,
+        error: `pip install mempalace==${installTarget} failed: ${(err as Error).message}${stderrText ? ` — ${stderrText.trim().slice(0, 400)}` : ""}`,
+      };
+    }
+    currentVersion = await detectMempalaceVersion(
+      pythonPath,
+      execFileImpl,
+      Math.min(timeoutMs, 20_000),
+    );
+  }
+
+  // 4. Final version check
+  if (currentVersion === null) {
+    return {
+      ok: false,
+      version: null,
+      steps,
+      error: `mempalace import failed after install attempt. Run manually: ${pythonPath} -m pip install 'mempalace==${installTarget}' and check for errors.`,
+    };
+  }
+  if (!isVersionSupported(currentVersion, minVersion)) {
+    return {
+      ok: false,
+      version: currentVersion,
+      steps,
+      error: `mempalace ${currentVersion} is below the supported minimum ${minVersion}. Upgrade with: ${pythonPath} -m pip install --upgrade 'mempalace==${installTarget}'`,
+    };
+  }
+
+  steps.push(`mempalace ${currentVersion} ready`);
+  return { ok: true, version: currentVersion, steps };
+}

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -152,11 +152,17 @@ const configSchema = z.object({
       /** Python binary path (default: ~/.talon/mempalace-venv/bin/python) */
       pythonPath: z.string().min(1).optional(),
       /**
-       * BCP 47 language codes for entity detection (mempalace >= 3.3).
+       * BCP 47 language codes for entity detection (mempalace >= 3.3.2).
        * Supported: en, es, fr, de, ja, ko, zh-CN, zh-TW, pt-br, ru, it, hi, id.
        * Sets MEMPALACE_ENTITY_LANGUAGES for the MCP server.
        */
       entityLanguages: z.array(z.string().min(2)).nonempty().optional(),
+      /**
+       * Create the venv (if missing) and pip install mempalace at the
+       * Talon-supported version during plugin init. Default false — we
+       * don't touch the user's python environment without explicit opt-in.
+       */
+      autoInstall: z.boolean().optional(),
       /** Enable mempalace diagnostic diaries (sets MEMPAL_VERBOSE=1). */
       verbose: z.boolean().optional(),
     })


### PR DESCRIPTION
## Summary

Extends #83 (version bump) with the automation around it. Three things:

1. **Automated setup** — new `mempalace.autoInstall` config flag. When `true`, the plugin's `init()` creates the venv (if missing), pip installs `mempalace==3.3.2`, and upgrades if the installed version is below the supported floor. Opt-in, default `false` — we don't touch the user's Python environment without consent.

2. **Pinned supported version** — two constants in `src/plugins/mempalace/install.ts`:
   - `MEMPALACE_INSTALL_TARGET = "3.3.2"` — the exact release Talon ships against and installs when `autoInstall` is on.
   - `MEMPALACE_MIN_VERSION = "3.3.2"` — the floor Talon will accept. Installed versions below it log a warning at startup (non-blocking, so MCP server still gets a chance to start).

3. **Functional CI** — new `.github/workflows/mempalace-smoke.yml` matrix over **Ubuntu / macOS / Windows × Python 3.11 / 3.12** that actually spawns the MCP server and exercises it over stdio (not just unit mocks). Triggered on PRs touching mempalace code, main pushes, and nightly cron at 05:30 UTC to catch upstream PyPI regressions.

## What the smoke test does

`scripts/mempalace-smoke.mjs`:

- **`install`** — create venv → `pip install mempalace==\${PINNED}` → verify `import mempalace` returns the exact pinned version.
- **`smoke`** — spawn `python -m mempalace.mcp_server --palace /tmp/...` over stdio. Minimal MCP client runs:
  - `initialize` → assert `protocolVersion` returned
  - `notifications/initialized`
  - `tools/list` → assert expected tools (including `mempalace_status`, `mempalace_search`) are present
  - `tools/call mempalace_status` → assert valid response shape

Both steps exit non-zero on any deviation, so CI fails loud on upstream drift.

## Files

| File | Purpose |
|---|---|
| `src/plugins/mempalace/install.ts` | New — ensureMempalaceInstalled + version utilities |
| `src/plugins/mempalace/index.ts` | Wires install helper into init, adds autoInstall knob |
| `src/util/config.ts` | New `mempalace.autoInstall` zod field |
| `src/core/plugin.ts` | Passes autoInstall through to createMempalacePlugin |
| `src/__tests__/mempalace-install.test.ts` | New — 21 cases on helpers + full ensure matrix |
| `src/__tests__/mempalace-plugin.test.ts` | Updated to match trimmed validateConfig contract |
| `.github/workflows/mempalace-smoke.yml` | New — multi-OS functional CI |
| `scripts/mempalace-smoke.mjs` | New — install + smoke driver for CI and local |
| `README.md` | Two-path install docs (automatic vs manual) |

## Local verification

- [x] `npx vitest run` — 1382/1382 passing
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — 0 errors (9 pre-existing warnings, unrelated)
- [x] `node scripts/mempalace-smoke.mjs install` — verified from fresh venv
- [x] `node scripts/mempalace-smoke.mjs smoke` — spawned MCP server, 29 tools visible, mempalace_status returned valid content

## Stack order

Depends on #83 landing first (or this can be rebased to include the simple doc changes from #83 if you prefer to merge only one PR).