### PR TITLE
feat(github,playwright): automated onboarding + pinned versions + CI smoke

### DIFF
--- a/.github/workflows/plugin-smoke.yml
+++ b/.github/workflows/plugin-smoke.yml
@@ -1,0 +1,99 @@
+name: Plugin Smoke (GitHub + Playwright)
+
+# Functional smoke tests for the GitHub and Playwright internal plugins.
+# Each plugin has an isolated job so failures don't mask each other.
+#
+# Triggers: PRs that touch the plugin code / config / this workflow, pushes
+# to main that touch the same paths, nightly cron, and manual dispatch.
+
+on:
+  pull_request:
+    paths:
+      - "src/plugins/github/**"
+      - "src/plugins/playwright/**"
+      - "src/util/config.ts"
+      - ".github/workflows/plugin-smoke.yml"
+      - "scripts/github-mcp-smoke.mjs"
+      - "scripts/playwright-mcp-smoke.mjs"
+      - "package.json"
+      - "package-lock.json"
+  push:
+    branches: [main]
+    paths:
+      - "src/plugins/github/**"
+      - "src/plugins/playwright/**"
+      - ".github/workflows/plugin-smoke.yml"
+      - "scripts/github-mcp-smoke.mjs"
+      - "scripts/playwright-mcp-smoke.mjs"
+  schedule:
+    # 05:45 UTC — catches upstream breakage (Docker image retag, upstream
+    # playwright release) the next morning.
+    - cron: "45 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: plugin-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  github-mcp:
+    name: github-mcp (ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Show Talon-supported image tag
+        shell: bash
+        run: grep GITHUB_MCP_IMAGE src/plugins/github/install.ts
+
+      - name: npm ci
+        run: npm ci
+
+      - name: Pull pinned image
+        run: node scripts/github-mcp-smoke.mjs pull
+
+      - name: MCP responsiveness smoke
+        run: node scripts/github-mcp-smoke.mjs smoke
+
+  playwright-mcp:
+    name: ${{ matrix.os }} (${{ matrix.browser }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        browser: [chromium]
+        # Extend with firefox/webkit here once we've pinned those too. Keeping
+        # to one browser per OS keeps CI cost reasonable while still covering
+        # all three platforms.
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Show Talon-supported @playwright/mcp pin
+        shell: bash
+        run: grep PLAYWRIGHT_MCP_VERSION src/plugins/playwright/install.ts
+
+      - name: npm ci
+        run: npm ci
+
+      - name: Install pinned version + browser
+        shell: bash
+        env:
+          PW_SMOKE_BROWSER: ${{ matrix.browser }}
+        run: node scripts/playwright-mcp-smoke.mjs install
+
+      - name: MCP responsiveness smoke
+        shell: bash
+        env:
+          PW_SMOKE_BROWSER: ${{ matrix.browser }}
+        run: node scripts/playwright-mcp-smoke.mjs smoke

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 # Compiled binaries
 talon-bin
 talon-bun
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -87,18 +87,21 @@ index.ts                    Composition root
 
 GitHub API access via the official GitHub MCP server. Gives the agent access to repositories, issues, PRs, code search, and more.
 
-**Requirements:** Docker installed and running.
+**Requirements:** Docker installed and running. Talon pins the upstream image tag (see `GITHUB_MCP_IMAGE` in `src/plugins/github/install.ts`).
 
 ```json
 {
   "github": {
     "enabled": true,
-    "token": "ghp_..."
+    "token": "ghp_...",
+    "autoPull": true
   }
 }
 ```
 
-The token is optional --- defaults to the output of `gh auth token` if the GitHub CLI is authenticated.
+- `token` is optional --- defaults to the output of `gh auth token` if the GitHub CLI is authenticated.
+- `autoPull` (default `false`) runs `docker pull` on the pinned image during startup if it's missing locally. Leave off to avoid surprising large downloads; the image will be pulled on first MCP call instead.
+- `image` is an advanced override --- prefer bumping `GITHUB_MCP_IMAGE` in source so CI covers the new tag.
 
 ### MemPalace
 
@@ -129,19 +132,22 @@ Both paths are optional --- defaults to `~/.talon/workspace/palace/` and the ven
 
 Headless browser automation via the Playwright MCP server. The agent can browse websites, take screenshots, generate PDFs, fill forms, and scrape content.
 
-**Requirements:** None --- `@playwright/mcp` is bundled with Talon.
+**Requirements:** `@playwright/mcp` is pinned in `package.json` and installed by `npm install`. Browser binaries (Chromium, Firefox, WebKit) are not pulled automatically; enable `installBrowsers` to have Talon run `npx playwright install <browser>` on startup.
 
 ```json
 {
   "playwright": {
     "enabled": true,
     "browser": "chromium",
-    "headless": true
+    "headless": true,
+    "installBrowsers": true
   }
 }
 ```
 
-Supported browsers: `chromium` (default), `chrome`, `firefox`, `webkit`, `msedge`.
+- Supported browsers: `chromium` (default), `chrome`, `firefox`, `webkit`, `msedge`.
+- `installBrowsers` (default `false`) downloads the chosen browser if it's missing. Browser binaries are hundreds of MB — opt in deliberately.
+- When using a remote browser via `endpoint` / `endpointFile` (e.g. a dockerized anti-detect browser), no local binary is needed and the browser check is skipped.
 
 ### Brave Search
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@grammyjs/transformer-throttler": "^1.2.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opencode-ai/sdk": "^1.4.0",
-        "@playwright/mcp": "^0.0.70",
+        "@playwright/mcp": "0.0.70",
         "big-integer": "^1.6.52",
         "cheerio": "^1.2.0",
         "croner": "^10.0.1",
@@ -352,29 +352,6 @@
       "resolved": "https://registry.npmjs.org/@cryptography/aes/-/aes-0.1.1.tgz",
       "integrity": "sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==",
       "license": "GPL-3.0-or-later"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -2304,6 +2281,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -3298,6 +3276,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3622,6 +3601,7 @@
       "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.42.0.tgz",
       "integrity": "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@grammyjs/types": "3.26.0",
         "abort-controller": "^3.0.0",
@@ -3677,6 +3657,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5633,6 +5614,7 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5753,6 +5735,7 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5831,6 +5814,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -6076,6 +6060,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "^1.4.0",
-    "@playwright/mcp": "^0.0.70",
+    "@playwright/mcp": "0.0.70",
     "big-integer": "^1.6.52",
     "cheerio": "^1.2.0",
     "croner": "^10.0.1",

--- a/scripts/github-mcp-smoke.mjs
+++ b/scripts/github-mcp-smoke.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * GitHub MCP functional smoke — CI-driven, Linux-only (Docker dependency).
+ *
+ * Subcommands:
+ *   pull   — docker pull the Talon-pinned image, verify it's resolvable.
+ *   smoke  — spawn the MCP server over stdio, run MCP initialize →
+ *            tools/list, assert expected GitHub tools are present.
+ *
+ * Uses a throwaway GITHUB_PERSONAL_ACCESS_TOKEN for the smoke step — the
+ * server only needs a syntactically valid token to boot; we don't make any
+ * authenticated API calls.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileP = promisify(execFile);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+function pinnedImage() {
+  const src = readFileSync(
+    resolve(REPO_ROOT, "src/plugins/github/install.ts"),
+    "utf-8",
+  );
+  const match = /GITHUB_MCP_IMAGE\s*=\s*"([^"]+)"/.exec(src);
+  if (!match) throw new Error("failed to parse GITHUB_MCP_IMAGE");
+  return match[1];
+}
+
+function log(...args) {
+  console.log("[gh-smoke]", ...args);
+}
+
+async function run(cmd, args, opts = {}) {
+  log(`$ ${cmd} ${args.join(" ")}`);
+  const { stdout, stderr } = await execFileP(cmd, args, {
+    maxBuffer: 50 * 1024 * 1024,
+    ...opts,
+  });
+  if (stdout.trim()) log(stdout.trim().split("\n").slice(0, 8).join("\n"));
+  if (stderr.trim()) log(`stderr: ${stderr.trim().split("\n").slice(0, 4).join("\n")}`);
+  return { stdout, stderr };
+}
+
+async function doPull() {
+  const image = pinnedImage();
+  log(`pinned image: ${image}`);
+  await run("docker", ["pull", image]);
+  await run("docker", ["image", "inspect", image]);
+  log("pull OK");
+}
+
+// Minimal MCP stdio client — same shape as mempalace-smoke.
+class StdioMcpClient {
+  constructor(child) {
+    this.child = child;
+    this.buffer = "";
+    this.pending = new Map();
+    this.nextId = 1;
+    this.child.stdout.setEncoding("utf-8");
+    this.child.stdout.on("data", (c) => this.onData(c));
+    this.child.stderr.setEncoding("utf-8");
+    this.child.stderr.on("data", (c) => process.stderr.write(`[mcp-stderr] ${c}`));
+    this.child.on("exit", (code, signal) => {
+      const err = new Error(`MCP server exited code=${code} signal=${signal}`);
+      for (const { reject } of this.pending.values()) reject(err);
+      this.pending.clear();
+    });
+  }
+  onData(chunk) {
+    this.buffer += chunk;
+    let nl;
+    while ((nl = this.buffer.indexOf("\n")) !== -1) {
+      const line = this.buffer.slice(0, nl).trim();
+      this.buffer = this.buffer.slice(nl + 1);
+      if (!line) continue;
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (msg.id !== undefined && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.error) reject(new Error(JSON.stringify(msg.error)));
+        else resolve(msg.result);
+      }
+    }
+  }
+  request(method, params, timeoutMs = 30_000) {
+    const id = this.nextId++;
+    const payload = { jsonrpc: "2.0", id, method, params };
+    return new Promise((resolveFn, rejectFn) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        rejectFn(new Error(`request ${method} timed out`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (v) => {
+          clearTimeout(timer);
+          resolveFn(v);
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          rejectFn(e);
+        },
+      });
+      this.child.stdin.write(`${JSON.stringify(payload)}\n`);
+    });
+  }
+  notify(method, params) {
+    this.child.stdin.write(
+      `${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`,
+    );
+  }
+  async close() {
+    this.child.stdin.end();
+    await new Promise((res) => this.child.on("exit", () => res()));
+  }
+}
+
+async function doSmoke() {
+  const image = pinnedImage();
+  log(`spawning ${image} via docker run`);
+
+  const fakeToken = process.env.GITHUB_SMOKE_TOKEN ?? "ghp_smoke_dummy_token_for_init_only";
+  const child = spawn(
+    "docker",
+    [
+      "run",
+      "--rm",
+      "-i",
+      "-e",
+      "GITHUB_PERSONAL_ACCESS_TOKEN",
+      image,
+    ],
+    {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, GITHUB_PERSONAL_ACCESS_TOKEN: fakeToken },
+    },
+  );
+  const client = new StdioMcpClient(child);
+
+  try {
+    log("initialize…");
+    const init = await client.request("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "talon-smoke", version: "0.0.0" },
+    });
+    if (!init?.protocolVersion) {
+      throw new Error(`bad initialize response: ${JSON.stringify(init)}`);
+    }
+    log(`server protocol: ${init.protocolVersion}`);
+    client.notify("notifications/initialized", {});
+
+    log("tools/list…");
+    const tools = await client.request("tools/list", {});
+    if (!Array.isArray(tools?.tools) || tools.tools.length === 0) {
+      throw new Error(`bad tools/list response: ${JSON.stringify(tools)}`);
+    }
+    const names = tools.tools.map((t) => t.name);
+    log(`tools (${names.length}): ${names.slice(0, 8).join(", ")}${names.length > 8 ? ", …" : ""}`);
+
+    // Expect a core subset — github-mcp-server tool names are stable across versions.
+    const expected = ["get_me", "search_repositories", "list_issues"];
+    for (const name of expected) {
+      if (!names.includes(name)) {
+        throw new Error(
+          `expected tool "${name}" not found in github-mcp tools/list`,
+        );
+      }
+    }
+    log("tools/list OK");
+  } finally {
+    await client.close().catch(() => {});
+  }
+
+  log(`smoke OK on ${process.platform}`);
+}
+
+async function main() {
+  const cmd = process.argv[2] ?? "smoke";
+  try {
+    if (cmd === "pull") await doPull();
+    else if (cmd === "smoke") await doSmoke();
+    else {
+      console.error(`unknown subcommand "${cmd}" — use pull | smoke`);
+      process.exit(2);
+    }
+  } catch (err) {
+    console.error(`[gh-smoke] FAILED: ${err.stack || err.message || err}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/playwright-mcp-smoke.mjs
+++ b/scripts/playwright-mcp-smoke.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * Playwright MCP functional smoke — CI-driven, multi-OS.
+ *
+ * Subcommands:
+ *   install  — ensure @playwright/mcp is resolved (via npm ci), run
+ *              `npx playwright install <browser>` for the target browser.
+ *   smoke    — spawn @playwright/mcp over stdio, run MCP initialize →
+ *              tools/list → tools/call browser_navigate (about:blank) →
+ *              tools/call browser_close. Assert responses are well-formed.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileP = promisify(execFile);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+const MCP_BIN = resolve(REPO_ROOT, "node_modules/@playwright/mcp/cli.js");
+
+function pinnedVersion() {
+  const src = readFileSync(
+    resolve(REPO_ROOT, "src/plugins/playwright/install.ts"),
+    "utf-8",
+  );
+  const match = /PLAYWRIGHT_MCP_VERSION\s*=\s*"([^"]+)"/.exec(src);
+  if (!match) throw new Error("failed to parse PLAYWRIGHT_MCP_VERSION");
+  return match[1];
+}
+
+function log(...args) {
+  console.log("[pw-smoke]", ...args);
+}
+
+async function run(cmd, args, opts = {}) {
+  log(`$ ${cmd} ${args.join(" ")}`);
+  const { stdout, stderr } = await execFileP(cmd, args, {
+    maxBuffer: 50 * 1024 * 1024,
+    ...opts,
+  });
+  if (stdout.trim()) log(stdout.trim().split("\n").slice(0, 6).join("\n"));
+  if (stderr.trim()) log(`stderr: ${stderr.trim().split("\n").slice(0, 4).join("\n")}`);
+  return { stdout, stderr };
+}
+
+async function doInstall() {
+  const target = pinnedVersion();
+  log(`pinned @playwright/mcp version: ${target}`);
+
+  if (!existsSync(MCP_BIN)) {
+    throw new Error(
+      `${MCP_BIN} not present — run 'npm ci' in the Talon repo first`,
+    );
+  }
+  const pkgJson = resolve(dirname(MCP_BIN), "package.json");
+  const installedVersion = JSON.parse(readFileSync(pkgJson, "utf-8")).version;
+  log(`installed @playwright/mcp: ${installedVersion}`);
+  if (installedVersion !== target) {
+    throw new Error(
+      `installed version ${installedVersion} != pinned target ${target}`,
+    );
+  }
+
+  const browser = process.env.PW_SMOKE_BROWSER ?? "chromium";
+  await run("npx", ["playwright", "install", browser]);
+  log(`browser installed: ${browser}`);
+}
+
+class StdioMcpClient {
+  constructor(child) {
+    this.child = child;
+    this.buffer = "";
+    this.pending = new Map();
+    this.nextId = 1;
+    this.child.stdout.setEncoding("utf-8");
+    this.child.stdout.on("data", (c) => this.onData(c));
+    this.child.stderr.setEncoding("utf-8");
+    this.child.stderr.on("data", (c) => process.stderr.write(`[mcp-stderr] ${c}`));
+    this.child.on("exit", (code, signal) => {
+      const err = new Error(`MCP server exited code=${code} signal=${signal}`);
+      for (const { reject } of this.pending.values()) reject(err);
+      this.pending.clear();
+    });
+  }
+  onData(chunk) {
+    this.buffer += chunk;
+    let nl;
+    while ((nl = this.buffer.indexOf("\n")) !== -1) {
+      const line = this.buffer.slice(0, nl).trim();
+      this.buffer = this.buffer.slice(nl + 1);
+      if (!line) continue;
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (msg.id !== undefined && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.error) reject(new Error(JSON.stringify(msg.error)));
+        else resolve(msg.result);
+      }
+    }
+  }
+  request(method, params, timeoutMs = 60_000) {
+    const id = this.nextId++;
+    const payload = { jsonrpc: "2.0", id, method, params };
+    return new Promise((resolveFn, rejectFn) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        rejectFn(new Error(`request ${method} timed out`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (v) => {
+          clearTimeout(timer);
+          resolveFn(v);
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          rejectFn(e);
+        },
+      });
+      this.child.stdin.write(`${JSON.stringify(payload)}\n`);
+    });
+  }
+  notify(method, params) {
+    this.child.stdin.write(
+      `${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`,
+    );
+  }
+  async close() {
+    this.child.stdin.end();
+    await new Promise((res) => this.child.on("exit", () => res()));
+  }
+}
+
+async function doSmoke() {
+  if (!existsSync(MCP_BIN)) {
+    throw new Error(`${MCP_BIN} missing — run install step first`);
+  }
+
+  const browser = process.env.PW_SMOKE_BROWSER ?? "chromium";
+  const args = [MCP_BIN, "--no-sandbox", "--headless"];
+  if (browser !== "chromium") args.push("--browser", browser);
+
+  log(`spawning @playwright/mcp with ${browser}`);
+  const child = spawn("node", args, {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const client = new StdioMcpClient(child);
+
+  try {
+    log("initialize…");
+    const init = await client.request("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "talon-smoke", version: "0.0.0" },
+    });
+    if (!init?.protocolVersion) {
+      throw new Error(`bad initialize response: ${JSON.stringify(init)}`);
+    }
+    log(`server protocol: ${init.protocolVersion}`);
+    client.notify("notifications/initialized", {});
+
+    log("tools/list…");
+    const tools = await client.request("tools/list", {});
+    if (!Array.isArray(tools?.tools) || tools.tools.length === 0) {
+      throw new Error(`bad tools/list response: ${JSON.stringify(tools)}`);
+    }
+    const names = tools.tools.map((t) => t.name);
+    log(`tools (${names.length}): ${names.slice(0, 6).join(", ")}${names.length > 6 ? ", …" : ""}`);
+    for (const required of ["browser_navigate", "browser_close"]) {
+      if (!names.includes(required)) {
+        throw new Error(
+          `expected tool "${required}" not found in tools/list`,
+        );
+      }
+    }
+
+    log("browser_navigate about:blank …");
+    await client.request(
+      "tools/call",
+      { name: "browser_navigate", arguments: { url: "about:blank" } },
+      90_000,
+    );
+    log("browser_navigate OK");
+
+    log("browser_close …");
+    await client.request(
+      "tools/call",
+      { name: "browser_close", arguments: {} },
+      30_000,
+    );
+    log("browser_close OK");
+  } finally {
+    await client.close().catch(() => {});
+  }
+
+  log(`smoke OK on ${process.platform} (${browser})`);
+}
+
+async function main() {
+  const cmd = process.argv[2] ?? "smoke";
+  try {
+    if (cmd === "install") await doInstall();
+    else if (cmd === "smoke") await doSmoke();
+    else {
+      console.error(`unknown subcommand "${cmd}" — use install | smoke`);
+      process.exit(2);
+    }
+  } catch (err) {
+    console.error(`[pw-smoke] FAILED: ${err.stack || err.message || err}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/__tests__/github-install.test.ts
+++ b/src/__tests__/github-install.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  GITHUB_MCP_IMAGE,
+  ensureGithubMcpAvailable,
+} from "../plugins/github/install.js";
+
+describe("GITHUB_MCP_IMAGE", () => {
+  it("is a pinned ghcr.io reference (never :latest)", () => {
+    expect(GITHUB_MCP_IMAGE).toMatch(
+      /^ghcr\.io\/github\/github-mcp-server:v\d+\.\d+\.\d+/,
+    );
+    expect(GITHUB_MCP_IMAGE).not.toContain(":latest");
+  });
+});
+
+describe("ensureGithubMcpAvailable", () => {
+  function queueExec(responses: Array<{ stdout?: string } | Error>) {
+    return vi.fn(async () => {
+      const next = responses.shift();
+      if (!next) throw new Error("unexpected exec call (no response queued)");
+      if (next instanceof Error) throw next;
+      return { stdout: next.stdout ?? "", stderr: "" };
+    });
+  }
+
+  it("reports ok when docker works and image is present", async () => {
+    const exec = queueExec([
+      { stdout: "Containers: 0" }, // docker info
+      { stdout: "[{...}]" }, // docker image inspect
+    ]);
+    const status = await ensureGithubMcpAvailable({
+      autoPull: false,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(status.image).toBe(GITHUB_MCP_IMAGE);
+    expect(status.error).toBeUndefined();
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it("errors when docker daemon is unreachable", async () => {
+    const exec = queueExec([
+      Object.assign(new Error("Cannot connect to the Docker daemon"), {
+        stderr: "daemon unreachable",
+      }),
+    ]);
+    const status = await ensureGithubMcpAvailable({
+      autoPull: true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("Docker is not installed");
+  });
+
+  it("errors without pulling when autoPull=false and image is missing", async () => {
+    const exec = queueExec([
+      { stdout: "Containers: 0" },
+      Object.assign(new Error("No such image"), {}),
+    ]);
+    const status = await ensureGithubMcpAvailable({
+      autoPull: false,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("not present locally");
+    expect(status.error).toContain("github.autoPull=true");
+  });
+
+  it("pulls when autoPull=true and image is missing, then reports ok", async () => {
+    const exec = queueExec([
+      { stdout: "Containers: 0" }, // docker info
+      Object.assign(new Error("No such image"), {}), // first inspect fails
+      { stdout: "pulled" }, // docker pull
+      { stdout: "[{...}]" }, // second inspect succeeds
+    ]);
+    const status = await ensureGithubMcpAvailable({
+      autoPull: true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(status.steps.some((s) => s.startsWith("pulling"))).toBe(true);
+    expect(status.steps.some((s) => s.startsWith("image pulled"))).toBe(true);
+  });
+
+  it("surfaces pull failure with useful error text", async () => {
+    const exec = queueExec([
+      { stdout: "Containers: 0" },
+      Object.assign(new Error("no image"), {}),
+      Object.assign(new Error("pull failed"), {
+        stderr: "manifest unknown: manifest unknown",
+      }),
+    ]);
+    const status = await ensureGithubMcpAvailable({
+      autoPull: true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("docker pull");
+    expect(status.error).toContain("manifest unknown");
+  });
+
+  it("errors when pull succeeds but image is still not detectable", async () => {
+    const exec = queueExec([
+      { stdout: "Containers: 0" },
+      Object.assign(new Error("no image"), {}),
+      { stdout: "pulled" },
+      Object.assign(new Error("still not there"), {}),
+    ]);
+    const status = await ensureGithubMcpAvailable({
+      autoPull: true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("claimed success");
+  });
+
+  it("respects image override", async () => {
+    const exec = queueExec([
+      { stdout: "Containers: 0" },
+      { stdout: "[{...}]" },
+    ]);
+    const status = await ensureGithubMcpAvailable({
+      autoPull: false,
+      image: "ghcr.io/github/github-mcp-server:v0.9.0-rc1",
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(status.image).toBe("ghcr.io/github/github-mcp-server:v0.9.0-rc1");
+  });
+});

--- a/src/__tests__/github-install.test.ts
+++ b/src/__tests__/github-install.test.ts
@@ -79,7 +79,25 @@ describe("ensureGithubMcpAvailable", () => {
     });
     expect(status.ok).toBe(true);
     expect(status.steps.some((s) => s.startsWith("pulling"))).toBe(true);
-    expect(status.steps.some((s) => s.startsWith("image pulled"))).toBe(true);
+    expect(status.steps.some((s) => s.startsWith("image ready"))).toBe(true);
+  });
+
+  it("refreshes the tag (re-pulls) when autoPull=true and image is already present", async () => {
+    const exec = queueExec([
+      { stdout: "Containers: 0" }, // docker info
+      { stdout: "[{...}]" }, // first inspect → present
+      { stdout: "Status: Image is up to date" }, // docker pull (no-op)
+      { stdout: "[{...}]" }, // re-inspect
+    ]);
+    const status = await ensureGithubMcpAvailable({
+      autoPull: true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(status.steps.some((s) => s.startsWith("refreshing"))).toBe(true);
+    expect(status.steps.some((s) => s.startsWith("image ready"))).toBe(true);
+    // 4 calls: info, inspect(present), pull, inspect(re-verify)
+    expect(exec).toHaveBeenCalledTimes(4);
   });
 
   it("surfaces pull failure with useful error text", async () => {

--- a/src/__tests__/playwright-install.test.ts
+++ b/src/__tests__/playwright-install.test.ts
@@ -60,6 +60,24 @@ describe("ensurePlaywrightMcpAvailable", () => {
     expect(exec).not.toHaveBeenCalled();
   });
 
+  it("errors with an actionable message when installed CLI version doesn't match the pin", async () => {
+    // Need a real file so detectMcpVersion can read adjacent package.json.
+    // Simulate by pointing mcpBin at the node_modules/@playwright/mcp/cli.js
+    // but override expectedVersion to something we don't have installed.
+    const exec = queueExec([]);
+    const status = await ensurePlaywrightMcpAvailable({
+      mcpBin:
+        "/home/dylan/telegram-claude-agent/node_modules/@playwright/mcp/cli.js",
+      installBrowsers: false,
+      expectedVersion: "99.99.99",
+      existsSyncImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("Talon pins 99.99.99");
+    expect(status.error).toContain("npm install");
+  });
+
   it("errors for unsupported browser names", async () => {
     const status = await ensurePlaywrightMcpAvailable({
       mcpBin: "/fake/cli.js",

--- a/src/__tests__/playwright-install.test.ts
+++ b/src/__tests__/playwright-install.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  PLAYWRIGHT_MCP_VERSION,
+  SUPPORTED_BROWSERS,
+  ensurePlaywrightMcpAvailable,
+} from "../plugins/playwright/install.js";
+
+describe("PLAYWRIGHT_MCP_VERSION", () => {
+  it("is a pinned semver", () => {
+    expect(PLAYWRIGHT_MCP_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});
+
+describe("SUPPORTED_BROWSERS", () => {
+  it("includes the canonical Playwright browsers", () => {
+    expect(SUPPORTED_BROWSERS).toEqual([
+      "chromium",
+      "chrome",
+      "firefox",
+      "webkit",
+      "msedge",
+    ]);
+  });
+});
+
+describe("ensurePlaywrightMcpAvailable", () => {
+  function queueExec(
+    responses: Array<{ stdout?: string; stderr?: string } | Error>,
+  ) {
+    return vi.fn(async () => {
+      const next = responses.shift();
+      if (!next) throw new Error("unexpected exec call (no response queued)");
+      if (next instanceof Error) throw next;
+      return { stdout: next.stdout ?? "", stderr: next.stderr ?? "" };
+    });
+  }
+
+  it("errors when the MCP CLI is missing", async () => {
+    const exec = queueExec([]);
+    const status = await ensurePlaywrightMcpAvailable({
+      mcpBin: "/fake/cli.js",
+      installBrowsers: false,
+      existsSyncImpl: () => false,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("@playwright/mcp not found");
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("reports ok when no browser check is requested (remote endpoint mode)", async () => {
+    const exec = queueExec([]);
+    const status = await ensurePlaywrightMcpAvailable({
+      mcpBin: "/fake/cli.js",
+      installBrowsers: false,
+      existsSyncImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("errors for unsupported browser names", async () => {
+    const status = await ensurePlaywrightMcpAvailable({
+      mcpBin: "/fake/cli.js",
+      browser: "safari" as never,
+      installBrowsers: false,
+      existsSyncImpl: () => true,
+      execFileImpl: (() => {
+        throw new Error("should not be called");
+      }) as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("Invalid browser");
+  });
+
+  it("reports ok when browser is detected as installed", async () => {
+    const exec = queueExec([
+      { stdout: "browser: chromium\nInstall location: /home/x/.cache" },
+    ]);
+    const status = await ensurePlaywrightMcpAvailable({
+      mcpBin: "/fake/cli.js",
+      browser: "chromium",
+      installBrowsers: false,
+      existsSyncImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+  });
+
+  it("errors without installing when installBrowsers=false and browser is missing", async () => {
+    const exec = queueExec([{ stdout: "downloading chromium 0MB / 120MB" }]);
+    const status = await ensurePlaywrightMcpAvailable({
+      mcpBin: "/fake/cli.js",
+      browser: "chromium",
+      installBrowsers: false,
+      existsSyncImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("not installed");
+    expect(status.error).toContain("installBrowsers=true");
+  });
+
+  it("installs the browser when installBrowsers=true and reports ok", async () => {
+    const exec = queueExec([
+      { stdout: "downloading chromium" }, // first dry-run: missing
+      { stdout: "installed" }, // actual install
+      { stdout: "browser: chromium\nInstall location: /home/x/.cache" }, // re-check
+    ]);
+    const status = await ensurePlaywrightMcpAvailable({
+      mcpBin: "/fake/cli.js",
+      browser: "chromium",
+      installBrowsers: true,
+      existsSyncImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(true);
+    expect(status.steps.some((s) => s.includes("installing playwright"))).toBe(
+      true,
+    );
+    expect(status.steps.some((s) => s.includes("browser installed"))).toBe(
+      true,
+    );
+  });
+
+  it("surfaces install failure with useful error", async () => {
+    const exec = queueExec([
+      { stdout: "downloading chromium" },
+      Object.assign(new Error("install crashed"), {
+        stderr: "Network unreachable",
+      }),
+    ]);
+    const status = await ensurePlaywrightMcpAvailable({
+      mcpBin: "/fake/cli.js",
+      browser: "chromium",
+      installBrowsers: true,
+      existsSyncImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("playwright install chromium failed");
+    expect(status.error).toContain("Network unreachable");
+  });
+
+  it("errors when install succeeds but browser still missing", async () => {
+    const exec = queueExec([
+      { stdout: "downloading chromium" },
+      { stdout: "installed" },
+      { stdout: "downloading chromium again" }, // still not installed
+    ]);
+    const status = await ensurePlaywrightMcpAvailable({
+      mcpBin: "/fake/cli.js",
+      browser: "chromium",
+      installBrowsers: true,
+      existsSyncImpl: () => true,
+      execFileImpl: exec as unknown as never,
+    });
+    expect(status.ok).toBe(false);
+    expect(status.error).toContain("claimed success");
+  });
+});

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -497,7 +497,11 @@ export async function loadBuiltinPlugins(config: TalonConfig): Promise<void> {
   if (github?.enabled) {
     try {
       const { createGitHubPlugin } = await import("../plugins/github/index.js");
-      const gh = createGitHubPlugin({ token: github.token });
+      const gh = createGitHubPlugin({
+        token: github.token,
+        autoPull: github.autoPull,
+        image: github.image,
+      });
       const ghConfig = github as unknown as Record<string, unknown>;
       const loaded = registerPlugin(gh, ghConfig);
       if (loaded) {
@@ -561,6 +565,7 @@ export async function loadBuiltinPlugins(config: TalonConfig): Promise<void> {
         headless: playwright.headless,
         endpoint: playwright.endpoint,
         endpointFile: playwright.endpointFile,
+        installBrowsers: playwright.installBrowsers,
       });
       const loaded = registerPlugin(pw, pwConfig);
       if (loaded) {

--- a/src/plugins/github/index.ts
+++ b/src/plugins/github/index.ts
@@ -1,19 +1,24 @@
 /**
  * GitHub plugin — GitHub API access via the official GitHub MCP server.
  *
- * Registers the GitHub MCP server (Docker image: ghcr.io/github/github-mcp-server),
+ * Registers the GitHub MCP server (Docker image: pinned by GITHUB_MCP_IMAGE),
  * giving the agent access to repository management, issues, PRs, code search, etc.
  *
  * Configuration in ~/.talon/config.json:
  *   "github": {
  *     "enabled": true,
- *     "token": "ghp_..."      // optional, defaults to `gh auth token` output
+ *     "token": "ghp_...",     // optional, defaults to `gh auth token` output
+ *     "autoPull": true,       // optional, docker pull the pinned image on init
+ *     "image": "ghcr.io/..."  // optional, advanced override of the pinned tag
  *   }
  */
 
 import { execFileSync } from "node:child_process";
 import type { TalonPlugin } from "../../core/plugin.js";
-import { log, logWarn } from "../../util/log.js";
+import { log, logError, logWarn } from "../../util/log.js";
+import { GITHUB_MCP_IMAGE, ensureGithubMcpAvailable } from "./install.js";
+
+export { GITHUB_MCP_IMAGE } from "./install.js";
 
 /**
  * Resolve a GitHub personal access token.
@@ -34,8 +39,22 @@ function resolveToken(configToken?: string): string | undefined {
   }
 }
 
-export function createGitHubPlugin(config: { token?: string }): TalonPlugin {
+export function createGitHubPlugin(config: {
+  token?: string;
+  /**
+   * If true, `docker pull` the pinned image during init when it's missing.
+   * Default false — we don't move 200MB+ onto the user's disk without consent.
+   */
+  autoPull?: boolean;
+  /**
+   * Advanced: override the pinned image tag. Use only for testing; normal
+   * upgrades bump {@link GITHUB_MCP_IMAGE} so CI covers the new version.
+   */
+  image?: string;
+}): TalonPlugin {
   const token = resolveToken(config.token);
+  const image = config.image ?? GITHUB_MCP_IMAGE;
+  const autoPull = config.autoPull === true;
 
   return {
     name: "github",
@@ -44,14 +63,7 @@ export function createGitHubPlugin(config: { token?: string }): TalonPlugin {
 
     mcpServer: {
       command: "docker",
-      args: [
-        "run",
-        "--rm",
-        "-i",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server",
-      ],
+      args: ["run", "--rm", "-i", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", image],
     },
 
     validateConfig() {
@@ -63,7 +75,9 @@ export function createGitHubPlugin(config: { token?: string }): TalonPlugin {
         );
       }
 
-      // Check Docker is available
+      // Check Docker is available — synchronous fast-fail check. The image
+      // presence / version check is deferred to async init() so we don't
+      // block startup for a pull.
       try {
         execFileSync("docker", ["info"], {
           timeout: 10_000,
@@ -79,22 +93,26 @@ export function createGitHubPlugin(config: { token?: string }): TalonPlugin {
     },
 
     async init() {
-      // Verify the Docker image exists locally
-      try {
-        execFileSync(
-          "docker",
-          ["image", "inspect", "ghcr.io/github/github-mcp-server"],
-          { timeout: 10_000, stdio: "pipe" },
-        );
-        log("github", "Docker image verified");
-      } catch {
-        logWarn(
-          "github",
-          "Docker image not found locally — will pull on first use (may be slow)",
-        );
+      const status = await ensureGithubMcpAvailable({
+        autoPull,
+        image,
+      });
+      for (const step of status.steps) log("github", step);
+      if (!status.ok) {
+        if (autoPull) {
+          logError(
+            "github",
+            status.error ?? "github MCP ensureAvailable failed",
+          );
+        } else {
+          logWarn(
+            "github",
+            status.error ??
+              `Docker image ${image} not present — will pull on first use (may be slow). Set github.autoPull=true to pull at startup.`,
+          );
+        }
       }
-
-      log("github", "Ready");
+      log("github", `Ready [${image}]`);
     },
 
     getEnvVars() {

--- a/src/plugins/github/install.ts
+++ b/src/plugins/github/install.ts
@@ -1,0 +1,145 @@
+/**
+ * GitHub MCP onboarding + sanity checks.
+ *
+ * The GitHub MCP server ships as a Docker image. We:
+ *   - Pin the image tag Talon supports (GITHUB_MCP_IMAGE)
+ *   - Verify Docker is installed and the daemon is reachable
+ *   - Verify the pinned image is present locally, optionally docker pull it
+ *   - Surface actionable errors when any step fails
+ *
+ * Bump GITHUB_MCP_IMAGE when the plugin has been tested and verified against
+ * a newer github-mcp-server release — not before.
+ */
+
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+/**
+ * Pinned github-mcp-server Docker image. Bump after testing against a new
+ * upstream release. `latest` is explicitly avoided — pinning protects us
+ * from silent breaking changes in the MCP protocol or tool schemas.
+ *
+ * @see https://github.com/github/github-mcp-server/releases
+ */
+export const GITHUB_MCP_IMAGE = "ghcr.io/github/github-mcp-server:v1.0.2";
+
+export type InstallStatus = {
+  /** True when the image is available locally and Docker is reachable. */
+  ok: boolean;
+  /** Image reference used for the check. */
+  image: string;
+  /** Human-readable steps taken during this ensure() call. */
+  steps: string[];
+  /** Populated when ok=false — actionable error for the user. */
+  error?: string;
+};
+
+export type EnsureOptions = {
+  /**
+   * If true, a missing image triggers `docker pull`. When false, the function
+   * only diagnoses and returns an error.
+   */
+  autoPull: boolean;
+  /** Image tag override. Defaults to {@link GITHUB_MCP_IMAGE}. */
+  image?: string;
+  /** Timeout for each subprocess call, ms. Default 120s (pulls can be slow). */
+  timeoutMs?: number;
+  /** Injected for tests — defaults to Node's promisified execFile. */
+  execFileImpl?: typeof execFile;
+};
+
+/**
+ * Ensure the pinned github-mcp-server image is pullable and available.
+ *
+ * When autoPull=true this is self-healing: missing image → docker pull.
+ * When autoPull=false the function is purely diagnostic.
+ */
+export async function ensureGithubMcpAvailable(
+  opts: EnsureOptions,
+): Promise<InstallStatus> {
+  const {
+    autoPull,
+    image = GITHUB_MCP_IMAGE,
+    timeoutMs = 120_000,
+    execFileImpl = execFile,
+  } = opts;
+
+  const steps: string[] = [];
+
+  // 1. Docker available?
+  try {
+    await execFileImpl("docker", ["info"], { timeout: 15_000 });
+  } catch (err) {
+    const msg = (err as Error).message;
+    return {
+      ok: false,
+      image,
+      steps,
+      error: `Docker is not installed or the daemon is not running. The GitHub MCP server requires Docker. Details: ${msg.slice(0, 200)}`,
+    };
+  }
+  steps.push("docker daemon reachable");
+
+  // 2. Image present locally?
+  const imagePresent = await isImagePresent(image, execFileImpl);
+  if (imagePresent) {
+    steps.push(`image present: ${image}`);
+    return { ok: true, image, steps };
+  }
+
+  // 3. Missing image — optionally pull
+  if (!autoPull) {
+    return {
+      ok: false,
+      image,
+      steps,
+      error: `GitHub MCP image ${image} is not present locally. Run: docker pull ${image} — or set github.autoPull=true to pull automatically.`,
+    };
+  }
+  steps.push(`pulling ${image}`);
+  try {
+    await execFileImpl("docker", ["pull", image], { timeout: timeoutMs });
+  } catch (err) {
+    const stderr = (err as { stderr?: string | Buffer }).stderr ?? "";
+    const stderrText =
+      typeof stderr === "string"
+        ? stderr
+        : Buffer.isBuffer(stderr)
+          ? stderr.toString("utf-8")
+          : "";
+    return {
+      ok: false,
+      image,
+      steps,
+      error: `docker pull ${image} failed: ${(err as Error).message}${stderrText ? ` — ${stderrText.trim().slice(0, 400)}` : ""}`,
+    };
+  }
+
+  // 4. Re-verify
+  if (!(await isImagePresent(image, execFileImpl))) {
+    return {
+      ok: false,
+      image,
+      steps,
+      error: `docker pull claimed success but image ${image} is still not present locally.`,
+    };
+  }
+  steps.push(`image pulled: ${image}`);
+  return { ok: true, image, steps };
+}
+
+async function isImagePresent(
+  image: string,
+  execFileImpl: typeof execFile,
+): Promise<boolean> {
+  try {
+    await execFileImpl("docker", ["image", "inspect", image], {
+      timeout: 15_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/plugins/github/install.ts
+++ b/src/plugins/github/install.ts
@@ -84,13 +84,17 @@ export async function ensureGithubMcpAvailable(
 
   // 2. Image present locally?
   const imagePresent = await isImagePresent(image, execFileImpl);
-  if (imagePresent) {
-    steps.push(`image present: ${image}`);
-    return { ok: true, image, steps };
-  }
 
-  // 3. Missing image — optionally pull
-  if (!autoPull) {
+  // 3. Decide whether to pull.
+  //    - missing + !autoPull → diagnostic error (user opts in or pulls manually)
+  //    - missing + autoPull  → pull
+  //    - present + autoPull  → re-pull to refresh digest. Upstream can
+  //                            force-push tags; pinning by tag alone is a
+  //                            floor, not a ceiling. `docker pull` is fast
+  //                            when the digest hasn't changed — no layers
+  //                            are re-downloaded.
+  //    - present + !autoPull → nothing to do, return ok
+  if (!imagePresent && !autoPull) {
     return {
       ok: false,
       image,
@@ -98,7 +102,12 @@ export async function ensureGithubMcpAvailable(
       error: `GitHub MCP image ${image} is not present locally. Run: docker pull ${image} — or set github.autoPull=true to pull automatically.`,
     };
   }
-  steps.push(`pulling ${image}`);
+  if (imagePresent && !autoPull) {
+    steps.push(`image present: ${image}`);
+    return { ok: true, image, steps };
+  }
+
+  steps.push(imagePresent ? `refreshing ${image}` : `pulling ${image}`);
   try {
     await execFileImpl("docker", ["pull", image], { timeout: timeoutMs });
   } catch (err) {
@@ -126,7 +135,7 @@ export async function ensureGithubMcpAvailable(
       error: `docker pull claimed success but image ${image} is still not present locally.`,
     };
   }
-  steps.push(`image pulled: ${image}`);
+  steps.push(`image ready: ${image}`);
   return { ok: true, image, steps };
 }
 

--- a/src/plugins/playwright/index.ts
+++ b/src/plugins/playwright/index.ts
@@ -7,11 +7,12 @@
  * Configuration in ~/.talon/config.json:
  *   "playwright": {
  *     "enabled": true,
- *     "browser": "chromium",     // optional, default "chromium"
- *     "headless": true           // optional, default true
+ *     "browser": "chromium",       // optional, default "chromium"
+ *     "headless": true,            // optional, default true
+ *     "installBrowsers": true       // optional, auto-download browser binaries on init
  *   }
  *
- * For Camoufox (anti-detect browser):
+ * For Camoufox / remote browser (no local binary needed):
  *   "playwright": {
  *     "enabled": true,
  *     "browser": "firefox",
@@ -22,16 +23,32 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { TalonPlugin } from "../../core/plugin.js";
-import { log } from "../../util/log.js";
+import { log, logError, logWarn } from "../../util/log.js";
+import {
+  PLAYWRIGHT_MCP_VERSION,
+  SUPPORTED_BROWSERS,
+  ensurePlaywrightMcpAvailable,
+  type SupportedBrowser,
+} from "./install.js";
+
+export { PLAYWRIGHT_MCP_VERSION, SUPPORTED_BROWSERS } from "./install.js";
 
 export function createPlaywrightPlugin(config: {
   browser?: string;
   headless?: boolean;
   endpoint?: string;
   endpointFile?: string;
+  /**
+   * When true, init() downloads the selected browser via
+   * `npx playwright install <browser>` if it's not already present.
+   * Default false — browser binaries are hundreds of MB and we don't
+   * touch the user's disk without consent.
+   */
+  installBrowsers?: boolean;
 }): TalonPlugin {
   const browser = config.browser ?? "chromium";
   const headless = config.headless !== false; // default true
+  const installBrowsers = config.installBrowsers === true;
 
   // Resolve endpoint: direct string or read from file
   let endpoint = config.endpoint;
@@ -83,23 +100,16 @@ export function createPlaywrightPlugin(config: {
       const errors: string[] = [];
 
       if (!endpoint) {
-        const validBrowsers = [
-          "chromium",
-          "chrome",
-          "firefox",
-          "webkit",
-          "msedge",
-        ];
-        if (!validBrowsers.includes(browser)) {
+        if (!(SUPPORTED_BROWSERS as readonly string[]).includes(browser)) {
           errors.push(
-            `Invalid browser "${browser}". Valid options: ${validBrowsers.join(", ")}`,
+            `Invalid browser "${browser}". Valid options: ${SUPPORTED_BROWSERS.join(", ")}`,
           );
         }
       }
 
       if (!existsSync(mcpBin)) {
         errors.push(
-          `@playwright/mcp not found at ${mcpBin} — run "npm install @playwright/mcp"`,
+          `@playwright/mcp not found at ${mcpBin} — run "npm install" in the Talon checkout.`,
         );
       }
 
@@ -107,9 +117,38 @@ export function createPlaywrightPlugin(config: {
     },
 
     async init() {
+      // Skip browser check when using a remote endpoint — no local binary
+      // needed. CLI presence / version pin is always checked.
+      const checkBrowser =
+        !endpoint && (SUPPORTED_BROWSERS as readonly string[]).includes(browser)
+          ? (browser as SupportedBrowser)
+          : undefined;
+      const status = await ensurePlaywrightMcpAvailable({
+        mcpBin,
+        browser: checkBrowser,
+        installBrowsers,
+      });
+      for (const step of status.steps) log("playwright", step);
+      if (!status.ok) {
+        if (installBrowsers) {
+          logError(
+            "playwright",
+            status.error ?? "playwright ensureAvailable failed",
+          );
+        } else {
+          logWarn(
+            "playwright",
+            status.error ??
+              "playwright browser not installed — set playwright.installBrowsers=true to auto-download",
+          );
+        }
+      }
+      const versionSuffix = status.version
+        ? ` [@playwright/mcp ${status.version}]`
+        : "";
       log(
         "playwright",
-        `Ready (${endpoint ? `Camoufox @ ${endpoint}` : `${browser}, headless=${headless}`})`,
+        `Ready (${endpoint ? `remote @ ${endpoint}` : `${browser}, headless=${headless}`})${versionSuffix}`,
       );
     },
   };

--- a/src/plugins/playwright/install.ts
+++ b/src/plugins/playwright/install.ts
@@ -1,0 +1,236 @@
+/**
+ * Playwright MCP onboarding + sanity checks.
+ *
+ * @playwright/mcp is bundled via package.json. Separate from the npm pin,
+ * Playwright browser binaries live outside node_modules (chromium, firefox,
+ * webkit — hundreds of MB each, installed via `playwright install`). This
+ * helper:
+ *   - Exposes the Talon-supported @playwright/mcp version (PLAYWRIGHT_MCP_VERSION)
+ *   - Verifies the npm package is resolvable at the MCP CLI path
+ *   - Verifies the chosen browser binary is present, optionally runs
+ *     `npx playwright install <browser>` to download it
+ *   - Surfaces actionable errors when any step fails
+ *
+ * Bump PLAYWRIGHT_MCP_VERSION + the package.json pin together when the
+ * plugin has been tested and verified against a newer upstream release.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve as pathResolve } from "node:path";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+/**
+ * Pinned @playwright/mcp version. Must match the pin in package.json
+ * (`"@playwright/mcp": "<version>"`). Keep in sync on upgrade.
+ *
+ * @see https://github.com/microsoft/playwright-mcp/releases
+ */
+export const PLAYWRIGHT_MCP_VERSION = "0.0.70";
+
+/** Browsers Playwright can automate, mapped to canonical `playwright install` names. */
+export const SUPPORTED_BROWSERS = [
+  "chromium",
+  "chrome",
+  "firefox",
+  "webkit",
+  "msedge",
+] as const;
+
+export type SupportedBrowser = (typeof SUPPORTED_BROWSERS)[number];
+
+export type InstallStatus = {
+  /** True when the MCP CLI is resolvable and (if checked) the browser is installed. */
+  ok: boolean;
+  /** Detected installed @playwright/mcp version, or null if not resolvable. */
+  version: string | null;
+  /** Browser checked (if any). */
+  browser?: SupportedBrowser;
+  /** Human-readable steps taken during this ensure() call. */
+  steps: string[];
+  /** Populated when ok=false — actionable error for the user. */
+  error?: string;
+};
+
+export type EnsureOptions = {
+  /** Absolute path to `@playwright/mcp/cli.js`. */
+  mcpBin: string;
+  /**
+   * Browser to verify. When provided, a missing browser triggers a
+   * `playwright install` if {@link installBrowsers} is true.
+   * Omit when using a remote `endpoint` — no local browser needed.
+   */
+  browser?: SupportedBrowser;
+  /**
+   * If true, missing browser binaries trigger `npx playwright install <browser>`.
+   * When false, the function only diagnoses and returns an error.
+   */
+  installBrowsers: boolean;
+  /** Timeout for each subprocess call, ms. Default 300s — browser install can be slow. */
+  timeoutMs?: number;
+  /** Expected @playwright/mcp version. Defaults to {@link PLAYWRIGHT_MCP_VERSION}. */
+  expectedVersion?: string;
+  /** Injected for tests — defaults to Node's promisified execFile. */
+  execFileImpl?: typeof execFile;
+  /** Injected for tests — defaults to fs.existsSync. */
+  existsSyncImpl?: (path: string) => boolean;
+};
+
+/**
+ * Read `@playwright/mcp/package.json` adjacent to the CLI to report the
+ * installed version. Returns null if anything fails.
+ */
+export function detectMcpVersion(mcpBin: string): string | null {
+  try {
+    // mcpBin is typically .../node_modules/@playwright/mcp/cli.js
+    // → .../node_modules/@playwright/mcp/package.json
+    const pkgJson = pathResolve(dirname(mcpBin), "package.json");
+    if (!existsSync(pkgJson)) return null;
+    const pkg = JSON.parse(readFileSync(pkgJson, "utf-8")) as {
+      version?: string;
+    };
+    return pkg.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensure @playwright/mcp is installed and (optionally) the chosen browser
+ * binary is available.
+ *
+ * When installBrowsers=true this is self-healing: missing browser →
+ * `npx playwright install <browser>`. When false the function only diagnoses.
+ */
+export async function ensurePlaywrightMcpAvailable(
+  opts: EnsureOptions,
+): Promise<InstallStatus> {
+  const {
+    mcpBin,
+    browser,
+    installBrowsers,
+    timeoutMs = 300_000,
+    expectedVersion = PLAYWRIGHT_MCP_VERSION,
+    execFileImpl = execFile,
+    existsSyncImpl = existsSync,
+  } = opts;
+
+  const steps: string[] = [];
+
+  // 1. CLI present?
+  if (!existsSyncImpl(mcpBin)) {
+    return {
+      ok: false,
+      version: null,
+      browser,
+      steps,
+      error: `@playwright/mcp not found at ${mcpBin} — run "npm install" in the Talon checkout.`,
+    };
+  }
+  steps.push(`@playwright/mcp CLI present: ${mcpBin}`);
+
+  // 2. Version matches pin?
+  const version = detectMcpVersion(mcpBin);
+  if (version && version !== expectedVersion) {
+    steps.push(
+      `@playwright/mcp ${version} (expected ${expectedVersion}) — run 'npm install' to align`,
+    );
+  } else if (version) {
+    steps.push(`@playwright/mcp ${version} matches pin`);
+  }
+
+  // 3. Browser check (optional — when using remote endpoint there is no
+  //    local browser to verify).
+  if (browser) {
+    if (!SUPPORTED_BROWSERS.includes(browser)) {
+      return {
+        ok: false,
+        version,
+        browser,
+        steps,
+        error: `Invalid browser "${browser}". Valid: ${SUPPORTED_BROWSERS.join(", ")}`,
+      };
+    }
+
+    const browserOk = await isBrowserInstalled(browser, execFileImpl);
+    if (!browserOk) {
+      if (!installBrowsers) {
+        return {
+          ok: false,
+          version,
+          browser,
+          steps,
+          error: `Playwright browser "${browser}" is not installed. Run: npx playwright install ${browser} — or set playwright.installBrowsers=true to do it automatically.`,
+        };
+      }
+      steps.push(`installing playwright browser: ${browser}`);
+      try {
+        await execFileImpl("npx", ["playwright", "install", browser], {
+          timeout: timeoutMs,
+        });
+      } catch (err) {
+        const stderr = (err as { stderr?: string | Buffer }).stderr ?? "";
+        const stderrText =
+          typeof stderr === "string"
+            ? stderr
+            : Buffer.isBuffer(stderr)
+              ? stderr.toString("utf-8")
+              : "";
+        return {
+          ok: false,
+          version,
+          browser,
+          steps,
+          error: `npx playwright install ${browser} failed: ${(err as Error).message}${stderrText ? ` — ${stderrText.trim().slice(0, 400)}` : ""}`,
+        };
+      }
+      if (!(await isBrowserInstalled(browser, execFileImpl))) {
+        return {
+          ok: false,
+          version,
+          browser,
+          steps,
+          error: `playwright install ${browser} claimed success but the browser is still not detectable via 'playwright install --dry-run'.`,
+        };
+      }
+      steps.push(`browser installed: ${browser}`);
+    } else {
+      steps.push(`browser present: ${browser}`);
+    }
+  }
+
+  return { ok: true, version, browser, steps };
+}
+
+/**
+ * Detect whether a Playwright browser is installed by asking
+ * `playwright install --dry-run`, which lists what *would* be installed.
+ * If the browser is missing the command exits non-zero or prints a "will
+ * download" line. We only trust "is already installed" markers.
+ */
+async function isBrowserInstalled(
+  browser: SupportedBrowser,
+  execFileImpl: typeof execFile,
+): Promise<boolean> {
+  try {
+    const { stdout, stderr } = await execFileImpl(
+      "npx",
+      ["playwright", "install", "--dry-run", browser],
+      { timeout: 30_000 },
+    );
+    const combined = `${stdout}\n${stderr}`.toLowerCase();
+    if (
+      combined.includes("downloading") ||
+      combined.includes("will download") ||
+      combined.includes("not found")
+    ) {
+      return false;
+    }
+    // playwright prints "browser: chromium ... Install location: ..." when installed
+    return combined.includes(browser.toLowerCase());
+  } catch {
+    return false;
+  }
+}

--- a/src/plugins/playwright/install.ts
+++ b/src/plugins/playwright/install.ts
@@ -132,12 +132,22 @@ export async function ensurePlaywrightMcpAvailable(
   steps.push(`@playwright/mcp CLI present: ${mcpBin}`);
 
   // 2. Version matches pin?
+  // @playwright/mcp is pinned in package.json; alignment is owned by npm,
+  // not by us. We deliberately don't mutate node_modules at runtime — that
+  // would desync with the lockfile and surface as bizarre behavior after
+  // the next `npm ci`. Instead we return an actionable error when drift
+  // is detected, so the plugin init surfaces it clearly.
   const version = detectMcpVersion(mcpBin);
   if (version && version !== expectedVersion) {
-    steps.push(
-      `@playwright/mcp ${version} (expected ${expectedVersion}) — run 'npm install' to align`,
-    );
-  } else if (version) {
+    return {
+      ok: false,
+      version,
+      browser,
+      steps,
+      error: `@playwright/mcp ${version} is installed but Talon pins ${expectedVersion}. Run: npm install in the Talon checkout to align.`,
+    };
+  }
+  if (version) {
     steps.push(`@playwright/mcp ${version} matches pin`);
   }
 

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -110,6 +110,12 @@ const playwrightConfigSchema = z.object({
   endpoint: z.string().optional(),
   /** Read the browser websocket endpoint from a file. */
   endpointFile: z.string().optional(),
+  /**
+   * When true, init() downloads the selected browser binary via
+   * `npx playwright install <browser>` if it's not already present.
+   * Default false — opt-in to avoid surprising large downloads.
+   */
+  installBrowsers: z.boolean().optional(),
 });
 
 const configSchema = z.object({
@@ -140,6 +146,17 @@ const configSchema = z.object({
       enabled: z.boolean().default(false),
       /** GitHub personal access token (default: from `gh auth token`) */
       token: z.string().min(1).optional(),
+      /**
+       * When true, init() will `docker pull` the Talon-pinned image if it
+       * isn't present locally. Default false — opt-in to avoid surprising
+       * large downloads on first start.
+       */
+      autoPull: z.boolean().optional(),
+      /**
+       * Override the pinned Docker image tag. Advanced use only. Defaults
+       * to the constant GITHUB_MCP_IMAGE in src/plugins/github/install.ts.
+       */
+      image: z.string().min(1).optional(),
     })
     .optional(),
 


### PR DESCRIPTION
## Summary

Same treatment as #84 (mempalace) for the two remaining internal plugins. Three things for each:

1. **Pinned version** — GitHub MCP Docker image pinned via `GITHUB_MCP_IMAGE = "ghcr.io/github/github-mcp-server:v1.0.2"` (was `:latest`). `@playwright/mcp` pinned to exact `0.0.70` in package.json (was `^0.0.70` caret-drift). Both constants live in a dedicated `install.ts` module next to the plugin.

2. **Automated onboarding** — opt-in config flags. Both default `false` so we never touch the user's Docker cache or disk without consent.
   - `github.autoPull` → `docker pull` the pinned image on init if missing.
   - `playwright.installBrowsers` → `npx playwright install <browser>` on init if the browser binary isn't there.

3. **Multi-OS functional CI** — `.github/workflows/plugin-smoke.yml` with two jobs:
   - **github-mcp** — ubuntu-latest (Docker). Pulls the pinned image, spawns `docker run -i`, runs MCP `initialize` → `tools/list`, asserts core tools are present (`get_me`, `search_repositories`, `list_issues`).
   - **playwright-mcp** — matrix `ubuntu-latest / macos-latest / windows-latest × chromium`. Installs the browser, spawns `@playwright/mcp` via Node, runs `initialize` → `tools/list` → `tools/call browser_navigate about:blank` → `tools/call browser_close`, asserts expected tool names and valid response shapes.

Triggered by plugin path changes, main pushes, nightly cron (05:45 UTC), and manual dispatch.

## Files

| File | Purpose |
|---|---|
| `src/plugins/github/install.ts` | New — `GITHUB_MCP_IMAGE` + `ensureGithubMcpAvailable` |
| `src/plugins/github/index.ts` | Wires install helper into init; adds `autoPull` / `image` knobs |
| `src/plugins/playwright/install.ts` | New — `PLAYWRIGHT_MCP_VERSION`, `SUPPORTED_BROWSERS`, `ensurePlaywrightMcpAvailable` |
| `src/plugins/playwright/index.ts` | Wires install helper into init; adds `installBrowsers` knob |
| `src/util/config.ts` | New zod fields: `github.autoPull`, `github.image`, `playwright.installBrowsers` |
| `src/core/plugin.ts` | Passes new flags through |
| `package.json` | `@playwright/mcp`: `^0.0.70` → `0.0.70` |
| `src/__tests__/github-install.test.ts` | New — 8 cases on ensureGithubMcpAvailable |
| `src/__tests__/playwright-install.test.ts` | New — 10 cases on ensurePlaywrightMcpAvailable |
| `.github/workflows/plugin-smoke.yml` | New — 4-job matrix (Ubuntu Docker + 3 OS × chromium) |
| `scripts/github-mcp-smoke.mjs` | New — pull + stdio smoke driver |
| `scripts/playwright-mcp-smoke.mjs` | New — install + stdio smoke driver |
| `.gitignore` | Ignore `.playwright-mcp/` artifact dir |

## Local verification

- [x] `npx vitest run` — 1379/1379 passing
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — 0 errors
- [x] `node scripts/github-mcp-smoke.mjs smoke` — pulled v1.0.2, spawned, 41 tools detected, core subset verified
- [x] `node scripts/playwright-mcp-smoke.mjs install + smoke` — 21 tools detected, `browser_navigate` + `browser_close` both returned valid responses

## Relationship to other PRs

Independent of #83 and #84 — this one only touches github + playwright. Can merge in any order.