### PR TITLE
Improve CI coverage and require green status

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,17 @@
+{
+  "branch": "main",
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["CI Status"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}

--- a/.github/scripts/enforce-ci-gate.mjs
+++ b/.github/scripts/enforce-ci-gate.mjs
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+
+const config = JSON.parse(
+  readFileSync(new URL("../branch-protection.json", import.meta.url), "utf8"),
+);
+
+const token =
+  process.env.GITHUB_TOKEN || process.env.GH_TOKEN || readGhAuthToken();
+if (!token) {
+  throw new Error(
+    "Set GITHUB_TOKEN or GH_TOKEN with repository administration permission, or authenticate the GitHub CLI with `gh auth login`.",
+  );
+}
+
+const remote = execFileSync("git", ["remote", "get-url", "origin"], {
+  encoding: "utf8",
+}).trim();
+const match = remote.match(
+  /github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/.]+)(?:\.git)?$/,
+);
+if (!match?.groups) {
+  throw new Error(`Could not infer GitHub owner/repo from origin: ${remote}`);
+}
+
+const { owner, repo } = match.groups;
+const { branch, ...protection } = config;
+const route = `repos/${owner}/${repo}/branches/${branch}/protection`;
+const body = JSON.stringify(protection);
+
+try {
+  await applyWithFetch(route, body);
+} catch (error) {
+  const gh = spawnSync("gh", ["api", "-X", "PUT", route, "--input", "-"], {
+    input: body,
+    encoding: "utf8",
+    env: { ...process.env, GH_TOKEN: token },
+  });
+  if (gh.status !== 0) {
+    throw new Error(
+      `Failed to protect ${owner}/${repo}@${branch}.\nfetch error: ${
+        error instanceof Error ? error.message : error
+      }\ngh error: ${gh.stderr || gh.stdout}`,
+    );
+  }
+}
+
+console.log(
+  `Protected ${owner}/${repo}@${branch}: required status check "CI Status" must pass before merge.`,
+);
+
+async function applyWithFetch(route, body) {
+  const response = await fetch(`https://api.github.com/${route}`, {
+    method: "PUT",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `${response.status} ${response.statusText}\n${await response.text()}`,
+    );
+  }
+}
+
+function readGhAuthToken() {
+  try {
+    return execFileSync("gh", ["auth", "token"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}

--- a/.github/scripts/vitest-summary.mjs
+++ b/.github/scripts/vitest-summary.mjs
@@ -1,0 +1,42 @@
+import { existsSync, readFileSync, appendFileSync } from "node:fs";
+
+const [resultPath, title, coveragePath] = process.argv.slice(2);
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+if (!summaryPath || !resultPath || !existsSync(resultPath)) {
+  process.exit(0);
+}
+
+const result = JSON.parse(readFileSync(resultPath, "utf8"));
+const durationMs =
+  result.testResults?.reduce(
+    (sum, suite) => sum + Math.max(0, suite.endTime - suite.startTime),
+    0,
+  ) ?? 0;
+
+const lines = [
+  `### ${title ?? "Vitest Results"}`,
+  "",
+  "| Metric | Value |",
+  "|--------|-------|",
+  `| Suites | ${result.numTotalTestSuites ?? 0} |`,
+  `| Passed | ${result.numPassedTests ?? 0} |`,
+  `| Failed | ${result.numFailedTests ?? 0} |`,
+  `| Total | ${result.numTotalTests ?? 0} |`,
+  `| Duration | ${(durationMs / 1000).toFixed(1)}s |`,
+  "",
+];
+
+if (coveragePath && existsSync(coveragePath)) {
+  const coverage = JSON.parse(readFileSync(coveragePath, "utf8")).total;
+  lines.push("### Coverage Report", "");
+  lines.push("| Category | Coverage |", "|----------|----------|");
+  for (const [key, value] of Object.entries(coverage)) {
+    lines.push(
+      `| ${key.charAt(0).toUpperCase()}${key.slice(1)} | ${value.pct}% |`,
+    );
+  }
+  lines.push("");
+}
+
+appendFileSync(summaryPath, `${lines.join("\n")}\n`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
 
       - name: Format check
         run: npm run format:check
-        continue-on-error: true
 
   # ── Unit & integration tests + coverage ────────────────────────
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
-          token: ${{ secrets.PAT || github.token }}
 
       - uses: actions/setup-node@v6
         with:
@@ -47,37 +44,34 @@ jobs:
           fi
 
       - name: Dead code analysis (informational)
-        run: npx knip --no-exit-code
+        run: npm run knip -- --no-exit-code
         continue-on-error: true
 
       - name: Format check
-        id: format-check
         run: npm run format:check
         continue-on-error: true
 
-      - name: Auto-format and push
-        if: steps.format-check.outcome == 'failure'
-        run: |
-          npm run format
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --cached --quiet; then
-            echo "No formatting changes needed"
-            exit 0
-          fi
-          git commit -m "style: auto-format with prettier"
-          git push
-
   # ── Unit & integration tests + coverage ────────────────────────
   test:
-    name: Tests (Node ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    name: Tests (${{ matrix.os }}, Node ${{ matrix.node-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 24]
+        include:
+          - os: ubuntu-latest
+            node-version: 22
+            coverage: true
+          - os: ubuntu-latest
+            node-version: 24
+            coverage: false
+          - os: macos-latest
+            node-version: 22
+            coverage: false
+          - os: windows-latest
+            node-version: 22
+            coverage: false
     steps:
       - uses: actions/checkout@v6
 
@@ -89,67 +83,32 @@ jobs:
       - run: npm ci
 
       - name: Run tests
-        if: matrix.node-version != 22
-        run: npx vitest run --reporter=verbose --reporter=json --outputFile=test-results.json
+        if: ${{ !matrix.coverage }}
+        run: npm run test:ci
 
       - name: Run tests with coverage
-        if: matrix.node-version == 22
+        if: ${{ matrix.coverage }}
         run: npx vitest run --coverage --reporter=verbose --reporter=json --outputFile=test-results.json
 
       - name: Test summary
         if: always()
-        run: |
-          if [ -f test-results.json ]; then
-            PASSED=$(node -e "const r=JSON.parse(require('fs').readFileSync('test-results.json','utf8')); console.log(r.numPassedTests ?? 0)")
-            FAILED=$(node -e "const r=JSON.parse(require('fs').readFileSync('test-results.json','utf8')); console.log(r.numFailedTests ?? 0)")
-            TOTAL=$(node -e "const r=JSON.parse(require('fs').readFileSync('test-results.json','utf8')); console.log(r.numTotalTests ?? 0)")
-            SUITES=$(node -e "const r=JSON.parse(require('fs').readFileSync('test-results.json','utf8')); console.log(r.numTotalTestSuites ?? 0)")
-            DURATION=$(node -e "const r=JSON.parse(require('fs').readFileSync('test-results.json','utf8')); const ms=r.testResults?.reduce((s,t)=>s+(t.endTime-t.startTime),0)??0; console.log((ms/1000).toFixed(1))")
-            echo "### Test Results (Node ${{ matrix.node-version }})" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
-            echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
-            echo "| Suites | $SUITES |" >> $GITHUB_STEP_SUMMARY
-            echo "| Passed | $PASSED |" >> $GITHUB_STEP_SUMMARY
-            echo "| Failed | $FAILED |" >> $GITHUB_STEP_SUMMARY
-            echo "| Total  | $TOTAL |" >> $GITHUB_STEP_SUMMARY
-            echo "| Duration | ${DURATION}s |" >> $GITHUB_STEP_SUMMARY
-          fi
+        run: node .github/scripts/vitest-summary.mjs test-results.json "Tests (${{ matrix.os }}, Node ${{ matrix.node-version }})" coverage/coverage-summary.json
 
       - name: Validate coverage report
-        if: matrix.node-version == 22
+        if: ${{ matrix.coverage }}
         run: |
-          if [ ! -f coverage/coverage-summary.json ]; then
-            echo "::error::Coverage report not generated"
-            exit 1
-          fi
-
-      - name: Coverage summary
-        if: always() && matrix.node-version == 22
-        run: |
-          if [ -f coverage/coverage-summary.json ]; then
-            echo "### Coverage Report" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "| Category | Coverage |" >> $GITHUB_STEP_SUMMARY
-            echo "|----------|----------|" >> $GITHUB_STEP_SUMMARY
-            node -e "
-              const c = JSON.parse(require('fs').readFileSync('coverage/coverage-summary.json','utf8')).total;
-              for (const [k,v] of Object.entries(c)) {
-                console.log('| ' + k.charAt(0).toUpperCase() + k.slice(1) + ' | ' + v.pct + '% |');
-              }
-            " >> $GITHUB_STEP_SUMMARY
-          fi
+          node -e "if (!require('fs').existsSync('coverage/coverage-summary.json')) { console.error('Coverage report not generated'); process.exit(1); }"
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-results-node-${{ matrix.node-version }}
+          name: test-results-${{ matrix.os }}-node-${{ matrix.node-version }}
           path: test-results.json
           retention-days: 14
 
       - name: Upload coverage
-        if: always() && matrix.node-version == 22
+        if: always() && matrix.coverage
         uses: actions/upload-artifact@v7
         with:
           name: coverage-report
@@ -163,7 +122,7 @@ jobs:
   functional-cross-platform:
     name: Functional (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -178,8 +137,20 @@ jobs:
 
       - run: npm ci
 
-      - name: Run launcher functional tests
-        run: npx vitest run src/__tests__/mcp-launcher-functional.test.ts src/__tests__/mcp-launcher.test.ts
+      - name: Run cross-platform functional tests
+        run: npm run test:functional
+
+      - name: Functional summary
+        if: always()
+        run: node .github/scripts/vitest-summary.mjs functional-results.json "Functional (${{ matrix.os }})"
+
+      - name: Upload functional results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: functional-results-${{ matrix.os }}
+          path: functional-results.json
+          retention-days: 14
 
   # ── Fuzz testing (property-based with fast-check) ─────────────
   fuzz:
@@ -203,17 +174,15 @@ jobs:
 
       - name: Fuzz summary
         if: always()
-        run: |
-          if [ -f fuzz-results.json ]; then
-            PASSED=$(node -e "const r=JSON.parse(require('fs').readFileSync('fuzz-results.json','utf8')); console.log(r.numPassedTests ?? 0)")
-            FAILED=$(node -e "const r=JSON.parse(require('fs').readFileSync('fuzz-results.json','utf8')); console.log(r.numFailedTests ?? 0)")
-            TOTAL=$(node -e "const r=JSON.parse(require('fs').readFileSync('fuzz-results.json','utf8')); console.log(r.numTotalTests ?? 0)")
-            echo "### Fuzz Test Results (10,000 iterations/property)" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "| Passed | Failed | Total |" >> $GITHUB_STEP_SUMMARY
-            echo "|--------|--------|-------|" >> $GITHUB_STEP_SUMMARY
-            echo "| $PASSED | $FAILED | $TOTAL |" >> $GITHUB_STEP_SUMMARY
-          fi
+        run: node .github/scripts/vitest-summary.mjs fuzz-results.json "Fuzz Test Results (10,000 iterations/property)"
+
+      - name: Upload fuzz results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-results
+          path: fuzz-results.json
+          retention-days: 14
 
   # ── Security audit ────────────────────────────────────────────
   security:

--- a/package.json
+++ b/package.json
@@ -41,13 +41,16 @@
     "setup": "tsx src/cli.ts setup",
     "dev": "tsx --watch src/index.ts",
     "test": "vitest run",
+    "test:ci": "vitest run --reporter=verbose --reporter=json --outputFile=test-results.json",
+    "test:functional": "vitest run --reporter=verbose --reporter=json --outputFile=functional-results.json src/__tests__/package.functional.test.ts src/__tests__/tool-functional.test.ts src/__tests__/mcp-launcher.test.ts src/__tests__/mcp-launcher-functional.test.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint src/",
     "knip": "knip",
     "format": "prettier --write src/ prompts/",
-    "format:check": "prettier --check src/ prompts/"
+    "format:check": "prettier --check src/ prompts/",
+    "ci:protect": "node .github/scripts/enforce-ci-gate.mjs"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.108",

--- a/src/__tests__/package.functional.test.ts
+++ b/src/__tests__/package.functional.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../..");
+const FUNCTIONAL_TIMEOUT_MS = 180_000;
+const NPM_CLI = process.env.npm_execpath;
+
+type RunResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+const workDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of workDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}, 60_000);
+
+function makeWorkDir(name: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `talon-${name}-`));
+  workDirs.push(dir);
+  return dir;
+}
+
+function childEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    TALON_QUIET: "1",
+    NO_COLOR: "1",
+  };
+}
+
+function run(
+  command: string,
+  args: string[],
+  options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    timeoutMs?: number;
+    shell?: boolean;
+  } = {},
+): RunResult {
+  const child = spawnSync(command, args, {
+    cwd: options.cwd ?? REPO_ROOT,
+    env: options.env ?? process.env,
+    encoding: "utf8",
+    timeout: options.timeoutMs ?? 30_000,
+    windowsHide: true,
+    shell: options.shell ?? false,
+  });
+
+  return {
+    code: child.status,
+    stdout: child.stdout ?? "",
+    stderr: child.error
+      ? `${child.stderr ?? ""}\n${child.error.message}`
+      : (child.stderr ?? ""),
+  };
+}
+
+function runNpm(
+  args: string[],
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; timeoutMs?: number } = {},
+): RunResult {
+  if (NPM_CLI) return run(process.execPath, [NPM_CLI, ...args], options);
+  return run(process.platform === "win32" ? "npm.cmd" : "npm", args, {
+    ...options,
+    shell: process.platform === "win32",
+  });
+}
+
+function expectOk(result: RunResult): void {
+  expectExitOk(result);
+  expect(
+    result.stderr,
+    `process exited with ${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  ).toBe("");
+}
+
+function expectExitOk(result: RunResult): void {
+  expect(
+    result.stderr,
+    `process exited with ${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  ).not.toContain("spawnSync");
+  expect(result.code).toBe(0);
+}
+
+function packInto(dir: string): string {
+  const result = runNpm(["pack", "--json", "--pack-destination", dir], {
+    timeoutMs: 30_000,
+  });
+  expectOk(result);
+
+  const entries = JSON.parse(result.stdout) as Array<{
+    filename: string;
+    files: Array<{ path: string }>;
+  }>;
+  const pack = entries[0];
+  expect(pack).toBeDefined();
+
+  const packedFiles = new Set(pack.files.map((file) => file.path));
+  for (const required of [
+    "bin/talon.js",
+    "src/cli.ts",
+    "src/util/mcp-launcher.mjs",
+    "prompts/base.md",
+    "tsconfig.json",
+  ]) {
+    expect(packedFiles.has(required), `${required} should be packed`).toBe(
+      true,
+    );
+  }
+
+  return join(dir, pack.filename);
+}
+
+describe("package functional smoke tests", () => {
+  it(
+    "published tarball includes runtime assets and exposes a working CLI",
+    () => {
+      const packDir = makeWorkDir("pack");
+      const installDir = makeWorkDir("install");
+      const homeDir = makeWorkDir("home");
+      const tarball = packInto(packDir);
+
+      writeFileSync(join(installDir, "package.json"), "{}\n");
+      expectExitOk(
+        runNpm(
+          ["install", "--ignore-scripts", "--no-audit", "--no-fund", tarball],
+          {
+            cwd: installDir,
+            timeoutMs: FUNCTIONAL_TIMEOUT_MS,
+          },
+        ),
+      );
+
+      const cli = join(
+        installDir,
+        "node_modules",
+        "talon-agent",
+        "bin",
+        "talon.js",
+      );
+      const help = run(process.execPath, [cli, "--help"], {
+        cwd: installDir,
+        env: childEnv(homeDir),
+      });
+
+      expectOk(help);
+      expect(help.stdout).toContain("Usage: talon [command]");
+      expect(help.stdout).toContain("doctor");
+    },
+    FUNCTIONAL_TIMEOUT_MS,
+  );
+
+  it("source CLI status command is non-interactive and isolated from the real home directory", () => {
+    const homeDir = makeWorkDir("source-home");
+    const result = run(process.execPath, ["bin/talon.js", "status"], {
+      env: childEnv(homeDir),
+    });
+
+    expectOk(result);
+    expect(result.stdout).toContain("Stopped");
+    expect(result.stdout).toContain("Run talon setup");
+  });
+});


### PR DESCRIPTION
## Summary
- expand CI testing across Ubuntu, macOS, and Windows with Node 22 plus Ubuntu Node 24
- add cross-platform functional coverage for package tarball contents, installed CLI startup, existing tool/action wiring, and MCP launcher process teardown
- add reusable Vitest summary artifacts and a checked-in branch-protection script/config requiring the aggregate `CI Status` gate

## Verification
- `npm test`
- `npm run test:functional`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run format:check` (clean)
- `npm run ci:protect`

## Notes
- Branch protection has been applied to `main`: strict required status check `CI Status` is enabled.
- `format:check` is now strict — a Prettier failure fails the Code Quality job and blocks merge through the `CI Status` gate.
- `knip` (dead code analysis) remains explicitly informational; the step name advertises that. Making it strict today would surface ~23 unused exports/types across `src/backend/opencode/`, `src/core/`, and `src/frontend/terminal/` that would need a separate cleanup.
