### PR TITLE
fix: six correctness and safety bugs (timer leak, HTML injection, log component, flush consistency, status regex)

### DIFF
--- a/src/__tests__/cron-store.test.ts
+++ b/src/__tests__/cron-store.test.ts
@@ -426,24 +426,21 @@ describe("cron-store", () => {
       });
     });
 
-    it("does not write when not dirty", () => {
-      // flushCronJobs calls save() which checks dirty flag.
-      // Since we haven't modified anything since last flush, the writeFileSync
-      // should not be called. But flushCronJobs doesn't set dirty=true like
-      // flushHistory does. Let's verify that behavior.
-      // Actually, looking at the code: flushCronJobs just calls save() directly
-      // without setting dirty=true. So if nothing was modified, it won't write.
+    it("always writes on flush, even when nothing changed (defensive flush pattern)", () => {
+      // flushCronJobs forces dirty=true before save() to guarantee the final
+      // write happens even if the auto-save timer ran just before shutdown
+      // and reset dirty to false. This matches the pattern in flushSessions /
+      // flushHistory and protects against silently dropping the last
+      // recordCronRun update on a SIGTERM that races the autosave window.
       writeFileSyncMock.mockClear();
-      existsSyncMock.mockReturnValue(true);
-
-      // Load cleans state, then flush immediately should be no-op
       existsSyncMock.mockReturnValue(false);
       loadCronJobs();
       writeFileSyncMock.mockClear();
       flushCronJobs();
 
-      // After loadCronJobs + no changes, dirty is false, so save() should not write
-      expect(writeFileSyncMock).not.toHaveBeenCalled();
+      // After loadCronJobs + no changes, dirty would be false, but
+      // flushCronJobs forces it to true so save() must still write.
+      expect(writeFileSyncMock).toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/dream.test.ts
+++ b/src/__tests__/dream.test.ts
@@ -956,11 +956,19 @@ describe("runDreamAgent — timeout arrow fn fires after DREAM_TIMEOUT_MS", () =
         dailyMemory: "/fake/.talon/workspace/memory/daily",
       },
     }));
-    // query never resolves — so the 10-minute timeout wins the race
+    // query stays pending until we externally resolve `agentDone`. This lets
+    // the 10-minute timeout win the race, then we simulate the agent finishing
+    // so the `await agentPromise.catch(() => {})` in the catch block (which
+    // matches the heartbeat.ts pattern — wait for the underlying subprocess
+    // before releasing the lock) can complete instead of hanging the test.
+    let resolveAgent: () => void;
+    const agentDone = new Promise<void>((r) => {
+      resolveAgent = r;
+    });
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
       query: vi.fn(async function* () {
         yield; // satisfy require-yield
-        await new Promise(() => {}); // never resolves
+        await agentDone;
       }),
     }));
 
@@ -970,6 +978,10 @@ describe("runDreamAgent — timeout arrow fn fires after DREAM_TIMEOUT_MS", () =
     const dreamPromise = mod.forceDream().catch(() => {});
     // Advance past DREAM_TIMEOUT_MS (10 minutes) to fire the setTimeout reject callback
     await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1);
+    // Simulate the underlying agent subprocess finishing post-timeout so the
+    // catch block's `await agentPromise.catch(...)` resolves and the dream
+    // promise can reject with the timeout error.
+    resolveAgent!();
     await dreamPromise;
 
     vi.useRealTimers();

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -201,10 +201,23 @@ describe("classify", () => {
   });
 
   it("uses extracted status instead of 429 default when status present", () => {
-    // "503" would match overloaded first, so use a message that hits rate_limit with a non-429 status
-    const err = classify(new Error("rate limit hit, error 200 ok"));
+    // The status regex now only matches 4xx/5xx error codes — 2xx/3xx values
+    // appearing in error messages (e.g. "took 200ms", "position 301") are
+    // ignored to avoid spurious status stamps. Use a 4xx code that does not
+    // trigger another classifier branch to verify extraction still works.
+    const err = classify(new Error("rate limit hit, error 418 teapot"));
     expect(err.reason).toBe("rate_limit");
-    expect(err.status).toBe(200);
+    expect(err.status).toBe(418);
+  });
+
+  it("ignores 2xx/3xx numbers in error messages (status regex narrowed to 4xx/5xx)", () => {
+    // Regression for the spurious-status bug: numbers like "200ms" or
+    // "position 301" used to be extracted as TalonError.status, polluting
+    // diagnostic logs. The classifier should fall back to the rate_limit
+    // default (429) instead of stamping the unrelated number.
+    const err = classify(new Error("rate limit hit, took 200ms"));
+    expect(err.reason).toBe("rate_limit");
+    expect(err.status).toBe(429);
   });
 
   // Mutant killers: overloaded/503/capacity branch

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -213,12 +213,15 @@ If commands fail, log the error and continue — this stage is optional.`
     disallowedTools: [...DISALLOWED_TOOLS_BACKGROUND],
   };
 
-  const timeoutPromise = new Promise<never>((_, reject) =>
-    setTimeout(
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    const t = setTimeout(
       () => reject(new Error("Dream agent timed out")),
       DREAM_TIMEOUT_MS,
-    ),
-  );
+    );
+    t.unref(); // Don't prevent Node.js from exiting cleanly during shutdown
+    timeoutHandle = t;
+  });
 
   const agentPromise = (async () => {
     const qi = query({
@@ -241,7 +244,12 @@ If commands fail, log the error and continue — this stage is optional.`
       dreamLogFile,
       `\n---\n**Dream FAILED at ${new Date().toISOString()}:** ${err}\n`,
     );
+    // On timeout, wait for the agent to actually finish before releasing the
+    // dreaming lock to prevent overlapping dream runs
+    await agentPromise.catch(() => {});
     throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
   return dreamLogFile;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -68,8 +68,10 @@ export function classify(err: unknown): TalonError {
   }
   const cause = err instanceof Error ? err : undefined;
 
-  // Extract HTTP status if present
-  const statusMatch = msg.match(/\b([2-5]\d{2})\b/);
+  // Extract HTTP error status if present (4xx/5xx only — success codes are
+  // not actionable and matching them from unrelated numbers, e.g. "200ms",
+  // would produce a spurious status on the returned TalonError)
+  const statusMatch = msg.match(/\b([45]\d{2})\b/);
   const status = statusMatch ? parseInt(statusMatch[1], 10) : undefined;
 
   // Rate limit

--- a/src/frontend/telegram/formatting.ts
+++ b/src/frontend/telegram/formatting.ts
@@ -80,9 +80,10 @@ export function markdownToTelegramHtml(text: string): string {
   );
   // Italic: _text_ (surrounded by non-word or start/end)
   processed = processed.replace(/(?<!\w)_(.+?)_(?!\w)/g, "<i>$1</i>");
-  // Links: [text](url) — only allow safe URL schemes
+  // Links: [text](url) — only allow safe URL schemes; escape the URL to
+  // prevent HTML attribute injection (e.g. href="url" onmouseover="x")
   processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) =>
-    /^https?:\/\//i.test(url) ? `<a href="${url}">${text}</a>` : text,
+    /^https?:\/\//i.test(url) ? `<a href="${escapeHtml(url)}">${text}</a>` : text,
   );
   // Strikethrough: ~~text~~
   processed = processed.replace(/~~(.+?)~~/g, "<s>$1</s>");

--- a/src/frontend/telegram/formatting.ts
+++ b/src/frontend/telegram/formatting.ts
@@ -83,7 +83,9 @@ export function markdownToTelegramHtml(text: string): string {
   // Links: [text](url) — only allow safe URL schemes; escape the URL to
   // prevent HTML attribute injection (e.g. href="url" onmouseover="x")
   processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) =>
-    /^https?:\/\//i.test(url) ? `<a href="${escapeHtml(url)}">${text}</a>` : text,
+    /^https?:\/\//i.test(url)
+      ? `<a href="${escapeHtml(url)}">${text}</a>`
+      : text,
   );
   // Strikethrough: ~~text~~
   processed = processed.replace(/~~(.+?)~~/g, "<s>$1</s>");

--- a/src/storage/chat-settings.ts
+++ b/src/storage/chat-settings.ts
@@ -111,6 +111,7 @@ registerCleanup(save);
 /** Flush settings to disk and stop the auto-save timer. */
 export function flushChatSettings(): void {
   clearInterval(autoSaveTimer);
+  dirty = true;
   save();
 }
 

--- a/src/storage/cron-store.ts
+++ b/src/storage/cron-store.ts
@@ -126,6 +126,7 @@ registerCleanup(save);
 /** Flush cron jobs to disk and stop the auto-save timer. */
 export function flushCronJobs(): void {
   clearInterval(autoSaveTimer);
+  dirty = true;
   save();
 }
 

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -56,7 +56,7 @@ export function loadHistory(): void {
         const trimmed = messages.slice(-MAX_HISTORY_PER_CHAT);
         chatHistories.set(chatId, trimmed);
       }
-      log("sessions", `Loaded history for ${chatHistories.size} chat(s)`);
+      log("history", `Loaded history for ${chatHistories.size} chat(s)`);
     }
   } catch {
     // Primary file corrupt — try backup
@@ -71,7 +71,7 @@ export function loadHistory(): void {
           chatHistories.set(chatId, messages.slice(-MAX_HISTORY_PER_CHAT));
         }
         logError(
-          "sessions",
+          "history",
           "Loaded history from backup (primary was corrupt)",
         );
         return;

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -70,10 +70,7 @@ export function loadHistory(): void {
         for (const [chatId, messages] of Object.entries(raw)) {
           chatHistories.set(chatId, messages.slice(-MAX_HISTORY_PER_CHAT));
         }
-        logError(
-          "history",
-          "Loaded history from backup (primary was corrupt)",
-        );
+        logError("history", "Loaded history from backup (primary was corrupt)");
         return;
       }
     } catch {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Deep review of the codebase found six concrete bugs across five files. All fixes are small and surgical — no refactoring, no behaviour changes beyond the bug fixes.

---

### Bug 1 — `dream.ts`: Timeout timer not cleared → `UnhandledPromiseRejection` + event-loop leak

**File:** `src/core/dream.ts`

The 10-minute safety timeout inside `runDreamAgent` was created but its handle was never captured, so:

1. The timer was never `.unref()`'d — it kept the Node.js event loop alive after a successful dream completed.
2. When the dream finished before the timeout, the timer eventually fired and rejected a `Promise` that nobody was awaiting, emitting an `UnhandledPromiseRejection` warning ~10 minutes later.
3. On a genuine timeout, the dreaming lock was released before the underlying agent subprocess had actually finished, allowing a second dream run to overlap.

**Fix:** Capture the handle, call `.unref()`, clear it in a `finally` block, and wait for the agent promise on timeout before rethrowing — matching the pattern already correct in `heartbeat.ts`.

---

### Bug 2 — `formatting.ts`: URL not HTML-escaped in `href` → HTML attribute injection

**File:** `src/frontend/telegram/formatting.ts`

In `markdownToTelegramHtml`, the URL captured from a `[text](url)` markdown link was inserted directly into the `<a href="…">` attribute without escaping:

```ts
// Before
`<a href="${url}">${text}</a>`
```

A URL such as `https://a.com" onmouseover="x` would produce `<a href="https://a.com" onmouseover="x">text</a>`, injecting arbitrary HTML attributes.

**Fix:** Apply `escapeHtml(url)` before embedding the URL in the `href`.

---

### Bug 3 — `history.ts`: Wrong log component (`"sessions"` → `"history"`)

**File:** `src/storage/history.ts`

Two logging calls in `loadHistory()` passed `"sessions"` as the component:

```ts
log("sessions", `Loaded history for ${chatHistories.size} chat(s)`);
logError("sessions", "Loaded history from backup (primary was corrupt)");
```

These are history-load events and should use `"history"`, which is the correct `LogComponent` for this module. The wrong tag causes these events to appear under `sessions` in structured logs, making triage harder.

---

### Bug 4 — `cron-store.ts` / `chat-settings.ts`: Missing `dirty = true` in flush functions

**Files:** `src/storage/cron-store.ts`, `src/storage/chat-settings.ts`

`flushCronJobs()` and `flushChatSettings()` call `save()` without first setting `dirty = true`. Because `save()` is a no-op when `dirty === false`, a shutdown that races with the auto-save timer (which resets `dirty` to `false` after writing) could silently skip the final flush — e.g. `recordCronRun` sets `dirty = true`, the auto-save fires and sets it back to `false`, then SIGTERM arrives and `flushCronJobs()` is a no-op even though there was no other opportunity to persist the last run timestamp.

`flushSessions()` and `flushHistory()` both already guard against this by forcing `dirty = true` before the final save. The fix brings the cron and settings stores into line with that defensive pattern.

---

### Bug 5 — `errors.ts`: Status-code regex matches 2xx/3xx codes

**File:** `src/core/errors.ts`

The regex used to extract an HTTP status code from error messages:

```ts
// Before
const statusMatch = msg.match(/\b([2-5]\d{2})\b/);
```

This matches 2xx and 3xx codes in addition to the 4xx/5xx error codes that the classifier actually acts on. Any number in the range 200–399 found in an error message string (e.g. `"took 200ms"`, `"position 301"`) could be extracted and stamped onto the returned `TalonError.status`, making diagnostic logs misleading.

**Fix:** Narrow the regex to `/\b([45]\d{2})\b/` — only match error-range codes.

---

## Test plan

- [ ] Confirm TypeScript compiles cleanly: `npm run typecheck`
- [ ] Run unit tests: `npm test`
- [ ] For `dream.ts`: verify no `UnhandledPromiseRejection` appears in logs after a dream completes normally
- [ ] For `formatting.ts`: confirm `markdownToTelegramHtml('[x](https://a.com" onX="y)')` no longer injects the `onX` attribute
- [ ] For `history.ts`: confirm `loadHistory()` logs now appear under the `history` component
- [ ] For `cron-store.ts` / `chat-settings.ts`: confirm flush always writes even when auto-save ran just before shutdown
- [ ] For `errors.ts`: confirm an error message containing `"200ms"` is not given `status: 200`

https://claude.ai/code/session_01Xq1CTjS2UG5ErEbqVaELRn
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xq1CTjS2UG5ErEbqVaELRn)_