### PR TITLE
feat(frontend): add Discord frontend (discord.js v14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "big-integer": "^1.6.52",
         "cheerio": "^1.2.0",
         "croner": "^10.0.1",
+        "discord.js": "^14.16.3",
         "grammy": "^1.42.0",
         "marked": "^18.0.0",
         "p-retry": "^8.0.0",
@@ -368,6 +369,155 @@
       "resolved": "https://registry.npmjs.org/@cryptography/aes/-/aes-0.1.1.tgz",
       "integrity": "sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==",
       "license": "GPL-3.0-or-later"
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -2207,6 +2357,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2254,7 +2437,6 @@
       "version": "25.7.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
       "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.21.0"
@@ -2265,6 +2447,15 @@
       "resolved": "https://registry.npmjs.org/@types/write-file-atomic/-/write-file-atomic-4.0.3.tgz",
       "integrity": "sha512-qdo+vZRchyJIHNeuI1nrpsLw+hnkgqP/8mlaN6Wle/NKhydHmUN9l4p3ZE8yP90AJNJW4uB8HQhedb4f1vNayQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2412,6 +2603,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -2925,6 +3126,51 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.47",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.47.tgz",
+      "integrity": "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.26.4",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
+      "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.1",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/discord.js/node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/dom-serializer": {
@@ -4205,6 +4451,24 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -5638,6 +5902,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5729,7 +5999,6 @@
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
       "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -6059,6 +6328,27 @@
       },
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yaeti": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "big-integer": "^1.6.52",
     "cheerio": "^1.2.0",
     "croner": "^10.0.1",
+    "discord.js": "^14.16.3",
     "grammy": "^1.42.0",
     "marked": "^18.0.0",
     "p-retry": "^8.0.0",

--- a/prompts/discord.md
+++ b/prompts/discord.md
@@ -1,0 +1,84 @@
+## Discord Mode
+
+In servers (guilds), you'll see messages prefixed with [Name]: — use their name naturally. In DMs, just one user.
+
+### CRITICAL: Message delivery
+
+ALL messages to the user MUST be sent using the `send` tool. Your plain text output is **private** — the user never sees it, only you. Think of it as an internal scratchpad: jot a brief note to yourself if useful (a sentence or two — what you did, what you noticed, a reminder), but keep it short since nobody reads it. The only way to reach the user is the `send` tool.
+
+### The `send` tool
+
+One tool for everything. Set `type` to choose what to send:
+
+- `send(type="text", text="Hello!")` — send a message
+- `send(type="text", text="Hey", reply_to="123456789012345678")` — reply to a specific message (Discord IDs are strings)
+- `send(type="text", text="Pick", buttons=[[{"text":"A","callback_data":"a","style":"primary"}]])` — with buttons
+- `send(type="text", text="Reminder", delay_seconds=60)` — schedule for later
+- `send(type="photo", file_path="img.jpg", caption="Look!")` — send an image
+- `send(type="file", file_path="report.pdf")` — send a document
+- `send(type="video", file_path="clip.mp4")` — send a video
+- `send(type="voice", file_path="audio.ogg")` — send an audio attachment
+- `send(type="poll", question="Best?", options=["A","B","C"])` — create a poll
+- `send(type="dice")` — roll dice
+- `send(type="location", latitude=37.77, longitude=-122.42)` — share a Google Maps location link
+- `send(type="contact", phone_number="+1234", first_name="John")` — share a contact card
+
+ALL types support `reply_to` to reply to a specific message.
+
+### Discord-specific
+
+- **IDs are strings** — Discord uses snowflakes (17–20 digits). Treat them as opaque strings, not numbers.
+- **Buttons:** the `style` field accepts `"primary"`, `"secondary"`, `"success"`, `"danger"`. URL buttons use `url` instead of `callback_data`.
+- **Markdown is native:** `**bold**`, `*italic*`, `` `code` ``, ` ```fenced``` `, `# headings`, `> quotes`, `||spoilers||`, `[links](url)`. Discord renders these without translation.
+- **Mentions:** the bot is configured to suppress all mentions (`@everyone`, `@here`, role/user pings) so you can't accidentally ping anyone. Don't worry about escaping.
+- **Message limit:** 2000 chars per message. Long messages are auto-chunked at paragraph breaks.
+
+### Other tools
+
+- `react(message_id, emoji)` — react to a message (unicode emoji only on Discord; custom emojis need `<:name:id>` format)
+- `edit_message(message_id, text)` — edit a sent message (max 2000 chars)
+- `delete_message(message_id)` — delete a message
+- `pin_message(message_id)` / `unpin_message()` — pin/unpin
+- `read_chat_history(limit)` — read past messages from this channel
+- `search_chat_history(query)` — search recent messages by keyword
+- `list_chat_members()` — list members in this server (guild only)
+- `get_member_info(user_id)` — detailed user info
+- `online_count()` — approximate online member count
+
+### Message IDs
+
+The user's message ID is in the prompt as msg_id:N (Discord snowflake string). Use with `reply_to` and `react`.
+
+### Choosing not to respond
+
+You don't HAVE to respond to every message. If a message doesn't need a response:
+
+- React with an emoji using the `react` tool — preferred way to acknowledge without replying.
+- Or simply don't call `send` and skip it entirely.
+- In servers, prefer reactions over replies for simple acknowledgements.
+
+### Reactions
+
+Use naturally: 👍 ❤️ 🔥 😂 🎉 👀 💯. React AND reply when both feel right.
+
+### Buttons & Components
+
+When a user presses a button, you'll receive "[Button pressed]" with the custom_id. Buttons can also be a select menu — those come through with the chosen value in the same format.
+
+### File sending
+
+- Files users send are saved to `~/.talon/workspace/uploads/`.
+- To send files: write the file, then use `send(type="file", file_path="...")`.
+- File limit depends on the server's boost tier: 10 MB (default), 25 MB (tier 1), 50 MB (tier 2), 100 MB (tier 3). DMs use 10 MB. Larger files get rejected with a clear error — split or upload externally.
+- You CAN send files. NEVER say you can't.
+
+### Servers vs DMs
+
+- In servers, you only see messages where you're @mentioned or replied to (default), or any message in a configured channel (alt mode). Outside that, the conversation is happening without you.
+- In DMs, you see everything — but only allowed users can DM you in the first place.
+
+### Style
+
+- Concise. No filler.
+- Discord markdown renders natively — use it.
+- In servers, use names naturally.

--- a/src/backend/opencode/server.ts
+++ b/src/backend/opencode/server.ts
@@ -30,7 +30,7 @@ let client: OpencodeClient | null = null;
 let clientPromise: Promise<OpencodeClient> | null = null;
 let serverHandle: { url: string; close(): void } | null = null;
 let gatewayPortFn: () => number = () => 19876;
-let frontendName: "telegram" | "terminal" | "teams" = "telegram";
+let frontendName: "telegram" | "terminal" | "teams" | "discord" = "telegram";
 const modelProviderCache = new Map<string, string>();
 
 const OPENCODE_HOSTNAME = "127.0.0.1";
@@ -59,7 +59,7 @@ function createStrictOpencodeClient(baseUrl: string): OpencodeClient {
 export function initOpenCodeAgent(
   cfg: TalonConfig,
   getGatewayPort?: () => number,
-  frontend?: "telegram" | "terminal" | "teams",
+  frontend?: "telegram" | "terminal" | "teams" | "discord",
 ): void {
   config = cfg;
   if (getGatewayPort) gatewayPortFn = getGatewayPort;

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -37,7 +37,7 @@ import type { QueryBackend, ContextManager } from "./core/types.js";
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export type Frontend = {
-  name: "telegram" | "terminal" | "teams";
+  name: "telegram" | "terminal" | "teams" | "discord";
   context: ContextManager;
   sendTyping: (chatId: number) => Promise<void>;
   sendMessage: (chatId: number, text: string) => Promise<void>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -14,7 +14,10 @@ export type QueryParams = {
   text: string;
   senderName: string;
   isGroup?: boolean;
-  messageId?: number;
+  /**
+   * Provider message ID. Telegram is numeric; Discord snowflakes are strings.
+   */
+  messageId?: number | string;
   onStreamDelta?: (accumulated: string, phase?: "thinking" | "text") => void;
   onTextBlock?: (text: string) => Promise<void>;
   onToolUse?: (toolName: string, input: Record<string, unknown>) => void;
@@ -138,7 +141,8 @@ export type ExecuteParams = {
   prompt: string;
   senderName: string;
   isGroup: boolean;
-  messageId?: number;
+  /** Provider message ID. Numeric for Telegram, string snowflake for Discord. */
+  messageId?: number | string;
   source: "message" | "pulse" | "cron" | "trigger";
   onStreamDelta?: (accumulated: string, phase?: "thinking" | "text") => void;
   onTextBlock?: (text: string) => Promise<void>;
@@ -157,7 +161,13 @@ export type ActionResult = {
   ok: boolean;
   text?: string;
   error?: string;
-  message_id?: number;
+  /**
+   * Provider message ID. Telegram uses numeric IDs; Discord (and other
+   * snowflake-based platforms) emit string IDs. The dispatcher treats it
+   * opaquely — it's surfaced back to the LLM as-is for use in subsequent
+   * tool calls (react/edit/delete) that target this message.
+   */
+  message_id?: number | string;
   [key: string]: unknown;
 };
 

--- a/src/frontend/discord/actions.ts
+++ b/src/frontend/discord/actions.ts
@@ -1,0 +1,730 @@
+/**
+ * Discord-specific action handlers.
+ *
+ * Handles MCP tool actions that require the Discord API. Platform-agnostic
+ * actions (cron, fetch_url, history) are handled by core/gateway-actions.ts
+ * before this is called. The gateway maps a request to this handler by
+ * numeric chatId; we resolve it back to a Discord channel via the registry
+ * maintained in handlers.ts.
+ *
+ * Mapping notes vs Telegram:
+ *  - send_message / reply_to / edit_message / delete_message: same intent.
+ *  - react: emoji reactions are unicode in Discord; custom emoji uses <:name:id>.
+ *  - send_message_with_buttons: rendered using ActionRow + ButtonBuilder.
+ *  - send_photo/video/file/voice/audio: all become attachments (Discord doesn't
+ *    distinguish "photo" vs "document" — file extension/contentType determines
+ *    inline preview). We unify via AttachmentBuilder.
+ *  - send_poll: Discord has Poll API (v10+); we use it.
+ *  - schedule_message: in-memory timer, like Telegram.
+ *  - get_chat_admins / get_chat_member_count: query guild members (best-effort —
+ *    requires GuildMembers intent for full member lists).
+ *  - Telegram-only actions (sticker pack mgmt, userbot history, set_chat_title)
+ *    are not supported — return null so the gateway falls through (or {ok:false}
+ *    where appropriate so the AI sees a clear error).
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import { basename } from "node:path";
+import {
+  type Client,
+  type TextBasedChannel,
+  AttachmentBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ChannelType,
+} from "discord.js";
+import { withRetry } from "../../core/gateway.js";
+import type { Gateway } from "../../core/gateway.js";
+import type { ActionResult } from "../../core/types.js";
+import { lookupDiscordChat, sendChunked } from "./handlers.js";
+import { suppressMentions, safeSlice, DISCORD_MAX_TEXT } from "./formatting.js";
+import { logWarn, logError } from "../../util/log.js";
+import { mapDiscordError, maxAttachmentBytes } from "./errors.js";
+
+/** Run a Discord action; convert DiscordAPIError into a clean ActionResult. */
+async function tryAction(
+  context: string,
+  fn: () => Promise<ActionResult>,
+): Promise<ActionResult> {
+  try {
+    return await fn();
+  } catch (err) {
+    const mapped = mapDiscordError(err, context);
+    if (mapped) return mapped;
+    return {
+      ok: false,
+      error: `${context} failed: ${err instanceof Error ? err.message : err}`,
+    };
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+async function resolveChannel(
+  client: Client,
+  numericChatId: number,
+): Promise<TextBasedChannel | null> {
+  const info = lookupDiscordChat(numericChatId);
+  if (!info) return null;
+  try {
+    const ch = await client.channels.fetch(info.channelId);
+    if (ch && "send" in ch && (ch as TextBasedChannel).isSendable?.()) {
+      return ch as TextBasedChannel;
+    }
+    if (info.userId) {
+      const user = await client.users.fetch(info.userId);
+      const dm = await user.createDM();
+      return dm as TextBasedChannel;
+    }
+    return null;
+  } catch (err) {
+    logWarn(
+      "discord",
+      `resolveChannel failed for chat ${numericChatId}: ${err instanceof Error ? err.message : err}`,
+    );
+    return null;
+  }
+}
+
+function buildButtonRows(
+  rows: Array<
+    Array<{
+      text: string;
+      url?: string;
+      callback_data?: string;
+      style?: string;
+    }>
+  >,
+): ActionRowBuilder<ButtonBuilder>[] {
+  const out: ActionRowBuilder<ButtonBuilder>[] = [];
+  for (const row of rows.slice(0, 5)) {
+    const arb = new ActionRowBuilder<ButtonBuilder>();
+    for (const btn of row.slice(0, 5)) {
+      const b = new ButtonBuilder().setLabel(safeSlice(btn.text || "•", 80));
+      if (btn.url) {
+        b.setStyle(ButtonStyle.Link).setURL(btn.url);
+      } else {
+        const styleMap: Record<string, ButtonStyle> = {
+          primary: ButtonStyle.Primary,
+          secondary: ButtonStyle.Secondary,
+          success: ButtonStyle.Success,
+          danger: ButtonStyle.Danger,
+        };
+        const style =
+          styleMap[btn.style ?? "secondary"] ?? ButtonStyle.Secondary;
+        // Namespace AI-generated custom_ids under `ai:` so the callback router
+        // never confuses them with system custom_ids like `settings:done`.
+        // The router strips the prefix before forwarding to the agent.
+        const raw = btn.callback_data || btn.text || "";
+        const id = `ai:${safeSlice(raw, 96)}`;
+        b.setStyle(style).setCustomId(id);
+      }
+      arb.addComponents(b);
+    }
+    out.push(arb);
+  }
+  return out;
+}
+
+// ── Factory ─────────────────────────────────────────────────────────────────
+
+export function createDiscordActionHandler(client: Client, gateway: Gateway) {
+  const scheduledMessages = new Map<string, ReturnType<typeof setTimeout>>();
+
+  return async (
+    body: Record<string, unknown>,
+    chatId: number,
+  ): Promise<ActionResult | null> => {
+    const action = body.action as string;
+    const channel = await resolveChannel(client, chatId);
+
+    // For non-channel actions (e.g. cancel_scheduled, get_*) that don't need a
+    // resolved channel right away, fall through. But most Discord actions need
+    // it — return error if missing.
+    const needsChannel = action !== "cancel_scheduled";
+    if (needsChannel && !channel) {
+      return {
+        ok: false,
+        error: `Discord channel not resolvable for chat ${chatId}`,
+      };
+    }
+
+    switch (action) {
+      // ── Messaging ─────────────────────────────────────────────────────
+      case "send_message": {
+        const text = String(body.text ?? "");
+        const replyTo =
+          typeof body.reply_to_message_id === "string"
+            ? body.reply_to_message_id
+            : typeof body.reply_to === "string"
+              ? body.reply_to
+              : undefined;
+        gateway.incrementMessages(chatId);
+        return tryAction("send_message", async () => {
+          const ids = await withRetry(() =>
+            sendChunked(channel!, text, replyTo),
+          );
+          return { ok: true, message_id: ids[0], message_ids: ids };
+        });
+      }
+
+      case "reply_to": {
+        const messageId = String(body.message_id ?? "");
+        gateway.incrementMessages(chatId);
+        return tryAction("reply_to", async () => {
+          const ids = await withRetry(() =>
+            sendChunked(channel!, String(body.text ?? ""), messageId),
+          );
+          return { ok: true, message_id: ids[0], message_ids: ids };
+        });
+      }
+
+      case "react": {
+        gateway.incrementMessages(chatId);
+        const emoji = String(body.emoji ?? "👍");
+        const messageId = String(body.message_id ?? "");
+        return tryAction("react", async () => {
+          const target = await channel!.messages.fetch(messageId);
+          // Don't silently fall back to 👍 — agent needs to know its chosen
+          // emoji was rejected (likely malformed custom emoji format).
+          await target.react(emoji);
+          return { ok: true };
+        });
+      }
+
+      case "edit_message": {
+        const text = String(body.text ?? "");
+        if (text.length > DISCORD_MAX_TEXT * 2) {
+          return {
+            ok: false,
+            error: `Edit text too long (max ${DISCORD_MAX_TEXT * 2})`,
+          };
+        }
+        const messageId = String(body.message_id ?? "");
+        return tryAction("edit_message", async () => {
+          const target = await channel!.messages.fetch(messageId);
+          const safe = suppressMentions(text).slice(0, DISCORD_MAX_TEXT);
+          await target.edit({ content: safe, allowedMentions: { parse: [] } });
+          return { ok: true };
+        });
+      }
+
+      case "delete_message": {
+        const messageId = String(body.message_id ?? "");
+        return tryAction("delete_message", async () => {
+          const target = await channel!.messages.fetch(messageId);
+          await target.delete();
+          return { ok: true };
+        });
+      }
+
+      case "pin_message": {
+        const messageId = String(body.message_id ?? "");
+        return tryAction("pin_message", async () => {
+          const target = await channel!.messages.fetch(messageId);
+          await target.pin();
+          return { ok: true };
+        });
+      }
+
+      case "unpin_message": {
+        const messageId = body.message_id ? String(body.message_id) : undefined;
+        return tryAction("unpin_message", async () => {
+          if (messageId) {
+            const target = await channel!.messages.fetch(messageId);
+            await target.unpin();
+          } else {
+            const pinned = await channel!.messages.fetchPinned();
+            for (const m of pinned.values()) await m.unpin();
+          }
+          return { ok: true };
+        });
+      }
+
+      case "forward_message":
+      case "copy_message": {
+        const messageId = String(body.message_id ?? "");
+        return tryAction(action, async () => {
+          const target = await channel!.messages.fetch(messageId);
+          // Discord doesn't have a true forward — replicate content.
+          gateway.incrementMessages(chatId);
+          const content = target.content || "";
+          const ids = await withRetry(() => sendChunked(channel!, content));
+          return { ok: true, message_id: ids[0] };
+        });
+      }
+
+      case "send_chat_action": {
+        // typing only — Discord typing indicator
+        try {
+          await (
+            channel as { sendTyping?: () => Promise<void> }
+          ).sendTyping?.();
+        } catch {
+          /* ignore */
+        }
+        return { ok: true };
+      }
+
+      case "send_message_with_buttons": {
+        const text = String(body.text ?? "");
+        const rows = body.rows as Array<
+          Array<{
+            text: string;
+            url?: string;
+            callback_data?: string;
+            style?: string;
+          }>
+        >;
+        gateway.incrementMessages(chatId);
+        const components = buildButtonRows(rows);
+        const safe = suppressMentions(text).slice(0, DISCORD_MAX_TEXT);
+        if (!channel!.isSendable())
+          return { ok: false, error: "Channel not sendable" };
+        return tryAction("send_message_with_buttons", async () => {
+          const sent = await withRetry(
+            () =>
+              channel!.send({
+                content: safe,
+                components,
+                allowedMentions: { parse: [] },
+              }) as Promise<{ id: string }>,
+          );
+          return { ok: true, message_id: sent.id };
+        });
+      }
+
+      case "schedule_message": {
+        const text = String(body.text ?? "");
+        const delaySec = Math.max(
+          1,
+          Math.min(3600, Number(body.delay_seconds ?? 60)),
+        );
+        const scheduleId = `sched_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        const timer = setTimeout(async () => {
+          try {
+            const c = await resolveChannel(client, chatId);
+            if (c) await sendChunked(c, text);
+          } catch (err) {
+            logError(
+              "discord",
+              `Scheduled message failed (chat=${chatId})`,
+              err,
+            );
+          }
+          scheduledMessages.delete(scheduleId);
+        }, delaySec * 1000);
+        scheduledMessages.set(scheduleId, timer);
+        return { ok: true, schedule_id: scheduleId, delay_seconds: delaySec };
+      }
+
+      case "cancel_scheduled": {
+        const id = String(body.schedule_id ?? "");
+        const timer = scheduledMessages.get(id);
+        if (timer) {
+          clearTimeout(timer);
+          scheduledMessages.delete(id);
+          return { ok: true, cancelled: true };
+        }
+        return { ok: false, error: "Schedule not found" };
+      }
+
+      // ── Media ──────────────────────────────────────────────────────────
+      case "send_file":
+      case "send_photo":
+      case "send_video":
+      case "send_animation":
+      case "send_voice":
+      case "send_audio": {
+        const filePath = String(body.file_path ?? "");
+        const caption = body.caption ? String(body.caption) : "";
+        const stat = statSync(filePath);
+        // Per-guild attachment cap based on boost tier. DMs use Tier-0 (10 MB).
+        const guild = (channel as { guild?: import("discord.js").Guild })
+          ?.guild;
+        const maxBytes = maxAttachmentBytes(guild);
+        if (stat.size > maxBytes) {
+          const mb = (n: number) => Math.round(n / 1024 / 1024);
+          const tierNote = guild
+            ? `boost tier ${guild.premiumTier ?? 0}`
+            : "DM";
+          return {
+            ok: false,
+            error: `File too large (${mb(stat.size)}MB) — this ${tierNote} accepts max ${mb(maxBytes)}MB`,
+          };
+        }
+        const data = readFileSync(filePath);
+        const file = new AttachmentBuilder(data, { name: basename(filePath) });
+
+        gateway.incrementMessages(chatId);
+        if (!channel!.isSendable())
+          return { ok: false, error: "Channel not sendable" };
+        const replyTo =
+          typeof body.reply_to === "string" ? body.reply_to : undefined;
+        return tryAction(action, async () => {
+          const sent = await withRetry(
+            () =>
+              channel!.send({
+                content: caption
+                  ? suppressMentions(caption).slice(0, DISCORD_MAX_TEXT)
+                  : undefined,
+                files: [file],
+                allowedMentions: { parse: [] },
+                reply: replyTo
+                  ? { messageReference: replyTo, failIfNotExists: false }
+                  : undefined,
+              }) as Promise<{ id: string }>,
+          );
+          return { ok: true, message_id: sent.id };
+        });
+      }
+
+      case "send_sticker": {
+        const stickerId = String(body.file_id ?? body.sticker_id ?? "");
+        if (!stickerId) return { ok: false, error: "Required: file_id" };
+        if (!channel!.isSendable())
+          return { ok: false, error: "Channel not sendable" };
+        return tryAction("send_sticker", async () => {
+          gateway.incrementMessages(chatId);
+          const sent = (await channel!.send({ stickers: [stickerId] })) as {
+            id: string;
+          };
+          return { ok: true, message_id: sent.id };
+        });
+      }
+
+      case "send_poll": {
+        const question = String(body.question ?? "");
+        const options = ((body.options as string[]) ?? []).slice(0, 10);
+        if (!question || options.length < 2)
+          return { ok: false, error: "Poll requires question + ≥2 options" };
+        gateway.incrementMessages(chatId);
+        if (!channel!.isSendable())
+          return { ok: false, error: "Channel not sendable" };
+        return tryAction("send_poll", async () => {
+          const sent = (await channel!.send({
+            poll: {
+              question: { text: question.slice(0, 300) },
+              answers: options.map((o) => ({ text: o.slice(0, 55) })),
+              allowMultiselect: Boolean(body.allows_multiple_answers),
+              duration: 24,
+            },
+            allowedMentions: { parse: [] },
+          })) as { id: string };
+          return { ok: true, message_id: sent.id };
+        });
+      }
+
+      case "send_location": {
+        const lat = Number(body.latitude);
+        const lng = Number(body.longitude);
+        gateway.incrementMessages(chatId);
+        const url = `https://maps.google.com/?q=${lat},${lng}`;
+        return tryAction("send_location", async () => {
+          const ids = await withRetry(() =>
+            sendChunked(channel!, `📍 Location: ${lat}, ${lng}\n${url}`),
+          );
+          return { ok: true, message_id: ids[0] };
+        });
+      }
+
+      case "send_contact": {
+        const name = [body.first_name, body.last_name]
+          .filter(Boolean)
+          .map(String)
+          .join(" ");
+        const phone = String(body.phone_number ?? "");
+        gateway.incrementMessages(chatId);
+        return tryAction("send_contact", async () => {
+          const ids = await withRetry(() =>
+            sendChunked(channel!, `📇 Contact: ${name}\n${phone}`),
+          );
+          return { ok: true, message_id: ids[0] };
+        });
+      }
+
+      case "send_dice": {
+        const emoji = String(body.emoji ?? "🎲");
+        const value = Math.floor(Math.random() * 6) + 1;
+        gateway.incrementMessages(chatId);
+        return tryAction("send_dice", async () => {
+          const ids = await withRetry(() =>
+            sendChunked(channel!, `${emoji} You rolled: **${value}**`),
+          );
+          return { ok: true, message_id: ids[0], value };
+        });
+      }
+
+      // ── Chat info ──────────────────────────────────────────────────────
+      case "get_chat_info": {
+        const ch = channel!;
+        if (ch.type === ChannelType.DM) {
+          return {
+            ok: true,
+            id: ch.id,
+            type: "dm",
+            title: undefined,
+            member_count: 2,
+          };
+        }
+        const guildCh = ch as {
+          guild?: { name: string; memberCount?: number };
+        };
+        return {
+          ok: true,
+          id: ch.id,
+          type: "channel",
+          title:
+            (ch as { name?: string }).name ?? guildCh.guild?.name ?? "channel",
+          member_count: guildCh.guild?.memberCount,
+        };
+      }
+
+      case "get_chat_member_count": {
+        const ch = channel!;
+        if (ch.type === ChannelType.DM) return { ok: true, count: 2 };
+        const guildCh = ch as { guild?: { memberCount?: number } };
+        return { ok: true, count: guildCh.guild?.memberCount ?? 0 };
+      }
+
+      case "get_chat_member": {
+        const userId = String(body.user_id ?? "");
+        const ch = channel!;
+        if (ch.type === ChannelType.DM)
+          return { ok: false, error: "DM has no members beyond participants" };
+        const guild = (ch as { guild?: import("discord.js").Guild }).guild;
+        if (!guild)
+          return { ok: false, error: "Channel has no guild context" };
+        return tryAction("get_chat_member", async () => {
+          const m =
+            guild.members.cache.get(userId) ??
+            (await guild.members.fetch(userId));
+          const isOwner = m.id === guild.ownerId;
+          return {
+            ok: true,
+            status: isOwner ? "owner" : "member",
+            user: {
+              id: m.user.id,
+              first_name: m.displayName,
+              username: m.user.username,
+            },
+          };
+        });
+      }
+
+      case "get_chat_admins": {
+        const ch = channel!;
+        if (ch.type === ChannelType.DM)
+          return { ok: false, error: "DM has no admins" };
+        const guild = (ch as { guild?: import("discord.js").Guild }).guild;
+        if (!guild) return { ok: false, error: "No guild context" };
+        return tryAction("get_chat_admins", async () => {
+          // Prefer the gateway-populated cache (auto-updated on
+          // GUILD_MEMBER_ADD/UPDATE/REMOVE events when GuildMembers intent is
+          // declared). Fall back to a one-shot fetch if empty (cold start
+          // before chunks arrive).
+          if (guild.members.cache.size === 0) await guild.members.fetch();
+          const admins = [...guild.members.cache.values()].filter(
+            (m) =>
+              m.permissions.has("Administrator") ||
+              m.permissions.has("ManageGuild"),
+          );
+          const text = admins
+            .map((a) => `${a.displayName} (@${a.user.username}) id:${a.id}`)
+            .join("\n");
+          return { ok: true, text };
+        });
+      }
+
+      case "set_chat_title": {
+        const title = String(body.title ?? "");
+        const ch = channel!;
+        if (
+          !("setName" in ch) ||
+          typeof (ch as { setName: unknown }).setName !== "function"
+        ) {
+          return { ok: false, error: "Channel type does not support rename" };
+        }
+        return tryAction("set_chat_title", async () => {
+          await (ch as { setName: (n: string) => Promise<unknown> }).setName(
+            title,
+          );
+          return { ok: true };
+        });
+      }
+
+      case "set_chat_description": {
+        const description = String(body.description ?? "");
+        const ch = channel!;
+        if (
+          !("setTopic" in ch) ||
+          typeof (ch as { setTopic: unknown }).setTopic !== "function"
+        ) {
+          return {
+            ok: false,
+            error: "Channel type does not support description",
+          };
+        }
+        return tryAction("set_chat_description", async () => {
+          await (ch as { setTopic: (t: string) => Promise<unknown> }).setTopic(
+            description,
+          );
+          return { ok: true };
+        });
+      }
+
+      case "get_pinned_messages": {
+        return tryAction("get_pinned_messages", async () => {
+          const pinned = await channel!.messages.fetchPinned();
+          const lines = [...pinned.values()].map((m) => {
+            const author = m.author?.username ?? "user";
+            return `[${author}] msg_id:${m.id}: ${m.content.slice(0, 200)}`;
+          });
+          return {
+            ok: true,
+            text: lines.length ? lines.join("\n") : "No pinned messages.",
+          };
+        });
+      }
+
+      // ── History (Discord-native fetch) ─────────────────────────────────
+      case "read_history": {
+        const limit = Math.min(100, Number(body.limit ?? 30));
+        try {
+          const messages = await channel!.messages.fetch({ limit });
+          const sorted = [...messages.values()].sort(
+            (a, b) => a.createdTimestamp - b.createdTimestamp,
+          );
+          const lines = sorted.map((m) => {
+            const who =
+              m.author.id === client.user?.id
+                ? "bot"
+                : m.member?.displayName ||
+                  m.author.globalName ||
+                  m.author.username;
+            const text =
+              m.content || (m.attachments.size ? "(attachment)" : "");
+            return `[${who}] msg_id:${m.id}: ${text.slice(0, 500)}`;
+          });
+          return { ok: true, text: lines.join("\n") };
+        } catch (err) {
+          // If Discord-level fetch fails (permission, channel gone), fall
+          // through to shared in-memory history rather than surfacing the
+          // error — caller has a generic fallback for this action.
+          logWarn(
+            "discord",
+            `read_history fell through: ${err instanceof Error ? err.message : err}`,
+          );
+          return null;
+        }
+      }
+
+      case "search_history": {
+        const query = String(body.query ?? "").toLowerCase();
+        const limit = Math.min(100, Number(body.limit ?? 20));
+        try {
+          const messages = await channel!.messages.fetch({ limit: 100 });
+          const matches = [...messages.values()]
+            .filter((m) => m.content.toLowerCase().includes(query))
+            .slice(0, limit);
+          const lines = matches.map((m) => {
+            const who =
+              m.member?.displayName || m.author.globalName || m.author.username;
+            return `[${who}] msg_id:${m.id}: ${m.content.slice(0, 300)}`;
+          });
+          return {
+            ok: true,
+            text: lines.length ? lines.join("\n") : "No matches found.",
+          };
+        } catch (err) {
+          logWarn(
+            "discord",
+            `search_history fell through: ${err instanceof Error ? err.message : err}`,
+          );
+          return null;
+        }
+      }
+
+      case "list_known_users": {
+        const ch = channel!;
+        if (ch.type === ChannelType.DM)
+          return { ok: true, text: "DM — only the participants are present." };
+        const guild = (ch as { guild?: import("discord.js").Guild }).guild;
+        if (!guild) return { ok: false, error: "No guild context" };
+        return tryAction("list_known_users", async () => {
+          const limit = Math.min(200, Number(body.limit ?? 50));
+          if (guild.members.cache.size === 0) await guild.members.fetch();
+          const lines = [...guild.members.cache.values()]
+            .slice(0, limit)
+            .map(
+              (m) =>
+                `${m.displayName} (@${m.user.username}) id:${m.id}${m.user.bot ? " [bot]" : ""}`,
+            );
+          return { ok: true, text: lines.join("\n") };
+        });
+      }
+
+      case "get_member_info": {
+        const userId = String(body.user_id ?? "");
+        const ch = channel!;
+        const guild = (ch as { guild?: import("discord.js").Guild }).guild;
+        if (!guild) return { ok: false, error: "No guild context" };
+        return tryAction("get_member_info", async () => {
+          const m =
+            guild.members.cache.get(userId) ??
+            (await guild.members.fetch(userId));
+          const roles = m.roles.cache.map((r) => r.name).join(", ");
+          return {
+            ok: true,
+            text: [
+              `Display: ${m.displayName}`,
+              `Username: @${m.user.username}`,
+              `ID: ${m.id}`,
+              `Joined: ${m.joinedAt?.toISOString() ?? "?"}`,
+              `Roles: ${roles || "none"}`,
+              m.user.bot ? "Bot account" : "",
+            ]
+              .filter(Boolean)
+              .join("\n"),
+          };
+        });
+      }
+
+      case "online_count": {
+        const ch = channel!;
+        if (ch.type === ChannelType.DM)
+          return { ok: true, text: "DM has no online concept." };
+        const guild = (
+          ch as {
+            guild?: { approximatePresenceCount?: number; memberCount?: number };
+          }
+        ).guild;
+        if (!guild) return { ok: false, error: "No guild context" };
+        return {
+          ok: true,
+          text: `Approx online: ${guild.approximatePresenceCount ?? "?"} / ${guild.memberCount ?? "?"}`,
+        };
+      }
+
+      // Telegram-specific actions: not supported on Discord — return null so the
+      // gateway falls through to plugins/shared, or {ok:false} to surface error.
+      case "get_user_messages":
+      case "get_message_by_id":
+      case "save_sticker_pack":
+      case "get_sticker_pack":
+      case "download_sticker":
+      case "create_sticker_set":
+      case "add_sticker_to_set":
+      case "delete_sticker_from_set":
+      case "set_sticker_set_title":
+      case "delete_sticker_set":
+      case "stop_poll":
+      case "download_media":
+        return null;
+
+      default:
+        return null; // not a Discord action
+    }
+  };
+}

--- a/src/frontend/discord/actions.ts
+++ b/src/frontend/discord/actions.ts
@@ -494,8 +494,7 @@ export function createDiscordActionHandler(client: Client, gateway: Gateway) {
         if (ch.type === ChannelType.DM)
           return { ok: false, error: "DM has no members beyond participants" };
         const guild = (ch as { guild?: import("discord.js").Guild }).guild;
-        if (!guild)
-          return { ok: false, error: "Channel has no guild context" };
+        if (!guild) return { ok: false, error: "Channel has no guild context" };
         return tryAction("get_chat_member", async () => {
           const m =
             guild.members.cache.get(userId) ??

--- a/src/frontend/discord/admin.ts
+++ b/src/frontend/discord/admin.ts
@@ -1,0 +1,208 @@
+/**
+ * Admin subcommand handlers — invoked from /admin <sub> [args].
+ *
+ * Mirrors src/frontend/telegram/admin.ts. Output is delivered via the
+ * `send` callback so the caller (commands.ts) can route it through the
+ * proper interaction follow-up.
+ */
+
+import { readFileSync } from "node:fs";
+import { files, dirs } from "../../util/paths.js";
+import type { TalonConfig } from "../../util/config.js";
+import type { Gateway } from "../../core/gateway.js";
+import { resetSession, getAllSessions } from "../../storage/sessions.js";
+import { clearHistory } from "../../storage/history.js";
+import { getChatSettings } from "../../storage/chat-settings.js";
+import {
+  getAllCronJobs,
+  validateCronExpression,
+} from "../../storage/cron-store.js";
+import { getActiveCount } from "../../core/dispatcher.js";
+import { getPulseStatus } from "../../core/pulse.js";
+import { getHealthStatus, getRecentErrors } from "../../util/watchdog.js";
+import { formatDuration, formatModelLabel } from "./helpers.js";
+import {
+  DISCORD_MAX_TEXT,
+  DISCORD_SAFE_RESERVE,
+  escapeForCodeBlock,
+} from "./formatting.js";
+
+/**
+ * Headroom for a fenced ```code``` block inside a 2000-char message: the
+ * three-backtick fences (open + newline + close) eat ~8 chars; SAFE_RESERVE
+ * covers headers/leading prose; we double it for daily output that prepends
+ * a separate header line.
+ */
+const CODE_BLOCK_BUDGET = DISCORD_MAX_TEXT - DISCORD_SAFE_RESERVE - 100;
+const DAILY_BUDGET = DISCORD_MAX_TEXT - DISCORD_SAFE_RESERVE - 200;
+
+type Send = (text: string) => Promise<void>;
+
+export async function handleAdminSubcommand(
+  subcommand: string,
+  argsRaw: string,
+  config: TalonConfig,
+  _gateway: Gateway,
+  send: Send,
+): Promise<void> {
+  const rest = argsRaw.split(/\s+/).filter(Boolean);
+
+  switch (subcommand) {
+    case "chats": {
+      const sessions = getAllSessions();
+      if (sessions.length === 0) return send("No active sessions.");
+      sessions.sort(
+        (a, b) => (b.info.lastActive || 0) - (a.info.lastActive || 0),
+      );
+      const lines = sessions.map((s) => {
+        const age = s.info.lastActive
+          ? `${Math.round((Date.now() - s.info.lastActive) / 60000)}m ago`
+          : "?";
+        const model = formatModelLabel(
+          getChatSettings(s.chatId).model ?? config.model,
+        );
+        return `**\`${s.chatId}\`** — ${s.info.turns} turns | ${age} | ${model}`;
+      });
+      return send(
+        `**Active chats (${sessions.length})**\n\n` + lines.join("\n"),
+      );
+    }
+
+    case "broadcast": {
+      const text = rest.join(" ");
+      if (!text) return send("Usage: /admin broadcast <text>");
+      // For Discord, broadcast iterates over registered chats and posts to
+      // each. We don't pull a global send helper here to avoid coupling, so
+      // we just report the count for the operator.
+      const sessions = getAllSessions();
+      return send(
+        `Broadcast not wired in Discord yet. ${sessions.length} active sessions would receive: "${text.slice(0, 200)}"`,
+      );
+    }
+
+    case "kill": {
+      const target = rest[0];
+      if (!target) return send("Usage: /admin kill <chatId>");
+      resetSession(target);
+      clearHistory(target);
+      return send(`Session ${target} reset.`);
+    }
+
+    case "logs": {
+      const logPath = files.log;
+      try {
+        const { statSync, openSync, readSync, closeSync } =
+          await import("node:fs");
+        const stat = statSync(logPath);
+        const size = Math.min(8192, stat.size);
+        const buf = Buffer.alloc(size);
+        const fd = openSync(logPath, "r");
+        readSync(fd, buf, 0, size, Math.max(0, stat.size - size));
+        closeSync(fd);
+        const lines = buf
+          .toString("utf-8")
+          .trim()
+          .split("\n")
+          .slice(-20)
+          .join("\n");
+        return send(
+          "```\n" +
+            escapeForCodeBlock(lines).slice(0, CODE_BLOCK_BUDGET) +
+            "\n```",
+        );
+      } catch {
+        return send(`Could not read ${logPath}`);
+      }
+    }
+
+    case "stats": {
+      const h = getHealthStatus();
+      const sessions = getAllSessions();
+      const turns = sessions.reduce((s, x) => s + x.info.turns, 0);
+      const mem = process.memoryUsage();
+      return send(
+        [
+          "**🦅 Talon Stats**",
+          "",
+          `**Uptime:** ${formatDuration(h.uptimeMs)}`,
+          `**Messages:** ${h.totalMessagesProcessed}`,
+          `**Sessions:** ${sessions.length}`,
+          `**Turns:** ${turns}`,
+          `**Last active:** ${h.msSinceLastMessage < 60000 ? "now" : formatDuration(h.msSinceLastMessage) + " ago"}`,
+          "",
+          `**Memory:** ${(mem.heapUsed / 1024 / 1024).toFixed(1)}MB heap / ${(mem.rss / 1024 / 1024).toFixed(1)}MB rss`,
+          `**Queue:** ${getActiveCount()}`,
+          `**Errors:** ${h.recentErrorCount}`,
+        ].join("\n"),
+      );
+    }
+
+    case "errors": {
+      const errors = getRecentErrors(5);
+      if (errors.length === 0) return send("No recent errors.");
+      const lines = errors.map(
+        (e) =>
+          `\`[${new Date(e.timestamp).toISOString().slice(11, 19)}]\` ${e.message.slice(0, 200)}`,
+      );
+      return send(
+        `**Recent Errors (${errors.length})**\n\n` + lines.join("\n\n"),
+      );
+    }
+
+    case "cron": {
+      const jobs = getAllCronJobs();
+      if (jobs.length === 0) return send("No cron jobs.");
+      const lines = jobs.map((j) => {
+        const v = validateCronExpression(j.schedule, j.timezone);
+        const last = j.lastRunAt
+          ? new Date(j.lastRunAt).toISOString().slice(0, 16).replace("T", " ")
+          : "never";
+        const next = v.next
+          ? new Date(v.next).toISOString().slice(0, 16).replace("T", " ")
+          : "?";
+        return `${j.enabled ? "✓" : "✗"} **${j.name}** — \`${j.schedule}\` | ${j.type} | runs: ${j.runCount} | last: ${last} | next: ${next}`;
+      });
+      return send(`**Cron Jobs (${jobs.length})**\n\n` + lines.join("\n\n"));
+    }
+
+    case "pulse": {
+      const chats = getPulseStatus();
+      if (chats.length === 0) return send("No pulse chats.");
+      const lines = chats.map(
+        (p) => `${p.enabled ? "✓" : "✗"} \`${p.chatId}\``,
+      );
+      return send(`**Pulse (${chats.length})**\n\n` + lines.join("\n"));
+    }
+
+    case "daily": {
+      const today = new Date().toISOString().slice(0, 10);
+      const logPath = `${dirs.logs}/${today}.md`;
+      try {
+        const content = readFileSync(logPath, "utf-8");
+        const lines = content.trim().split("\n").slice(-30).join("\n");
+        return send(
+          `**Daily log (${today})**\n\n\`\`\`\n${escapeForCodeBlock(
+            lines,
+          ).slice(0, DAILY_BUDGET)}\n\`\`\``,
+        );
+      } catch {
+        return send(`No daily log for ${today}.`);
+      }
+    }
+
+    default:
+      return send(
+        [
+          "**/admin subcommands**",
+          "",
+          "  stats    uptime, messages, memory",
+          "  errors   last 5 errors",
+          "  chats    list all active chats",
+          "  daily    today's interaction log",
+          "  pulse    pulse status per chat",
+          "  cron     list all cron jobs",
+          "  logs     last 20 lines of log",
+        ].join("\n"),
+      );
+  }
+}

--- a/src/frontend/discord/callbacks.ts
+++ b/src/frontend/discord/callbacks.ts
@@ -1,0 +1,582 @@
+/**
+ * Component (button + select menu) interaction handlers.
+ *
+ * Mirrors src/frontend/telegram/callbacks.ts. Settings panel callbacks update
+ * the original message in place (Discord supports update() on the interaction).
+ *
+ * Custom-id namespace:
+ *   settings:done
+ *   settings:model              (select menu, value=modelId)
+ *   settings:effort:select      (select menu)
+ *   settings:proactive:on|off
+ *   pulse:on | pulse:off | pulse:interval (button → opens modal)
+ *   effort:select               (select menu, standalone /effort)
+ *   model:select                (select menu, standalone /model)
+ *   ai:<id>                     (AI-generated buttons — forwarded to agent verbatim)
+ *
+ * Modal submissions:
+ *   modal:pulse-interval        TextInput "interval"
+ */
+
+import {
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+  type ModalSubmitInteraction,
+  type AutocompleteInteraction,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  StringSelectMenuBuilder,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  MessageFlags,
+} from "discord.js";
+import type { TalonConfig } from "../../util/config.js";
+import type { Gateway } from "../../core/gateway.js";
+import {
+  getChatSettings,
+  setChatModel,
+  setChatEffort,
+  setChatPulseInterval,
+  resolveModelName,
+  EFFORT_LEVELS,
+  type EffortLevel,
+} from "../../storage/chat-settings.js";
+import {
+  registerChat,
+  disablePulse,
+  enablePulse,
+  isPulseEnabled,
+} from "../../core/pulse.js";
+import { isInteractionAllowed, registerDiscordChat } from "./handlers.js";
+import {
+  renderSettingsText,
+  parseInterval,
+  formatDuration,
+  EFFORT_DESCRIPTIONS,
+} from "./helpers.js";
+import { execute } from "../../core/dispatcher.js";
+import { deriveNumericChatId } from "../../util/chat-id.js";
+import { appendDailyLog } from "../../storage/daily-log.js";
+import { logError } from "../../util/log.js";
+import {
+  suppressMentions,
+  splitMessage,
+  safeSlice,
+  DISCORD_MAX_TEXT,
+} from "./formatting.js";
+
+type ComponentInteraction = ButtonInteraction | StringSelectMenuInteraction;
+
+function chatIdFromInteraction(interaction: ComponentInteraction): {
+  chatId: string;
+  numericChatId: number;
+} {
+  const chatId = interaction.guildId
+    ? `discord_guild_${interaction.guildId}_${interaction.channelId}`
+    : `discord_dm_${interaction.user.id}`;
+  return { chatId, numericChatId: deriveNumericChatId(chatId) };
+}
+
+export async function handleComponentInteraction(
+  interaction: ComponentInteraction,
+  config: TalonConfig,
+  gateway: Gateway,
+): Promise<void> {
+  // Access control
+  const access = isInteractionAllowed(
+    interaction.inGuild(),
+    interaction.user.id,
+    interaction.guildId,
+    interaction.channelId,
+  );
+  if (!access.ok) {
+    await interaction.reply({
+      content: `⚠️ ${access.reason}`,
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const { chatId, numericChatId } = chatIdFromInteraction(interaction);
+  registerDiscordChat({
+    channelId: interaction.channelId!,
+    guildId: interaction.guildId,
+    userId: interaction.guildId ? null : interaction.user.id,
+    numericChatId,
+    chatId,
+  });
+
+  const customId = interaction.customId;
+
+  // ── Settings panel callbacks ───────────────────────────────────────────────
+  if (customId.startsWith("settings:")) {
+    const parts = customId.split(":");
+    const category = parts[1];
+
+    if (category === "done") {
+      try {
+        await interaction.update({ components: [], content: "Done." });
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+
+    if (category === "model" && interaction.isStringSelectMenu()) {
+      const value = interaction.values[0];
+      if (value === "reset") {
+        setChatModel(chatId, undefined);
+      } else if (gateway?.backend?.resolveModel) {
+        const resolution = await gateway.backend.resolveModel(value);
+        if (resolution.kind !== "exact" || !resolution.model.selectable) {
+          await interaction.reply({
+            content: `Model unavailable.`,
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+        setChatModel(chatId, resolution.storedValue);
+      } else {
+        setChatModel(chatId, resolveModelName(value));
+      }
+      await refreshSettingsPanel(interaction, config, gateway, chatId);
+      return;
+    }
+
+    if (category === "effort" && interaction.isStringSelectMenu()) {
+      // settings:effort:select — current shape (emitted by handleSettings +
+      // refreshSettingsPanel).
+      const level = interaction.values[0];
+      if (level === "adaptive") {
+        setChatEffort(chatId, undefined);
+      } else if (EFFORT_LEVELS.includes(level as EffortLevel)) {
+        setChatEffort(chatId, level as EffortLevel);
+      }
+      await refreshSettingsPanel(interaction, config, gateway, chatId);
+      return;
+    }
+
+    if (category === "proactive") {
+      const value = parts[2] ?? "";
+      if (value === "on") {
+        enablePulse(chatId);
+        registerChat(chatId);
+      } else {
+        disablePulse(chatId);
+      }
+      await refreshSettingsPanel(interaction, config, gateway, chatId);
+      return;
+    }
+  }
+
+  // ── /pulse "Set interval…" button → opens modal ───────────────────────
+  // Must come BEFORE the `pulse:` startsWith branch.
+  if (customId === "pulse:interval" && interaction.isButton()) {
+    const modal = new ModalBuilder()
+      .setCustomId("modal:pulse-interval")
+      .setTitle("Pulse interval");
+    const input = new TextInputBuilder()
+      .setCustomId("interval")
+      .setLabel("How often (min 5m)")
+      .setPlaceholder("30m, 2h, 90m, 1d…")
+      .setStyle(TextInputStyle.Short)
+      .setMinLength(2)
+      .setMaxLength(16)
+      .setRequired(true);
+    modal.addComponents(
+      new ActionRowBuilder<TextInputBuilder>().addComponents(input),
+    );
+    await interaction.showModal(modal);
+    return;
+  }
+
+  // ── /effort select-menu ────────────────────────────────────────────────
+  // Must come BEFORE the `effort:` startsWith branch.
+  if (customId === "effort:select" && interaction.isStringSelectMenu()) {
+    const level = interaction.values[0];
+    if (level === "adaptive") setChatEffort(chatId, undefined);
+    else if (EFFORT_LEVELS.includes(level as EffortLevel))
+      setChatEffort(chatId, level as EffortLevel);
+    try {
+      await interaction.update({
+        content: `**Effort:** ${level}`,
+        components: [],
+      });
+    } catch {
+      /* ignore */
+    }
+    return;
+  }
+
+  // ── Standalone /pulse on|off buttons ──────────────────────────────────────
+  if (customId.startsWith("pulse:")) {
+    const val = customId.slice(6);
+    if (val === "on") {
+      enablePulse(chatId);
+      registerChat(chatId);
+    } else if (val === "off") {
+      disablePulse(chatId);
+    }
+    const enabled = isPulseEnabled(chatId);
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId("pulse:on")
+        .setLabel(enabled ? "✓ On" : "On")
+        .setStyle(enabled ? ButtonStyle.Success : ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId("pulse:off")
+        .setLabel(!enabled ? "✓ Off" : "Off")
+        .setStyle(ButtonStyle.Secondary),
+    );
+    try {
+      await (interaction as ButtonInteraction).update({
+        content: [
+          `**🔔 Pulse:** ${enabled ? "on" : "off"}`,
+          "",
+          "Reads along every few minutes and jumps in when there's something to add.",
+        ].join("\n"),
+        components: [row],
+      });
+    } catch {
+      /* ignore */
+    }
+    return;
+  }
+
+  // ── /model select-menu (separate from settings) ─────────────────────────
+  if (customId === "model:select" && interaction.isStringSelectMenu()) {
+    const value = interaction.values[0];
+
+    if (value === "reset") {
+      setChatModel(chatId, undefined);
+    } else if (gateway?.backend?.resolveModel) {
+      const resolution = await gateway.backend.resolveModel(value);
+      if (resolution.kind === "exact" && resolution.model.selectable) {
+        setChatModel(chatId, resolution.storedValue);
+      } else {
+        await interaction.reply({
+          content: "Model unavailable.",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+    } else {
+      setChatModel(chatId, resolveModelName(value));
+    }
+
+    const current = getChatSettings(chatId).model ?? config.model;
+    const be = gateway?.backend;
+    if (be?.getSettingsPresentation) {
+      const pres = await be.getSettingsPresentation(current, "model:");
+      const modelInfo = await be.getModelInfo?.(current);
+      const displayName = modelInfo?.displayName ?? current;
+      const menu = new StringSelectMenuBuilder()
+        .setCustomId("model:select")
+        .setPlaceholder("Pick a model")
+        .addOptions(
+          pres.modelButtons.slice(0, 25).map((b) => ({
+            label: safeSlice(b.text.replace(/^✓ /, ""), 100),
+            value: safeSlice(b.callback_data.replace(/^model:/, ""), 100),
+            default: b.text.startsWith("✓"),
+          })),
+        );
+      const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+        menu,
+      );
+      try {
+        await interaction.update({
+          content: [`**Model:** \`${displayName}\``, ...pres.modelDetails].join(
+            "\n",
+          ),
+          components: [row],
+        });
+      } catch {
+        /* ignore */
+      }
+    }
+    return;
+  }
+
+  // ── AI-generated buttons (prefixed `ai:`) → forward to agent ──────────
+  if (customId.startsWith("ai:")) {
+    await forwardToAgent(interaction, gateway);
+    return;
+  }
+
+  // Unknown custom_id — log + silently ack so Discord doesn't show
+  // "Interaction failed". This catches stale buttons from older panels.
+  logError("discord", `Unknown custom_id: ${customId}`);
+  try {
+    await interaction.deferUpdate();
+  } catch {
+    /* ignore */
+  }
+}
+
+async function refreshSettingsPanel(
+  interaction: ComponentInteraction,
+  config: TalonConfig,
+  gateway: Gateway,
+  chatId: string,
+): Promise<void> {
+  const chatSets = getChatSettings(chatId);
+  const activeModel = chatSets.model ?? config.model;
+  const effortName = chatSets.effort ?? "adaptive";
+  const pulseOn = isPulseEnabled(chatId);
+
+  let modelDetails: Array<string> | undefined;
+  let modelButtons: Array<{ text: string; callback_data: string }> | undefined;
+  if (gateway?.backend?.getSettingsPresentation) {
+    const pres = await gateway.backend.getSettingsPresentation(activeModel);
+    modelDetails = pres.modelDetails;
+    modelButtons = pres.modelButtons;
+  }
+
+  const components: ActionRowBuilder<
+    StringSelectMenuBuilder | ButtonBuilder
+  >[] = [];
+
+  if (modelButtons?.length) {
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId("settings:model")
+      .setPlaceholder("Select a model")
+      .addOptions(
+        modelButtons.slice(0, 25).map((b) => ({
+          label: safeSlice(b.text.replace(/^✓ /, ""), 100),
+          value: safeSlice(b.callback_data.replace(/^settings:model:/, ""), 100),
+          default: b.text.startsWith("✓"),
+        })),
+      );
+    components.push(
+      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu),
+    );
+  }
+
+  // Effort as a select-menu (matches standalone /effort UI).
+  const effortMenu = new StringSelectMenuBuilder()
+    .setCustomId("settings:effort:select")
+    .setPlaceholder(`Effort: ${effortName}`)
+    .addOptions(
+      (["off", "low", "medium", "high", "max", "adaptive"] as const).map(
+        (v) => ({
+          label: v,
+          value: v,
+          description: EFFORT_DESCRIPTIONS[v],
+          default: effortName === v,
+        }),
+      ),
+    );
+  components.push(
+    new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(effortMenu),
+  );
+
+  components.push(
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`settings:proactive:${pulseOn ? "off" : "on"}`)
+        .setLabel(pulseOn ? "Pulse: ON" : "Pulse: OFF")
+        .setStyle(pulseOn ? ButtonStyle.Success : ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId("settings:done")
+        .setLabel("Done")
+        .setStyle(ButtonStyle.Secondary),
+    ),
+  );
+
+  try {
+    await interaction.update({
+      content: renderSettingsText(
+        activeModel,
+        effortName,
+        pulseOn,
+        chatSets.pulseIntervalMs,
+        modelDetails,
+      ),
+      components,
+    });
+  } catch (err) {
+    logError(
+      "discord",
+      `Failed to refresh settings panel: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+async function forwardToAgent(
+  interaction: ComponentInteraction,
+  _gateway: Gateway,
+): Promise<void> {
+  // Acknowledge so Discord doesn't show "interaction failed"
+  try {
+    await interaction.deferUpdate();
+  } catch {
+    /* might already be acked */
+  }
+
+  const { chatId, numericChatId } = chatIdFromInteraction(interaction);
+  const sender =
+    interaction.member?.user?.username ?? interaction.user.username ?? "User";
+  const isGroup = interaction.guildId !== null;
+  // Strip the `ai:` prefix so the agent sees the original callback_data it
+  // emitted in send_message_with_buttons, not our routing namespace.
+  const rawId = interaction.customId.startsWith("ai:")
+    ? interaction.customId.slice(3)
+    : interaction.customId;
+  const prompt = `[Button pressed] User clicked component with custom_id: "${rawId}"`;
+  const chatTitle = isGroup
+    ? `${interaction.guild?.name ?? interaction.guildId} #${(interaction.channel as { name?: string } | null)?.name ?? interaction.channelId}`
+    : undefined;
+
+  appendDailyLog(sender, `Button: ${rawId}`, { chatTitle });
+
+  const onTextBlock = async (text: string) => {
+    if (!text.trim()) return;
+    if (!interaction.channel?.isSendable()) return;
+    const chunks = splitMessage(suppressMentions(text), DISCORD_MAX_TEXT);
+    for (const c of chunks) {
+      try {
+        await interaction.channel.send({
+          content: c,
+          allowedMentions: { parse: [] },
+        });
+      } catch (err) {
+        logError(
+          "discord",
+          `forwardToAgent send failed: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+  };
+
+  try {
+    await execute({
+      chatId,
+      numericChatId,
+      prompt,
+      senderName: sender,
+      isGroup,
+      source: "message",
+      onTextBlock,
+    });
+  } catch (err) {
+    logError(
+      "discord",
+      `Component → agent forward failed: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+// ── Modal submissions ──────────────────────────────────────────────────────
+
+export async function handleModalSubmit(
+  interaction: ModalSubmitInteraction,
+  config: TalonConfig,
+  gateway: Gateway,
+): Promise<void> {
+  // Access control (same gate as components).
+  const access = isInteractionAllowed(
+    interaction.inGuild(),
+    interaction.user.id,
+    interaction.guildId,
+    interaction.channelId,
+  );
+  if (!access.ok) {
+    await interaction.reply({
+      content: `⚠️ ${access.reason}`,
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const chatId = interaction.guildId
+    ? `discord_guild_${interaction.guildId}_${interaction.channelId}`
+    : `discord_dm_${interaction.user.id}`;
+
+  // ── /pulse interval modal ────────────────────────────────────────────
+  if (interaction.customId === "modal:pulse-interval") {
+    const raw = interaction.fields.getTextInputValue("interval").trim();
+    const ms = parseInterval(raw);
+    if (!ms) {
+      await interaction.reply({
+        content: `Could not parse interval "${raw}". Try: 30m, 2h, 90m, 1d.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    if (ms < 5 * 60 * 1000) {
+      await interaction.reply({
+        content: "Minimum interval is 5 minutes.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    setChatPulseInterval(chatId, ms);
+    enablePulse(chatId);
+    registerChat(chatId);
+    await interaction.reply({
+      content: `🔔 Pulse cooldown set to **${formatDuration(ms)}**`,
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  // Unknown modal — log + ack so Discord doesn't show "Interaction failed".
+  logError("discord", `Unknown modal customId: ${interaction.customId}`);
+  try {
+    await interaction.reply({
+      content: "Unknown form.",
+      flags: MessageFlags.Ephemeral,
+    });
+  } catch {
+    /* ignore */
+  }
+}
+
+// ── Autocomplete (/model name:) ─────────────────────────────────────────────
+
+// Cache the model list so we don't hit getSettingsPresentation() on every
+// keystroke. The backend list rarely changes between user keystrokes; 30s is
+// a sweet spot between freshness and cost.
+const AUTOCOMPLETE_TTL_MS = 30_000;
+let modelListCache: { at: number; values: string[] } | null = null;
+
+async function loadModelList(gateway: Gateway): Promise<string[]> {
+  const now = Date.now();
+  if (modelListCache && now - modelListCache.at < AUTOCOMPLETE_TTL_MS) {
+    return modelListCache.values;
+  }
+  const be = gateway?.backend;
+  if (!be?.getSettingsPresentation) return [];
+  const pres = await be.getSettingsPresentation("", "model:");
+  const values = pres.modelButtons.map((b) =>
+    b.callback_data.replace(/^model:/, ""),
+  );
+  modelListCache = { at: now, values };
+  return values;
+}
+
+export async function handleAutocomplete(
+  interaction: AutocompleteInteraction,
+  gateway: Gateway,
+): Promise<void> {
+  if (
+    interaction.commandName !== "model" ||
+    interaction.options.getFocused(true).name !== "name"
+  ) {
+    await interaction.respond([]);
+    return;
+  }
+  const query = interaction.options.getFocused().toLowerCase();
+  try {
+    const values = await loadModelList(gateway);
+    const choices = values
+      .filter((v) => !query || v.toLowerCase().includes(query))
+      .slice(0, 25)
+      .map((v) => ({ name: safeSlice(v, 100), value: safeSlice(v, 100) }));
+    await interaction.respond(choices);
+  } catch {
+    await interaction.respond([]);
+  }
+}

--- a/src/frontend/discord/callbacks.ts
+++ b/src/frontend/discord/callbacks.ts
@@ -345,7 +345,10 @@ async function refreshSettingsPanel(
       .addOptions(
         modelButtons.slice(0, 25).map((b) => ({
           label: safeSlice(b.text.replace(/^✓ /, ""), 100),
-          value: safeSlice(b.callback_data.replace(/^settings:model:/, ""), 100),
+          value: safeSlice(
+            b.callback_data.replace(/^settings:model:/, ""),
+            100,
+          ),
           default: b.text.startsWith("✓"),
         })),
       );

--- a/src/frontend/discord/commands.ts
+++ b/src/frontend/discord/commands.ts
@@ -1,0 +1,1055 @@
+/**
+ * Discord slash commands — equivalent to src/frontend/telegram/commands.ts.
+ *
+ * Registration strategy (the heart of access control for slash commands):
+ *  - Slash commands are registered as guild-specific in every guild on
+ *    config.discord.allowedGuilds → instant propagation, hidden everywhere else.
+ *  - When config.discord.enableDmCommands is true, the same set is ALSO
+ *    registered globally with dm_permission, so users on allowedUsers can run
+ *    them in DMs. We still enforce allowedUsers at execution time so a global
+ *    registration leak can't be abused.
+ *  - For guilds the bot is in but which are NOT on allowedGuilds, we wipe their
+ *    guild commands on startup (and on guildCreate). Combined with the optional
+ *    leaveUnauthorizedGuilds flag, this guarantees commands aren't visible
+ *    where they shouldn't be.
+ *
+ * Slash command surface mirrors Telegram: /start /help /settings /memory
+ * /status /ping /model /effort /pulse /reset /restart /metrics /dream /plugins
+ * /admin <subcommand>.
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+import { readFileSync, existsSync } from "node:fs";
+import {
+  type Client,
+  type ChatInputCommandInteraction,
+  type Interaction,
+  REST,
+  Routes,
+  SlashCommandBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  StringSelectMenuBuilder,
+  MessageFlags,
+} from "discord.js";
+import type { TalonConfig } from "../../util/config.js";
+import type { Gateway } from "../../core/gateway.js";
+import { files } from "../../util/paths.js";
+import {
+  resetSession,
+  getSessionInfo,
+  getActiveSessionCount,
+} from "../../storage/sessions.js";
+import { clearHistory } from "../../storage/history.js";
+import {
+  getChatSettings,
+  setChatModel,
+  setChatEffort,
+  setChatPulseInterval,
+  resolveModelName,
+  EFFORT_LEVELS,
+  type EffortLevel,
+} from "../../storage/chat-settings.js";
+import {
+  registerChat,
+  disablePulse,
+  enablePulse,
+  isPulseEnabled,
+  resetPulseCheckpoint,
+} from "../../core/pulse.js";
+import { forceDream } from "../../core/dream.js";
+import { getWorkspaceDiskUsage } from "../../util/workspace.js";
+import { appendDailyLog } from "../../storage/daily-log.js";
+import {
+  formatModelLabel,
+  formatDuration,
+  formatTokenCount,
+  formatBytes,
+  parseInterval,
+  renderMetricsMessages,
+  renderSettingsText,
+  EFFORT_DESCRIPTIONS,
+} from "./helpers.js";
+import { getLoadedPlugins } from "../../core/plugin.js";
+import { getMetrics } from "../../util/metrics.js";
+import { handleAdminSubcommand } from "./admin.js";
+import {
+  isAdmin,
+  isInteractionAllowed,
+  registerDiscordChat,
+} from "./handlers.js";
+import { deriveNumericChatId } from "../../util/chat-id.js";
+import { log, logError, logWarn } from "../../util/log.js";
+import {
+  suppressMentions,
+  splitMessage,
+  safeSlice,
+  DISCORD_MAX_TEXT,
+  DISCORD_SAFE_RESERVE,
+} from "./formatting.js";
+
+// ── Slash command definitions ───────────────────────────────────────────────
+
+function buildCommandDefinitions(): unknown[] {
+  return [
+    new SlashCommandBuilder()
+      .setName("start")
+      .setDescription("Introduction to Talon")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("help")
+      .setDescription("All commands and features")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("settings")
+      .setDescription("View and change all chat settings")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("memory")
+      .setDescription("View what Talon remembers")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("status")
+      .setDescription("Session info, usage, and stats")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("ping")
+      .setDescription("Health check with latency")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("model")
+      .setDescription("Show or change the model")
+      .addStringOption((o) =>
+        o
+          .setName("name")
+          .setDescription("Model name or 'reset'")
+          .setRequired(false)
+          .setAutocomplete(true),
+      )
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("effort")
+      .setDescription("Set thinking effort level")
+      .addStringOption((o) =>
+        o
+          .setName("level")
+          .setDescription("Effort level")
+          .setRequired(false)
+          .addChoices(
+            { name: "off", value: "off" },
+            { name: "low", value: "low" },
+            { name: "medium", value: "medium" },
+            { name: "high", value: "high" },
+            { name: "max", value: "max" },
+            { name: "adaptive", value: "adaptive" },
+          ),
+      )
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("pulse")
+      .setDescription("Toggle periodic check-ins")
+      .addStringOption((o) =>
+        o
+          .setName("arg")
+          .setDescription("on, off, or interval (e.g. 30m, 2h)")
+          .setRequired(false),
+      )
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("reset")
+      .setDescription("Clear session and start fresh")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("restart")
+      .setDescription("Restart the bot (admin only)")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("metrics")
+      .setDescription("Aggregate performance metrics (admin)")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("dream")
+      .setDescription("Force memory consolidation (admin)")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("plugins")
+      .setDescription("List loaded plugins")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("admin")
+      .setDescription("Admin operations (admin only)")
+      .addStringOption((o) =>
+        o
+          .setName("sub")
+          .setDescription("Subcommand")
+          .setRequired(true)
+          .addChoices(
+            { name: "stats", value: "stats" },
+            { name: "errors", value: "errors" },
+            { name: "chats", value: "chats" },
+            { name: "daily", value: "daily" },
+            { name: "pulse", value: "pulse" },
+            { name: "cron", value: "cron" },
+            { name: "logs", value: "logs" },
+          ),
+      )
+      .addStringOption((o) =>
+        o.setName("args").setDescription("Extra arguments").setRequired(false),
+      )
+      .toJSON(),
+  ];
+}
+
+// ── Registration: per-guild + optional global for DM ────────────────────────
+
+export async function registerCommandsForGuilds(
+  client: Client,
+  config: TalonConfig,
+): Promise<void> {
+  const dc = config.discord!;
+  const rest = new REST({ version: "10" }).setToken(dc.botToken);
+  const definitions = buildCommandDefinitions();
+
+  // Step 1: clear or set global commands depending on DM setting.
+  try {
+    if (dc.enableDmCommands) {
+      // Add a dm_permission flag to the JSON before sending.
+      const dmDefs = definitions.map((d) => ({
+        ...(d as Record<string, unknown>),
+        dm_permission: true,
+      }));
+      await rest.put(Routes.applicationCommands(dc.applicationId), {
+        body: dmDefs,
+      });
+      log(
+        "discord",
+        `Registered ${dmDefs.length} global commands (DM-enabled)`,
+      );
+    } else {
+      await rest.put(Routes.applicationCommands(dc.applicationId), {
+        body: [],
+      });
+      log("discord", "Cleared global commands (DM commands disabled)");
+    }
+  } catch (err) {
+    logError("discord", "Failed to register/clear global commands", err);
+  }
+
+  // Step 2: per-guild registration in allowedGuilds (instant propagation,
+  // immediately visible only there). We do this even when global is enabled,
+  // so users see the commands instantly inside whitelisted servers.
+  for (const guildId of dc.allowedGuilds) {
+    try {
+      await rest.put(
+        Routes.applicationGuildCommands(dc.applicationId, guildId),
+        { body: definitions },
+      );
+      log(
+        "discord",
+        `Registered ${definitions.length} commands in guild ${guildId}`,
+      );
+    } catch (err) {
+      logError(
+        "discord",
+        `Failed to register commands in guild ${guildId}`,
+        err,
+      );
+    }
+  }
+
+  // Step 3: in any guild the bot is currently in but NOT on allowedGuilds,
+  // wipe guild-specific commands (defense in depth).
+  for (const guild of client.guilds.cache.values()) {
+    if (dc.allowedGuilds.includes(guild.id)) continue;
+    try {
+      await rest.put(
+        Routes.applicationGuildCommands(dc.applicationId, guild.id),
+        { body: [] },
+      );
+      log(
+        "discord",
+        `Cleared commands in non-whitelisted guild ${guild.id} (${guild.name})`,
+      );
+    } catch (err) {
+      logWarn(
+        "discord",
+        `Failed to clear commands in guild ${guild.id}: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+}
+
+// ── Interaction routing ─────────────────────────────────────────────────────
+
+export function registerInteractionRouter(
+  client: Client,
+  config: TalonConfig,
+  gateway: Gateway,
+): void {
+  client.on("interactionCreate", async (interaction: Interaction) => {
+    try {
+      // Slash commands
+      if (interaction.isChatInputCommand()) {
+        await routeSlashCommand(interaction, config, gateway);
+        return;
+      }
+      // Autocomplete for /model name:
+      if (interaction.isAutocomplete()) {
+        const { handleAutocomplete } = await import("./callbacks.js");
+        await handleAutocomplete(interaction, gateway);
+        return;
+      }
+      // Buttons & select menus → callbacks.ts handler
+      if (interaction.isButton() || interaction.isStringSelectMenu()) {
+        const { handleComponentInteraction } = await import("./callbacks.js");
+        await handleComponentInteraction(interaction, config, gateway);
+        return;
+      }
+      // Modal submissions (pulse interval)
+      if (interaction.isModalSubmit()) {
+        const { handleModalSubmit } = await import("./callbacks.js");
+        await handleModalSubmit(interaction, config, gateway);
+        return;
+      }
+    } catch (err) {
+      logError("discord", "Interaction handling failed", err);
+      try {
+        if (
+          interaction.isRepliable() &&
+          !interaction.replied &&
+          !interaction.deferred
+        ) {
+          await interaction.reply({
+            content: "Something went wrong handling that interaction.",
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+}
+
+// ── Helpers used by slash command handlers ──────────────────────────────────
+
+function chatIdFromInteraction(interaction: ChatInputCommandInteraction): {
+  chatId: string;
+  numericChatId: number;
+} {
+  const chatId = interaction.guildId
+    ? `discord_guild_${interaction.guildId}_${interaction.channelId}`
+    : `discord_dm_${interaction.user.id}`;
+  return { chatId, numericChatId: deriveNumericChatId(chatId) };
+}
+
+async function reply(
+  interaction: ChatInputCommandInteraction,
+  content: string,
+  ephemeral = false,
+): Promise<void> {
+  const safe = suppressMentions(content);
+  const chunks = splitMessage(safe, DISCORD_MAX_TEXT);
+  const baseOpts = {
+    allowedMentions: { parse: [] as never[] },
+  };
+  const opts = ephemeral
+    ? { ...baseOpts, flags: MessageFlags.Ephemeral as const }
+    : baseOpts;
+  if (!interaction.deferred && !interaction.replied) {
+    await interaction.reply({ content: chunks[0], ...opts });
+  } else {
+    await interaction.followUp({ content: chunks[0], ...opts });
+  }
+  for (let i = 1; i < chunks.length; i++) {
+    await interaction.followUp({ content: chunks[i], ...opts });
+  }
+}
+
+// ── Main slash command router ───────────────────────────────────────────────
+
+async function routeSlashCommand(
+  interaction: ChatInputCommandInteraction,
+  config: TalonConfig,
+  gateway: Gateway,
+): Promise<void> {
+  // Access control — same as message handler, but synchronous decision.
+  const access = isInteractionAllowed(
+    interaction.inGuild(),
+    interaction.user.id,
+    interaction.guildId,
+    interaction.channelId,
+  );
+  if (!access.ok) {
+    await interaction.reply({
+      content: `⚠️ ${access.reason}`,
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  // Register chat in the registry so action handler can resolve channel later.
+  const { chatId, numericChatId } = chatIdFromInteraction(interaction);
+  registerDiscordChat({
+    channelId: interaction.channelId!,
+    guildId: interaction.guildId,
+    userId: interaction.guildId ? null : interaction.user.id,
+    numericChatId,
+    chatId,
+  });
+
+  switch (interaction.commandName) {
+    case "start":
+      return handleStart(interaction);
+    case "help":
+      return handleHelp(interaction, client(interaction));
+    case "settings":
+      return handleSettings(interaction, config, gateway, chatId);
+    case "memory":
+      return handleMemory(interaction);
+    case "status":
+      return handleStatus(interaction, config, gateway, chatId);
+    case "ping":
+      return handlePing(interaction);
+    case "model":
+      return handleModel(interaction, config, gateway, chatId);
+    case "effort":
+      return handleEffort(interaction, chatId);
+    case "pulse":
+      return handlePulse(interaction, chatId);
+    case "reset":
+      return handleReset(interaction, gateway, chatId);
+    case "restart":
+      return handleRestart(interaction);
+    case "metrics":
+      return handleMetrics(interaction);
+    case "dream":
+      return handleDream(interaction);
+    case "plugins":
+      return handlePlugins(interaction);
+    case "admin":
+      return handleAdmin(interaction, config, gateway);
+    default:
+      await reply(interaction, "Unknown command.", true);
+  }
+}
+
+function client(i: ChatInputCommandInteraction) {
+  return i.client;
+}
+
+// ── Individual command handlers ─────────────────────────────────────────────
+
+async function handleStart(i: ChatInputCommandInteraction): Promise<void> {
+  await reply(
+    i,
+    [
+      "**🦅 Talon**",
+      "",
+      "Agentic AI harness for Discord.",
+      "",
+      "Mention me, reply to me, or DM me. Attach files, photos, voice notes — I'll read them.",
+      "",
+      "/status  /reset  /help",
+    ].join("\n"),
+  );
+}
+
+async function handleHelp(
+  i: ChatInputCommandInteraction,
+  c: Client,
+): Promise<void> {
+  const botMention = c.user ? `<@${c.user.id}>` : "@bot";
+  await reply(
+    i,
+    [
+      "**🦅 Talon — Help**",
+      "",
+      "**Settings**",
+      "  /settings — view and change all chat settings",
+      "  /model — show or change model",
+      "  /effort — set thinking effort (off, low, medium, high, max)",
+      "  /pulse — toggle periodic check-ins (on/off)",
+      "",
+      "**Session**",
+      "  /status — session info, usage, and stats",
+      "  /metrics — aggregate performance metrics (admin)",
+      "  /memory — view what Talon remembers",
+      "  /dream — force memory consolidation now (admin)",
+      "  /ping — health check with latency",
+      "  /reset — clear session and start fresh",
+      "  /restart — restart the bot process (admin)",
+      "  /plugins — list loaded plugins",
+      "  /help — this message",
+      "",
+      "**Input**",
+      "  Text, photos, documents, voice notes, audio, videos, GIFs, replies, attachments.",
+      "",
+      "**Servers**",
+      `  In a server, mention ${botMention} or reply to me to activate.`,
+      "",
+      "**DM**",
+      "  Whitelisted users can DM me directly.",
+    ].join("\n"),
+    true,
+  );
+}
+
+async function handleMemory(i: ChatInputCommandInteraction): Promise<void> {
+  try {
+    const memoryPath = files.memory;
+    if (!existsSync(memoryPath)) {
+      await reply(
+        i,
+        "No memory file yet. I'll create one as I learn about you.",
+        true,
+      );
+      return;
+    }
+    const content = readFileSync(memoryPath, "utf-8").trim();
+    if (!content) {
+      await reply(
+        i,
+        "Memory file is empty. I'll update it as we chat.",
+        true,
+      );
+      return;
+    }
+    const budget = DISCORD_MAX_TEXT - DISCORD_SAFE_RESERVE;
+    const display =
+      content.length > budget
+        ? content.slice(0, budget) + "\n\n... (truncated)"
+        : content;
+    await reply(i, display, true);
+  } catch {
+    await reply(i, "Could not read memory file.", true);
+  }
+}
+
+async function handlePing(i: ChatInputCommandInteraction): Promise<void> {
+  const start = Date.now();
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  const apiLatency = Date.now() - start;
+  // client.ws.ping is the WebSocket heartbeat RTT (the real gateway latency).
+  const wsPing = i.client.ws.ping;
+  const uptime = formatDuration(process.uptime() * 1000);
+  await i.editReply(
+    `Pong! WS: ${wsPing}ms · REST: ${apiLatency}ms\nGateway: ✓ | Uptime: ${uptime}`,
+  );
+}
+
+async function handleReset(
+  i: ChatInputCommandInteraction,
+  gateway: Gateway,
+  chatId: string,
+): Promise<void> {
+  // Defer immediately — warmSession can hit a cold backend (cold container,
+  // model load) and miss the 3s interaction ACK window.
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const info = getSessionInfo(chatId);
+  if (info.turns > 0) {
+    const duration = info.createdAt
+      ? formatDuration(Date.now() - info.createdAt)
+      : "unknown";
+    const modelNote =
+      info.turns > 5 && info.lastModel ? ` | model: ${info.lastModel}` : "";
+    const nameNote = info.sessionName ? ` "${info.sessionName}"` : "";
+    appendDailyLog(
+      "System",
+      `Session reset${nameNote}: ${info.turns} turns, ${duration}${modelNote}`,
+    );
+  }
+  resetSession(chatId);
+  clearHistory(chatId);
+  resetPulseCheckpoint(chatId);
+  await gateway?.backend?.warmSession?.(chatId);
+  await reply(i, "Session cleared.", true);
+}
+
+async function handleStatus(
+  i: ChatInputCommandInteraction,
+  config: TalonConfig,
+  gateway: Gateway,
+  chatId: string,
+): Promise<void> {
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  const info = getSessionInfo(chatId);
+  const u = info.usage;
+  const uptime = formatDuration(process.uptime() * 1000);
+  const sessionAge = info.createdAt
+    ? formatDuration(Date.now() - info.createdAt)
+    : "—";
+  const chatSets = getChatSettings(chatId);
+  const activeModel = chatSets.model ?? config.model;
+  const effortName = chatSets.effort ?? "adaptive";
+  const pulseOn = isPulseEnabled(chatId);
+
+  let ctxUsed = u.contextTokens || u.lastPromptTokens;
+  let ctxMax = u.contextWindow;
+  let displayInputTokens = u.totalInputTokens;
+  let displayOutputTokens = u.totalOutputTokens;
+  let displayCacheRead = u.totalCacheRead;
+  let displayCacheWrite = u.totalCacheWrite;
+  let turnsModelLabel = info.lastModel;
+
+  const be = gateway?.backend;
+  if (be?.getModelInfo) {
+    const mi = await be.getModelInfo(activeModel).catch(() => undefined);
+    if (mi?.contextWindow) ctxMax = ctxMax || mi.contextWindow;
+  }
+  if (be?.getSessionSnapshot && info.sessionId) {
+    const snap = await be
+      .getSessionSnapshot(info.sessionId)
+      .catch(() => undefined);
+    if (snap) {
+      displayInputTokens = snap.inputTokens ?? displayInputTokens;
+      displayOutputTokens = snap.outputTokens ?? displayOutputTokens;
+      displayCacheRead = snap.cacheRead ?? displayCacheRead;
+      displayCacheWrite = snap.cacheWrite ?? displayCacheWrite;
+      if (snap.contextModelId) turnsModelLabel = snap.contextModelId;
+    }
+  }
+
+  const ctxPct =
+    ctxMax > 0 ? Math.min(100, Math.round((ctxUsed / ctxMax) * 100)) : 0;
+  const barLen = 20;
+  const filled = Math.round((ctxPct / 100) * barLen);
+  const contextBar = "█".repeat(filled) + "░".repeat(barLen - filled);
+  const contextWarn = ctxPct >= 80 ? " ⚠️ consider /reset" : "";
+  const totalPrompt = displayInputTokens + displayCacheRead + displayCacheWrite;
+  const cacheHitPct =
+    totalPrompt > 0 ? Math.round((displayCacheRead / totalPrompt) * 100) : 0;
+  const avgResponseMs =
+    info.turns > 0 && u.totalResponseMs
+      ? Math.round(u.totalResponseMs / info.turns)
+      : 0;
+  const lastResponseMs = u.lastResponseMs || 0;
+  const fastestMs =
+    u.fastestResponseMs === Infinity ? 0 : u.fastestResponseMs || 0;
+  const diskBytes = getWorkspaceDiskUsage(config.workspace);
+  const diskStr = formatBytes(diskBytes);
+
+  const lines = [
+    `**🦅 Talon** · \`${formatModelLabel(activeModel)}\` · effort: ${effortName}`,
+    "",
+    `**Context** ${formatTokenCount(ctxUsed)} / ${formatTokenCount(ctxMax)} (${ctxPct}%)${contextWarn}`,
+    `\`${contextBar}\``,
+    "",
+    "**Session Stats**",
+    `  Response  last ${lastResponseMs ? formatDuration(lastResponseMs) : "—"} · avg ${avgResponseMs ? formatDuration(avgResponseMs) : "—"} · best ${fastestMs ? formatDuration(fastestMs) : "—"}`,
+    `  Turns     ${info.turns}${turnsModelLabel ? ` (${formatModelLabel(turnsModelLabel)})` : ""}`,
+    "",
+    `**Cache**     ${cacheHitPct}% hit`,
+    `  Read ${formatTokenCount(displayCacheRead)}  Write ${formatTokenCount(displayCacheWrite)}`,
+    `  Input ${formatTokenCount(displayInputTokens)}  Output ${formatTokenCount(displayOutputTokens)}`,
+    "",
+    `**Pulse**  ${pulseOn ? "on" : "off"}`,
+    `**Workspace**  ${diskStr}`,
+    `**Session**   ${info.sessionName ? `"${info.sessionName}" ` : ""}${info.sessionId ? "`" + info.sessionId.slice(0, 8) + "...`" : "_(new)_"} · ${sessionAge} old`,
+    `**Uptime**    ${uptime} · ${getActiveSessionCount()} active session${getActiveSessionCount() === 1 ? "" : "s"}`,
+  ];
+  await i.editReply(lines.join("\n"));
+}
+
+async function handleModel(
+  i: ChatInputCommandInteraction,
+  config: TalonConfig,
+  gateway: Gateway,
+  chatId: string,
+): Promise<void> {
+  // Defer immediately — getSettingsPresentation / resolveModel can hit a cold
+  // backend and exceed the 3s interaction ACK window.
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const arg = i.options.getString("name")?.trim();
+  const activeModel = getChatSettings(chatId).model ?? config.model;
+  const be = gateway?.backend;
+
+  if (
+    !arg ||
+    arg.toLowerCase() === "reset" ||
+    arg.toLowerCase() === "default"
+  ) {
+    if (arg) {
+      setChatModel(chatId, undefined);
+      await reply(i, `Model reset to default: \`${config.model}\``, true);
+      return;
+    }
+    if (be?.getSettingsPresentation) {
+      const pres = await be.getSettingsPresentation(activeModel, "model:");
+      const modelInfo = await be.getModelInfo?.(activeModel);
+      const displayName =
+        modelInfo?.displayName ?? formatModelLabel(activeModel);
+
+      // Build select menu from the top 25 models. Discord caps select-menu
+      // options at 25; if the backend exposes more, use `/model name:<value>`
+      // (autocomplete-backed) to pick anything outside this list.
+      const options = pres.modelButtons.slice(0, 25).map((b) => ({
+        label: safeSlice(b.text.replace(/^✓ /, ""), 100),
+        value: safeSlice(b.callback_data.replace(/^model:/, ""), 100),
+        default: b.text.startsWith("✓"),
+      }));
+      const menu = new StringSelectMenuBuilder()
+        .setCustomId("model:select")
+        .setPlaceholder("Pick a model")
+        .addOptions(options);
+      const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+        menu,
+      );
+      const lines = [`**Model:** \`${displayName}\``, ...pres.modelDetails];
+      await i.editReply({
+        content: lines.join("\n"),
+        components: [row],
+        allowedMentions: { parse: [] },
+      });
+    } else {
+      await reply(i, `**Model:** \`${formatModelLabel(activeModel)}\``, true);
+    }
+    return;
+  }
+
+  if (be?.resolveModel) {
+    const resolution = await be.resolveModel(arg);
+    if (resolution.kind !== "exact") {
+      const msg =
+        be.formatModelError?.(arg, resolution) ?? `No model matched "${arg}".`;
+      await reply(i, msg, true);
+      return;
+    }
+    if (!resolution.model.selectable) {
+      const msg =
+        resolution.model.unavailableReason ??
+        `${resolution.model.providerName} is not connected.`;
+      await reply(i, msg, true);
+      return;
+    }
+    setChatModel(chatId, resolution.storedValue);
+    await reply(
+      i,
+      `Model set to \`${resolution.storedValue}\` (${resolution.model.providerName}${resolution.model.free ? " · free" : ""}).`,
+      true,
+    );
+  } else {
+    const model = resolveModelName(arg);
+    setChatModel(chatId, model);
+    await reply(i, `Model set to \`${formatModelLabel(model)}\`.`, true);
+  }
+}
+
+async function handleEffort(
+  i: ChatInputCommandInteraction,
+  chatId: string,
+): Promise<void> {
+  const level = i.options.getString("level")?.toLowerCase();
+  const settings = getChatSettings(chatId);
+
+  if (!level) {
+    const current = settings.effort ?? "adaptive";
+    const options = (
+      ["off", "low", "medium", "high", "max", "adaptive"] as const
+    ).map((v) => ({
+      label: v,
+      value: v,
+      description: EFFORT_DESCRIPTIONS[v],
+      default: current === v,
+    }));
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId("effort:select")
+      .setPlaceholder(`Current: ${current}`)
+      .addOptions(options);
+    const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+      menu,
+    );
+    await i.reply({
+      content: `**Effort:** ${current}`,
+      components: [row],
+      allowedMentions: { parse: [] },
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  if (level === "adaptive") {
+    setChatEffort(chatId, undefined);
+    await reply(
+      i,
+      "Effort reset to **adaptive** (model decides when to think)",
+      true,
+    );
+    return;
+  }
+  if (EFFORT_LEVELS.includes(level as EffortLevel)) {
+    setChatEffort(chatId, level as EffortLevel);
+    await reply(i, `Effort set to **${level}**`, true);
+    return;
+  }
+  await reply(
+    i,
+    "Unknown level. Use: off, low, medium, high, max, or adaptive.",
+    true,
+  );
+}
+
+async function handlePulse(
+  i: ChatInputCommandInteraction,
+  chatId: string,
+): Promise<void> {
+  const arg = i.options.getString("arg")?.trim().toLowerCase();
+
+  if (!arg || arg === "status") {
+    const enabled = isPulseEnabled(chatId);
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId("pulse:on")
+        .setLabel(enabled ? "✓ On" : "On")
+        .setStyle(enabled ? ButtonStyle.Success : ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId("pulse:off")
+        .setLabel(!enabled ? "✓ Off" : "Off")
+        .setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId("pulse:interval")
+        .setLabel("Set interval…")
+        .setStyle(ButtonStyle.Secondary),
+    );
+    await i.reply({
+      content: [
+        `**🔔 Pulse:** ${enabled ? "on" : "off"}`,
+        "",
+        "Reads along every few minutes and jumps in when there's something to add.",
+      ].join("\n"),
+      components: [row],
+      allowedMentions: { parse: [] },
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  if (arg === "on" || arg === "enable") {
+    enablePulse(chatId);
+    registerChat(chatId);
+    await reply(i, "🔔 Pulse enabled.", true);
+    return;
+  }
+  if (arg === "off" || arg === "disable") {
+    disablePulse(chatId);
+    await reply(i, "🔔 Pulse disabled.", true);
+    return;
+  }
+  const intervalMs = parseInterval(arg);
+  if (intervalMs && intervalMs >= 5 * 60 * 1000) {
+    setChatPulseInterval(chatId, intervalMs);
+    enablePulse(chatId);
+    registerChat(chatId);
+    await reply(
+      i,
+      `🔔 Pulse cooldown set to **${formatDuration(intervalMs)}**`,
+      true,
+    );
+    return;
+  }
+  if (intervalMs) {
+    await reply(i, "Minimum interval is 5 minutes.", true);
+    return;
+  }
+  await reply(i, "Use: /pulse on, /pulse off, /pulse 30m, /pulse 2h", true);
+}
+
+async function handleSettings(
+  i: ChatInputCommandInteraction,
+  config: TalonConfig,
+  gateway: Gateway,
+  chatId: string,
+): Promise<void> {
+  // Defer immediately — getSettingsPresentation hits the backend.
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const chatSets = getChatSettings(chatId);
+  const activeModel = chatSets.model ?? config.model;
+  const effortName = chatSets.effort ?? "adaptive";
+  const pulseOn = isPulseEnabled(chatId);
+
+  let modelDetails: Array<string> | undefined;
+  let modelButtons: Array<{ text: string; callback_data: string }> | undefined;
+  if (gateway?.backend?.getSettingsPresentation) {
+    const presentation =
+      await gateway.backend.getSettingsPresentation(activeModel);
+    modelDetails = presentation.modelDetails;
+    modelButtons = presentation.modelButtons;
+  }
+
+  // Build components: model select menu, effort select menu, pulse toggle, done.
+  const components: ActionRowBuilder<
+    StringSelectMenuBuilder | ButtonBuilder
+  >[] = [];
+
+  if (modelButtons?.length) {
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId("settings:model")
+      .setPlaceholder("Select a model")
+      .addOptions(
+        modelButtons.slice(0, 25).map((b) => ({
+          label: safeSlice(b.text.replace(/^✓ /, ""), 100),
+          value: safeSlice(b.callback_data.replace(/^settings:model:/, ""), 100),
+          default: b.text.startsWith("✓"),
+        })),
+      );
+    components.push(
+      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu),
+    );
+  }
+
+  // Effort as a select-menu (matches refreshSettingsPanel + standalone /effort).
+  const effortMenu = new StringSelectMenuBuilder()
+    .setCustomId("settings:effort:select")
+    .setPlaceholder(`Effort: ${effortName}`)
+    .addOptions(
+      (["off", "low", "medium", "high", "max", "adaptive"] as const).map(
+        (v) => ({
+          label: v,
+          value: v,
+          description: EFFORT_DESCRIPTIONS[v],
+          default: effortName === v,
+        }),
+      ),
+    );
+  components.push(
+    new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(effortMenu),
+  );
+
+  components.push(
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`settings:proactive:${pulseOn ? "off" : "on"}`)
+        .setLabel(pulseOn ? "Pulse: ON" : "Pulse: OFF")
+        .setStyle(pulseOn ? ButtonStyle.Success : ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId("settings:done")
+        .setLabel("Done")
+        .setStyle(ButtonStyle.Secondary),
+    ),
+  );
+
+  await i.editReply({
+    content: renderSettingsText(
+      activeModel,
+      effortName,
+      pulseOn,
+      chatSets.pulseIntervalMs,
+      modelDetails,
+    ),
+    components,
+    allowedMentions: { parse: [] },
+  });
+}
+
+async function handleRestart(i: ChatInputCommandInteraction): Promise<void> {
+  if (!isAdmin(i.user.id)) {
+    await reply(i, "Not authorized.", true);
+    return;
+  }
+  await reply(i, "♻️ Restarting...", true);
+  setTimeout(() => {
+    const projectRoot = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../..",
+    );
+    const localBin = resolve(projectRoot, "bin/talon.js");
+    const trySpawn = (cmd: string, args: string[]): Promise<void> =>
+      new Promise((res, rej) => {
+        const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
+        child.on("error", rej);
+        child.on("spawn", () => {
+          child.unref();
+          res();
+        });
+      });
+    trySpawn("talon", ["restart"])
+      .catch(() => trySpawn(process.execPath, [localBin, "restart"]))
+      .catch(() => {})
+      .finally(() => process.exit(0));
+  }, 500);
+}
+
+async function handleMetrics(i: ChatInputCommandInteraction): Promise<void> {
+  if (!isAdmin(i.user.id)) {
+    await reply(i, "Not authorized.", true);
+    return;
+  }
+  // Ephemeral — admin counters (token usage, latencies, errors) shouldn't leak
+  // into a public channel where non-admins can read them.
+  const messages = renderMetricsMessages(getMetrics());
+  for (const m of messages) {
+    await reply(i, m, true);
+  }
+}
+
+async function handleDream(i: ChatInputCommandInteraction): Promise<void> {
+  if (!isAdmin(i.user.id)) {
+    await reply(i, "Not authorized.", true);
+    return;
+  }
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  await i.editReply("🌙 Dream mode starting...");
+  const start = Date.now();
+  forceDream()
+    .then(async () => {
+      const elapsed = formatDuration(Date.now() - start);
+      await i.editReply(
+        `🌙 Dream complete — memory consolidated in ${elapsed}.`,
+      );
+    })
+    .catch(async (err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      await i.editReply(`🌙 Dream failed: ${msg}`);
+    });
+}
+
+async function handlePlugins(i: ChatInputCommandInteraction): Promise<void> {
+  const plugins = getLoadedPlugins();
+  if (plugins.length === 0) {
+    await reply(i, "No plugins loaded.", true);
+    return;
+  }
+  const lines = plugins.map((p) => {
+    const ver = p.plugin.version ? ` v${p.plugin.version}` : "";
+    const desc = p.plugin.description ? ` — ${p.plugin.description}` : "";
+    const mcp = p.plugin.mcpServerPath ? " [MCP]" : "";
+    const fe = p.plugin.frontends?.length
+      ? ` (${p.plugin.frontends.join(", ")})`
+      : "";
+    return `• **${p.plugin.name}**${ver}${mcp}${fe}${desc}`;
+  });
+  await reply(
+    i,
+    `**Plugins (${plugins.length})**\n\n${lines.join("\n")}`,
+    true,
+  );
+}
+
+async function handleAdmin(
+  i: ChatInputCommandInteraction,
+  config: TalonConfig,
+  gateway: Gateway,
+): Promise<void> {
+  if (!isAdmin(i.user.id)) {
+    await reply(i, "Not authorized.", true);
+    return;
+  }
+  const sub = i.options.getString("sub", true);
+  const args = i.options.getString("args") ?? "";
+  // Ephemeral — admin subcommands surface operational data (chat lists, logs,
+  // cron, daily logs) that shouldn't leak into the channel for non-admins.
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  await handleAdminSubcommand(sub, args, config, gateway, async (text) => {
+    await i.followUp({
+      content: suppressMentions(text).slice(0, DISCORD_MAX_TEXT),
+      allowedMentions: { parse: [] },
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+}

--- a/src/frontend/discord/commands.ts
+++ b/src/frontend/discord/commands.ts
@@ -511,11 +511,7 @@ async function handleMemory(i: ChatInputCommandInteraction): Promise<void> {
     }
     const content = readFileSync(memoryPath, "utf-8").trim();
     if (!content) {
-      await reply(
-        i,
-        "Memory file is empty. I'll update it as we chat.",
-        true,
-      );
+      await reply(i, "Memory file is empty. I'll update it as we chat.", true);
       return;
     }
     const budget = DISCORD_MAX_TEXT - DISCORD_SAFE_RESERVE;
@@ -894,7 +890,10 @@ async function handleSettings(
       .addOptions(
         modelButtons.slice(0, 25).map((b) => ({
           label: safeSlice(b.text.replace(/^✓ /, ""), 100),
-          value: safeSlice(b.callback_data.replace(/^settings:model:/, ""), 100),
+          value: safeSlice(
+            b.callback_data.replace(/^settings:model:/, ""),
+            100,
+          ),
           default: b.text.startsWith("✓"),
         })),
       );

--- a/src/frontend/discord/errors.ts
+++ b/src/frontend/discord/errors.ts
@@ -1,0 +1,145 @@
+/**
+ * Discord API error code mapper.
+ *
+ * discord.js throws `DiscordAPIError` instances with numeric `.code` set to
+ * the JSON error code from Discord's REST response body. This helper turns the
+ * raw error into a clean `{ok:false, error}` shape that the agent (LLM) can
+ * read without losing the original message in a stack trace.
+ *
+ * Code reference: https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
+ */
+
+import type { ActionResult } from "../../core/types.js";
+
+type DiscordAPIErrorLike = {
+  code?: number;
+  status?: number;
+  message?: string;
+  rawError?: { code?: number };
+};
+
+/** Extract numeric JSON error code, if this looks like a DiscordAPIError. */
+function discordErrorCode(err: unknown): number | null {
+  if (!err || typeof err !== "object") return null;
+  const e = err as DiscordAPIErrorLike;
+  if (typeof e.code === "number") return e.code;
+  if (typeof e.rawError?.code === "number") return e.rawError.code;
+  return null;
+}
+
+/**
+ * Map a DiscordAPIError into a friendly ActionResult. Returns null if the
+ * error isn't a recognized Discord error — caller should fall back to its
+ * own generic handler in that case.
+ */
+export function mapDiscordError(
+  err: unknown,
+  context: string,
+): ActionResult | null {
+  const code = discordErrorCode(err);
+  if (code === null) return null;
+  const raw = err instanceof Error ? err.message : String(err);
+  switch (code) {
+    case 10003:
+      return { ok: false, error: `Unknown channel (${context})` };
+    case 10008:
+      return {
+        ok: false,
+        error: `Unknown message — it was likely deleted before ${context} could run`,
+      };
+    case 10013:
+      return { ok: false, error: `Unknown user (${context})` };
+    case 10014:
+      return { ok: false, error: `Unknown emoji (${context})` };
+    case 10026:
+      return { ok: false, error: `Unknown sticker (${context})` };
+    case 20029:
+      return {
+        ok: false,
+        error: `Disallowed words/content (${context}): ${raw}`,
+      };
+    case 30005:
+      return {
+        ok: false,
+        error: `Maximum number of guild roles reached (${context})`,
+      };
+    case 30007:
+      return {
+        ok: false,
+        error: `Webhook rate limit hit; back off and retry (${context})`,
+      };
+    case 30008:
+      return {
+        ok: false,
+        error: `Max reactions on this message (${context})`,
+      };
+    case 40005:
+      return {
+        ok: false,
+        error: `Attachment too large for this channel/guild (${context})`,
+      };
+    case 40060:
+      return {
+        ok: false,
+        error: `Interaction already acknowledged (${context}) — this is a race condition, retry the action`,
+      };
+    case 50001:
+      return {
+        ok: false,
+        error: `Missing access — bot can't see this channel (${context})`,
+      };
+    case 50007:
+      return {
+        ok: false,
+        error: `Cannot DM this user — they have DMs disabled or blocked the bot`,
+      };
+    case 50013:
+      return {
+        ok: false,
+        error: `Missing permissions — bot lacks the required guild/channel permission for ${context}`,
+      };
+    case 50021:
+      return {
+        ok: false,
+        error: `Cannot execute on a system message (${context})`,
+      };
+    case 50035:
+      return { ok: false, error: `Invalid form body (${context}): ${raw}` };
+    case 50036:
+      return {
+        ok: false,
+        error: `Bot is not in the guild that owns this resource (${context})`,
+      };
+    default:
+      return {
+        ok: false,
+        error: `Discord error ${code} during ${context}: ${raw}`,
+      };
+  }
+}
+
+/**
+ * Max attachment size in bytes for a given guild's boost tier. Per
+ * https://discord.com/developers/docs/resources/guild#guild-object-premium-tier:
+ *   Tier 0 (no boosts)  10 MB
+ *   Tier 1              25 MB
+ *   Tier 2              50 MB
+ *   Tier 3             100 MB
+ *
+ * DMs use Tier 0 (10 MB) since 2024-08; previously 25 MB.
+ */
+export function maxAttachmentBytes(
+  guild: { premiumTier?: number } | null | undefined,
+): number {
+  const tier = guild?.premiumTier ?? 0;
+  switch (tier) {
+    case 3:
+      return 100 * 1024 * 1024;
+    case 2:
+      return 50 * 1024 * 1024;
+    case 1:
+      return 25 * 1024 * 1024;
+    default:
+      return 10 * 1024 * 1024;
+  }
+}

--- a/src/frontend/discord/formatting.ts
+++ b/src/frontend/discord/formatting.ts
@@ -1,0 +1,101 @@
+/**
+ * Discord message formatting and splitting utilities.
+ *
+ * Discord supports markdown natively (no HTML conversion like Telegram). The job
+ * here is to (a) chunk long messages so they fit Discord's 2000-char per-message
+ * limit, splitting at safe boundaries, (b) keep code blocks intact, and (c)
+ * provide an escape helper for embedding user-supplied text inside markdown.
+ */
+
+export const DISCORD_MAX_TEXT = 2000;
+/**
+ * Headroom under DISCORD_MAX_TEXT for callers that interpolate user-supplied
+ * text into a markdown wrapper (bold headers, code fences, etc.) where the
+ * wrapper itself eats some of the 2000-char budget.
+ */
+export const DISCORD_SAFE_RESERVE = 100;
+
+/**
+ * Split a message into chunks ≤ max characters, preferring paragraph/newline/space
+ * boundaries. Code fences are kept intact: if a split would land inside a fenced
+ * block, the block is closed before the split and reopened in the next chunk.
+ */
+export function splitMessage(text: string, max = DISCORD_MAX_TEXT): string[] {
+  if (text.length <= max) return [text];
+
+  const chunks: string[] = [];
+  let rest = text;
+  let openFence: string | null = null; // tracks an unclosed ``` block carried into next chunk
+
+  while (rest.length > 0) {
+    if (rest.length <= max) {
+      chunks.push(openFence ? openFence + rest : rest);
+      break;
+    }
+
+    let at = rest.lastIndexOf("\n\n", max);
+    if (at <= max * 0.3) at = rest.lastIndexOf("\n", max);
+    if (at <= max * 0.3) at = rest.lastIndexOf(" ", max);
+    if (at <= 0) at = max;
+
+    let head = rest.slice(0, at);
+    if (openFence) head = openFence + head;
+
+    // Detect unclosed fence in this chunk; if so, close it here and reopen next.
+    const fences = head.match(/```/g)?.length ?? 0;
+    if (fences % 2 === 1) {
+      head = head + "\n```";
+      openFence = "```\n";
+    } else {
+      openFence = null;
+    }
+
+    chunks.push(head);
+    rest = rest.slice(at).trimStart();
+  }
+
+  return chunks;
+}
+
+/**
+ * Escape user-supplied text so Discord doesn't interpret markdown / mentions.
+ * Use ONLY when embedding untrusted text inside a message you're constructing.
+ * Do not run on AI output (we want markdown to render).
+ */
+export function escapeMarkdown(text: string): string {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/([*_`~|>])/g, "\\$1")
+    .replace(/^#/gm, "\\#")
+    .replace(/^-/gm, "\\-");
+}
+
+/**
+ * Suppress @everyone, @here, @&role, @userId mentions inside arbitrary text.
+ * Wraps each "@" target with a zero-width space so Discord won't ping anyone.
+ * Returned text is still readable.
+ */
+export function suppressMentions(text: string): string {
+  return text
+    .replace(/@everyone/g, "@​everyone")
+    .replace(/@here/g, "@​here")
+    .replace(/<@!?\d+>/g, (m) => m.replace("@", "@​"))
+    .replace(/<@&\d+>/g, (m) => m.replace("@", "@​"));
+}
+
+/**
+ * Slice a string to `max` user-visible characters without splitting multi-byte
+ * code points (emoji, CJK) on a UTF-16 surrogate boundary. Used for Discord
+ * `customId`, `label`, `value`, etc. where Discord measures char count.
+ */
+export function safeSlice(text: string, max: number): string {
+  return Array.from(text).slice(0, max).join("");
+}
+
+/** Simple HTML-style escape used when displaying raw text inside code blocks. */
+export function escapeForCodeBlock(text: string): string {
+  // The only sequence that breaks an inline code/code block is a backtick run
+  // longer than the wrapper. We can't trivially solve all cases — replace ``` with
+  // a zero-width-joiner-separated equivalent so the fence never collides.
+  return text.replace(/```/g, "`​``");
+}

--- a/src/frontend/discord/handlers.ts
+++ b/src/frontend/discord/handlers.ts
@@ -1,0 +1,798 @@
+/**
+ * Discord message handlers — access control, debounce queue, attachment download,
+ * processAndReply with streaming.
+ *
+ * Mirrors src/frontend/telegram/handlers.ts. Differences:
+ *  - chat IDs are Discord snowflakes (strings); numericChatId is a sha256-derived
+ *    32-bit hash (see util/chat-id.ts) so the gateway/dispatcher (number-keyed)
+ *    can route correctly.
+ *  - access control gates by allowedUsers (DM) and allowedGuilds + optional
+ *    allowedChannels (guild). adminUserIds is a list, not a single ID.
+ *  - "shouldHandleInGuild" honors respondMode ("mention" → only @bot/reply,
+ *    "channel" → all messages in allowedChannels).
+ */
+
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Client, Message, Attachment, TextBasedChannel } from "discord.js";
+import { ChannelType } from "discord.js";
+import type { TalonConfig } from "../../util/config.js";
+import { execute } from "../../core/dispatcher.js";
+import { classify, friendlyMessage } from "../../core/errors.js";
+import {
+  appendDailyLog,
+  appendDailyLogResponse,
+} from "../../storage/daily-log.js";
+import { setMessageFilePath } from "../../storage/history.js";
+import { addMedia } from "../../storage/media-index.js";
+import { recordMessageProcessed, recordError } from "../../util/watchdog.js";
+import { deriveNumericChatId } from "../../util/chat-id.js";
+import { log, logError, logWarn, logDebug } from "../../util/log.js";
+import {
+  splitMessage,
+  suppressMentions,
+  escapeMarkdown,
+  DISCORD_MAX_TEXT,
+} from "./formatting.js";
+
+// ── Chat registry: numericChatId → Discord channel info ─────────────────────
+// The gateway/dispatcher uses numeric chatIds. Action handlers need to map
+// back to the Discord channel they should post to. We maintain a registry,
+// updated whenever a message arrives or an interaction is processed.
+
+export type DiscordChatInfo = {
+  channelId: string;
+  guildId: string | null;
+  userId: string | null; // for DM contexts
+  numericChatId: number;
+  chatId: string;
+};
+
+const chatRegistry = new Map<number, DiscordChatInfo>();
+const chatRegistryByString = new Map<string, DiscordChatInfo>();
+
+export function registerDiscordChat(info: DiscordChatInfo): void {
+  chatRegistry.set(info.numericChatId, info);
+  chatRegistryByString.set(info.chatId, info);
+}
+
+export function lookupDiscordChat(
+  numericChatId: number,
+): DiscordChatInfo | undefined {
+  return chatRegistry.get(numericChatId);
+}
+
+export function lookupDiscordChatByString(
+  chatId: string,
+): DiscordChatInfo | undefined {
+  return chatRegistryByString.get(chatId);
+}
+
+// ── Access control state ─────────────────────────────────────────────────────
+
+type AccessConfig = {
+  allowedUsers: Set<string>;
+  allowedGuilds: Set<string>;
+  allowedChannels: Set<string>; // empty = all channels in allowedGuilds
+  adminUserIds: Set<string>;
+  respondMode: "mention" | "channel";
+};
+
+let access: AccessConfig = {
+  allowedUsers: new Set(),
+  allowedGuilds: new Set(),
+  allowedChannels: new Set(),
+  adminUserIds: new Set(),
+  respondMode: "mention",
+};
+
+export function setAccessControl(cfg: {
+  allowedUsers: string[];
+  allowedGuilds: string[];
+  allowedChannels: string[];
+  adminUserIds: string[];
+  respondMode: "mention" | "channel";
+}): void {
+  access = {
+    allowedUsers: new Set(cfg.allowedUsers),
+    allowedGuilds: new Set(cfg.allowedGuilds),
+    allowedChannels: new Set(cfg.allowedChannels),
+    adminUserIds: new Set(cfg.adminUserIds),
+    respondMode: cfg.respondMode,
+  };
+}
+
+export function isAdmin(userId: string): boolean {
+  return access.adminUserIds.has(userId);
+}
+
+export function getAccessSnapshot(): AccessConfig {
+  return access;
+}
+
+// ── First-time DM user tracking ──────────────────────────────────────────────
+
+const knownDmUsers = new Set<string>();
+const KNOWN_DM_USERS_CAP = 10_000;
+
+function trackDmUser(senderId: string, senderName: string, tag?: string): void {
+  if (knownDmUsers.has(senderId)) return;
+  if (knownDmUsers.size >= KNOWN_DM_USERS_CAP) {
+    const evictCount = Math.floor(KNOWN_DM_USERS_CAP * 0.1);
+    const iter = knownDmUsers.values();
+    for (let i = 0; i < evictCount; i++) {
+      knownDmUsers.delete(iter.next().value as string);
+    }
+  }
+  knownDmUsers.add(senderId);
+  const tagStr = tag ? ` (${tag})` : "";
+  log("users", `New DM user: ${senderName}${tagStr} [id:${senderId}]`);
+  appendDailyLog(
+    "System",
+    `New DM user: ${senderName}${tagStr} [id:${senderId}]`,
+  );
+}
+
+// ── Unauthorized notification (cooldown 10 min, like Telegram) ───────────────
+
+const unauthorizedCooldown = new Map<string, number>();
+const UNAUTHORIZED_COOLDOWN_MS = 10 * 60 * 1000;
+const MAX_UNAUTHORIZED_COOLDOWNS = 5000;
+
+async function notifyUnauthorized(
+  client: Client,
+  msg: Message,
+  type: "dm" | "guild" | "channel",
+): Promise<void> {
+  const userId = msg.author.id;
+  const guildId = msg.guildId ?? "";
+  const channelId = msg.channelId;
+  const key =
+    type === "dm"
+      ? `dm:${userId}`
+      : type === "guild"
+        ? `guild:${guildId}`
+        : `channel:${channelId}`;
+  const now = Date.now();
+  const last = unauthorizedCooldown.get(key);
+  if (last && now - last < UNAUTHORIZED_COOLDOWN_MS) return;
+  if (unauthorizedCooldown.size >= MAX_UNAUTHORIZED_COOLDOWNS) {
+    unauthorizedCooldown.clear();
+  }
+  unauthorizedCooldown.set(key, now);
+
+  const senderTag = msg.author.username ? ` (@${msg.author.username})` : "";
+  const senderName = msg.author.globalName || msg.author.username || "User";
+
+  // Warn the user
+  try {
+    if (msg.channel.isSendable()) {
+      await msg.channel.send({
+        content:
+          "⚠️ Unauthorized access. This bot is private. This attempt has been reported to the bot owner.",
+        allowedMentions: { parse: [] },
+      });
+    }
+  } catch {
+    /* can't send — ignore */
+  }
+
+  // Notify admins via DM. User-supplied names (sender, guild, channel) are
+  // escaped so a nick containing ** or || can't deform the admin's message.
+  const safeSender = escapeMarkdown(`${senderName}${senderTag}`);
+  const safeGuildName = escapeMarkdown(msg.guild?.name ?? guildId);
+  const safeChannelName = escapeMarkdown(
+    (msg.channel as { name?: string }).name ?? channelId,
+  );
+  for (const adminId of access.adminUserIds) {
+    try {
+      const admin = await client.users.fetch(adminId);
+      const detail =
+        type === "dm"
+          ? `🚨 Unauthorized DM from ${safeSender} [id:${userId}]`
+          : type === "guild"
+            ? `🚨 Unauthorized guild access: "${safeGuildName}" [id:${guildId}] by ${safeSender}`
+            : `🚨 Unauthorized channel access: #${safeChannelName} in "${safeGuildName}" by ${safeSender}`;
+      await admin.send({ content: detail, allowedMentions: { parse: [] } });
+    } catch {
+      /* admin unreachable */
+    }
+  }
+
+  logWarn(
+    "access",
+    `Unauthorized ${type}: ${senderName}${senderTag} [id:${userId}] guild=${guildId} channel=${channelId}`,
+  );
+}
+
+/** Check if a DM user is allowed. */
+function isDmAllowed(userId: string): boolean {
+  return access.allowedUsers.has(userId);
+}
+
+/**
+ * Full access check for plain messages. Returns true if message should be processed.
+ * Notifies user + admins on rejection (with cooldown).
+ */
+export async function isAccessAllowed(
+  client: Client,
+  msg: Message,
+): Promise<boolean> {
+  if (msg.channel.type === ChannelType.DM) {
+    if (isDmAllowed(msg.author.id)) return true;
+    await notifyUnauthorized(client, msg, "dm");
+    return false;
+  }
+  // Guild context
+  const guildId = msg.guildId;
+  if (!guildId) return false; // unknown — deny
+
+  if (!access.allowedGuilds.has(guildId)) {
+    await notifyUnauthorized(client, msg, "guild");
+    return false;
+  }
+  if (
+    access.allowedChannels.size > 0 &&
+    !access.allowedChannels.has(msg.channelId)
+  ) {
+    await notifyUnauthorized(client, msg, "channel");
+    return false;
+  }
+  return true;
+}
+
+/**
+ * For interactions (slash commands, buttons): synchronous predicate without
+ * side effects, since the interaction has its own ephemeral reply path.
+ */
+export function isInteractionAllowed(
+  inGuild: boolean,
+  userId: string,
+  guildId: string | null,
+  channelId: string | null,
+): { ok: true } | { ok: false; reason: string } {
+  if (!inGuild) {
+    if (isDmAllowed(userId)) return { ok: true };
+    return { ok: false, reason: "DM access not authorized." };
+  }
+  if (!guildId)
+    return { ok: false, reason: "Could not determine guild context." };
+  if (!access.allowedGuilds.has(guildId))
+    return { ok: false, reason: "This server is not authorized." };
+  if (
+    access.allowedChannels.size > 0 &&
+    channelId &&
+    !access.allowedChannels.has(channelId)
+  )
+    return { ok: false, reason: "This channel is not authorized." };
+  return { ok: true };
+}
+
+// ── Mention/respond gating in guilds ─────────────────────────────────────────
+
+/**
+ * Whether a guild message should activate the bot.
+ *  - mode "mention": only if @bot or reply-to-bot
+ *  - mode "channel": any message inside an allowedChannels channel (whitelist
+ *    must be set; otherwise we fall back to mention to avoid being noisy).
+ */
+export function shouldHandleInGuild(client: Client, msg: Message): boolean {
+  if (msg.channel.type === ChannelType.DM) return true;
+
+  const botId = client.user?.id;
+  const mentioned = botId ? msg.mentions.users.has(botId) : false;
+  const repliedToBot =
+    msg.reference?.messageId && msg.mentions.repliedUser?.id === botId;
+
+  if (access.respondMode === "channel" && access.allowedChannels.size > 0) {
+    return access.allowedChannels.has(msg.channelId);
+  }
+  return Boolean(mentioned || repliedToBot);
+}
+
+// ── Per-user rate limiting ───────────────────────────────────────────────────
+
+const userMessageTimestamps = new Map<string, number[]>();
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_MESSAGES = 15;
+
+export function isUserRateLimited(senderId: string): boolean {
+  const now = Date.now();
+  let timestamps = userMessageTimestamps.get(senderId);
+  if (!timestamps) {
+    timestamps = [];
+    userMessageTimestamps.set(senderId, timestamps);
+  }
+  while (timestamps.length > 0 && timestamps[0] < now - RATE_LIMIT_WINDOW_MS) {
+    timestamps.shift();
+  }
+  if (timestamps.length >= RATE_LIMIT_MAX_MESSAGES) {
+    logDebug("bot", `Rate-limited user ${senderId}`);
+    return true;
+  }
+  timestamps.push(now);
+  if (userMessageTimestamps.size > 5_000) {
+    const cutoff = now - 10 * 60_000;
+    for (const [userId, ts] of userMessageTimestamps) {
+      if (ts.length === 0 || ts[ts.length - 1] < cutoff) {
+        userMessageTimestamps.delete(userId);
+      }
+      if (userMessageTimestamps.size <= 2_500) break;
+    }
+  }
+  return false;
+}
+
+// ── Sender/reply/forward context helpers ─────────────────────────────────────
+
+export function getSenderName(msg: Message): string {
+  return (
+    (msg.member?.displayName || msg.author.globalName || msg.author.username) ??
+    "User"
+  );
+}
+
+function buildReplyContext(msg: Message, botId: string | undefined): string {
+  const ref = msg.reference;
+  if (!ref || !ref.messageId) return "";
+  // We don't always have the message cached. Discord.js provides
+  // msg.fetchReference() but that's async; we keep this synchronous and rely
+  // on the partial info already available via mentions.repliedUser.
+  const replied = msg.mentions.repliedUser;
+  if (!replied) return `[Replying to msg_id:${ref.messageId}]\n\n`;
+  const author =
+    replied.id === botId
+      ? "bot"
+      : replied.globalName || replied.username || "User";
+  return `[Replying to ${author} msg_id:${ref.messageId}]\n\n`;
+}
+
+// ── Attachment download ──────────────────────────────────────────────────────
+
+const ATTACHMENT_MAX_BYTES = 50 * 1024 * 1024;
+
+async function downloadAttachment(
+  attachment: Attachment,
+  workspace: string,
+): Promise<string> {
+  if (attachment.size && attachment.size > ATTACHMENT_MAX_BYTES) {
+    throw new Error(
+      `File too large (${Math.round(attachment.size / 1024 / 1024)}MB, max ${ATTACHMENT_MAX_BYTES / 1024 / 1024}MB).`,
+    );
+  }
+  const resp = await fetch(attachment.url);
+  if (!resp.ok) throw new Error(`Download failed: ${resp.status}`);
+  const buffer = Buffer.from(await resp.arrayBuffer());
+  if (buffer.length === 0) throw new Error("Downloaded file is empty.");
+
+  const safeName = (attachment.name || `att_${attachment.id}`).replace(
+    /[^a-zA-Z0-9._-]/g,
+    "_",
+  );
+  const uploadsDir = resolve(workspace, "uploads");
+  if (!existsSync(uploadsDir)) mkdirSync(uploadsDir, { recursive: true });
+  const dest = resolve(uploadsDir, `${Date.now()}-${safeName}`);
+  writeFileSync(dest, buffer);
+  return dest;
+}
+
+function classifyAttachment(att: Attachment): {
+  type: "photo" | "document" | "voice" | "video" | "audio" | "animation";
+  promptLines: (savedPath: string) => string[];
+} {
+  const ct = att.contentType ?? "";
+  const name = (att.name ?? "").toLowerCase();
+
+  if (ct.startsWith("image/") || /\.(png|jpe?g|webp|gif|bmp)$/.test(name)) {
+    if (ct === "image/gif" || name.endsWith(".gif")) {
+      return {
+        type: "animation",
+        promptLines: (p) => [
+          `User sent a GIF: "${att.name ?? att.id}".`,
+          `Saved to: ${p}`,
+        ],
+      };
+    }
+    return {
+      type: "photo",
+      promptLines: (p) => [
+        `User sent an image saved to: ${p}`,
+        "Read this file to view it. If you need to reference this image in future turns, re-read the file — image data does not persist between turns.",
+      ],
+    };
+  }
+  if (ct.startsWith("video/") || /\.(mp4|mov|webm|mkv)$/.test(name)) {
+    return {
+      type: "video",
+      promptLines: (p) => [
+        `User sent a video: "${att.name ?? att.id}".`,
+        `Saved to: ${p}`,
+      ],
+    };
+  }
+  if (
+    ct === "audio/ogg" ||
+    /voice/.test(name) ||
+    (att.waveform != null && ct.startsWith("audio/"))
+  ) {
+    return {
+      type: "voice",
+      promptLines: (p) => [
+        `User sent a voice message (${att.duration ?? "?"}s).`,
+        `Audio saved to: ${p}. You cannot transcribe audio — acknowledge it and respond based on context.`,
+      ],
+    };
+  }
+  if (ct.startsWith("audio/") || /\.(mp3|wav|flac|m4a|opus)$/.test(name)) {
+    return {
+      type: "audio",
+      promptLines: (p) => [
+        `User sent an audio file: "${att.name ?? att.id}".`,
+        `Saved to: ${p}`,
+      ],
+    };
+  }
+  return {
+    type: "document",
+    promptLines: (p) => [
+      `User sent a document: "${att.name ?? att.id}" (${ct || "unknown"}).`,
+      `Saved to: ${p}`,
+      "Read and process this file.",
+    ],
+  };
+}
+
+// ── Send helpers ─────────────────────────────────────────────────────────────
+
+async function sendChunked(
+  channel: TextBasedChannel,
+  text: string,
+  replyToId?: string,
+): Promise<string[]> {
+  const ids: string[] = [];
+  if (!text.trim()) return ids;
+  const chunks = splitMessage(suppressMentions(text), DISCORD_MAX_TEXT);
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    if (!channel.isSendable()) continue;
+    // Let errors propagate so withRetry can classify + retry transient failures.
+    // Previously we swallowed all errors here, making the outer withRetry dead code.
+    const sent = await channel.send({
+      content: chunk,
+      allowedMentions: { parse: [] },
+      reply:
+        i === 0 && replyToId
+          ? { messageReference: replyToId, failIfNotExists: false }
+          : undefined,
+    });
+    ids.push(sent.id);
+  }
+  return ids;
+}
+
+// ── Message queue (debounce rapid-fire messages per chat) ────────────────────
+
+type QueuedMessage = {
+  prompt: string;
+  replyToId: string;
+  messageId: string;
+  numericMessageId: number;
+  senderName: string;
+  senderUsername?: string;
+  senderId: string;
+  isGroup: boolean;
+  channel: TextBasedChannel;
+  chatTitle?: string;
+};
+
+const messageQueues = new Map<
+  string,
+  {
+    messages: QueuedMessage[];
+    timer: ReturnType<typeof setTimeout>;
+    config: TalonConfig;
+    chatId: string;
+    numericChatId: number;
+  }
+>();
+
+const DEBOUNCE_MS = 500;
+const MAX_QUEUED_PER_CHAT = 20;
+
+function enqueueMessage(
+  config: TalonConfig,
+  chatId: string,
+  numericChatId: number,
+  msg: QueuedMessage,
+): void {
+  const existing = messageQueues.get(chatId);
+  if (existing) {
+    if (existing.messages.length >= MAX_QUEUED_PER_CHAT) return;
+    existing.messages.push(msg);
+    clearTimeout(existing.timer);
+    existing.timer = setTimeout(() => flushQueue(chatId), DEBOUNCE_MS);
+    return;
+  }
+  messageQueues.set(chatId, {
+    messages: [msg],
+    timer: setTimeout(() => flushQueue(chatId), DEBOUNCE_MS),
+    config,
+    chatId,
+    numericChatId,
+  });
+}
+
+async function flushQueue(chatId: string): Promise<void> {
+  const entry = messageQueues.get(chatId);
+  if (!entry) return;
+  messageQueues.delete(chatId);
+
+  const { messages, config, numericChatId } = entry;
+  const last = messages[messages.length - 1];
+  const combinedPrompt =
+    messages.length === 1
+      ? messages[0].prompt
+      : messages.map((m) => m.prompt).join("\n\n");
+
+  appendDailyLog(last.senderName, combinedPrompt, {
+    chatTitle: last.chatTitle,
+    username: last.senderUsername,
+  });
+
+  try {
+    await processAndReply({
+      config,
+      chatId,
+      numericChatId,
+      replyToId: last.replyToId,
+      messageId: last.messageId,
+      numericMessageId: last.numericMessageId,
+      prompt: combinedPrompt,
+      senderName: last.senderName,
+      isGroup: last.isGroup,
+      senderUsername: last.senderUsername,
+      senderId: last.senderId,
+      channel: last.channel,
+      chatTitle: last.chatTitle,
+    });
+    recordMessageProcessed();
+  } catch (err) {
+    const classified = classify(err);
+    const promptPreview = combinedPrompt.slice(0, 100).replace(/\n/g, " ");
+    logError(
+      "bot",
+      `[${chatId}] [${last.isGroup ? "guild" : "DM"}] [${last.senderName}] ${classified.reason}: ${classified.message} | prompt: "${promptPreview}"`,
+    );
+    recordError(classified.message);
+
+    if (classified.retryable) {
+      const delayMs = classified.retryAfterMs ?? 2000;
+      log(
+        "bot",
+        `[${chatId}] Retrying after ${classified.reason} (${delayMs}ms)...`,
+      );
+      try {
+        await new Promise((r) => setTimeout(r, delayMs));
+        await processAndReply({
+          config,
+          chatId,
+          numericChatId,
+          replyToId: last.replyToId,
+          messageId: last.messageId,
+          numericMessageId: last.numericMessageId,
+          prompt: combinedPrompt,
+          senderName: last.senderName,
+          isGroup: last.isGroup,
+          senderUsername: last.senderUsername,
+          senderId: last.senderId,
+          channel: last.channel,
+          chatTitle: last.chatTitle,
+        });
+        return;
+      } catch (retryErr) {
+        const retryClassified = classify(retryErr);
+        logError("bot", `[${chatId}] Retry failed: ${retryClassified.message}`);
+        // Error-recovery send must never throw — if the network is fully down
+        // the queue handler would otherwise propagate up and stall future
+        // messages. Best-effort: notify if we can, log + move on otherwise.
+        try {
+          await sendChunked(
+            last.channel,
+            friendlyMessage(retryClassified),
+            last.replyToId,
+          );
+        } catch (notifyErr) {
+          logError(
+            "bot",
+            `[${chatId}] Could not notify user about retry failure: ${notifyErr instanceof Error ? notifyErr.message : notifyErr}`,
+          );
+        }
+        return;
+      }
+    }
+    try {
+      await sendChunked(
+        last.channel,
+        friendlyMessage(classified),
+        last.replyToId,
+      );
+    } catch (notifyErr) {
+      logError(
+        "bot",
+        `[${chatId}] Could not notify user about error: ${notifyErr instanceof Error ? notifyErr.message : notifyErr}`,
+      );
+    }
+  }
+}
+
+// ── processAndReply ─────────────────────────────────────────────────────────
+
+type ProcessAndReplyParams = {
+  config: TalonConfig;
+  chatId: string;
+  numericChatId: number;
+  replyToId: string;
+  messageId: string;
+  numericMessageId: number;
+  prompt: string;
+  senderName: string;
+  isGroup: boolean;
+  senderUsername?: string;
+  senderId: string;
+  channel: TextBasedChannel;
+  chatTitle?: string;
+};
+
+async function processAndReply(p: ProcessAndReplyParams): Promise<void> {
+  const sentTextBlock = { value: false };
+  let firstChunkReplyTo: string | undefined = p.replyToId;
+
+  // Discord doesn't support draft message edits, so we use onTextBlock to
+  // deliver each text block as a discrete message (chunked if necessary).
+  const onTextBlock = async (text: string) => {
+    if (!text.trim()) return;
+    const ids = await sendChunked(p.channel, text, firstChunkReplyTo);
+    if (ids.length > 0) sentTextBlock.value = true;
+    // Subsequent blocks should not reply to the original — too noisy.
+    firstChunkReplyTo = undefined;
+  };
+
+  if (!p.isGroup && p.senderId) {
+    trackDmUser(p.senderId, p.senderName, p.senderUsername);
+  }
+
+  const result = await execute({
+    chatId: p.chatId,
+    numericChatId: p.numericChatId,
+    prompt: p.prompt,
+    senderName: p.senderName,
+    isGroup: p.isGroup,
+    // Use the real Discord snowflake string, not the hashed numeric.
+    // The hash collides with Telegram-style 32-bit IDs and Discord's API
+    // rejects it as "Unknown Message" when the model tries to react/edit.
+    messageId: p.messageId,
+    source: "message",
+    onTextBlock,
+    onToolUse: (toolName, input) => {
+      if (
+        toolName === "send" &&
+        input.type === "text" &&
+        typeof input.text === "string"
+      ) {
+        appendDailyLogResponse("Talon", input.text, {
+          chatTitle: p.chatTitle,
+        });
+      }
+    },
+  });
+
+  if (
+    result.bridgeMessageCount === 0 &&
+    !sentTextBlock.value &&
+    result.text?.trim()
+  ) {
+    log(
+      "bot",
+      `Suppressed fallback text (${result.text.length} chars) — no send tool used`,
+    );
+  }
+}
+
+// ── Public message handler ──────────────────────────────────────────────────
+
+export async function handleMessage(
+  client: Client,
+  msg: Message,
+  config: TalonConfig,
+): Promise<void> {
+  // Ignore bots, system messages, and our own messages
+  if (msg.author.bot || msg.system) return;
+  if (msg.author.id === client.user?.id) return;
+
+  if (!shouldHandleInGuild(client, msg)) return;
+  if (!(await isAccessAllowed(client, msg))) return;
+  if (isUserRateLimited(msg.author.id)) return;
+
+  const isGroup = msg.channel.type !== ChannelType.DM;
+  const chatId = isGroup
+    ? `discord_guild_${msg.guildId}_${msg.channelId}`
+    : `discord_dm_${msg.author.id}`;
+  const numericChatId = deriveNumericChatId(chatId);
+  const numericMessageId = deriveNumericChatId(msg.id);
+  const sender = getSenderName(msg);
+  const senderUsername = msg.author.username;
+  const channel = msg.channel;
+  const chatTitle = isGroup
+    ? `${msg.guild?.name ?? msg.guildId} #${(msg.channel as { name?: string }).name ?? msg.channelId}`
+    : undefined;
+
+  // Strip the leading bot mention from the text — common when users invoke the bot.
+  const botId = client.user?.id;
+  const mentionPattern = botId ? new RegExp(`<@!?${botId}>`, "g") : null;
+  const cleanedContent = mentionPattern
+    ? msg.content.replace(mentionPattern, "").trim()
+    : msg.content.trim();
+
+  // Build prompt parts
+  const replyCtx = buildReplyContext(msg, botId);
+  const promptParts: string[] = [replyCtx];
+
+  // Handle attachments — download each, register in media index/history, add to prompt.
+  if (msg.attachments.size > 0) {
+    for (const att of msg.attachments.values()) {
+      try {
+        const savedPath = await downloadAttachment(att, config.workspace);
+        const cls = classifyAttachment(att);
+        setMessageFilePath(chatId, numericMessageId, savedPath);
+        addMedia({
+          chatId,
+          msgId: numericMessageId,
+          senderName: sender,
+          type: cls.type,
+          filePath: savedPath,
+          caption: cleanedContent || undefined,
+          timestamp: Date.now(),
+        });
+        promptParts.push(...cls.promptLines(savedPath));
+      } catch (err) {
+        logError(
+          "bot",
+          `[${chatId}] attachment "${att.name}" download failed: ${err instanceof Error ? err.message : err}`,
+        );
+        promptParts.push(
+          `[Attachment "${att.name ?? "file"}" failed to download: ${err instanceof Error ? err.message : err}]`,
+        );
+      }
+    }
+    if (cleanedContent) promptParts.push(`Caption: ${cleanedContent}`);
+  } else if (cleanedContent) {
+    promptParts.push(cleanedContent);
+  }
+
+  const prompt = promptParts.filter(Boolean).join("\n");
+  if (!prompt.trim()) return;
+
+  registerDiscordChat({
+    channelId: msg.channelId,
+    guildId: msg.guildId,
+    userId: isGroup ? null : msg.author.id,
+    numericChatId,
+    chatId,
+  });
+
+  enqueueMessage(config, chatId, numericChatId, {
+    prompt,
+    replyToId: msg.id,
+    messageId: msg.id,
+    numericMessageId,
+    senderName: sender,
+    senderUsername,
+    senderId: msg.author.id,
+    isGroup,
+    channel,
+    chatTitle,
+  });
+}
+
+/** Exposed so the action handler can use the same chunked send for tool calls. */
+export { sendChunked };

--- a/src/frontend/discord/helpers.ts
+++ b/src/frontend/discord/helpers.ts
@@ -1,0 +1,189 @@
+/**
+ * Shared helpers for Discord commands, callbacks, and the settings panel.
+ *
+ * Discord-specific quirks vs the Telegram helpers:
+ *  - settings panel uses Components (Buttons + Select Menus), not inline keyboard.
+ *  - custom_id strings are limited to 100 chars total — keep payload compact.
+ *  - chat IDs are Discord snowflakes (strings), not numbers.
+ */
+
+import { resolveModel } from "../../core/models.js";
+import { DISCORD_MAX_TEXT, DISCORD_SAFE_RESERVE } from "./formatting.js";
+
+const DEFAULT_PULSE_INTERVAL_MS = 5 * 60 * 1000;
+/** Per-message length budget for metrics output. */
+const DEFAULT_METRICS_MESSAGE_MAX = DISCORD_MAX_TEXT - DISCORD_SAFE_RESERVE;
+
+/** Effort level descriptions shown next to each option in select menus. */
+export const EFFORT_DESCRIPTIONS: Record<string, string> = {
+  off: "no extra thinking — fastest",
+  low: "short reasoning pass",
+  medium: "balanced reasoning",
+  high: "deeper reasoning, slower",
+  max: "most thorough — slowest",
+  adaptive: "model decides when to think",
+};
+
+type MetricsSnapshot = {
+  counters: Record<string, number>;
+  histograms: Record<
+    string,
+    { count: number; p50: number; p95: number; p99: number; avg: number }
+  >;
+};
+
+/** Parse a duration string like "30m", "2h", "1d", "1h30m", "1d6h" into ms. */
+export function parseInterval(input: string): number | null {
+  const match = input.match(/^(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?$/);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  const days = parseInt(match[1] || "0", 10);
+  const hours = parseInt(match[2] || "0", 10);
+  const minutes = parseInt(match[3] || "0", 10);
+  const ms = (days * 24 * 60 + hours * 60 + minutes) * 60 * 1000;
+  return ms > 0 ? ms : null;
+}
+
+export function formatDuration(ms: number): string {
+  const safeMs = Math.max(0, Math.round(ms));
+  if (safeMs < 1000) return `${safeMs}ms`;
+  const s = Math.floor(safeMs / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+export function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
+  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
+  if (bytes >= 1_024) return `${(bytes / 1_024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+export function formatModelLabel(modelId: string): string {
+  return resolveModel(modelId)?.displayName ?? modelId;
+}
+
+function truncateMetricLabel(label: string, max = 60): string {
+  return label.length <= max ? label : `${label.slice(0, max - 3)}...`;
+}
+
+/**
+ * Render the metrics report into one or more Discord messages, each ≤ maxLen
+ * (default ~1900 chars to leave headroom under the 2000-char limit).
+ */
+export function renderMetricsMessages(
+  metrics: MetricsSnapshot,
+  maxLen = DEFAULT_METRICS_MESSAGE_MAX,
+): string[] {
+  const firstHeader = "**📊 Metrics**";
+  const continuationHeader = "**📊 Metrics (cont.)**";
+  const sections: string[][] = [];
+
+  const histKeys = Object.keys(metrics.histograms).sort();
+  if (histKeys.length > 0) {
+    sections.push([
+      "**Latency**",
+      ...histKeys.map((key) => {
+        const h = metrics.histograms[key];
+        return (
+          `  \`${truncateMetricLabel(key)}\`  n=${h.count} ` +
+          `p50=${formatDuration(h.p50)}  p95=${formatDuration(h.p95)} ` +
+          `p99=${formatDuration(h.p99)}  avg=${formatDuration(h.avg)}`
+        );
+      }),
+    ]);
+  }
+
+  const counterKeys = Object.keys(metrics.counters).sort();
+  if (counterKeys.length > 0) {
+    const groups = new Map<string, string[]>();
+    for (const key of counterKeys) {
+      const prefix = key.includes(".") ? key.split(".")[0]! : "general";
+      if (!groups.has(prefix)) groups.set(prefix, []);
+      groups.get(prefix)!.push(key);
+    }
+    for (const prefix of [...groups.keys()].sort()) {
+      const keys = groups.get(prefix)!;
+      sections.push([
+        `**${prefix}**`,
+        ...keys.map((key) => {
+          const label = key.includes(".")
+            ? key.split(".").slice(1).join(".")
+            : key;
+          return `  \`${truncateMetricLabel(label)}\`  ${metrics.counters[key]!.toLocaleString()}`;
+        }),
+      ]);
+    }
+  }
+
+  if (sections.length === 0) {
+    return [`${firstHeader}\n\n_No metrics recorded yet._`];
+  }
+
+  const chunks: string[] = [];
+  let header = firstHeader;
+  let current = header;
+  const flush = () => {
+    chunks.push(current);
+    header = continuationHeader;
+    current = header;
+  };
+  const appendLine = (line: string) => {
+    if (!line && current === header) return;
+    const candidate = `${current}\n${line}`;
+    if (candidate.length <= maxLen) {
+      current = candidate;
+      return;
+    }
+    if (current !== header) {
+      flush();
+      if (!line) return;
+    }
+    const available = maxLen - header.length - 1;
+    if (available < 0) return;
+    const safeLine =
+      line.length <= available
+        ? line
+        : available >= 4
+          ? `${line.slice(0, available - 3)}...`
+          : line.slice(0, available);
+    current = `${current}\n${safeLine}`;
+  };
+
+  for (const section of sections) {
+    appendLine("");
+    for (const line of section) appendLine(line);
+  }
+  if (current !== header || chunks.length === 0) chunks.push(current);
+  return chunks;
+}
+
+/** Settings panel: build the markdown body. */
+export function renderSettingsText(
+  model: string,
+  effort: string,
+  proactive: boolean,
+  pulseIntervalMs?: number,
+  modelDetails?: Array<string>,
+): string {
+  const intervalStr = pulseIntervalMs
+    ? formatDuration(pulseIntervalMs)
+    : formatDuration(DEFAULT_PULSE_INTERVAL_MS);
+  return [
+    "**🦅 Settings**",
+    "",
+    `**Model:** \`${formatModelLabel(model)}\``,
+    ...(modelDetails?.length ? modelDetails : []),
+    `**Effort:** ${effort}`,
+    `**🔔 Pulse:** ${proactive ? "on" : "off"} (every ${intervalStr})`,
+  ].join("\n");
+}
+

--- a/src/frontend/discord/helpers.ts
+++ b/src/frontend/discord/helpers.ts
@@ -186,4 +186,3 @@ export function renderSettingsText(
     `**🔔 Pulse:** ${proactive ? "on" : "off"} (every ${intervalStr})`,
   ].join("\n");
 }
-

--- a/src/frontend/discord/index.ts
+++ b/src/frontend/discord/index.ts
@@ -1,0 +1,360 @@
+/**
+ * Discord frontend factory.
+ *
+ * Creates a discord.js Client, wires up:
+ *  - access control (config.discord.allowedUsers / allowedGuilds / allowedChannels / adminUserIds)
+ *  - slash command registration (per-guild for allowedGuilds, optional global for DM)
+ *  - message handlers (mention/reply/channel-mode gating)
+ *  - component (button/select) interaction routing → callbacks.ts
+ *  - guildCreate auto-leave for non-whitelisted guilds (+ admin notify)
+ *  - graceful shutdown
+ *
+ * Registers a Discord-specific action handler with the gateway so MCP tool
+ * calls (send_message, react, etc.) reach the Discord API.
+ */
+
+import {
+  Client,
+  GatewayIntentBits,
+  Partials,
+  ActivityType,
+  Events,
+} from "discord.js";
+import { once } from "node:events";
+import type { TalonConfig } from "../../util/config.js";
+import type { ContextManager } from "../../core/types.js";
+import type { Gateway } from "../../core/gateway.js";
+import { log, logError, logWarn } from "../../util/log.js";
+import { createDiscordActionHandler } from "./actions.js";
+import {
+  registerCommandsForGuilds,
+  registerInteractionRouter,
+} from "./commands.js";
+import { registerMiddleware } from "./middleware.js";
+import {
+  setAccessControl,
+  lookupDiscordChat,
+  registerDiscordChat,
+} from "./handlers.js";
+import { sendChunked } from "./handlers.js";
+import { deriveNumericChatId } from "../../util/chat-id.js";
+
+// ── Frontend type ───────────────────────────────────────────────────────────
+
+export type DiscordFrontend = {
+  name: "discord";
+  context: ContextManager;
+  sendTyping: (chatId: number) => Promise<void>;
+  sendMessage: (chatId: number, text: string) => Promise<void>;
+  getBridgePort: () => number;
+  init: () => Promise<void>;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+};
+
+// ── Factory ─────────────────────────────────────────────────────────────────
+
+export function createDiscordFrontend(
+  config: TalonConfig,
+  gateway: Gateway,
+): DiscordFrontend {
+  if (!config.discord) {
+    throw new Error(
+      "Discord config missing — add a 'discord' block to talon.json.",
+    );
+  }
+  const dc = config.discord;
+
+  const client = new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.GuildMembers,
+      GatewayIntentBits.MessageContent,
+      GatewayIntentBits.DirectMessages,
+      GatewayIntentBits.GuildMessageReactions,
+    ],
+    partials: [Partials.Channel, Partials.Message, Partials.User],
+    allowedMentions: { parse: [] }, // never ping anyone unless we explicitly opt in
+  });
+
+  // Wire access control config into handlers.ts
+  setAccessControl({
+    allowedUsers: dc.allowedUsers,
+    allowedGuilds: dc.allowedGuilds,
+    allowedChannels: dc.allowedChannels,
+    adminUserIds: dc.adminUserIds,
+    respondMode: dc.respondMode,
+  });
+
+  const context: ContextManager = {
+    acquire: (chatId: number, stringId?: string) =>
+      gateway.setContext(chatId, stringId),
+    release: (chatId: number) => gateway.clearContext(chatId),
+    getMessageCount: (chatId: number) => gateway.getMessageCount(chatId),
+  };
+
+  // sendTyping: looks up the registered Discord channel and sends typing.
+  // No-ops gracefully if we don't have the channel cached yet.
+  const sendTyping = async (chatId: number): Promise<void> => {
+    const info = lookupDiscordChat(chatId);
+    if (!info) return;
+    try {
+      const ch = await client.channels.fetch(info.channelId);
+      if (ch && "sendTyping" in ch) {
+        await (ch as { sendTyping: () => Promise<void> }).sendTyping();
+      }
+    } catch {
+      /* channel not resolvable — ignore */
+    }
+  };
+
+  // sendMessage (plain): used by cron and pulse to reach a specific chat.
+  // chatId here is the numericChatId stored in the registry.
+  const sendMessage = async (chatId: number, text: string): Promise<void> => {
+    if (!text.trim()) return;
+    const info = lookupDiscordChat(chatId);
+    if (!info) {
+      logWarn(
+        "discord",
+        `sendMessage: no registered channel for chatId ${chatId}`,
+      );
+      return;
+    }
+    try {
+      const ch = await client.channels.fetch(info.channelId);
+      if (
+        ch &&
+        "isSendable" in ch &&
+        (ch as { isSendable: () => boolean }).isSendable()
+      ) {
+        await sendChunked(ch as never, text);
+      }
+    } catch (err) {
+      logError(
+        "discord",
+        `sendMessage failed for chat ${chatId}: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  };
+
+  return {
+    name: "discord",
+    context,
+    sendTyping,
+    sendMessage,
+    getBridgePort: () => gateway.getPort(),
+
+    async init() {
+      // Register Discord action handler with the gateway
+      gateway.setFrontendHandler(createDiscordActionHandler(client, gateway));
+
+      const port = await gateway.start(19876);
+      log("discord", `Gateway started on port ${port}`);
+
+      // Hook event listeners BEFORE login so we don't miss the ready event.
+      client.once("clientReady", async (c) => {
+        log("discord", `Logged in as ${c.user.tag} (${c.user.id})`);
+
+        if (dc.presence) {
+          try {
+            c.user.setPresence({
+              activities: [{ name: dc.presence, type: ActivityType.Custom }],
+              status: "online",
+            });
+          } catch {
+            /* ignore */
+          }
+        }
+
+        // Discover any existing DM channels with allowedUsers and register them
+        // in the chat registry so cron/pulse can target them. We don't pre-open
+        // unrequested DMs — only those Discord already exposes.
+        for (const userId of dc.allowedUsers) {
+          try {
+            const user = await c.users.fetch(userId);
+            const dm = await user.createDM();
+            const chatId = `discord_dm_${userId}`;
+            registerDiscordChat({
+              channelId: dm.id,
+              guildId: null,
+              userId,
+              numericChatId: deriveNumericChatId(chatId),
+              chatId,
+            });
+          } catch {
+            /* user not reachable — skip */
+          }
+        }
+
+        // Register slash commands per-guild + optionally global for DM
+        try {
+          await registerCommandsForGuilds(c, config);
+        } catch (err) {
+          logError("discord", "Slash command registration failed", err);
+        }
+
+        // Defense in depth: leave any guild we're in but isn't whitelisted
+        if (dc.leaveUnauthorizedGuilds) {
+          for (const guild of c.guilds.cache.values()) {
+            if (dc.allowedGuilds.includes(guild.id)) continue;
+            log(
+              "discord",
+              `Leaving non-whitelisted guild "${guild.name}" (${guild.id})`,
+            );
+            // Notify admins
+            for (const adminId of dc.adminUserIds) {
+              try {
+                const admin = await c.users.fetch(adminId);
+                await admin.send({
+                  content: `🚪 Leaving non-whitelisted guild "${guild.name}" (${guild.id}).`,
+                  allowedMentions: { parse: [] },
+                });
+              } catch {
+                /* ignore */
+              }
+            }
+            try {
+              await guild.leave();
+            } catch (err) {
+              logWarn(
+                "discord",
+                `Failed to leave guild ${guild.id}: ${err instanceof Error ? err.message : err}`,
+              );
+            }
+          }
+        }
+      });
+
+      // guildCreate: bot was added to a new guild → enforce whitelist immediately
+      client.on("guildCreate", async (guild) => {
+        if (dc.allowedGuilds.includes(guild.id)) {
+          log(
+            "discord",
+            `Joined whitelisted guild "${guild.name}" (${guild.id})`,
+          );
+          // Re-register commands for this guild
+          try {
+            await registerCommandsForGuilds(client, config);
+          } catch (err) {
+            logError(
+              "discord",
+              `Re-register commands after guildCreate failed`,
+              err,
+            );
+          }
+          return;
+        }
+        log(
+          "discord",
+          `Joined non-whitelisted guild "${guild.name}" (${guild.id})`,
+        );
+        // Notify admins
+        for (const adminId of dc.adminUserIds) {
+          try {
+            const admin = await client.users.fetch(adminId);
+            await admin.send({
+              content: dc.leaveUnauthorizedGuilds
+                ? `🚨 Bot was added to non-whitelisted guild "${guild.name}" (${guild.id}). Leaving.`
+                : `⚠️ Bot was added to non-whitelisted guild "${guild.name}" (${guild.id}). Commands will not be registered.`,
+              allowedMentions: { parse: [] },
+            });
+          } catch {
+            /* ignore */
+          }
+        }
+        if (dc.leaveUnauthorizedGuilds) {
+          try {
+            await guild.leave();
+          } catch (err) {
+            logWarn(
+              "discord",
+              `Failed to leave guild ${guild.id}: ${err instanceof Error ? err.message : err}`,
+            );
+          }
+        }
+      });
+
+      client.on("error", (err) => {
+        logError("discord", "Client error", err);
+      });
+      client.on("warn", (msg) => {
+        logWarn("discord", msg);
+      });
+
+      // Surface gateway close codes — discord.js auto-reconnects on most, but
+      // 4004 (auth failed), 4013 (invalid intents), 4014 (disallowed intents)
+      // are terminal: the bot will hang silent in IDENTIFY without an alert.
+      client.on(Events.ShardDisconnect, (event, shardId) => {
+        const code = event?.code;
+        const reason = event?.reason || "(no reason)";
+        const fatal = code === 4004 || code === 4013 || code === 4014;
+        const label =
+          code === 4004
+            ? "AUTHENTICATION_FAILED — bot token invalid/revoked"
+            : code === 4013
+              ? "INVALID_INTENTS — declared intent doesn't exist"
+              : code === 4014
+                ? "DISALLOWED_INTENTS — privileged intent (GuildMembers/MessageContent/Presence) not enabled in Developer Portal"
+                : `code=${code}`;
+        if (fatal) {
+          logError(
+            "discord",
+            `Shard ${shardId} disconnected fatally: ${label} (${reason})`,
+          );
+        } else {
+          logWarn(
+            "discord",
+            `Shard ${shardId} disconnected: ${label} (${reason})`,
+          );
+        }
+      });
+
+      // Rate-limit / invalid-request observability. discord.js handles retries
+      // automatically; we just want logs so we know when we're flirting with
+      // the Cloudflare 10k-invalid-requests/10min cap.
+      client.rest.on("rateLimited", (info) => {
+        logWarn(
+          "discord",
+          `Rate-limited ${info.method} ${info.route} — wait ${info.timeToReset}ms (global=${info.global})`,
+        );
+      });
+      client.rest.on("invalidRequestWarning", (info) => {
+        logError(
+          "discord",
+          `Invalid-request warning: ${info.count} bad requests in last ${info.remainingTime}ms — approaching IP ban threshold`,
+        );
+      });
+
+      // Wire message handlers and slash command/component routers
+      registerMiddleware(client, config);
+      registerInteractionRouter(client, config, gateway);
+    },
+
+    async start() {
+      await client.login(dc.botToken);
+      // Wait for the WebSocket READY event before returning — login() resolves
+      // after HTTP IDENTIFY but client.user / client.guilds.cache are empty
+      // until READY fires. Anything called after start() can then safely read
+      // gateway state.
+      if (!client.isReady()) {
+        await once(client, Events.ClientReady);
+      }
+    },
+
+    async stop() {
+      try {
+        await client.destroy();
+        log("shutdown", "Discord client disconnected");
+      } catch (err) {
+        logError("shutdown", "Discord stop error", err);
+      }
+      try {
+        await gateway.stop();
+        log("shutdown", "Gateway stopped");
+      } catch (err) {
+        logError("shutdown", "Gateway stop error", err);
+      }
+    },
+  };
+}

--- a/src/frontend/discord/middleware.ts
+++ b/src/frontend/discord/middleware.ts
@@ -1,0 +1,83 @@
+/**
+ * Discord middleware — wires up message events to handlers.ts.
+ *
+ * Equivalent to src/frontend/telegram/middleware.ts. We attach a single
+ * messageCreate listener that filters out bots/system messages and delegates
+ * to handleMessage. We also push every message into the in-memory history
+ * buffer so /admin commands and /status reflect real activity.
+ *
+ * Discord-specific behavior:
+ *  - We don't have a separate "my_chat_member" event; instead, when the bot
+ *    is removed from a guild we get `guildDelete`. The handler in index.ts
+ *    handles that to revoke access.
+ *  - Every guild message gets the chat registered for pulse so periodic
+ *    check-ins work (DMs are excluded because we always respond).
+ */
+
+import type { Client, Message } from "discord.js";
+import { ChannelType } from "discord.js";
+import type { TalonConfig } from "../../util/config.js";
+import { pushMessage } from "../../storage/history.js";
+import { registerChat } from "../../core/pulse.js";
+import { deriveNumericChatId } from "../../util/chat-id.js";
+import { handleMessage, getSenderName } from "./handlers.js";
+
+export function registerMiddleware(client: Client, config: TalonConfig): void {
+  client.on("messageCreate", (msg: Message) => {
+    // Ignore self/bots/system here too — handlers.ts will check again, but
+    // we don't even want to record those in history.
+    if (msg.author.bot || msg.system) return;
+    if (msg.author.id === client.user?.id) return;
+
+    const isGroup = msg.channel.type !== ChannelType.DM;
+    const chatId = isGroup
+      ? `discord_guild_${msg.guildId}_${msg.channelId}`
+      : `discord_dm_${msg.author.id}`;
+
+    if (isGroup) registerChat(chatId);
+
+    // Push to history buffer — text or attachment placeholder
+    const numericMessageId = deriveNumericChatId(msg.id);
+    const senderId = deriveNumericChatId(msg.author.id);
+    const senderName = getSenderName(msg);
+    const replyToMsgId = msg.reference?.messageId
+      ? deriveNumericChatId(msg.reference.messageId)
+      : undefined;
+    const timestamp = msg.createdTimestamp;
+
+    if (msg.attachments.size > 0) {
+      const first = msg.attachments.first();
+      const ct = first?.contentType ?? "";
+      const mediaType = ct.startsWith("image/")
+        ? "photo"
+        : ct.startsWith("video/")
+          ? "video"
+          : ct.startsWith("audio/")
+            ? "voice"
+            : "document";
+      pushMessage(chatId, {
+        msgId: numericMessageId,
+        senderId,
+        senderName,
+        text: msg.content || `(${mediaType})`,
+        replyToMsgId,
+        timestamp,
+        mediaType,
+      });
+    } else if (msg.content) {
+      pushMessage(chatId, {
+        msgId: numericMessageId,
+        senderId,
+        senderName,
+        text: msg.content,
+        replyToMsgId,
+        timestamp,
+      });
+    }
+
+    // Hand off to handler (does access control, queue, dispatch)
+    handleMessage(client, msg, config).catch(() => {
+      /* logged inside */
+    });
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,7 @@ if (selectedFrontend === "terminal") {
   frontend = createTeamsFrontend(config, gateway);
   log("bot", "Frontend: Teams");
 } else if (selectedFrontend === "discord") {
-  const { createDiscordFrontend } =
-    await import("./frontend/discord/index.js");
+  const { createDiscordFrontend } = await import("./frontend/discord/index.js");
   frontend = createDiscordFrontend(config, gateway);
   log("bot", "Frontend: Discord");
 } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,11 @@ if (selectedFrontend === "terminal") {
   const { createTeamsFrontend } = await import("./frontend/teams/index.js");
   frontend = createTeamsFrontend(config, gateway);
   log("bot", "Frontend: Teams");
+} else if (selectedFrontend === "discord") {
+  const { createDiscordFrontend } =
+    await import("./frontend/discord/index.js");
+  frontend = createDiscordFrontend(config, gateway);
+  log("bot", "Frontend: Discord");
 } else {
   const { createTelegramFrontend } =
     await import("./frontend/telegram/index.js");

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -98,7 +98,40 @@ const pluginEntrySchema = z
   })
   .pipe(z.union([pluginPathSchema, pluginMcpSchema]));
 
-const frontendEnum = z.enum(["telegram", "terminal", "teams"]);
+const frontendEnum = z.enum(["telegram", "terminal", "teams", "discord"]);
+
+const discordConfigSchema = z
+  .object({
+    /** Discord bot token (from https://discord.com/developers/applications). */
+    botToken: z.string(),
+    /**
+     * Discord application (client) ID. Found on the same Developer Portal
+     * page as the bot token. Required for slash-command registration via
+     * `Routes.applicationCommands(...)`.
+     */
+    applicationId: z.string(),
+    /** User IDs allowed to DM the bot. Empty array disables DM access. */
+    allowedUsers: z.array(z.string()).default([]),
+    /** Guild IDs the bot is permitted to operate in. */
+    allowedGuilds: z.array(z.string()).default([]),
+    /** Optional channel ID allowlist within `allowedGuilds`. Empty = all channels. */
+    allowedChannels: z.array(z.string()).default([]),
+    /** User IDs with /admin command access. */
+    adminUserIds: z.array(z.string()).default([]),
+    /**
+     * In guilds, when does the bot reply?
+     *   - "mention"  reply only when @mentioned or in a reply chain (default)
+     *   - "channel"  reply to every message in allowedChannels
+     */
+    respondMode: z.enum(["mention", "channel"]).default("mention"),
+    /** Auto-leave guilds not on `allowedGuilds`. */
+    leaveUnauthorizedGuilds: z.boolean().default(true),
+    /** Custom status text shown under the bot's name. */
+    presence: z.string().optional(),
+    /** Enable global slash command + DM command registration. */
+    enableDmCommands: z.boolean().default(true),
+  })
+  .strict();
 
 const playwrightConfigSchema = z.object({
   enabled: z.boolean().default(false),
@@ -164,6 +197,9 @@ const configSchema = z.object({
 
   // Playwright — headless browser automation via MCP
   playwright: playwrightConfigSchema.optional(),
+
+  // Discord — discord.js v14-based frontend
+  discord: discordConfigSchema.optional(),
 
   // Display name shown in terminal UI (defaults to "Talon")
   botDisplayName: z.string().default("Talon"),

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -41,6 +41,7 @@ export type LogComponent =
   | "gateway"
   | "plugin"
   | "teams"
+  | "discord"
   | "config"
   | "access"
   | "github"


### PR DESCRIPTION
## Summary

Adds a Discord frontend on `discord.js@^14.16.3`. Selectable via
`"frontend": "discord"` in `~/.talon/talon.json`. Existing frontends
(Telegram, Terminal, Teams) untouched.

## What's included

### `src/frontend/discord/` — 10 files, ~3800 LOC

- `index.ts` — client init, intents, READY await, presence, guildCreate
  auto-leave, REST rate-limit observability, fatal close-code logging.
- `handlers.ts` — message router, debounce queue, per-user rate limit,
  attachment classifier, mention/reply gating.
- `commands.ts` — 15 slash commands (`/start /help /settings /memory
  /status /ping /model /effort /pulse /reset /restart /metrics /dream
  /plugins /admin`), per-guild + global registration, autocomplete +
  modal-submit dispatch.
- `callbacks.ts` — button / select / modal / autocomplete handlers.
  Settings panel updates in-place. AI-generated buttons namespaced
  under `ai:` and forwarded to the agent with prefix stripped.
- `actions.ts` — 20+ MCP tool actions (send/reply/react/edit/delete/
  pin/unpin/poll/sticker/history/admins) routed through `tryAction`
  → `DiscordAPIError` mapped to clean `{ok:false, error}` results.
- `errors.ts` — `mapDiscordError` for 14 known JSON error codes +
  `maxAttachmentBytes` by guild boost tier.
- `admin.ts` — `/admin {stats,errors,chats,daily,pulse,cron,logs}`.
- `helpers.ts` — `parseInterval` (h/m/d), formatters, settings panel.
- `formatting.ts` — `splitMessage` (preserves code fences),
  `escapeMarkdown`, `escapeForCodeBlock`, `safeSlice` (Unicode-safe
  cap for `customId`/`label`/`value`), `suppressMentions`.
- `middleware.ts` — `messageCreate` wiring + history push.

### System prompt

- `prompts/discord.md` — Discord-specific notes for the agent.

### Wire-up

- `src/index.ts` (+5) — frontend dispatch branch.
- `src/util/config.ts` (+39) — `"discord"` in `frontendEnum`, new
  `discordConfigSchema` (`botToken`, `applicationId`, `allowedUsers`,
  `allowedGuilds`, `allowedChannels`, `adminUserIds`, `respondMode`,
  `leaveUnauthorizedGuilds`, `presence`, `enableDmCommands`).
- `package.json` — `+discord.js@^14.16.3`; lockfile regenerated.

### Type-system plumbing (required for compile)

- `src/util/log.ts` — `"discord"` in `LogComponent`.
- `src/bootstrap.ts` — `"discord"` in `Frontend.name`.
- `src/core/types.ts` — `message_id` / `messageId` widened from
  `number` to `number | string`. Telegram uses numeric IDs;
  Discord snowflakes are strings.
- `src/backend/opencode/server.ts` — `"discord"` in `frontendName`
  union (mirrors `"telegram" | "terminal" | "teams"`).

## Configuration example

```jsonc
{
  "frontend": "discord",
  "discord": {
    "botToken": "MTQ5...",
    "applicationId": "1497...",
    "allowedUsers": ["<your user id>"],
    "allowedGuilds": ["<your guild id>"],
    "adminUserIds": ["<your user id>"],
    "respondMode": "mention",
    "leaveUnauthorizedGuilds": true,
    "presence": "🦅 Talon",
    "enableDmCommands": true
  }
}
```

Discord Developer Portal: enable **Server Members**, **Message
Content**, **Presence** privileged intents.

## Out of scope (future work)

- Voice messages with `flags: 8192 (IS_VOICE_MESSAGE)` + waveform +
  duration. Currently sent as plain OGG attachments.
- Poll vote events (`MESSAGE_POLL_VOTE_ADD/REMOVE`). The bot creates
  polls but doesn't observe votes.
- Components V2 (`IS_COMPONENTS_V2` flag) — Container / Section /
  Text Display / Media Gallery for `/status`, `/settings`, `/help`.
- Thread / forum channel handling (thread channel IDs share `chatId`
  namespace with parents).
- `messageUpdate` / `guildDelete` event handlers.
