### PR TITLE
fix: three correctness bugs (retry delay, sticker rate-limit, chatId null check)

### DIFF
--- a/src/__tests__/bridge.test.ts
+++ b/src/__tests__/bridge.test.ts
@@ -130,8 +130,9 @@ describe("createBridge", () => {
 
   it("chat_id=0 is promoted (gateway decides what to do)", async () => {
     // The bridge doesn't validate chat_id — it just routes. Whether 0 is a
-    // valid chat ID is the gateway/handler's call (gateway rejects it via
-    // its `if (!chatId)` falsy guard, but the bridge correctly forwards).
+    // valid chat ID is the gateway/handler's call (gateway now passes 0
+    // through via its `chatId === null` guard; the bridge correctly forwards
+    // either way).
     const bridge = createBridge("http://test/", "");
     await bridge("send_message", { text: "zero", chat_id: 0 });
 

--- a/src/__tests__/gateway-http.test.ts
+++ b/src/__tests__/gateway-http.test.ts
@@ -357,18 +357,23 @@ describe("gateway HTTP server", () => {
       );
     });
 
-    it("rejects chat_id=0 (the gateway's falsy-guard catches it)", async () => {
-      // Number("0") = 0, which is falsy. The gateway uses `if (!chatId)`
-      // as its final guard so 0 always falls through to the rejection
-      // path — no real chat has ID 0.
+    it("accepts chat_id=0 (no longer rejected by falsy guard; uses chatId === null)", async () => {
+      // Number("0") = 0, which is falsy but a valid resolved value. The
+      // gateway now uses `if (chatId === null)` as its routing guard so 0
+      // passes through correctly. (Chat ID 0 doesn't appear in practice
+      // for Telegram or Teams, but the type contract is `number | null`
+      // and the previous `!chatId` check conflated the two.)
       const { body } = await post({
         action: "send_message",
         _chatId: "0",
         chat_id: 0,
         text: "to zero",
       });
-      expect(body.ok).toBe(false);
-      expect(body.error).toContain("No active chat context");
+      expect(body.ok).toBe(true);
+      expect(mockFrontendHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ chat_id: 0 }),
+        0,
+      );
     });
 
     it("rejects the heartbeat sentinel even when chat_id property is present", async () => {

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -49,12 +49,24 @@ export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
           // Wrap in AbortError to prevent further retries
           throw new AbortError(classified);
         }
-        const delayMs =
-          classified.retryAfterMs ?? 1000 * Math.pow(2, attempt - 1);
+        const pRetryDelay = 1000 * Math.pow(2, attempt - 1);
+        const delayMs = classified.retryAfterMs ?? pRetryDelay;
         log(
           "gateway",
           `Retry ${attempt}/3 (${classified.reason}) after ${delayMs}ms`,
         );
+        // When retryAfterMs exceeds p-retry's own backoff (e.g. a Retry-After
+        // header from the Telegram API), sleep the difference here so the
+        // actual wait matches what was advertised. Without this, p-retry uses
+        // only its own short backoff and the retry arrives before the
+        // rate-limit window has expired.
+        if (classified.retryAfterMs && classified.retryAfterMs > pRetryDelay) {
+          const extra = classified.retryAfterMs - pRetryDelay;
+          await new Promise<void>((resolve) => {
+            const t = setTimeout(resolve, extra);
+            if (typeof t === "object" && t !== null && "unref" in t) t.unref();
+          });
+        }
         throw classified; // rethrow to trigger p-retry delay
       }
     },
@@ -189,7 +201,7 @@ export class Gateway {
       // String-id routing (Teams) — must match an active context.
       chatId = this.findContextByStringId(rawChatId);
     }
-    if (!chatId) {
+    if (chatId === null) {
       return { ok: false, error: "No active chat context" };
     }
 

--- a/src/frontend/telegram/handlers.ts
+++ b/src/frontend/telegram/handlers.ts
@@ -1162,6 +1162,7 @@ export async function handleStickerMessage(
 ): Promise<void> {
   if (!ctx.message || !ctx.chat || !shouldHandleInGroup(ctx)) return;
   if (!(await isAccessAllowed(ctx, bot))) return;
+  if (ctx.from?.id && isUserRateLimited(ctx.from.id)) return;
 
   const chatId = String(ctx.chat.id);
   const isGroup = ctx.chat.type === "group" || ctx.chat.type === "supergroup";


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Three bugs found during a deep code review. Each is a real correctness issue — no speculative cleanup.

---

### Bug 1 — `withRetry` ignores `retryAfterMs` (`src/core/gateway.ts`)

**What was wrong:** `withRetry` computed a `delayMs` from `classified.retryAfterMs` (e.g. from a Telegram 429 `Retry-After` header) and logged it, but the delay was never used. `p-retry`'s own fixed backoff (1 s after attempt 1, 2 s after attempt 2) was the *actual* wait — so retries against a server that said "wait 30 seconds" would arrive in 1–2 s and fail again with the same 429.

**Fix:** Before re-throwing to `p-retry`, sleep `retryAfterMs − pRetryDelay` (the gap between what the server asked for and what p-retry would wait on its own). The total wait then matches the advertised Retry-After window. If `retryAfterMs` doesn't exceed p-retry's backoff, no extra sleep is added.

```ts
// Before: delayMs computed, logged, but discarded — p-retry used ~1 s regardless
throw classified;

// After: honour the difference
if (classified.retryAfterMs && classified.retryAfterMs > pRetryDelay) {
  const extra = classified.retryAfterMs - pRetryDelay;
  await new Promise<void>((resolve) => { ... setTimeout(resolve, extra) ... });
}
throw classified; // p-retry adds its own delay on top
```

---

### Bug 2 — `handleStickerMessage` bypasses per-user rate limiting (`src/frontend/telegram/handlers.ts`)

**What was wrong:** Every other incoming-message handler (`handleTextMessage`, `handleAudioMessage`, `handleVideoNoteMessage`, and all handlers that go through `handleMediaMessage`) calls `isUserRateLimited()` before enqueuing. `handleStickerMessage` did not. A user could send unlimited stickers per minute while the same user would be blocked after 15 text messages.

**Fix:** Add the same one-line guard that all other handlers use.

```ts
if (ctx.from?.id && isUserRateLimited(ctx.from.id)) return;
```

---

### Bug 3 — `chatId === 0` falsely rejected as "No active chat context" (`src/core/gateway.ts`)

**What was wrong:** `handleAction` used `if (!chatId)` to check whether routing found a valid chat. `chatId` is typed `number | null`; when `chatId === 0` the condition is `true`, so the action would be rejected even though 0 is a valid resolved value (not the null sentinel meaning "routing failed").

**Fix:** Change to an explicit null check:
```ts
// Before
if (!chatId) { return { ok: false, error: "No active chat context" }; }

// After
if (chatId === null) { return { ok: false, error: "No active chat context" }; }
```

Chat ID 0 doesn't appear in practice for Telegram or Teams, but the code's intent is clearly "routing failed to find any context", which is expressed by `null`, not by zero.

---

## Test plan

- [ ] Rate-limit scenario: mock a Telegram 429 with `Retry-After: 30` and confirm the retry arrives after ~30 s (not after ~1 s)
- [ ] Send rapid stickers from a single user and confirm the 15 msg/min cap fires (same as for text messages)
- [ ] Existing test suite passes (`npm test`)

https://claude.ai/code/session_011fx6Suu2uoRaPyG6dkswyy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011fx6Suu2uoRaPyG6dkswyy)_