### PR TITLE
fix: seven bugs found in deep code review

### DIFF
--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -30,6 +30,8 @@ export type DreamState = {
   last_run: number;
   /** Human-readable ISO timestamp of the last completed dream run. */
   last_run_at?: string;
+  /** Unix millisecond timestamp of the last time a dream was started (success or failure). */
+  last_started?: number;
   /** "idle" when no dream is running, "running" while one is active. */
   status: "idle" | "running";
 };
@@ -39,6 +41,7 @@ export type DreamState = {
 const DREAM_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
 const DREAM_STATE_FILE = pathFiles.dreamState;
 const DREAM_TIMEOUT_MS = 10 * 60 * 1000; // 10-minute max
+const DREAM_ABORT_GRACE_MS = 30 * 1000; // wait up to 30s for SDK to honour abort
 const DREAM_LOGS_DIR = resolve(dirs.logs, "dreams");
 
 // ── State ────────────────────────────────────────────────────────────────────
@@ -96,24 +99,29 @@ export async function forceDream(): Promise<void> {
 async function executeDream(trigger: "auto" | "forced"): Promise<void> {
   const state = readDreamState();
   const now = Date.now();
+  const previousLastRun = state?.last_run ?? 0;
 
   dreaming = true;
-  writeDreamState({ last_run: now, status: "running" });
+  // Preserve last_run from the previous completed run so a crash between here
+  // and completion doesn't reset the 12-hour interval to the start of the
+  // failed run (which would suppress the next dream for up to 12h from the
+  // crash). Use a separate last_started to track when this attempt began.
+  writeDreamState({ last_run: previousLastRun, last_started: now, status: "running" });
   log(
     "dream",
-    `${trigger === "forced" ? "Force-triggering" : "Triggering"} memory consolidation (last run: ${state?.last_run ? new Date(state.last_run).toISOString() : "never"})`,
+    `${trigger === "forced" ? "Force-triggering" : "Triggering"} memory consolidation (last run: ${previousLastRun ? new Date(previousLastRun).toISOString() : "never"})`,
   );
 
   try {
-    const dreamLogPath = await runDreamAgent(state?.last_run ?? 0);
-    writeDreamState({ last_run: Date.now(), status: "idle" });
+    const dreamLogPath = await runDreamAgent(previousLastRun);
+    writeDreamState({ last_run: Date.now(), last_started: now, status: "idle" });
     log(
       "dream",
       `Memory consolidation complete (${trigger}), log: ${dreamLogPath}`,
     );
   } catch (err) {
     logError("dream", `Memory consolidation failed (${trigger})`, err);
-    writeDreamState({ last_run: Date.now(), status: "idle" });
+    writeDreamState({ last_run: previousLastRun, last_started: now, status: "idle" });
     if (trigger === "forced") throw err;
   } finally {
     dreaming = false;
@@ -195,6 +203,8 @@ If commands fail, log the error and continue — this stage is optional.`
     `**Prompt:**\n\`\`\`\n${prompt}\n\`\`\`\n\n---\n`,
   );
 
+  const abortController = new AbortController();
+
   const options = {
     model,
     systemPrompt: configRef.mempalace
@@ -203,6 +213,7 @@ If commands fail, log the error and continue — this stage is optional.`
     cwd: workspace,
     permissionMode: "bypassPermissions" as const,
     allowDangerouslySkipPermissions: true,
+    abortController,
     ...(configRef.claudeBinary
       ? { pathToClaudeCodeExecutable: configRef.claudeBinary }
       : {}),
@@ -213,12 +224,18 @@ If commands fail, log the error and continue — this stage is optional.`
     disallowedTools: [...DISALLOWED_TOOLS_BACKGROUND],
   };
 
+  let timeoutFired = false;
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    const t = setTimeout(
-      () => reject(new Error("Dream agent timed out")),
-      DREAM_TIMEOUT_MS,
-    );
+    const t = setTimeout(() => {
+      timeoutFired = true;
+      try {
+        abortController.abort();
+      } catch {
+        /* ignore */
+      }
+      reject(new Error("Dream agent timed out"));
+    }, DREAM_TIMEOUT_MS);
     t.unref(); // Don't prevent Node.js from exiting cleanly during shutdown
     timeoutHandle = t;
   });
@@ -240,13 +257,33 @@ If commands fail, log the error and continue — this stage is optional.`
   try {
     await Promise.race([agentPromise, timeoutPromise]);
   } catch (err) {
+    const wasTimeout = timeoutFired;
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+      timeoutHandle = null;
+    }
     appendDreamLog(
       dreamLogFile,
       `\n---\n**Dream FAILED at ${new Date().toISOString()}:** ${err}\n`,
     );
-    // On timeout, wait for the agent to actually finish before releasing the
-    // dreaming lock to prevent overlapping dream runs
-    await agentPromise.catch(() => {});
+    if (wasTimeout) {
+      // Give the SDK a bounded grace window to honour the abort signal.
+      // If it still hasn't settled we release the dreaming lock anyway —
+      // better to allow the next dream than hang forever.
+      const settled = await raceWithTimeout(
+        agentPromise.catch(() => "settled" as const),
+        DREAM_ABORT_GRACE_MS,
+      );
+      if (settled === "timed_out") {
+        logWarn(
+          "dream",
+          `Dream SDK ignored abort after ${DREAM_ABORT_GRACE_MS}ms — releasing lock`,
+        );
+      }
+    } else {
+      // Non-timeout failure — agentPromise has already settled.
+      await agentPromise.catch(() => {});
+    }
     throw err;
   } finally {
     if (timeoutHandle) clearTimeout(timeoutHandle);
@@ -377,5 +414,25 @@ function writeDreamState(state: DreamState): void {
     );
   } catch (err) {
     logError("dream", "Failed to write dream state", err);
+  }
+}
+
+// ── Async helpers ────────────────────────────────────────────────────────────
+
+async function raceWithTimeout<T>(
+  p: Promise<T>,
+  ms: number,
+): Promise<T | "timed_out"> {
+  let t: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      p,
+      new Promise<"timed_out">((resolve) => {
+        t = setTimeout(() => resolve("timed_out"), ms);
+        t.unref();
+      }),
+    ]);
+  } finally {
+    if (t) clearTimeout(t);
   }
 }

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -47,7 +47,7 @@ export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
         const classified = classify(err);
         if (!classified.retryable) {
           // Wrap in AbortError to prevent further retries
-          throw new AbortError(classified);
+          throw new AbortError(classified.message);
         }
         const delayMs =
           classified.retryAfterMs ?? 1000 * Math.pow(2, attempt - 1);
@@ -189,7 +189,7 @@ export class Gateway {
       // String-id routing (Teams) — must match an active context.
       chatId = this.findContextByStringId(rawChatId);
     }
-    if (!chatId) {
+    if (chatId == null) {
       return { ok: false, error: "No active chat context" };
     }
 

--- a/src/frontend/telegram/callbacks.ts
+++ b/src/frontend/telegram/callbacks.ts
@@ -18,7 +18,7 @@ import {
   enablePulse,
   isPulseEnabled,
 } from "../../core/pulse.js";
-import { handleCallbackQuery } from "./handlers.js";
+import { handleCallbackQuery, isAccessAllowed } from "./handlers.js";
 import { escapeHtml } from "./formatting.js";
 import {
   renderSettingsText,
@@ -279,7 +279,11 @@ export function registerCallbacks(
       return;
     }
 
-    // Forward other callbacks to the AI backend
+    // Forward other callbacks to the AI backend — access-controlled
+    if (!(await isAccessAllowed(ctx, bot))) {
+      await ctx.answerCallbackQuery().catch(() => {});
+      return;
+    }
     handleCallbackQuery(ctx, bot, config);
   });
 }

--- a/src/frontend/telegram/handlers.ts
+++ b/src/frontend/telegram/handlers.ts
@@ -1162,6 +1162,7 @@ export async function handleStickerMessage(
 ): Promise<void> {
   if (!ctx.message || !ctx.chat || !shouldHandleInGroup(ctx)) return;
   if (!(await isAccessAllowed(ctx, bot))) return;
+  if (ctx.from?.id && isUserRateLimited(ctx.from.id)) return;
 
   const chatId = String(ctx.chat.id);
   const isGroup = ctx.chat.type === "group" || ctx.chat.type === "supergroup";

--- a/src/storage/cron-store.ts
+++ b/src/storage/cron-store.ts
@@ -146,9 +146,12 @@ export function validateCronExpression(
   try {
     const cron = new Cron(expr, { timezone: timezone ?? undefined });
     const nextDate = cron.nextRun();
+    if (!nextDate) {
+      return { valid: false, error: "Expression has no future occurrences" };
+    }
     return {
       valid: true,
-      next: (nextDate as Date).toISOString(),
+      next: nextDate.toISOString(),
     };
   } catch (err) {
     return {

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -77,7 +77,7 @@ export function loadHistory(): void {
       /* backup also corrupt */
     }
     logError(
-      "sessions",
+      "history",
       "History data corrupt and no valid backup — starting fresh",
     );
   }


### PR DESCRIPTION
## Summary

Deep review of the full `src/` tree, finding and fixing seven bugs ranging from a user-triggerable null dereference crash to an access-control bypass and an unbounded async hang that would permanently deadlock the dream subsystem.

### Bug fixes

| # | File | Severity | Issue |
|---|------|----------|-------|
| 1 | `src/storage/history.ts` | Low | Wrong log component label `"sessions"` in the corrupt-data fallback — copy-paste from `sessions.ts` |
| 2 | `src/frontend/telegram/handlers.ts` | Medium | `handleStickerMessage` was missing the `isUserRateLimited` check present on every other message handler, allowing unlimited AI-triggering sticker spam from one user |
| 3 | `src/core/dream.ts` | Medium | `executeDream` wrote `last_run = Date.now()` at run *start* instead of preserving the previous completed timestamp. A crash mid-dream would suppress the next scheduled dream for up to 12 h, even if the last *successful* dream was much earlier. Mirrors the correct `previousLastRun` + `last_started` pattern in `heartbeat.ts` |
| 4 | `src/core/dream.ts` | High | No `AbortController` passed to `query()`, so on timeout the SDK subprocess received no cancellation signal. The post-timeout `await agentPromise.catch(() => {})` was also unbounded — if the SDK ignored the timeout it would hang forever, holding the `dreaming` mutex and preventing all future dream runs (including forced `/dream` commands). Fixed by wiring an `AbortController`, calling `abort()` on timeout, and replacing the unbounded await with a `DREAM_ABORT_GRACE_MS` (30 s) `raceWithTimeout`, matching the `heartbeat.ts` pattern |
| 5 | `src/frontend/telegram/callbacks.ts` | Medium/Security | The catch-all `callback_query:data` handler forwarded unrecognised callbacks directly to `handleCallbackQuery` (AI backend) without calling `isAccessAllowed` first — any user who knows a `callback_data` string could bypass access control and trigger AI queries |
| 6 | `src/core/gateway.ts` | Medium | `AbortError` constructed with a `TalonError` object instead of a string, causing p-retry to record `"[object Object]"` as the error message. Also tightened the chatId guard from `!chatId` (falsy, incorrectly rejects `0`) to `chatId == null` |
| 7 | `src/storage/cron-store.ts` | High | `validateCronExpression` cast `cron.nextRun()` directly to `Date` without checking for `null`. croner returns `null` when an expression has no future occurrences (e.g. a one-shot schedule in the past), causing an unhandled `TypeError` on a user-supplied input. Now returns a proper validation error |

## Test plan

- [ ] Sticker messages from rate-limited users are silently dropped (no AI response)
- [ ] Dream state `last_run` in `dream_state.json` is unchanged after a failed/crashed dream run; only `last_started` advances
- [ ] `/dream` forced run aborts cleanly after timeout; subsequent `/dream` calls succeed (mutex released)
- [ ] Unknown inline keyboard button presses from unauthorised users receive no AI response
- [ ] Scheduling a cron job with a past-only expression returns a friendly error instead of crashing
- [ ] `withRetry` exhausted-retry log shows the original error message, not `[object Object]`
- [ ] Log search for `[history]` shows the correct component label on corrupt-data recovery

https://claude.ai/code/session_01D4EX7RLNwAdyh2iZi9qYmZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4EX7RLNwAdyh2iZi9qYmZ)_