### PR TITLE
fix: four correctness and code-quality bugs from deep review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1114,6 +1114,140 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@openai/codex": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0.tgz",
+      "integrity": "sha512-WGDj+RZ3TXWC/7MlwprgLWOqzpwatPIINPhP3IRzHA0ni+o3QZ4i4xrS2uWwGmHUJ395J5JHwoZAAZYyfJyz6w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.130.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.130.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.130.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.130.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.130.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.130.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-arm64.tgz",
+      "integrity": "sha512-R9pkGC7kwC8yQ8el5hvBlmugQlcsG/pHMEFgZluu03X9fD2TezGxdq3KqRDRCZuMYl07ILamVEoqknuJ0cq7MA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-x64.tgz",
+      "integrity": "sha512-gJ+7J8djevgtdra+NgDAiQQPW+O3KTsgGfE3E5dpDfww3zS5OCeV0V2dhxqnJdlOjOSDw99o0P2LqBv19mhpRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-arm64.tgz",
+      "integrity": "sha512-tFtH0V9/hEI3d9y7zP92BXI9FM4Z3+STNQaOR52Czv18TRtCFUp7CbIUYaToopuq6UBfnE1VKr8RLhwT5FcbmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-x64.tgz",
+      "integrity": "sha512-3VcNlez99xdnEf+kB1IOpWv9fICYV9PiGj4sLCO4TCcShLnyxe+YBGa3poknkvXLnMG0qiN9SMnYS2FGrMxQcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-sdk": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.130.0.tgz",
+      "integrity": "sha512-ICKaZ5zrIDg71AiQcsUToVoe5Icmrc3LwSM5+2z7Cf8F1x6nOaY7/ucpFlr4aH8oDe7t3dangc+MsWZTkdvDFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openai/codex": "0.130.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-arm64.tgz",
+      "integrity": "sha512-vdpmiNp57L/arZabltLXn8TyEtNa7W1meOEkr+3R6W/8ZyBt++wuqz1Orv134OT2grrcFJsIVCAIPiqUxCvBkA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-x64.tgz",
+      "integrity": "sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@opencode-ai/sdk": {
       "version": "1.14.48",
       "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.48.tgz",
@@ -6403,140 +6537,6 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
-      }
-    },
-    "node_modules/@openai/codex": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0.tgz",
-      "integrity": "sha512-WGDj+RZ3TXWC/7MlwprgLWOqzpwatPIINPhP3IRzHA0ni+o3QZ4i4xrS2uWwGmHUJ395J5JHwoZAAZYyfJyz6w==",
-      "license": "Apache-2.0",
-      "bin": {
-        "codex": "bin/codex.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.130.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.130.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.130.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.130.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.130.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.130.0-win32-x64"
-      }
-    },
-    "node_modules/@openai/codex-darwin-arm64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-arm64.tgz",
-      "integrity": "sha512-R9pkGC7kwC8yQ8el5hvBlmugQlcsG/pHMEFgZluu03X9fD2TezGxdq3KqRDRCZuMYl07ILamVEoqknuJ0cq7MA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-darwin-x64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-x64.tgz",
-      "integrity": "sha512-gJ+7J8djevgtdra+NgDAiQQPW+O3KTsgGfE3E5dpDfww3zS5OCeV0V2dhxqnJdlOjOSDw99o0P2LqBv19mhpRw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-linux-arm64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-arm64.tgz",
-      "integrity": "sha512-tFtH0V9/hEI3d9y7zP92BXI9FM4Z3+STNQaOR52Czv18TRtCFUp7CbIUYaToopuq6UBfnE1VKr8RLhwT5FcbmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-linux-x64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-x64.tgz",
-      "integrity": "sha512-3VcNlez99xdnEf+kB1IOpWv9fICYV9PiGj4sLCO4TCcShLnyxe+YBGa3poknkvXLnMG0qiN9SMnYS2FGrMxQcA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-sdk": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.130.0.tgz",
-      "integrity": "sha512-ICKaZ5zrIDg71AiQcsUToVoe5Icmrc3LwSM5+2z7Cf8F1x6nOaY7/ucpFlr4aH8oDe7t3dangc+MsWZTkdvDFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@openai/codex": "0.130.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@openai/codex-win32-arm64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-arm64.tgz",
-      "integrity": "sha512-vdpmiNp57L/arZabltLXn8TyEtNa7W1meOEkr+3R6W/8ZyBt++wuqz1Orv134OT2grrcFJsIVCAIPiqUxCvBkA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-win32-x64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-x64.tgz",
-      "integrity": "sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
       }
     }
   }

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -155,7 +155,10 @@ export async function handleMessage(
             try {
               onToolUse(tool.name, tool.input);
             } catch (err) {
-              logWarn("agent", `onToolUse callback threw for ${tool.name}: ${err instanceof Error ? err.message : err}`);
+              logWarn(
+                "agent",
+                `onToolUse callback threw for ${tool.name}: ${err instanceof Error ? err.message : err}`,
+              );
             }
           }
         }

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -154,8 +154,8 @@ export async function handleMessage(
           if (onToolUse) {
             try {
               onToolUse(tool.name, tool.input);
-            } catch {
-              /* non-fatal */
+            } catch (err) {
+              logWarn("agent", `onToolUse callback threw for ${tool.name}: ${err instanceof Error ? err.message : err}`);
             }
           }
         }

--- a/src/backend/claude-sdk/stream.ts
+++ b/src/backend/claude-sdk/stream.ts
@@ -256,38 +256,9 @@ export function processResultMessage(
 }
 
 // ── Trailing-text fallback dedup ────────────────────────────────────────────
-
-/**
- * Normalize text for fuzzy comparison — trim, lowercase, collapse whitespace,
- * strip emoji. Used to detect whether trailing prose duplicates content
- * already delivered via `end_turn` / `send(type="text")`.
- */
-export function normalizeForDedupe(text: string): string {
-  return text
-    .trim()
-    .toLowerCase()
-    .replace(/\p{Emoji_Presentation}|\p{Extended_Pictographic}/gu, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-const MIN_DEDUP_LENGTH = 10;
-
-/**
- * Returns true if `candidate` is substantively the same as any text in
- * `deliveredNorms`. "Substantively" = one is a substring of the other after
- * normalization; both must be at least MIN_DEDUP_LENGTH chars to avoid
- * dropping short legitimate replies.
- */
-export function isDuplicateOfDelivered(
-  candidate: string,
-  deliveredNorms: string[],
-): boolean {
-  if (deliveredNorms.length === 0) return false;
-  const norm = normalizeForDedupe(candidate);
-  if (norm.length < MIN_DEDUP_LENGTH) return false;
-  return deliveredNorms.some(
-    (d) =>
-      d.length >= MIN_DEDUP_LENGTH && (norm.includes(d) || d.includes(norm)),
-  );
-}
+// Re-exported from the shared module so that consumers importing from
+// stream.ts continue to work without maintaining a separate implementation.
+export {
+  normalizeForDedupe,
+  isDuplicateOfDelivered,
+} from "../shared/delivered-text.js";

--- a/src/frontend/terminal/input.ts
+++ b/src/frontend/terminal/input.ts
@@ -289,6 +289,11 @@ export function createInput(promptStr: string): InputHandler {
       paused = false;
     },
     close() {
+      if (pendingResolve) {
+        const resolve = pendingResolve;
+        pendingResolve = null;
+        resolve("");
+      }
       process.stdout.write("\x1b[?2004l");
       if (process.stdin.isTTY) process.stdin.setRawMode(false);
       process.stdin.pause();

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -156,7 +156,8 @@ export function getSession(chatId: string): SessionState {
     session.usage.lastResponseMs = 0;
   if (
     session.usage.fastestResponseMs === undefined ||
-    session.usage.fastestResponseMs === 0
+    session.usage.fastestResponseMs === 0 ||
+    session.usage.fastestResponseMs === null
   )
     session.usage.fastestResponseMs = Infinity;
   // Migrate sessions from before context tracking was added


### PR DESCRIPTION
## Summary

Deep review of the full codebase surfaced four verified bugs. Each fix is small and targeted.

---

### Bug 1 — `fastestResponseMs` permanently broken after process restart (`sessions.ts`)

**Severity: High**

`SessionUsage.fastestResponseMs` is initialized to `Infinity`. `JSON.stringify` serialises `Infinity` as `null`, so every persisted session file on disk contains `"fastestResponseMs": null`. On reload, the migration guard:

```ts
if (
  session.usage.fastestResponseMs === undefined ||
  session.usage.fastestResponseMs === 0
)
  session.usage.fastestResponseMs = Infinity;
```

…does **not** catch `null` (`null !== undefined`, `null !== 0`). The field stays `null`. All subsequent comparisons like `turn.durationMs < null` are always `false` (null coerces to 0, all durations are positive), so the fastest-response tracker never updates after a restart.

**Fix:** added `|| session.usage.fastestResponseMs === null` to the migration guard.

---

### Bug 2 — Duplicate `normalizeForDedupe` / `isDuplicateOfDelivered` in `stream.ts` (`stream.ts`)

**Severity: Medium**

`stream.ts` contained full copies of both dedup helpers that already live in `shared/delivered-text.ts`. The copy in `stream.ts` had a subtle signature difference (`string[]` instead of `readonly string[]` for `deliveredNorms`), meaning a fix to the shared version wouldn't automatically fix the copy.

**Fix:** removed the duplicate implementations and replaced them with a re-export from the shared module. Consumers that import from `stream.ts` (including `end-turn.test.ts`) continue to work unchanged, and there is now a single source of truth.

---

### Bug 3 — `close()` leaves a pending `waitForInput` promise hanging forever (`terminal/input.ts`)

**Severity: Low**

`waitForInput()` stores a `pendingResolve` callback that is normally cleared when the user presses Enter or Escape. `close()` shuts down stdin but never calls or clears `pendingResolve`, so any caller awaiting `waitForInput()` at the time of shutdown is leaked — the promise never settles.

**Fix:** `close()` now resolves the pending promise with an empty string (matching the Escape-cancel behaviour) before tearing down stdin.

---

### Bug 4 — `onToolUse` callback errors silently discarded in `handler.ts` (`handler.ts`)

**Severity: Low**

The `onToolUse` callback is marked non-fatal (correct — a broken observer must not abort the turn), but the `catch` block was empty, making callback exceptions completely invisible. Debugging a misbehaving `onToolUse` hook was impossible.

**Fix:** the catch block now logs at `warn` level with the tool name and error message.

---

## Test plan

- [x] Full unit-test suite passes (`npm test`): 2365 tests pass, 0 regressions introduced
- [x] The 2 pre-existing failures are integration tests that require the Claude Code native binary and are unrelated to these changes
- [x] `end-turn.test.ts` (which imports `normalizeForDedupe`/`isDuplicateOfDelivered` from `stream.js`) continues to pass after the re-export refactor

---
_Generated by [Claude Code](https://claude.ai/code/session_01L13ce8EKaoTNrjgw4HRvy3)_