### PR TITLE
feat(triggers): add persistent triggers that survive Talon restarts

### DIFF
--- a/src/__tests__/trigger-store.test.ts
+++ b/src/__tests__/trigger-store.test.ts
@@ -243,6 +243,37 @@ describe("trigger-store", () => {
       loadTriggers();
       expect(getTrigger(t.id)!.status).toBe("fired");
     });
+
+    it("parks persistent running triggers as pending and preserves pid for orphan check", () => {
+      const t = makeTrigger({ status: "running", pid: 1234, persistent: true });
+      inMemoryFiles.set(pathFiles.triggers, JSON.stringify({ [t.id]: t }));
+
+      _resetTriggersForTesting();
+      loadTriggers();
+
+      const restored = getTrigger(t.id)!;
+      expect(restored.status).toBe("pending");
+      // pid is kept so resumeAfterRestart() can detect/kill an orphaned child
+      expect(restored.pid).toBe(1234);
+      expect(restored.lastError).toBeUndefined();
+      expect(restored.endedAt).toBeUndefined();
+    });
+
+    it("does not touch persistent triggers already in terminal state", () => {
+      const t = makeTrigger({
+        status: "cancelled",
+        persistent: true,
+        endedAt: Date.now() - 1000,
+        lastError: "Cancelled by user",
+      });
+      inMemoryFiles.set(pathFiles.triggers, JSON.stringify({ [t.id]: t }));
+
+      _resetTriggersForTesting();
+      loadTriggers();
+
+      // Cancelled persistent stays cancelled — only running/pending are converted
+      expect(getTrigger(t.id)!.status).toBe("cancelled");
+    });
   });
 
   describe("flushTriggers", () => {

--- a/src/__tests__/triggers.test.ts
+++ b/src/__tests__/triggers.test.ts
@@ -27,6 +27,7 @@ const {
   cancelTrigger,
   shutdownTriggers,
   getRunningCount,
+  resumeAfterRestart,
 } = await import("../core/triggers.js");
 
 import type { Trigger } from "../storage/trigger-store.js";
@@ -260,5 +261,178 @@ describe("trigger supervisor", () => {
     expect(log).toMatch(/\[stderr\] from stderr/);
     expect(log).toMatch(/--- spawn/);
     expect(log).toMatch(/--- exit code=0/);
+  });
+
+  describe("persistent triggers", () => {
+    it("shutdownTriggers parks persistent triggers as 'pending' and does not fire wake", async () => {
+      const t = makeTrigger({ body: "sleep 30\n" });
+      const stored = getTrigger(t.id)!;
+      stored.persistent = true;
+
+      spawnTrigger(t);
+      await waitForStatus(t.id, (s) => s === "running");
+
+      await shutdownTriggers();
+      // shutdownTriggers sets status=pending immediately; finalizeExit clears
+      // pid async when the child actually dies from SIGTERM. Poll for both.
+      const deadline = Date.now() + 2000;
+      while (Date.now() < deadline) {
+        const cur = getTrigger(t.id)!;
+        if (cur.status === "pending" && cur.pid === undefined) break;
+        await new Promise((r) => setTimeout(r, 25));
+      }
+
+      const after = getTrigger(t.id)!;
+      expect(after.status).toBe("pending");
+      expect(after.pid).toBeUndefined();
+      expect(executeSpy).not.toHaveBeenCalled();
+    });
+
+    it("resumeAfterRestart respawns persistent+pending triggers without firing a wake", async () => {
+      const t = makeTrigger({
+        body: 'echo "back up"\nsleep 30\n',
+      });
+      const stored = getTrigger(t.id)!;
+      stored.persistent = true;
+      stored.status = "pending";
+
+      const baseline = getRunningCount();
+      await resumeAfterRestart();
+      await waitForStatus(t.id, (s) => s === "running");
+      expect(getRunningCount()).toBe(baseline + 1);
+      expect(executeSpy).not.toHaveBeenCalled();
+
+      // Clean up the long-running child so it doesn't bleed into other tests
+      await shutdownTriggers();
+    });
+
+    it("resumeAfterRestart does NOT respawn non-persistent terminated triggers (only fires wake)", async () => {
+      const t = makeTrigger({ body: "echo done\nexit 0\n" });
+      const stored = getTrigger(t.id)!;
+      stored.status = "terminated";
+      stored.endedAt = Date.now();
+      stored.lastError = "Talon restarted while trigger was running";
+
+      const baseline = getRunningCount();
+      await resumeAfterRestart();
+      expect(getRunningCount()).toBe(baseline);
+      expect(executeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // Helper: read starttime from /proc/<pid>/stat (field 22). Linux only.
+    const readStarttime = (pid: number): number => {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+      const last = stat.lastIndexOf(")");
+      return Number(stat.slice(last + 2).split(" ")[19]);
+    };
+
+    const itLinux = process.platform === "linux" ? it : it.skip;
+
+    itLinux(
+      "resumeAfterRestart kills orphan with matching starttime before respawning",
+      async () => {
+        const { spawn: rawSpawn } = await import("node:child_process");
+        const orphanScript = resolve(tmpRoot, "orphan.sh");
+        writeFileSync(orphanScript, "while true; do sleep 1; done\n", {
+          mode: 0o700,
+        });
+        const orphan = rawSpawn("bash", [orphanScript], {
+          detached: true,
+          stdio: "ignore",
+        });
+        orphan.unref();
+        const orphanExited = new Promise<void>((res) =>
+          orphan.on("exit", () => res()),
+        );
+        await new Promise((r) => setTimeout(r, 50));
+        const orphanPid = orphan.pid!;
+        expect(orphanPid).toBeDefined();
+
+        const t = makeTrigger({ body: "sleep 30\n" });
+        const stored = getTrigger(t.id)!;
+        stored.persistent = true;
+        stored.status = "pending";
+        stored.pid = orphanPid;
+        stored.pidStarttime = readStarttime(orphanPid);
+
+        await resumeAfterRestart();
+        await waitForStatus(t.id, (s) => s === "running");
+        await Promise.race([
+          orphanExited,
+          new Promise((r) => setTimeout(r, 2000)),
+        ]);
+
+        let alive = true;
+        try {
+          process.kill(orphanPid, 0);
+        } catch {
+          alive = false;
+        }
+        expect(alive).toBe(false);
+
+        await shutdownTriggers();
+      },
+    );
+
+    itLinux(
+      "PID-reuse defence: starttime mismatch leaves the live process alone",
+      async () => {
+        // Simulate the "PID was recycled to an unrelated process" case by
+        // recording a deliberately-wrong starttime. killOrphan must NOT
+        // kill this process — it's not ours anymore.
+        const { spawn: rawSpawn } = await import("node:child_process");
+        const innocent = rawSpawn("bash", ["-c", "sleep 30"], {
+          detached: true,
+          stdio: "ignore",
+        });
+        innocent.unref();
+        await new Promise((r) => setTimeout(r, 50));
+        const innocentPid = innocent.pid!;
+
+        const t = makeTrigger({ body: "sleep 30\n" });
+        const stored = getTrigger(t.id)!;
+        stored.persistent = true;
+        stored.status = "pending";
+        stored.pid = innocentPid;
+        stored.pidStarttime = 1; // bogus — guaranteed not to match real starttime
+
+        await resumeAfterRestart();
+        await waitForStatus(t.id, (s) => s === "running");
+
+        // Innocent process must still be alive
+        let alive = false;
+        try {
+          process.kill(innocentPid, 0);
+          alive = true;
+        } catch {
+          /* dead — bug */
+        }
+        expect(alive).toBe(true);
+
+        // Clean up: kill the "innocent" sleeper ourselves
+        try {
+          process.kill(innocentPid, "SIGKILL");
+        } catch {
+          /* already gone */
+        }
+        await shutdownTriggers();
+      },
+    );
+
+    it("persistent triggers ignore timeout_seconds (no hard kill)", async () => {
+      // 1s timeout — non-persistent would die; persistent must keep running.
+      const t = makeTrigger({ body: "sleep 5\n", timeoutSeconds: 1 });
+      const stored = getTrigger(t.id)!;
+      stored.persistent = true;
+
+      spawnTrigger(t);
+      await waitForStatus(t.id, (s) => s === "running");
+
+      // Wait past the would-be timeout
+      await new Promise((r) => setTimeout(r, 1500));
+      expect(getTrigger(t.id)!.status).toBe("running");
+
+      await shutdownTriggers();
+    });
   });
 });

--- a/src/core/gateway-actions.ts
+++ b/src/core/gateway-actions.ts
@@ -344,6 +344,7 @@ export async function handleSharedAction(
       const description = body.description
         ? String(body.description)
         : undefined;
+      const persistent = body.persistent === true;
 
       const nameErr = validateName(name);
       if (nameErr) return { ok: false, error: nameErr };
@@ -406,6 +407,7 @@ export async function handleSharedAction(
         createdAt: Date.now(),
         timeoutSeconds,
         fireCount: 0,
+        persistent,
       };
       addTrigger(trigger);
 
@@ -439,6 +441,7 @@ export async function handleSharedAction(
           `Created trigger "${name}" (id: ${id})\n` +
           `Language: ${lang}\n` +
           `Timeout: ${timeoutSeconds}s\n` +
+          `Persistent: ${persistent ? "yes (respawns on Talon restart)" : "no"}\n` +
           `Status: ${stored.status}`,
       };
     }
@@ -457,7 +460,7 @@ export async function handleSharedAction(
             ? `${t.fireCount} fire(s)${t.lastFireAt ? `, last ${new Date(t.lastFireAt).toISOString().slice(0, 19).replace("T", " ")}` : ""}`
             : "no fires yet";
         const detail = [
-          `- ${t.name} [${t.status}]`,
+          `- ${t.name} [${t.status}]${t.persistent ? " (persistent)" : ""}`,
           `  ID: ${t.id}`,
           `  Language: ${t.language}`,
           `  Created: ${created} (timeout ${t.timeoutSeconds}s)`,

--- a/src/core/tools/triggers.ts
+++ b/src/core/tools/triggers.ts
@@ -43,7 +43,13 @@ Examples:
         start = px
       time.sleep(120)
 
-The script is killed if Talon shuts down. Per-chat cap of 5 active triggers.`;
+The script is killed if Talon shuts down. Set persistent=true to respawn it
+automatically on the next Talon start — only triggers interrupted by
+shutdown/crash are respawned (not ones that exited on their own), the
+script must be safe to re-run from scratch, and timeout_seconds is ignored
+(persistent triggers run until cancelled or until Talon shuts down).
+
+Per-chat cap of 5 active triggers.`;
 
 export const triggerTools: ToolDefinition[] = [
   {
@@ -79,6 +85,12 @@ export const triggerTools: ToolDefinition[] = [
         .max(500)
         .optional()
         .describe("Human-readable note about what the trigger watches for"),
+      persistent: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, respawn this trigger automatically when Talon restarts. Default false.",
+        ),
     },
     execute: (params, bridge) => bridge("trigger_create", params),
     tag: "triggers",

--- a/src/core/triggers.ts
+++ b/src/core/triggers.ts
@@ -13,15 +13,19 @@
  *     wake prompt so the bot can decide what to do.
  *   - Hard timeout: SIGTERM → 5s grace → SIGKILL. Fires a "timed_out" wake.
  *
- * Children are killed on Talon shutdown — triggers do NOT survive a restart.
- * On startup, any trigger left in `running`/`pending` is marked `terminated`
- * by the store loader, and the bot can decide whether to recreate it.
+ * Children are killed on Talon shutdown. By default a trigger does NOT
+ * survive a restart — on startup any trigger left in `running`/`pending` is
+ * marked `terminated` by the store loader, and the bot can decide whether
+ * to recreate it. Triggers created with `persistent: true` are an exception:
+ * they're parked in `pending` instead of `terminated` and `resumeAfterRestart`
+ * re-spawns them (with an orphan-kill probe to avoid duplicates outside
+ * cgroup-managed setups). Persistent triggers also skip the hard timeout.
  *
  * Knows nothing about backend or frontend — dependencies are injected.
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { createWriteStream, type WriteStream } from "node:fs";
+import { createWriteStream, readFileSync, type WriteStream } from "node:fs";
 import { createInterface } from "node:readline";
 import { execute as dispatcherExecute } from "./dispatcher.js";
 import {
@@ -135,7 +139,13 @@ export function spawnTrigger(trigger: Trigger): void {
     status: "running",
     pid: child.pid,
     startedAt,
+    pidStarttime: readPidStarttimeSync(child.pid),
   });
+  // For persistent triggers, flush pid + pidStarttime to disk synchronously.
+  // Without this, a crash within the ~10s autosave window would leave the
+  // stored pid undefined and resumeAfterRestart() couldn't orphan-check on
+  // the next boot — producing a duplicate child outside cgroup-managed setups.
+  if (trigger.persistent) persistNow();
 
   log(
     "triggers",
@@ -181,12 +191,16 @@ export function spawnTrigger(trigger: Trigger): void {
     );
   });
 
-  // Hard timeout
-  const timeoutMs =
-    Math.min(Math.max(trigger.timeoutSeconds, 1), 7 * 24 * 60 * 60) * 1000;
-  const timer = setTimeout(() => handleTimeout(trigger), timeoutMs);
-  timer.unref();
-  timeouts.set(trigger.id, timer);
+  // Hard timeout — persistent triggers run without one. They're long-running
+  // watchers whose lifetime is tied to Talon's, not to a wall-clock deadline.
+  // If a persistent script hangs, the user can trigger_cancel it explicitly.
+  if (!trigger.persistent) {
+    const timeoutMs =
+      Math.min(Math.max(trigger.timeoutSeconds, 1), 7 * 24 * 60 * 60) * 1000;
+    const timer = setTimeout(() => handleTimeout(trigger), timeoutMs);
+    timer.unref();
+    timeouts.set(trigger.id, timer);
+  }
 }
 
 function handleTimeout(trigger: Trigger): void {
@@ -269,10 +283,21 @@ export async function shutdownTriggers(): Promise<void> {
   for (const id of ids) {
     const c = children.get(id);
     if (!c) continue;
-    updateTrigger(id, {
-      status: "terminated",
-      lastError: "Killed by Talon shutdown",
-    });
+    const t = getTrigger(id);
+    if (t?.persistent) {
+      // Park persistent triggers in "pending" so resumeAfterRestart() respawns
+      // them on next startup. Keep the stored pid — finalizeExit clears it
+      // when the child actually exits (normal case, SIGTERM honoured). If the
+      // child explicitly ignores SIGTERM (rare — `trap '' TERM` or equivalent)
+      // and outlives Talon, the pid survives to disk so the next boot's
+      // resumeAfterRestart() can SIGKILL the orphan before respawning.
+      updateTrigger(id, { status: "pending" });
+    } else {
+      updateTrigger(id, {
+        status: "terminated",
+        lastError: "Killed by Talon shutdown",
+      });
+    }
     killChild(id, c);
   }
   // Give children a brief grace window to actually exit so logs flush
@@ -333,6 +358,19 @@ async function finalizeExit(
   let status: TriggerStatus = t.status;
   let payload: string | undefined;
 
+  // Persistent triggers parked as "pending" by shutdownTriggers must stay
+  // "pending" so resumeAfterRestart respawns them on next boot. Skip the
+  // status-rewrite and the endedAt stamp; just clear the PID and persist.
+  if (t.persistent && t.status === "pending") {
+    updateTrigger(id, { pid: undefined, pidStarttime: undefined });
+    persistNow();
+    log(
+      "triggers",
+      `Exited (persistent) "${t.name}" [${id}] code=${code} signal=${signal} — will respawn on next start`,
+    );
+    return;
+  }
+
   if (t.status === "running" || t.status === "pending") {
     if (code === 0) {
       status = "fired";
@@ -349,6 +387,7 @@ async function finalizeExit(
     status,
     endedAt: Date.now(),
     pid: undefined,
+    pidStarttime: undefined,
     exitCode: code ?? undefined,
   });
   // Terminal status reached — persist immediately so a crash between here and
@@ -480,6 +519,28 @@ async function fireWake(
 export async function resumeAfterRestart(): Promise<void> {
   if (!deps) return;
   for (const t of getAllTriggers()) {
+    // Persistent triggers were parked in "pending" by loadTriggers (crash
+    // path) or shutdownTriggers (clean path) — respawn them silently. The
+    // script body re-runs from the top (we don't checkpoint state), so it
+    // must be safe to re-run. No wake fire so we don't spam the bot on
+    // every Talon restart.
+    if (t.persistent && t.status === "pending") {
+      if (t.pid !== undefined) {
+        killOrphan(t);
+        updateTrigger(t.id, { pid: undefined, pidStarttime: undefined });
+      }
+      try {
+        spawnTrigger(t);
+        log("triggers", `Respawned persistent trigger "${t.name}" [${t.id}]`);
+      } catch (err) {
+        logError(
+          "triggers",
+          `Failed to respawn persistent trigger [${t.id}]`,
+          err,
+        );
+      }
+      continue;
+    }
     if (
       t.status === "terminated" &&
       t.lastFireAt === undefined &&
@@ -488,6 +549,70 @@ export async function resumeAfterRestart(): Promise<void> {
     ) {
       await fireWake(t.id, "terminated", t.lastError, /* terminal */ true);
     }
+  }
+}
+
+/**
+ * Read field 22 (start time in jiffies since boot) from /proc/<pid>/stat.
+ * Returns undefined if /proc isn't available (non-Linux) or the read fails.
+ *
+ * Parsing note: the `comm` field (2nd) is wrapped in parens and may itself
+ * contain ')' — `/proc/<pid>/stat` is the only place in /proc that allows
+ * this. The safe parse is to find the LAST ')' and split the rest on space.
+ * After that split, index 19 corresponds to field 22 (state=3 → starttime=22,
+ * so 22-3 = 19 positions further in the post-comm tail).
+ */
+function readPidStarttimeSync(pid: number): number | undefined {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+    const lastParen = stat.lastIndexOf(")");
+    if (lastParen < 0) return undefined;
+    const tail = stat.slice(lastParen + 2).split(" ");
+    const starttime = Number(tail[19]);
+    return Number.isFinite(starttime) ? starttime : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Probe a stored PID from a previous Talon run and SIGKILL it if it's still
+ * alive AND really is our former child (not a recycled PID). Used by
+ * resumeAfterRestart to avoid duplicate-spawn when Talon crashed outside a
+ * cgroup-managed environment and its persistent child got reparented to init
+ * instead of being torn down.
+ *
+ * PID-reuse defence (Linux): we compare /proc/<pid>/stat field 22 (start
+ * time in jiffies) against the value we captured at spawn. Start time is
+ * monotonic per boot and unchanged by exec(), so a match means the PID
+ * still belongs to our process — robust against both kernel PID reuse and
+ * bash scripts that `exec` into a different binary mid-flight. On non-Linux
+ * (no /proc, e.g. macOS dev), pidStarttime is undefined and we fall through
+ * to SIGKILL — PID reuse on a sub-second restart cycle is rare enough to
+ * accept in a dev environment.
+ */
+function killOrphan(t: Trigger): void {
+  if (t.pid === undefined) return;
+  try {
+    process.kill(t.pid, 0);
+  } catch {
+    return; // dead — nothing to do
+  }
+  if (t.pidStarttime !== undefined) {
+    const current = readPidStarttimeSync(t.pid);
+    if (current !== undefined && current !== t.pidStarttime) {
+      log(
+        "triggers",
+        `Orphan probe: pid=${t.pid} starttime ${current} ≠ stored ${t.pidStarttime} — PID reused, leaving alone`,
+      );
+      return;
+    }
+  }
+  try {
+    process.kill(t.pid, "SIGKILL");
+    log("triggers", `Killed orphan pid=${t.pid} from previous "${t.name}"`);
+  } catch {
+    /* raced — exited between probe and kill */
   }
 }
 

--- a/src/storage/trigger-store.ts
+++ b/src/storage/trigger-store.ts
@@ -53,6 +53,12 @@ export type Trigger = {
   endedAt?: number;
   /** PID of the child process while running (cleared on exit). */
   pid?: number;
+  /** Linux /proc/<pid>/stat field 22 (start time in jiffies) captured at
+   *  spawn. Used by killOrphan to defend against PID reuse — start time is
+   *  monotonic per boot and unchanged by exec(), so a match guarantees the
+   *  current owner of the PID is the same process we spawned. Undefined on
+   *  non-Linux platforms. */
+  pidStarttime?: number;
   /** Hard timeout in seconds. Default 24h, max 7d. */
   timeoutSeconds: number;
   /** Exit code on terminal status. */
@@ -64,6 +70,12 @@ export type Trigger = {
   /** Truncated tail of the most recent fire payload (for diagnostics). */
   lastFirePayload?: string;
   lastError?: string;
+  /** If true, the trigger is respawned on Talon startup if it was still
+   *  active when Talon went down. Triggers in any terminal state
+   *  (fired/errored/cancelled) are NOT respawned — only ones interrupted
+   *  by Talon shutdown or crash. (Persistent triggers have no hard timeout,
+   *  so timed_out is unreachable for them — see spawnTrigger.) */
+  persistent?: boolean;
 };
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -100,26 +112,46 @@ export function loadTriggers(): void {
     }
   }
 
-  // On startup any "running" trigger from a previous process is dead — its
-  // child PID was orphaned (we kill children on shutdown, but a crash bypasses
-  // that path). Mark as terminated so the bot can see what happened.
+  // On startup any "running" trigger from a previous process needs handling.
+  // For non-persistent we treat it as dead and mark "terminated" so the bot
+  // gets a wake fire about what happened — its child was either killed on
+  // clean shutdown, or torn down with a Docker/systemd cgroup on crash.
+  // (Outside a cgroup, a crash could leave the child orphaned and alive, but
+  // we don't try to recover non-persistent triggers — that's what persistent
+  // is for.) Persistent triggers are parked in "pending" so resumeAfterRestart
+  // can probe the stored pid, SIGKILL any surviving orphan, and re-spawn.
   let resurrected = 0;
+  let respawnable = 0;
   for (const t of Object.values(store)) {
     if (t.status === "running" || t.status === "pending") {
-      t.status = "terminated";
-      t.endedAt = t.endedAt ?? Date.now();
-      t.lastError = t.lastError ?? "Talon restarted while trigger was running";
-      t.pid = undefined;
-      dirty = true;
-      resurrected++;
+      if (t.persistent) {
+        // Keep the stored pid — resumeAfterRestart() probes it to detect an
+        // orphaned previous child (possible outside cgroup-managed setups,
+        // where a Talon crash leaves the child reparented to init still alive)
+        // and SIGKILLs it before respawning, to avoid duplicates.
+        t.status = "pending";
+        dirty = true;
+        respawnable++;
+      } else {
+        t.pid = undefined;
+        t.status = "terminated";
+        t.endedAt = t.endedAt ?? Date.now();
+        t.lastError =
+          t.lastError ?? "Talon restarted while trigger was running";
+        dirty = true;
+        resurrected++;
+      }
     }
   }
 
   const count = Object.keys(store).length;
   if (count > 0) {
+    const notes: string[] = [];
+    if (resurrected > 0) notes.push(`${resurrected} terminated by restart`);
+    if (respawnable > 0) notes.push(`${respawnable} persistent → will respawn`);
     log(
       "triggers",
-      `Loaded ${count} trigger(s)${resurrected > 0 ? ` (${resurrected} terminated by previous restart)` : ""}`,
+      `Loaded ${count} trigger(s)${notes.length ? ` (${notes.join(", ")})` : ""}`,
     );
   }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `persistent: true` flag to `trigger_create` so long-running watchers (Discord listeners, status pollers, etc.) survive a Talon restart. Default behaviour is unchanged — without the flag a trigger is killed on shutdown and marked `terminated` on next load, same as today.

## Motivation

Persistent watchers currently disappear whenever the container restarts (host reboot, Docker `restart: unless-stopped`, OOM, `docker compose up` after a rebuild). The bot can recreate them, but it has to remember to, which it often doesn't. With `persistent: true` the supervisor re-spawns the script automatically.

## State machine

- `shutdownTriggers` parks persistent triggers in `pending` (keeping the stored pid for the orphan probe). `finalizeExit` clears the pid when SIGTERM is honoured (the normal case).
- `loadTriggers` converts `running` persistent triggers to `pending`; non-persistent ones get the existing `terminated` + wake-fire path.
- `resumeAfterRestart` re-spawns persistent + pending **silently** (no wake fire so the bot isn't spammed on every restart).
- Triggers that exited on their own (fired/errored/cancelled) stay ended and wake the bot as usual.

## Orphan-kill defence

In Docker / systemd cgroup the pidnamespace teardown kills the child, so this is a no-op. Outside a cgroup, a crash can leave the persistent child reparented to init and still alive — without a check, the next boot would spawn a duplicate. `resumeAfterRestart` therefore:

1. `process.kill(pid, 0)` to probe liveness.
2. On Linux, compares `/proc/<pid>/stat` field 22 (start time, monotonic per boot and **unchanged by `exec()`**) against the value captured at spawn. Match → SIGKILL; mismatch → PID was recycled, leave alone.
3. On non-Linux (macOS dev) `pidStarttime` is `undefined` and we fall through to SIGKILL — PID reuse on a sub-second restart cycle is rare enough to accept in a dev environment.

This defends against both kernel PID reuse and bash scripts that `exec` into a different binary mid-flight (a `comm`-based check would mis-handle the latter).

## Other behaviours

- Persistent triggers **skip the hard timeout** — they're long-running watchers, not deadline-bound jobs. If a persistent script hangs, the user can `trigger_cancel` it explicitly.
- `spawnTrigger` calls `persistNow()` for persistent triggers so a crash within the 10s autosave window can't lose the pid.
- `trigger_list` shows `(persistent)` next to the status.

## Tests

8 new cases in `triggers.test.ts` and `trigger-store.test.ts` cover:

- Load-time `running`/`pending` → `pending` conversion (persistent), pid retained for orphan probe.
- Terminal-state persistent triggers left alone on load.
- `shutdownTriggers` parks as `pending` and does not wake-fire.
- `resumeAfterRestart` respawns persistent + pending without wake fire.
- `resumeAfterRestart` does NOT respawn non-persistent terminated (only fires wake — regression guard on existing flow).
- Real orphan kill with matching `/proc` starttime (Linux only).
- PID-reuse defence: bogus starttime leaves the live process alone (Linux only).
- Persistent triggers ignore `timeout_seconds`.

All 82 trigger-related tests pass. `tsc --noEmit` is clean on the trigger files (pre-existing codex-sdk type errors are unrelated).
