### PR TITLE
feat(tools): expose Talon MCP tools to the Discord frontend

### DIFF
--- a/src/__tests__/end-turn.test.ts
+++ b/src/__tests__/end-turn.test.ts
@@ -267,7 +267,7 @@ describe("end_turn tool definition", () => {
   it("is registered in messagingTools", () => {
     expect(endTurn).toBeDefined();
     expect(endTurn?.tag).toBe("messaging");
-    expect(endTurn?.frontends).toEqual(["telegram", "teams"]);
+    expect(endTurn?.frontends).toEqual(["telegram", "teams", "discord"]);
   });
 
   it("has text, reply_to, and buttons schema fields", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -896,7 +896,13 @@ async function mainMenu(): Promise<void> {
     : [config.frontend];
   const frontendLabel = fes
     .map((f) =>
-      f === "telegram" ? "Telegram" : f === "teams" ? "Teams" : "Terminal",
+      f === "telegram"
+        ? "Telegram"
+        : f === "teams"
+          ? "Teams"
+          : f === "discord"
+            ? "Discord"
+            : "Terminal",
     )
     .join(" + ");
 

--- a/src/core/tools/chat.ts
+++ b/src/core/tools/chat.ts
@@ -19,7 +19,7 @@ export const chatTools: ToolDefinition[] = [
     description: "List chat administrators.",
     schema: {},
     execute: (_params, bridge) => bridge("get_chat_admins", {}),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "chat",
   },
 
@@ -28,7 +28,7 @@ export const chatTools: ToolDefinition[] = [
     description: "Get total member count.",
     schema: {},
     execute: (_params, bridge) => bridge("get_chat_member_count", {}),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "chat",
   },
 
@@ -37,7 +37,7 @@ export const chatTools: ToolDefinition[] = [
     description: "Change chat title (admin).",
     schema: { title: z.string() },
     execute: (params, bridge) => bridge("set_chat_title", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "chat",
   },
 
@@ -46,7 +46,7 @@ export const chatTools: ToolDefinition[] = [
     description: "Change chat description (admin).",
     schema: { description: z.string() },
     execute: (params, bridge) => bridge("set_chat_description", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "chat",
   },
 ];

--- a/src/core/tools/history.ts
+++ b/src/core/tools/history.ts
@@ -28,7 +28,7 @@ export const historyTools: ToolDefinition[] = [
         before: params.before,
         offset_id: params.offset_id,
       }),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "history",
   },
 
@@ -40,7 +40,7 @@ export const historyTools: ToolDefinition[] = [
       limit: z.number().optional(),
     },
     execute: (params, bridge) => bridge("search_history", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "history",
   },
 
@@ -52,7 +52,7 @@ export const historyTools: ToolDefinition[] = [
       limit: z.number().optional(),
     },
     execute: (params, bridge) => bridge("get_user_messages", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "history",
   },
 
@@ -61,7 +61,7 @@ export const historyTools: ToolDefinition[] = [
     description: "Get a specific message by ID.",
     schema: { message_id: idSchema },
     execute: (params, bridge) => bridge("get_message_by_id", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "history",
   },
 
@@ -75,7 +75,7 @@ export const historyTools: ToolDefinition[] = [
       ),
     },
     execute: (params, bridge) => bridge("download_media", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "history",
   },
 ];

--- a/src/core/tools/mcp-server.ts
+++ b/src/core/tools/mcp-server.ts
@@ -8,7 +8,7 @@
  * Environment:
  *   TALON_BRIDGE_URL  — HTTP bridge URL (default: http://127.0.0.1:19876)
  *   TALON_CHAT_ID     — Current chat ID
- *   TALON_FRONTEND    — Frontend type: "telegram" | "teams" | "terminal" (default: "telegram")
+ *   TALON_FRONTEND    — Frontend type: "telegram" | "teams" | "terminal" | "discord" (default: "telegram")
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -36,6 +36,7 @@ const VALID_FRONTENDS = new Set<ToolFrontend>([
   "telegram",
   "teams",
   "terminal",
+  "discord",
 ]);
 const BRIDGE_URL = process.env.TALON_BRIDGE_URL || "http://127.0.0.1:19876";
 const CHAT_ID = process.env.TALON_CHAT_ID || "";

--- a/src/core/tools/media.ts
+++ b/src/core/tools/media.ts
@@ -17,7 +17,7 @@ export const mediaTools: ToolDefinition[] = [
         .describe("Number of entries (default 10, max 20)"),
     },
     execute: (params, bridge) => bridge("list_media", { limit: params.limit }),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "media",
   },
 ];

--- a/src/core/tools/members.ts
+++ b/src/core/tools/members.ts
@@ -13,7 +13,7 @@ export const memberTools: ToolDefinition[] = [
     schema: { limit: z.number().optional() },
     execute: (params, bridge) =>
       bridge("list_known_users", { limit: params.limit }),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "members",
   },
 
@@ -22,7 +22,7 @@ export const memberTools: ToolDefinition[] = [
     description: "Get detailed info about a user by ID.",
     schema: { user_id: idSchema },
     execute: (params, bridge) => bridge("get_member_info", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "members",
   },
 
@@ -32,7 +32,7 @@ export const memberTools: ToolDefinition[] = [
       "Get how many members are currently online or recently active.",
     schema: {},
     execute: (_params, bridge) => bridge("online_count", {}),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "members",
   },
 
@@ -41,7 +41,7 @@ export const memberTools: ToolDefinition[] = [
     description: "Get all pinned messages in the current chat.",
     schema: {},
     execute: (_params, bridge) => bridge("get_pinned_messages", {}),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "members",
   },
 ];

--- a/src/core/tools/messaging.ts
+++ b/src/core/tools/messaging.ts
@@ -80,7 +80,7 @@ Notes:
         reply_to_message_id: params.reply_to,
       });
     },
-    frontends: ["telegram", "teams"],
+    frontends: ["telegram", "teams", "discord"],
     tag: "messaging",
     endsTurn: true,
   },
@@ -284,7 +284,7 @@ Examples:
           return { ok: false, error: `Unknown type: ${type}` };
       }
     },
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "messaging",
   },
 
@@ -371,7 +371,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
       const { end_turn: _endTurn, ...rest } = params;
       return bridge("react", rest);
     },
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "messaging",
     endsTurn: true,
   },
@@ -382,7 +382,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
     description: "Edit a previously sent message.",
     schema: { message_id: idSchema, text: z.string() },
     execute: (params, bridge) => bridge("edit_message", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "messaging",
   },
 
@@ -392,7 +392,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
     description: "Delete a message.",
     schema: { message_id: idSchema },
     execute: (params, bridge) => bridge("delete_message", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "messaging",
   },
 
@@ -402,7 +402,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
     description: "Forward a message within the chat.",
     schema: { message_id: idSchema },
     execute: (params, bridge) => bridge("forward_message", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "messaging",
   },
 
@@ -412,7 +412,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
     description: "Pin a message.",
     schema: { message_id: idSchema },
     execute: (params, bridge) => bridge("pin_message", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "messaging",
   },
 
@@ -422,7 +422,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
     description: "Unpin a message.",
     schema: { message_id: idSchema.optional() },
     execute: (params, bridge) => bridge("unpin_message", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "messaging",
   },
 

--- a/src/core/tools/scheduling.ts
+++ b/src/core/tools/scheduling.ts
@@ -11,7 +11,7 @@ export const schedulingTools: ToolDefinition[] = [
     description: "Cancel a scheduled message.",
     schema: { schedule_id: z.string() },
     execute: (params, bridge) => bridge("cancel_scheduled", params),
-    frontends: ["telegram"],
+    frontends: ["telegram", "discord"],
     tag: "scheduling",
   },
 

--- a/src/core/tools/types.ts
+++ b/src/core/tools/types.ts
@@ -8,7 +8,12 @@
 import type { ZodRawShape } from "zod";
 
 /** Which frontends a tool is available on.  "all" = every frontend. */
-export type ToolFrontend = "telegram" | "teams" | "terminal" | "all";
+export type ToolFrontend =
+  | "telegram"
+  | "teams"
+  | "terminal"
+  | "discord"
+  | "all";
 
 /** Domain tags for runtime filtering and grouping. */
 export type ToolTag =


### PR DESCRIPTION
## Problem

Discord was added as a frontend in #160 but the tool registry was never updated to know about it. Two layers both miss `discord`:

1. `src/core/tools/mcp-server.ts` whitelists only `telegram`/`teams`/`terminal` in `VALID_FRONTENDS`. The Claude SDK backend (`src/backend/claude-sdk/options.ts`) and the Codex backend (`src/backend/codex/mcp-config.ts`) both iterate `getActiveFrontends()` and spawn `${frontend}-tools`, so on a Discord-only setup the `discord-tools` MCP subprocess crashes at startup with `Invalid TALON_FRONTEND: "discord"`.
2. Every tool definition in `src/core/tools/{chat,history,media,members,messaging,scheduling}.ts` is gated `frontends:["telegram"]` (or `["telegram","teams"]` for `end_turn`). Even if the MCP did start, `composeTools({frontend:"discord"})` would return an empty set.

Net effect on Discord: agent has zero Talon-side tools (no `send` / `end_turn` / `react` / `edit_message` / `read_chat_history` / etc.), trips `flow violation: trailing prose without end_turn/send` on every turn, and can't deliver replies. Live bot reports `MCP discord-tools just disconnected (34 tools no longer available)` to the user.

## Fix

- `core/tools/types.ts` — add `"discord"` to `ToolFrontend` union
- `core/tools/mcp-server.ts` — add `"discord"` to `VALID_FRONTENDS` + the `TALON_FRONTEND` doc string
- `core/tools/{chat,history,media,members,scheduling}.ts` — add `"discord"` to every gate whose bridge action has a Discord handler in `src/frontend/discord/actions.ts`
- `core/tools/messaging.ts` — same for `end_turn`, `send`, `react`, `edit_message`, `delete_message`, `forward_message`, `pin_message`, `unpin_message`
- `cli.ts` interactive label formerly mapped any non-`telegram`/`teams` frontend to `"Terminal"` — Discord now renders as `"Discord"`

## Intentionally left telegram-only

- `stickers.ts` — Discord doesn't have Telegram-style sticker packs
- `stop_poll` — only Telegram polls have a stop endpoint

## Companion PR

Even after this PR, Discord snowflakes (17–19 digits, exceed 2^53) get truncated by `Number()` inside `idSchema` before reaching the bridge — fixed separately as a sibling schema. See follow-up PR.

## Verification

Running live on Talon + Discord with these changes applied. `discord-tools` MCP boots cleanly, `composeTools({frontend:"discord"})` returns all expected tools, model can `end_turn` / `send` / `react` / etc. into Discord chats.