### PR TITLE
fix(tools): preserve Discord snowflake IDs in tool input schemas

### DIFF
--- a/src/__tests__/tool-functional.test.ts
+++ b/src/__tests__/tool-functional.test.ts
@@ -287,9 +287,15 @@ describe("Tool → bridge round-trip", () => {
     }
   });
 
-  // ── Coercion goes end-to-end through execute() ───────────────────────────
-  describe("ID coercion survives the schema → execute pipeline", () => {
-    it("react with stringified message_id arrives at bridge as a number", async () => {
+  // ── ID forwarding goes end-to-end through execute() ──────────────────────
+  // Tools shared with the Discord frontend use `snowflakeOrIdSchema` which
+  // passes digit strings through verbatim (snowflakes can't survive a
+  // Number() round-trip). Telegram-only tools still coerce via `idSchema`.
+  // The bridge layer normalizes at its boundary, so both shapes are valid
+  // on the wire — these tests just assert the value semantically equals
+  // the input ID, accepting either representation.
+  describe("ID values survive the schema → execute pipeline", () => {
+    it("react with stringified message_id arrives at bridge intact", async () => {
       const tool = getTool("react");
       const bridge = makeBridge();
       const parsed = parseSchema(tool, {
@@ -300,10 +306,8 @@ describe("Tool → bridge round-trip", () => {
       await tool.execute(parsed, bridge);
 
       const [, params] = bridge.mock.calls[0]!;
-      expect((params as { message_id: unknown }).message_id).toBe(2081);
-      expect(typeof (params as { message_id: unknown }).message_id).toBe(
-        "number",
-      );
+      const messageId = (params as { message_id: unknown }).message_id;
+      expect(messageId === 2081 || messageId === "2081").toBe(true);
     });
 
     it("send.reply_to with stringified value survives to send_message", async () => {
@@ -318,12 +322,12 @@ describe("Tool → bridge round-trip", () => {
       await tool.execute(parsed, bridge);
 
       const [, params] = bridge.mock.calls[0]!;
-      expect(
-        (params as { reply_to_message_id: unknown }).reply_to_message_id,
-      ).toBe(2081);
+      const replyTo = (params as { reply_to_message_id: unknown })
+        .reply_to_message_id;
+      expect(replyTo === 2081 || replyTo === "2081").toBe(true);
     });
 
-    it("get_member_info with stringified user_id arrives as number", async () => {
+    it("get_member_info with stringified user_id arrives at bridge intact", async () => {
       const tool = getTool("get_member_info");
       const bridge = makeBridge();
       const parsed = parseSchema(tool, { user_id: "352042062" });
@@ -331,7 +335,8 @@ describe("Tool → bridge round-trip", () => {
       await tool.execute(parsed, bridge);
 
       const [, params] = bridge.mock.calls[0]!;
-      expect((params as { user_id: unknown }).user_id).toBe(352042062);
+      const userId = (params as { user_id: unknown }).user_id;
+      expect(userId === 352042062 || userId === "352042062").toBe(true);
     });
   });
 });

--- a/src/__tests__/tool-id-coercion.test.ts
+++ b/src/__tests__/tool-id-coercion.test.ts
@@ -1,6 +1,21 @@
 /**
- * Regression + audit tests — ID-shaped tool params use the strict
- * shared `idSchema` from `core/tools/schemas.ts`.
+ * Regression + audit tests — ID-shaped tool params use one of the two
+ * supported schemas from `core/tools/schemas.ts`:
+ *
+ *   - `idSchema` — strict Telegram-style ID. Accepts a positive integer
+ *     OR a digit-only string that is COERCED to a positive integer.
+ *     Used by telegram-only tools (stop_poll, sticker tools).
+ *
+ *   - `snowflakeOrIdSchema` — Discord-compatible. Accepts a positive
+ *     integer OR a digit-only string that PASSES THROUGH unchanged.
+ *     Used by every tool exposed to the discord frontend. Snowflakes
+ *     (17–19 digits, exceed 2^53) MUST stay as strings — `Number()`
+ *     rounds and silently drops trailing digits, after which Discord's
+ *     REST API rejects the request as "Unknown Message".
+ *
+ * Both schemas reject the empty/null/boolean/non-digit/non-integer/
+ * negative/zero inputs that a bare `z.coerce.number().int()` was too
+ * lax about.
  *
  * Background: some MCP transport / model paths deliver `message_id`,
  * `user_id`, `reply_to`, `offset_id` as JSON strings ("2081") rather
@@ -9,12 +24,6 @@
  * `react`/`pin_message`/`get_member_info`/`download_media` failing
  * out of nowhere even when the model formatted the call correctly
  * for a number-typed JSON Schema field.
- *
- * Initial fix used `z.coerce.number().int()`, but per Copilot review
- * that was too lax — `""`/`null` coerce to 0 and `true` to 1, which
- * then pass `.int()` and reach the bot API. The current `idSchema` is
- * a union: `z.number().int().positive()` OR a digit-only string that
- * gets transformed to a positive integer. Everything else is rejected.
  */
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
@@ -27,12 +36,26 @@ const ID_FIELD_NAMES = new Set([
   "offset_id",
 ]);
 
+const SNOWFLAKE = "1497549923779084388"; // 19-digit Discord snowflake > 2^53
+
 function getIdSchema(toolName: string, field: string): z.ZodTypeAny {
   const tool = ALL_TOOLS.find((t) => t.name === toolName);
   if (!tool) throw new Error(`tool ${toolName} not found`);
   const schema = (tool.schema as Record<string, z.ZodTypeAny>)[field];
   if (!schema) throw new Error(`field ${field} not found on ${toolName}`);
   return schema;
+}
+
+/**
+ * A snowflake-or-numeric schema preserves the input string verbatim
+ * (no Number() coercion). Detect by parsing a snowflake-sized digit
+ * string and checking the result type/value. Strict idSchema would
+ * either reject (precision overflow in safe-int check) or coerce to
+ * a rounded number.
+ */
+function acceptsSnowflakeAsString(schema: z.ZodTypeAny): boolean {
+  const r = schema.safeParse(SNOWFLAKE);
+  return r.success && r.data === SNOWFLAKE;
 }
 
 describe("ID-shaped tool params accept stringified numbers", () => {
@@ -61,10 +84,13 @@ describe("ID-shaped tool params accept stringified numbers", () => {
       expect(out).toBe(2081);
     });
 
-    it(`${tool}.${field} accepts a numeric string and coerces it`, () => {
+    it(`${tool}.${field} accepts a numeric string`, () => {
       const s = getIdSchema(tool, field);
+      // snowflakeOrIdSchema passes the string through; strict idSchema
+      // coerces to number. Both outcomes are valid — the bridge layer
+      // normalizes at the boundary.
       const out = s.parse("2081");
-      expect(out).toBe(2081);
+      expect(out === 2081 || out === "2081").toBe(true);
     });
 
     it(`${tool}.${field} rejects a non-numeric string`, () => {
@@ -79,20 +105,19 @@ describe("ID-shaped tool params accept stringified numbers", () => {
   }
 });
 
-describe("Audit: every ID-shaped field in tool schemas is the strict idSchema", () => {
+describe("Audit: every ID-shaped field uses idSchema or snowflakeOrIdSchema", () => {
   /**
-   * For each ID field on every tool, this test asserts the full
-   * accept/reject contract of `idSchema` — not just "accepts a
-   * string." That guards against a future replacement that passes
-   * the loose check (`safeParse("123")` succeeds) but doesn't
-   * actually return a positive integer (e.g. `z.string()` would
-   * accept "123" and return the string "123").
+   * Asserts the full accept/reject contract for both supported ID
+   * schemas. Guards against a future replacement that passes loose
+   * checks (e.g. bare `z.string()` accepts "123" but doesn't reject
+   * empty/non-numeric inputs).
    */
   for (const tool of ALL_TOOLS) {
     const schema = tool.schema as Record<string, unknown>;
     for (const field of Object.keys(schema)) {
       if (!ID_FIELD_NAMES.has(field)) continue;
       const zSchema = schema[field] as z.ZodTypeAny;
+      const isSnowflake = acceptsSnowflakeAsString(zSchema);
 
       it(`${tool.name}.${field}: accepts a positive integer number`, () => {
         const r = zSchema.safeParse(2081);
@@ -100,19 +125,40 @@ describe("Audit: every ID-shaped field in tool schemas is the strict idSchema", 
         if (r.success) expect(r.data).toBe(2081);
       });
 
-      it(`${tool.name}.${field}: accepts a digit string and returns a number`, () => {
+      it(`${tool.name}.${field}: accepts a digit string`, () => {
         const r = zSchema.safeParse("2081");
         expect(r.success).toBe(true);
         if (r.success) {
-          expect(typeof r.data).toBe("number");
-          expect(Number.isInteger(r.data as number)).toBe(true);
-          expect(r.data).toBe(2081);
+          if (isSnowflake) {
+            // Pass-through schema keeps the string verbatim.
+            expect(r.data).toBe("2081");
+          } else {
+            // Strict idSchema coerces to number.
+            expect(typeof r.data).toBe("number");
+            expect(Number.isInteger(r.data as number)).toBe(true);
+            expect(r.data).toBe(2081);
+          }
         }
       });
 
+      if (isSnowflake) {
+        it(`${tool.name}.${field}: preserves Discord snowflakes without precision loss`, () => {
+          const r = zSchema.safeParse(SNOWFLAKE);
+          expect(r.success).toBe(true);
+          if (r.success) {
+            // The string must survive intact — `Number(SNOWFLAKE)`
+            // rounds the last digit off (2^53 ceiling) and Discord
+            // would reject the result as Unknown Message.
+            expect(r.data).toBe(SNOWFLAKE);
+            expect(typeof r.data).toBe("string");
+          }
+        });
+      }
+
       // Reject the inputs that bare `z.coerce.number().int()` was too
       // permissive about — empty/whitespace/null/booleans coerce to
-      // 0/0/0/1 and would pass `.int()`. The strict union rejects all.
+      // 0/0/0/1 and would pass `.int()`. Both strict union schemas
+      // reject all of these.
       const rejectCases: Array<[unknown, string]> = [
         ["", "empty string"],
         ["   ", "whitespace string"],

--- a/src/core/tools/history.ts
+++ b/src/core/tools/history.ts
@@ -4,7 +4,7 @@
 
 import { z } from "zod";
 import type { ToolDefinition } from "./types.js";
-import { idSchema } from "./schemas.js";
+import { snowflakeOrIdSchema } from "./schemas.js";
 
 export const historyTools: ToolDefinition[] = [
   {
@@ -20,7 +20,9 @@ export const historyTools: ToolDefinition[] = [
         .string()
         .optional()
         .describe("Fetch messages before this date (ISO format)"),
-      offset_id: idSchema.optional().describe("Fetch before this message ID"),
+      offset_id: snowflakeOrIdSchema
+        .optional()
+        .describe("Fetch before this message ID"),
     },
     execute: (params, bridge) =>
       bridge("read_history", {
@@ -59,7 +61,7 @@ export const historyTools: ToolDefinition[] = [
   {
     name: "get_message_by_id",
     description: "Get a specific message by ID.",
-    schema: { message_id: idSchema },
+    schema: { message_id: snowflakeOrIdSchema },
     execute: (params, bridge) => bridge("get_message_by_id", params),
     frontends: ["telegram", "discord"],
     tag: "history",
@@ -70,7 +72,7 @@ export const historyTools: ToolDefinition[] = [
     description:
       "Download a photo, document, or other media from a message by its ID. Saves the file to the workspace and returns the file path so you can read/analyze it. Use this when you see a [photo] or [document] in chat history but don't have the file.",
     schema: {
-      message_id: idSchema.describe(
+      message_id: snowflakeOrIdSchema.describe(
         "Message ID containing the media to download",
       ),
     },

--- a/src/core/tools/members.ts
+++ b/src/core/tools/members.ts
@@ -4,7 +4,7 @@
 
 import { z } from "zod";
 import type { ToolDefinition } from "./types.js";
-import { idSchema } from "./schemas.js";
+import { snowflakeOrIdSchema } from "./schemas.js";
 
 export const memberTools: ToolDefinition[] = [
   {
@@ -20,7 +20,7 @@ export const memberTools: ToolDefinition[] = [
   {
     name: "get_member_info",
     description: "Get detailed info about a user by ID.",
-    schema: { user_id: idSchema },
+    schema: { user_id: snowflakeOrIdSchema },
     execute: (params, bridge) => bridge("get_member_info", params),
     frontends: ["telegram", "discord"],
     tag: "members",

--- a/src/core/tools/messaging.ts
+++ b/src/core/tools/messaging.ts
@@ -5,7 +5,7 @@
 
 import { z } from "zod";
 import type { ToolDefinition } from "./types.js";
-import { chatIdSchema, idSchema } from "./schemas.js";
+import { chatIdSchema, idSchema, snowflakeOrIdSchema } from "./schemas.js";
 
 export const messagingTools: ToolDefinition[] = [
   // ── end_turn — explicit final-reply delivery ──────────────────────────
@@ -43,7 +43,7 @@ Notes:
         .describe(
           "Final reply text. Supports Markdown. Omit to end the turn silently (no message sent).",
         ),
-      reply_to: idSchema
+      reply_to: snowflakeOrIdSchema
         .optional()
         .describe("Message ID to reply to (typically the user's [msg_id:N])"),
       buttons: z
@@ -122,7 +122,9 @@ Examples:
         .string()
         .optional()
         .describe("Message text (for type=text). Supports Markdown."),
-      reply_to: idSchema.optional().describe("Message ID to reply to"),
+      reply_to: snowflakeOrIdSchema
+        .optional()
+        .describe("Message ID to reply to"),
       file_path: z
         .string()
         .optional()
@@ -350,7 +352,7 @@ Pass \`end_turn: false\` if you want to react now and keep working on something 
 
 Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 🤩 🤮 💩 🙏 👌 🕊 🤡 🥱 🥴 😍 🐳 ❤‍🔥 🌚 🌭 💯 🤣 ⚡ 🍌 🏆 💔 🤨 😐 🍓 🍾 💋 🖕 😈 😴 😭 🤓 👻 👨‍💻 👀 🎃 🙈 😇 😨 🤝 ✍ 🤗 🫡 🎅 🎄 ☃ 💅 🤪 🗿 🆒 💘 🙉 🦄 😘 💊 🙊 😎 👾 🤷 🤷‍♂ 🤷‍♀ 😡`,
     schema: {
-      message_id: idSchema.describe("Message ID"),
+      message_id: snowflakeOrIdSchema.describe("Message ID"),
       emoji: z.string().describe("Reaction emoji"),
       end_turn: z
         .boolean()
@@ -380,7 +382,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
   {
     name: "edit_message",
     description: "Edit a previously sent message.",
-    schema: { message_id: idSchema, text: z.string() },
+    schema: { message_id: snowflakeOrIdSchema, text: z.string() },
     execute: (params, bridge) => bridge("edit_message", params),
     frontends: ["telegram", "discord"],
     tag: "messaging",
@@ -390,7 +392,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
   {
     name: "delete_message",
     description: "Delete a message.",
-    schema: { message_id: idSchema },
+    schema: { message_id: snowflakeOrIdSchema },
     execute: (params, bridge) => bridge("delete_message", params),
     frontends: ["telegram", "discord"],
     tag: "messaging",
@@ -400,7 +402,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
   {
     name: "forward_message",
     description: "Forward a message within the chat.",
-    schema: { message_id: idSchema },
+    schema: { message_id: snowflakeOrIdSchema },
     execute: (params, bridge) => bridge("forward_message", params),
     frontends: ["telegram", "discord"],
     tag: "messaging",
@@ -410,7 +412,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
   {
     name: "pin_message",
     description: "Pin a message.",
-    schema: { message_id: idSchema },
+    schema: { message_id: snowflakeOrIdSchema },
     execute: (params, bridge) => bridge("pin_message", params),
     frontends: ["telegram", "discord"],
     tag: "messaging",
@@ -420,7 +422,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
   {
     name: "unpin_message",
     description: "Unpin a message.",
-    schema: { message_id: idSchema.optional() },
+    schema: { message_id: snowflakeOrIdSchema.optional() },
     execute: (params, bridge) => bridge("unpin_message", params),
     frontends: ["telegram", "discord"],
     tag: "messaging",

--- a/src/core/tools/schemas.ts
+++ b/src/core/tools/schemas.ts
@@ -72,3 +72,25 @@ export const chatIdSchema = z.union([
     .transform((s) => Number(s))
     .pipe(nonZeroInt),
 ]);
+
+/**
+ * Snowflake-or-numeric ID schema. Accepts either:
+ *   - a positive integer (Telegram-style numeric IDs, up to 2^53)
+ *   - a digit-only string (Discord snowflakes — 17–19 digits exceed
+ *     2^53, so they must stay as strings: `Number(snowflake)` rounds
+ *     silently to the nearest float and drops the last digit, after
+ *     which Discord's REST API rejects the result as "Unknown Message")
+ *
+ * No transform to number — the string passes through to the bridge
+ * untouched. Frontend action handlers coerce with `String(...)` anyway,
+ * so the loose union is safe for both Telegram and Discord call sites.
+ *
+ * Use this for `message_id` / `user_id` / `reply_to` / `offset_id` on
+ * tool input schemas whose tool definition includes "discord" in its
+ * `frontends:[]` list. The strict `idSchema` is still appropriate for
+ * Telegram-only tools.
+ */
+export const snowflakeOrIdSchema = z.union([
+  z.number().int().positive(),
+  z.string().regex(/^\d+$/, "must be a positive integer"),
+]);


### PR DESCRIPTION
## Problem

The shared `idSchema` in `src/core/tools/schemas.ts` accepts digit-only strings but transforms them via `Number(s)` before piping into `z.number().int().positive()`. Discord message/user IDs are 17–19 digit snowflakes that **exceed 2^53**, so `Number()` silently rounds to the nearest float and drops the last digit:

```js
> Number("1497549923779084388")
1497549923779084300                ← last digit lost
> Number("1497549923779084388").toString() === "1497549923779084388"
false
```

Once truncated, Discord's REST API rejects the request with `Unknown Message`. Affected on the Discord frontend (assuming #<PR-tools-discord> is merged so these tools are actually exposed): `react` / `edit_message` / `delete_message` / `forward_message` / `pin_message` / `unpin_message` / `send.reply_to` / `end_turn.reply_to` / `read_chat_history.offset_id` / `get_message_by_id` / `download_media` / `get_member_info`.

The bug is silent because the model sees IDs as strings in chat history (`[msg_id:1497549923779084388]`) and parrots them back as strings — `idSchema` accepts the string at zod-parse time, then truncates it before the bridge sees the value. Logs show a plausible-looking ID with no obvious corruption.

## Fix

Add a sibling schema `snowflakeOrIdSchema = z.union([z.number().int().positive(), z.string().regex(/^\d+$/)])` that preserves the string end-to-end (no transform). Numeric IDs (Telegram) still go through the number branch. Swap `idSchema` → `snowflakeOrIdSchema` on every ID field whose containing tool is exposed to the Discord frontend.

Frontend action handlers (`src/frontend/{discord,telegram}/actions.ts`) already coerce IDs with `String(...)` / `Number(...)` as needed at the bridge boundary, so the loosened union is safe for both call sites.

`stop_poll` keeps the strict `idSchema` — it's telegram-only.

## Stacking

This PR is independent of the frontend-gates PR and can land in either order. Its value is only fully realised once the Discord frontend actually sees the tools (other PR), but the schema fix itself is correct standalone.