### PR TITLE
fix: three correctness bugs (withRetry delay, history log label, cron null-deref)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1114,6 +1114,140 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@openai/codex": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0.tgz",
+      "integrity": "sha512-WGDj+RZ3TXWC/7MlwprgLWOqzpwatPIINPhP3IRzHA0ni+o3QZ4i4xrS2uWwGmHUJ395J5JHwoZAAZYyfJyz6w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.130.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.130.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.130.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.130.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.130.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.130.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-arm64.tgz",
+      "integrity": "sha512-R9pkGC7kwC8yQ8el5hvBlmugQlcsG/pHMEFgZluu03X9fD2TezGxdq3KqRDRCZuMYl07ILamVEoqknuJ0cq7MA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-x64.tgz",
+      "integrity": "sha512-gJ+7J8djevgtdra+NgDAiQQPW+O3KTsgGfE3E5dpDfww3zS5OCeV0V2dhxqnJdlOjOSDw99o0P2LqBv19mhpRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-arm64.tgz",
+      "integrity": "sha512-tFtH0V9/hEI3d9y7zP92BXI9FM4Z3+STNQaOR52Czv18TRtCFUp7CbIUYaToopuq6UBfnE1VKr8RLhwT5FcbmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-x64.tgz",
+      "integrity": "sha512-3VcNlez99xdnEf+kB1IOpWv9fICYV9PiGj4sLCO4TCcShLnyxe+YBGa3poknkvXLnMG0qiN9SMnYS2FGrMxQcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-sdk": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.130.0.tgz",
+      "integrity": "sha512-ICKaZ5zrIDg71AiQcsUToVoe5Icmrc3LwSM5+2z7Cf8F1x6nOaY7/ucpFlr4aH8oDe7t3dangc+MsWZTkdvDFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openai/codex": "0.130.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-arm64.tgz",
+      "integrity": "sha512-vdpmiNp57L/arZabltLXn8TyEtNa7W1meOEkr+3R6W/8ZyBt++wuqz1Orv134OT2grrcFJsIVCAIPiqUxCvBkA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-x64.tgz",
+      "integrity": "sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@opencode-ai/sdk": {
       "version": "1.14.48",
       "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.48.tgz",
@@ -6403,140 +6537,6 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
-      }
-    },
-    "node_modules/@openai/codex": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0.tgz",
-      "integrity": "sha512-WGDj+RZ3TXWC/7MlwprgLWOqzpwatPIINPhP3IRzHA0ni+o3QZ4i4xrS2uWwGmHUJ395J5JHwoZAAZYyfJyz6w==",
-      "license": "Apache-2.0",
-      "bin": {
-        "codex": "bin/codex.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.130.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.130.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.130.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.130.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.130.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.130.0-win32-x64"
-      }
-    },
-    "node_modules/@openai/codex-darwin-arm64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-arm64.tgz",
-      "integrity": "sha512-R9pkGC7kwC8yQ8el5hvBlmugQlcsG/pHMEFgZluu03X9fD2TezGxdq3KqRDRCZuMYl07ILamVEoqknuJ0cq7MA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-darwin-x64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-x64.tgz",
-      "integrity": "sha512-gJ+7J8djevgtdra+NgDAiQQPW+O3KTsgGfE3E5dpDfww3zS5OCeV0V2dhxqnJdlOjOSDw99o0P2LqBv19mhpRw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-linux-arm64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-arm64.tgz",
-      "integrity": "sha512-tFtH0V9/hEI3d9y7zP92BXI9FM4Z3+STNQaOR52Czv18TRtCFUp7CbIUYaToopuq6UBfnE1VKr8RLhwT5FcbmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-linux-x64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-x64.tgz",
-      "integrity": "sha512-3VcNlez99xdnEf+kB1IOpWv9fICYV9PiGj4sLCO4TCcShLnyxe+YBGa3poknkvXLnMG0qiN9SMnYS2FGrMxQcA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-sdk": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.130.0.tgz",
-      "integrity": "sha512-ICKaZ5zrIDg71AiQcsUToVoe5Icmrc3LwSM5+2z7Cf8F1x6nOaY7/ucpFlr4aH8oDe7t3dangc+MsWZTkdvDFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@openai/codex": "0.130.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@openai/codex-win32-arm64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-arm64.tgz",
-      "integrity": "sha512-vdpmiNp57L/arZabltLXn8TyEtNa7W1meOEkr+3R6W/8ZyBt++wuqz1Orv134OT2grrcFJsIVCAIPiqUxCvBkA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-win32-x64": {
-      "name": "@openai/codex",
-      "version": "0.130.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-x64.tgz",
-      "integrity": "sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
       }
     }
   }

--- a/src/__tests__/gateway-retry.test.ts
+++ b/src/__tests__/gateway-retry.test.ts
@@ -244,19 +244,20 @@ describe("withRetry", () => {
 
   describe("exhausting all retries", () => {
     it("throws the last error after 3 total attempts for retryable errors", async () => {
-      const networkErr = talonErr("network");
+      // retryAfterMs: 1 keeps real delays to ~1 ms each so no fake timers needed
+      const networkErr = talonErr("network", 1);
       const fn = vi.fn(async () => {
         throw networkErr;
       });
 
-      await expect(withRetry(fn)).rejects.toThrow();
       // withRetry is configured with retries: 2 (3 total attempts)
+      await expect(withRetry(fn)).rejects.toThrow();
       expect(fn).toHaveBeenCalledTimes(3);
     });
 
     it("throws the last error after 3 total attempts for overloaded errors", async () => {
       const fn = vi.fn(async () => {
-        throw talonErr("overloaded");
+        throw talonErr("overloaded", 1);
       });
 
       await expect(withRetry(fn)).rejects.toThrow();
@@ -310,11 +311,10 @@ describe("withRetry", () => {
     });
 
     it("after exhausted retries the thrown error is a TalonError", async () => {
-      await expect(
-        withRetry(async () => {
-          throw talonErr("network");
-        }),
-      ).rejects.toBeInstanceOf(TalonError);
+      const fn = async () => {
+        throw talonErr("network", 1);
+      };
+      await expect(withRetry(fn)).rejects.toBeInstanceOf(TalonError);
     });
 
     it("non-Error throws are classified and the TalonError is thrown for non-retryable", async () => {

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -55,14 +55,19 @@ export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
           "gateway",
           `Retry ${attempt}/3 (${classified.reason}) after ${delayMs}ms`,
         );
-        throw classified; // rethrow to trigger p-retry delay
+        // Actually wait for the computed delay before rethrowing so that
+        // rate-limit retry-after hints (often 60 s) are honoured rather than
+        // silently ignored.  p-retry's own minTimeout/factor backoff would
+        // otherwise cap the wait at 1–2 s regardless of the API's instruction.
+        await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+        throw classified; // rethrow; p-retry records the attempt
       }
     },
     {
       retries: 2, // 3 total attempts
-      minTimeout: 1000,
-      maxTimeout: 60_000,
-      factor: 2,
+      minTimeout: 0, // delay is applied manually above
+      maxTimeout: 0,
+      factor: 1,
       onFailedAttempt: (err) => {
         if (err.retriesLeft === 0) {
           logError("gateway", `All retries exhausted: ${err.error.message}`);

--- a/src/storage/cron-store.ts
+++ b/src/storage/cron-store.ts
@@ -148,7 +148,7 @@ export function validateCronExpression(
     const nextDate = cron.nextRun();
     return {
       valid: true,
-      next: (nextDate as Date).toISOString(),
+      next: nextDate != null ? nextDate.toISOString() : undefined,
     };
   } catch (err) {
     return {

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -77,7 +77,7 @@ export function loadHistory(): void {
       /* backup also corrupt */
     }
     logError(
-      "sessions",
+      "history",
       "History data corrupt and no valid backup — starting fresh",
     );
   }


### PR DESCRIPTION
## Summary

Deep code review of the full repository surfaced three correctness bugs:

- **`src/core/gateway.ts` — `withRetry` silently ignored rate-limit `retry-after` hints (HIGH)**
  `delayMs` was computed from `classified.retryAfterMs` and logged, but p-retry's own `minTimeout: 1000 / factor: 2` backoff was the actual wait — capping delays at 1–2 s regardless of what the API instructed (often 60 s for rate limits). Fixed by inserting `await sleep(delayMs)` before rethrowing and setting p-retry's own timeout to 0 to avoid double-waiting.

- **`src/storage/history.ts` — wrong log label in corrupt-backup error path (LOW)**
  `loadHistory` emitted `logError("sessions", ...)` instead of `logError("history", ...)` when both the primary store and its backup were unreadable — a copy-paste error from `sessions.ts`. Fixed.

- **`src/storage/cron-store.ts` — unsafe `Date` cast on `Cron#nextRun()` (MEDIUM)**
  `validateCronExpression` did `(nextDate as Date).toISOString()` without checking for `null`. `Cron#nextRun()` returns `Date | null` (e.g. for schedules whose window has already passed), so this throws a `TypeError` at runtime. Fixed with a null guard.

- **`src/__tests__/gateway-retry.test.ts` — exhaustion tests had unhandled rejections**
  The fake-timer approach (`vi.useFakeTimers` + `vi.runAllTimersAsync`) left p-retry's internal promise chains unsettled after assertions completed, producing 3 unhandled-rejection warnings and a non-zero `Errors` count in Vitest output. Replaced with `retryAfterMs: 1` so real timers fire in ~1 ms — no fake timers needed.

## Test plan

- [ ] `npx vitest run src/__tests__/gateway-retry.test.ts` — 26 tests pass, 0 errors
- [ ] Manual: trigger a rate-limited call and confirm the bot waits the full `retry-after` duration before retrying
- [ ] Manual: create a cron expression with no upcoming run dates and confirm `/cron add` returns a valid response rather than a 500

https://claude.ai/code/session_01ENgnJb7py1ZCKA9ET7EMxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENgnJb7py1ZCKA9ET7EMxm)_