### PR TITLE
feat(picker): backend-agnostic model picker — provider groups, persisted free filter, decoupled /settings

### DIFF
--- a/src/__tests__/codex-models.test.ts
+++ b/src/__tests__/codex-models.test.ts
@@ -77,9 +77,8 @@ describe("codex / getModelInfo", () => {
 
 describe("codex / getSettingsPresentation", () => {
   it("returns one button per model with active marker on the current one", () => {
-    const { modelButtons, modelDetails } = getSettingsPresentation("gpt-5");
+    const { modelButtons } = getSettingsPresentation("gpt-5");
     expect(modelButtons).toHaveLength(CODEX_MODELS.length);
-    expect(modelDetails).toHaveLength(CODEX_MODELS.length);
 
     const active = modelButtons.find((b) => b.callback_data.endsWith("gpt-5"));
     const others = modelButtons.filter(
@@ -91,8 +90,19 @@ describe("codex / getSettingsPresentation", () => {
     }
   });
 
+  it("reports a single-page result for a small fixed catalog", () => {
+    const { page, totalPages, filter, totalCount } =
+      getSettingsPresentation("gpt-5");
+    expect(page).toBe(1);
+    expect(totalPages).toBe(1);
+    expect(filter).toBe("all");
+    expect(totalCount).toBe(CODEX_MODELS.length);
+  });
+
   it("uses the supplied callbackPrefix", () => {
-    const { modelButtons } = getSettingsPresentation("gpt-5", "custom:prefix:");
+    const { modelButtons } = getSettingsPresentation("gpt-5", {
+      callbackPrefix: "custom:prefix:",
+    });
     for (const b of modelButtons) {
       expect(b.callback_data.startsWith("custom:prefix:")).toBe(true);
     }

--- a/src/__tests__/openai-agents-builtins.test.ts
+++ b/src/__tests__/openai-agents-builtins.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for the filesystem + shell tools registered by the OpenAI
+ * Agents backend.
+ *
+ * Each tool is exercised through its public `invoke()` entrypoint —
+ * the same path the SDK uses at runtime — so input parsing, schema
+ * validation, and result shaping are covered alongside the actual
+ * filesystem/process behavior. Real disk operations run against a
+ * per-test temp directory to avoid coupling to the project layout.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { RunContext } from "@openai/agents";
+
+import { OPENAI_AGENTS_BUILTIN_TOOLS } from "../backend/openai-agents/builtins.js";
+
+type FunctionTool = {
+  name: string;
+  description: string;
+  invoke: (ctx: RunContext, input: string) => Promise<string | unknown>;
+};
+
+function getTool(name: string): FunctionTool {
+  const t = OPENAI_AGENTS_BUILTIN_TOOLS.find((x) => x.name === name);
+  if (!t) throw new Error(`tool '${name}' not found in builtin toolset`);
+  return t as unknown as FunctionTool;
+}
+
+async function call(
+  name: string,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const tool = getTool(name);
+  const ctx = new RunContext();
+  const result = await tool.invoke(ctx, JSON.stringify(input));
+  return typeof result === "string" ? result : JSON.stringify(result);
+}
+
+// ── Toolset shape ───────────────────────────────────────────────────────────
+
+describe("openai-agents / builtins / toolset shape", () => {
+  it("exposes the six Claude-Code-equivalent tools", () => {
+    const names = OPENAI_AGENTS_BUILTIN_TOOLS.map((t) => t.name).sort();
+    expect(names).toEqual(["Bash", "Edit", "Glob", "Grep", "Read", "Write"]);
+  });
+
+  it("every tool has a non-empty description", () => {
+    for (const t of OPENAI_AGENTS_BUILTIN_TOOLS) {
+      expect(t.description.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("every tool is a function tool (not hosted)", () => {
+    for (const t of OPENAI_AGENTS_BUILTIN_TOOLS) {
+      expect((t as { type: string }).type).toBe("function");
+    }
+  });
+});
+
+// ── Filesystem fixture ──────────────────────────────────────────────────────
+
+let workdir: string;
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "talon-builtins-"));
+});
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+// ── Read ────────────────────────────────────────────────────────────────────
+
+describe("openai-agents / builtins / Read", () => {
+  it("returns cat -n-style line numbering", async () => {
+    const path = join(workdir, "a.txt");
+    await writeFile(path, "alpha\nbeta\ngamma\n");
+    const out = await call("Read", {
+      file_path: path,
+      offset: null,
+      limit: null,
+    });
+    expect(out).toMatch(/^\s+1\talpha\n\s+2\tbeta\n\s+3\tgamma/);
+  });
+
+  it("respects offset (1-indexed) and limit", async () => {
+    const path = join(workdir, "b.txt");
+    await writeFile(path, ["one", "two", "three", "four", "five"].join("\n"));
+    const out = await call("Read", { file_path: path, offset: 2, limit: 2 });
+    const lines = out.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatch(/^\s+2\ttwo$/);
+    expect(lines[1]).toMatch(/^\s+3\tthree$/);
+  });
+
+  it("expands ~/ to the home directory in error paths", async () => {
+    // The path resolver expands ~/ before hitting readFile, so the
+    // ENOENT-style error message ends up referencing an absolute
+    // path under $HOME, not the literal ~/ form.
+    const fake = "~/__talon_test_does_not_exist__.txt";
+    const out = await call("Read", {
+      file_path: fake,
+      offset: null,
+      limit: null,
+    });
+    expect(out).toMatch(/ENOENT|no such file/i);
+    expect(out).not.toContain("~/");
+  });
+
+  it("surfaces a not-found error when the file does not exist", async () => {
+    const out = await call("Read", {
+      file_path: join(workdir, "missing.txt"),
+      offset: null,
+      limit: null,
+    });
+    expect(out).toMatch(/ENOENT|no such file/i);
+  });
+});
+
+// ── Write ───────────────────────────────────────────────────────────────────
+
+describe("openai-agents / builtins / Write", () => {
+  it("creates missing parent directories", async () => {
+    const nested = join(workdir, "a/b/c/out.txt");
+    const result = await call("Write", { file_path: nested, content: "hello" });
+    expect(existsSync(nested)).toBe(true);
+    expect(await readFile(nested, "utf8")).toBe("hello");
+    expect(result).toContain("wrote 5 bytes");
+  });
+
+  it("overwrites existing content", async () => {
+    const path = join(workdir, "f.txt");
+    await writeFile(path, "old");
+    await call("Write", { file_path: path, content: "new" });
+    expect(await readFile(path, "utf8")).toBe("new");
+  });
+});
+
+// ── Edit ────────────────────────────────────────────────────────────────────
+
+describe("openai-agents / builtins / Edit", () => {
+  it("replaces a unique match in place", async () => {
+    const path = join(workdir, "edit.txt");
+    await writeFile(path, "first second third");
+    const result = await call("Edit", {
+      file_path: path,
+      old_string: "second",
+      new_string: "TWO",
+      replace_all: null,
+    });
+    expect(result).toContain("replaced 1 occurrence");
+    expect(await readFile(path, "utf8")).toBe("first TWO third");
+  });
+
+  it("surfaces a not-unique error when old_string matches multiple times and replace_all is false", async () => {
+    const path = join(workdir, "edit2.txt");
+    await writeFile(path, "x x x");
+    const out = await call("Edit", {
+      file_path: path,
+      old_string: "x",
+      new_string: "y",
+      replace_all: null,
+    });
+    expect(out).toMatch(/not unique/i);
+    // File should be untouched since the edit was rejected.
+    expect(await readFile(path, "utf8")).toBe("x x x");
+  });
+
+  it("replaces every occurrence when replace_all is true", async () => {
+    const path = join(workdir, "edit3.txt");
+    await writeFile(path, "x x x");
+    const result = await call("Edit", {
+      file_path: path,
+      old_string: "x",
+      new_string: "y",
+      replace_all: true,
+    });
+    expect(result).toContain("replaced 3 occurrences");
+    expect(await readFile(path, "utf8")).toBe("y y y");
+  });
+
+  it("surfaces a not-found error when old_string isn't in the file", async () => {
+    const path = join(workdir, "edit4.txt");
+    await writeFile(path, "hello world");
+    const out = await call("Edit", {
+      file_path: path,
+      old_string: "missing",
+      new_string: "z",
+      replace_all: null,
+    });
+    expect(out).toMatch(/not found/i);
+  });
+
+  it("rejects identical old and new strings", async () => {
+    const path = join(workdir, "edit5.txt");
+    await writeFile(path, "abc");
+    const out = await call("Edit", {
+      file_path: path,
+      old_string: "abc",
+      new_string: "abc",
+      replace_all: null,
+    });
+    expect(out).toMatch(/must differ/i);
+    expect(await readFile(path, "utf8")).toBe("abc");
+  });
+});
+
+// ── Bash ────────────────────────────────────────────────────────────────────
+
+describe("openai-agents / builtins / Bash", () => {
+  it("captures stdout and reports exit 0 on success", async () => {
+    const out = await call("Bash", {
+      command: "echo hello-from-bash",
+      description: null,
+      timeout_ms: null,
+    });
+    expect(out).toContain("hello-from-bash");
+    expect(out).toContain("exit 0");
+  });
+
+  it("captures stderr and reports a non-zero exit code", async () => {
+    const out = await call("Bash", {
+      command: "echo oops 1>&2; exit 7",
+      description: null,
+      timeout_ms: null,
+    });
+    expect(out).toContain("--- stderr ---");
+    expect(out).toContain("oops");
+    expect(out).toMatch(/exit 7/);
+  });
+
+  it("kills commands that exceed the timeout", async () => {
+    const out = await call("Bash", {
+      command: "sleep 5",
+      description: null,
+      timeout_ms: 1000,
+    });
+    expect(out).toContain("timed out");
+  }, 10_000);
+});
+
+// ── Glob ────────────────────────────────────────────────────────────────────
+
+describe("openai-agents / builtins / Glob", () => {
+  beforeEach(async () => {
+    await mkdir(join(workdir, "src/nested"), { recursive: true });
+    await writeFile(join(workdir, "a.ts"), "");
+    await writeFile(join(workdir, "b.md"), "");
+    await writeFile(join(workdir, "src/c.ts"), "");
+    await writeFile(join(workdir, "src/nested/d.ts"), "");
+  });
+
+  it("matches a recursive pattern relative to a given path", async () => {
+    const out = await call("Glob", { pattern: "**/*.ts", path: workdir });
+    const lines = out.split("\n");
+    expect(lines).toHaveLength(3);
+    // Sorted alphabetically; the leading absolute path makes /nested/
+    // sort before /src so use Set membership rather than positional
+    // checks for stability across platforms.
+    const names = lines.map((l) => l.split("/").pop());
+    expect(new Set(names)).toEqual(new Set(["a.ts", "c.ts", "d.ts"]));
+  });
+
+  it("returns `(no matches)` when nothing matches", async () => {
+    const out = await call("Glob", {
+      pattern: "**/*.nonexistent",
+      path: workdir,
+    });
+    expect(out).toBe("(no matches)");
+  });
+});
+
+// ── Grep ────────────────────────────────────────────────────────────────────
+
+describe("openai-agents / builtins / Grep", () => {
+  beforeEach(async () => {
+    await writeFile(
+      join(workdir, "haystack.txt"),
+      ["first line", "needle here", "another line", "needle again"].join("\n"),
+    );
+    await writeFile(join(workdir, "other.txt"), "nothing relevant");
+  });
+
+  it("finds matching lines with line numbers", async () => {
+    const out = await call("Grep", {
+      pattern: "needle",
+      path: workdir,
+      include: null,
+    });
+    expect(out).toContain("haystack.txt");
+    expect(out).toContain("needle here");
+    expect(out).toContain("needle again");
+    expect(out).not.toContain("other.txt");
+  });
+
+  it("returns `(no matches)` for a pattern that doesn't match", async () => {
+    const out = await call("Grep", {
+      pattern: "zzz_definitely_not_here_zzz",
+      path: workdir,
+      include: null,
+    });
+    expect(out).toBe("(no matches)");
+  });
+});

--- a/src/__tests__/openai-agents-builtins.test.ts
+++ b/src/__tests__/openai-agents-builtins.test.ts
@@ -12,10 +12,16 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { RunContext } from "@openai/agents";
 
 import { OPENAI_AGENTS_BUILTIN_TOOLS } from "../backend/openai-agents/builtins.js";
+
+// Bash and Grep rely on `spawn("bash", ["-lc", ...])`. On Windows the
+// Bash tool itself works correctly (spawn error is now handled), but the
+// tool's output degrades to an error message rather than the expected shell
+// output, so the tests are skipped on that platform.
+const isWindows = process.platform === "win32";
 
 type FunctionTool = {
   name: string;
@@ -208,7 +214,7 @@ describe("openai-agents / builtins / Edit", () => {
 
 // ── Bash ────────────────────────────────────────────────────────────────────
 
-describe("openai-agents / builtins / Bash", () => {
+describe.skipIf(isWindows)("openai-agents / builtins / Bash", () => {
   it("captures stdout and reports exit 0 on success", async () => {
     const out = await call("Bash", {
       command: "echo hello-from-bash",
@@ -258,7 +264,8 @@ describe("openai-agents / builtins / Glob", () => {
     // Sorted alphabetically; the leading absolute path makes /nested/
     // sort before /src so use Set membership rather than positional
     // checks for stability across platforms.
-    const names = lines.map((l) => l.split("/").pop());
+    // Use path.basename to handle both POSIX ("/") and Windows ("\") separators.
+    const names = lines.map((l) => basename(l));
     expect(new Set(names)).toEqual(new Set(["a.ts", "c.ts", "d.ts"]));
   });
 
@@ -273,7 +280,7 @@ describe("openai-agents / builtins / Glob", () => {
 
 // ── Grep ────────────────────────────────────────────────────────────────────
 
-describe("openai-agents / builtins / Grep", () => {
+describe.skipIf(isWindows)("openai-agents / builtins / Grep", () => {
   beforeEach(async () => {
     await writeFile(
       join(workdir, "haystack.txt"),

--- a/src/__tests__/openai-agents-enrichment.test.ts
+++ b/src/__tests__/openai-agents-enrichment.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for `fetchEndpointModels()`: parsing the heterogeneous
+ * `/models` responses that OpenAI-compatible endpoints emit.
+ *
+ * We exercise the three shapes Talon encounters in the wild:
+ *
+ *   1. OpenRouter — top-level `context_length` plus a richer
+ *      `top_provider.context_length`, with `pricing.prompt === "0"`
+ *      flagging free tiers.
+ *   2. vLLM-style — just an `id` and `context_length`.
+ *   3. OpenAI / Ollama — id-only entries; nothing to enrich beyond
+ *      surfacing the id in the catalog.
+ *
+ * Plus failure modes (non-200, timeout, malformed JSON, abort signal).
+ *
+ * Fetch is stubbed via `globalThis.fetch` so no network is hit; the
+ * fake doubles as a way to assert the request shape (URL, Auth
+ * header).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchEndpointModels } from "../backend/openai-agents/init.js";
+import { getState, resetState } from "../backend/openai-agents/state.js";
+
+type FetchInput = { url: string; init?: RequestInit };
+let fetchSpy: ReturnType<typeof vi.fn>;
+const realFetch = globalThis.fetch;
+
+function stubFetchWith(
+  responder: (
+    input: FetchInput,
+  ) =>
+    | { status: number; body: unknown }
+    | Promise<{ status: number; body: unknown }>,
+): void {
+  fetchSpy = vi.fn(
+    async (input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        input instanceof URL
+          ? input.toString()
+          : typeof input === "string"
+            ? input
+            : input.url;
+      const result = await responder({ url, init });
+      return new Response(JSON.stringify(result.body), {
+        status: result.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  );
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+}
+
+beforeEach(() => resetState());
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  resetState();
+});
+
+// ── Provider shapes ────────────────────────────────────────────────────────
+
+describe("openai-agents / fetchEndpointModels / response shapes", () => {
+  it("parses the OpenRouter shape (context_length + pricing.prompt)", async () => {
+    stubFetchWith(() => ({
+      status: 200,
+      body: {
+        data: [
+          {
+            id: "openrouter/owl-alpha",
+            name: "Owl Alpha",
+            context_length: 1_000_000,
+            pricing: { prompt: "0", completion: "0" },
+          },
+          {
+            id: "openai/gpt-5",
+            name: "GPT-5",
+            context_length: 400_000,
+            pricing: { prompt: "0.000010" },
+          },
+        ],
+      },
+    }));
+
+    await fetchEndpointModels("https://openrouter.ai/api/v1", "sk-or-1");
+
+    const catalog = getState().endpointModels;
+    expect(catalog.size).toBe(2);
+
+    const owl = catalog.get("openrouter/owl-alpha");
+    expect(owl?.contextWindow).toBe(1_000_000);
+    expect(owl?.displayName).toBe("Owl Alpha");
+    expect(owl?.free).toBe(true);
+
+    const gpt = catalog.get("openai/gpt-5");
+    expect(gpt?.contextWindow).toBe(400_000);
+    expect(gpt?.free).toBeUndefined();
+  });
+
+  it("prefers top_provider.context_length when the top-level field is missing", async () => {
+    stubFetchWith(() => ({
+      status: 200,
+      body: {
+        data: [
+          {
+            id: "split-provider/model",
+            top_provider: { context_length: 64_000 },
+          },
+        ],
+      },
+    }));
+
+    await fetchEndpointModels("https://example.com/v1", "k");
+    expect(
+      getState().endpointModels.get("split-provider/model")?.contextWindow,
+    ).toBe(64_000);
+  });
+
+  it("parses the vLLM-style shape (id + context_length only)", async () => {
+    stubFetchWith(() => ({
+      status: 200,
+      body: {
+        data: [
+          { id: "meta-llama/Llama-3-8B", context_length: 8192 },
+          { id: "Qwen/Qwen-7B", context_length: 32_768 },
+        ],
+      },
+    }));
+
+    await fetchEndpointModels("https://vllm.local:8000/v1", undefined);
+    const catalog = getState().endpointModels;
+    expect(catalog.get("meta-llama/Llama-3-8B")?.contextWindow).toBe(8192);
+    expect(catalog.get("Qwen/Qwen-7B")?.contextWindow).toBe(32_768);
+  });
+
+  it("skips entries with neither context_length nor name nor pricing", async () => {
+    // OpenAI's /v1/models returns just `{id, object, created, owned_by}`.
+    // There's nothing to enrich, so the entry isn't useful and is
+    // dropped to keep /status from rendering a meaningless row.
+    stubFetchWith(() => ({
+      status: 200,
+      body: {
+        data: [
+          { id: "gpt-4o", object: "model", created: 1, owned_by: "openai" },
+          { id: "gpt-4o-mini", object: "model" },
+        ],
+      },
+    }));
+
+    await fetchEndpointModels("https://api.openai.com/v1", "sk-test");
+    expect(getState().endpointModels.size).toBe(0);
+  });
+
+  it("includes entries that have a display name even without context_length", async () => {
+    stubFetchWith(() => ({
+      status: 200,
+      body: { data: [{ id: "x/y", name: "X Why" }] },
+    }));
+    await fetchEndpointModels("https://e.example/v1", "k");
+    expect(getState().endpointModels.get("x/y")?.displayName).toBe("X Why");
+  });
+
+  it("ignores entries with no id", async () => {
+    stubFetchWith(() => ({
+      status: 200,
+      body: {
+        data: [{ context_length: 4096 }, { id: "real", context_length: 8192 }],
+      },
+    }));
+    await fetchEndpointModels("https://e.example/v1", "k");
+    const catalog = getState().endpointModels;
+    expect(catalog.size).toBe(1);
+    expect(catalog.get("real")?.contextWindow).toBe(8192);
+  });
+
+  it("handles a missing `data` array gracefully (no throw)", async () => {
+    stubFetchWith(() => ({ status: 200, body: {} }));
+    await fetchEndpointModels("https://e.example/v1", "k");
+    expect(getState().endpointModels.size).toBe(0);
+  });
+});
+
+// ── Request shape ──────────────────────────────────────────────────────────
+
+describe("openai-agents / fetchEndpointModels / request shape", () => {
+  it("normalises trailing slashes on baseURL", async () => {
+    stubFetchWith(({ url }) => {
+      expect(url).toBe("https://e.example/v1/models");
+      return { status: 200, body: { data: [] } };
+    });
+    await fetchEndpointModels("https://e.example/v1///", "k");
+  });
+
+  it("sends Authorization header when an apiKey is provided", async () => {
+    stubFetchWith(({ init }) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      expect(headers?.Authorization).toBe("Bearer sk-test");
+      return { status: 200, body: { data: [] } };
+    });
+    await fetchEndpointModels("https://e.example/v1", "sk-test");
+  });
+
+  it("omits the Authorization header when no apiKey is provided", async () => {
+    stubFetchWith(({ init }) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      expect(headers?.Authorization).toBeUndefined();
+      return { status: 200, body: { data: [] } };
+    });
+    await fetchEndpointModels("https://e.example/v1", undefined);
+  });
+});
+
+// ── Failure modes ──────────────────────────────────────────────────────────
+
+describe("openai-agents / fetchEndpointModels / failures", () => {
+  it("throws on non-200 responses", async () => {
+    stubFetchWith(() => ({ status: 503, body: { error: "down" } }));
+    await expect(
+      fetchEndpointModels("https://e.example/v1", "k"),
+    ).rejects.toThrow(/503/);
+  });
+
+  it("leaves the catalog untouched when fetch rejects", async () => {
+    getState().endpointModels.set("preexisting", { contextWindow: 1 });
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    await expect(
+      fetchEndpointModels("https://e.example/v1", "k"),
+    ).rejects.toThrow(/ECONNREFUSED/);
+    expect(getState().endpointModels.get("preexisting")?.contextWindow).toBe(1);
+  });
+});

--- a/src/__tests__/openai-agents-models.test.ts
+++ b/src/__tests__/openai-agents-models.test.ts
@@ -154,49 +154,179 @@ describe("openai-agents / getModelInfo", () => {
 
 // ── /settings presentation ──────────────────────────────────────────────────
 
-describe("openai-agents / getSettingsPresentation", () => {
-  it("marks the active model with a bullet and includes it first", () => {
+describe("openai-agents / getSettingsPresentation — small catalog (flat view)", () => {
+  it('returns view="models" with the active model bullet-marked', () => {
     seedCatalog([
       ["gpt-5.5", { displayName: "GPT-5.5", contextWindow: 400_000 }],
       ["gpt-5", { displayName: "GPT-5", contextWindow: 400_000 }],
     ]);
     const pres = getSettingsPresentation("gpt-5.5");
-    expect(pres.modelButtons[0].text).toContain("● ");
-    expect(pres.modelButtons[0].callback_data).toBe("settings:model:gpt-5.5");
+    expect(pres.view).toBe("models");
+    const activeBtn = pres.modelButtons.find((b) =>
+      b.callback_data.endsWith("gpt-5.5"),
+    );
+    expect(activeBtn?.text.startsWith("● ")).toBe(true);
+    expect(activeBtn?.callback_data).toBe("settings:model:gpt-5.5");
   });
 
-  it("caps the visible button list to a sensible number", () => {
+  it("paginates correctly", () => {
     const entries: Array<[string, EndpointModelCapabilities]> = [];
-    for (let i = 0; i < 50; i++) entries.push([`m${i}`, {}]);
+    for (let i = 0; i < 25; i++)
+      entries.push([`m${String(i).padStart(2, "0")}`, {}]);
     seedCatalog(entries);
-    const pres = getSettingsPresentation("m0");
-    expect(pres.modelButtons.length).toBeLessThanOrEqual(12);
-    expect(pres.modelButtons.length).toBeGreaterThan(0);
+    const page1 = getSettingsPresentation("m00", { pageSize: 8 });
+    const page2 = getSettingsPresentation("m00", { pageSize: 8, page: 2 });
+    expect(page1.view).toBe("models");
+    expect(page1.page).toBe(1);
+    expect(page2.page).toBe(2);
+    expect(page1.modelButtons).not.toEqual(page2.modelButtons);
+    expect(page1.totalPages).toBe(Math.ceil(25 / 8));
   });
 
-  it("prefers entries with known context windows over bare passthroughs", () => {
+  it("clamps page > totalPages to the last page", () => {
+    const entries: Array<[string, EndpointModelCapabilities]> = [];
+    for (let i = 0; i < 12; i++) entries.push([`m${i}`, {}]);
+    seedCatalog(entries);
+    const pres = getSettingsPresentation("m0", { pageSize: 4, page: 999 });
+    expect(pres.page).toBe(3);
+    expect(pres.totalPages).toBe(3);
+  });
+
+  it("applies the free filter and reports freeCount as a hint", () => {
     seedCatalog([
-      ["bare", {}],
-      ["enriched", { contextWindow: 128_000 }],
+      ["paid-a", {}],
+      ["paid-b", {}],
+      ["free-a", { free: true }],
+      ["free-b", { free: true }],
     ]);
-    const pres = getSettingsPresentation("(unset)");
-    // The enriched entry should appear ahead of the bare one
-    const enrichedIdx = pres.modelButtons.findIndex((b) =>
-      b.callback_data.endsWith("enriched"),
-    );
-    const bareIdx = pres.modelButtons.findIndex((b) =>
-      b.callback_data.endsWith("bare"),
-    );
-    expect(enrichedIdx).toBeGreaterThanOrEqual(0);
-    expect(bareIdx).toBeGreaterThanOrEqual(0);
-    expect(enrichedIdx).toBeLessThan(bareIdx);
+    const all = getSettingsPresentation("(none)");
+    expect(all.freeCount).toBe(2);
+    expect(all.totalCount).toBe(4);
+    const free = getSettingsPresentation("(none)", { filter: "free" });
+    expect(free.filter).toBe("free");
+    expect(free.modelButtons).toHaveLength(2);
+    for (const b of free.modelButtons) {
+      expect(b.callback_data).toMatch(/free-/);
+    }
   });
 
-  it("formats context window and free flag in details when present", () => {
-    seedCatalog([["m", { contextWindow: 128_000, free: true }]]);
-    const pres = getSettingsPresentation("m");
-    expect(pres.modelDetails[0]).toContain("128k ctx");
-    expect(pres.modelDetails[0]).toContain("free");
+  it("modelDetails carries plain-text backend status (no markup)", () => {
+    seedCatalog([["m1", { contextWindow: 128_000, free: true }]]);
+    const pres = getSettingsPresentation("m1");
+    for (const line of pres.modelDetails) {
+      expect(line).not.toContain("<b>");
+      expect(line).not.toContain("**");
+      expect(line).not.toContain("`");
+    }
+    expect(pres.modelDetails.some((l) => /discovered/.test(l))).toBe(true);
+  });
+
+  it("button labels strip vendor prefix and surface ctx + free flag", () => {
+    seedCatalog([
+      ["openrouter/owl-alpha", { contextWindow: 1_000_000, free: true }],
+    ]);
+    const pres = getSettingsPresentation("(none)");
+    const btn = pres.modelButtons[0];
+    expect(btn.text).toContain("owl-alpha");
+    expect(btn.text).not.toContain("openrouter/");
+    expect(btn.text).toMatch(/1M/);
+    expect(btn.text).toContain("🆓");
+  });
+
+  it("hides models whose `<prefix><id>` would overflow Telegram's 64-byte callback_data limit", () => {
+    // 61-char id + `model:` (6) = 67 bytes — over Telegram's limit.
+    // OpenRouter ships exactly one such id today
+    // (`cognitivecomputations/dolphin-mistral-24b-venice-edition:free`),
+    // which crashed BUTTON_DATA_INVALID before this guard.
+    const overflow = "a".repeat(61);
+    const ok = "short-id";
+    seedCatalog([
+      [overflow, { contextWindow: 8192 }],
+      [ok, { contextWindow: 8192 }],
+    ]);
+    const pres = getSettingsPresentation("(none)", {
+      callbackPrefix: "model:",
+    });
+    for (const b of pres.modelButtons) {
+      expect(Buffer.byteLength(b.callback_data, "utf8")).toBeLessThanOrEqual(
+        64,
+      );
+    }
+    expect(pres.modelButtons.some((b) => b.callback_data.endsWith(ok))).toBe(
+      true,
+    );
+    expect(
+      pres.modelButtons.some((b) => b.callback_data.includes(overflow)),
+    ).toBe(false);
+    // The totalCount reflects what's *renderable*, not the raw catalog,
+    // so /status and the menu status line don't lie about visibility.
+    expect(pres.totalCount).toBe(1);
+  });
+});
+
+describe("openai-agents / getSettingsPresentation — large catalog (provider groups)", () => {
+  function seedLarge(): void {
+    // Build a 60-model catalog spread across 4 providers — well over
+    // the 30-model PROVIDER_GROUP_THRESHOLD.
+    const entries: Array<[string, EndpointModelCapabilities]> = [];
+    for (let i = 0; i < 20; i++)
+      entries.push([`anthropic/m${i}`, { contextWindow: 200_000 }]);
+    for (let i = 0; i < 15; i++)
+      entries.push([`openai/m${i}`, { contextWindow: 400_000 }]);
+    for (let i = 0; i < 15; i++)
+      entries.push([`google/m${i}`, { contextWindow: 1_000_000 }]);
+    for (let i = 0; i < 10; i++)
+      entries.push([`mistralai/m${i}`, { contextWindow: 64_000 }]);
+    seedCatalog(entries);
+  }
+
+  it('returns view="groups" with provider chips when no provider is selected', () => {
+    seedLarge();
+    const pres = getSettingsPresentation("(none)");
+    expect(pres.view).toBe("groups");
+    expect(pres.modelButtons.length).toBe(4); // anthropic / openai / google / mistralai
+    expect(pres.modelButtons[0].text).toMatch(/\((\d+)\)/);
+  });
+
+  it("provider buttons carry a `:provider:` drill callback under the default navPrefix", () => {
+    seedLarge();
+    const pres = getSettingsPresentation("(none)");
+    for (const b of pres.modelButtons) {
+      expect(b.callback_data).toMatch(/^settings:models:provider:/);
+    }
+  });
+
+  it("honors an explicit navCallbackPrefix", () => {
+    seedLarge();
+    const pres = getSettingsPresentation("(none)", {
+      callbackPrefix: "model:",
+      navCallbackPrefix: "model:nav",
+    });
+    for (const b of pres.modelButtons) {
+      expect(b.callback_data).toMatch(/^model:nav:provider:/);
+    }
+  });
+
+  it("drills into a provider via options.provider", () => {
+    seedLarge();
+    const pres = getSettingsPresentation("(none)", { provider: "google" });
+    expect(pres.view).toBe("models");
+    expect(pres.provider).toBe("google");
+    for (const b of pres.modelButtons) {
+      expect(b.callback_data).toMatch(/settings:model:google\//);
+    }
+  });
+
+  it("skips the group view when the filtered catalog is small (free filter)", () => {
+    // Only one free model — under the threshold even before grouping.
+    const entries: Array<[string, EndpointModelCapabilities]> = [];
+    for (let i = 0; i < 40; i++)
+      entries.push([`p/m${i}`, { contextWindow: 100_000 }]);
+    entries.push(["free/only", { free: true, contextWindow: 50_000 }]);
+    seedCatalog(entries);
+    const pres = getSettingsPresentation("(none)", { filter: "free" });
+    expect(pres.view).toBe("models");
+    expect(pres.modelButtons).toHaveLength(1);
   });
 });
 

--- a/src/__tests__/openai-agents-models.test.ts
+++ b/src/__tests__/openai-agents-models.test.ts
@@ -1,15 +1,15 @@
 /**
- * OpenAI Agents backend — model catalog tests.
+ * Tests for the OpenAI Agents backend's model surface.
  *
- * The Agents SDK accepts any string the OpenAI Responses API accepts,
- * but Talon ships a hand-maintained catalog for the model picker UI.
- * These tests pin the catalog shape + the standard `resolveModel` /
- * `formatModelError` / `listModels` behaviour.
+ * The backend has no hardcoded catalog — everything is driven by
+ * `state.endpointModels`, which `init.ts#fetchEndpointModels`
+ * populates from the active endpoint's `/models` response. These
+ * tests seed that map directly instead of going through a live
+ * fetch, so behavior of the resolver, picker, and listing is
+ * verified deterministically.
  */
-
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
-  OPENAI_AGENTS_MODELS,
   resolveModel,
   getModelInfo,
   getSettingsPresentation,
@@ -20,136 +20,291 @@ import {
 } from "../backend/openai-agents/models.js";
 import {
   initOpenAIAgentsAgent,
+  getOpenAIApiKey,
   getOpenAIBaseUrl,
 } from "../backend/openai-agents/init.js";
-import { resetState } from "../backend/openai-agents/state.js";
+import {
+  getState,
+  resetState,
+  type EndpointModelCapabilities,
+} from "../backend/openai-agents/state.js";
 
-describe("openai-agents / model catalog", () => {
-  it("exposes at least the gpt-5.5 flagship", () => {
-    expect(OPENAI_AGENTS_MODELS.find((m) => m.id === "gpt-5.5")).toBeDefined();
-  });
+function seedCatalog(
+  entries: Array<[string, EndpointModelCapabilities | undefined]>,
+): void {
+  const map = getState().endpointModels;
+  map.clear();
+  for (const [id, caps] of entries) {
+    map.set(id, caps ?? {});
+  }
+}
 
-  it("every model carries the openai provider", () => {
-    for (const m of OPENAI_AGENTS_MODELS) {
-      expect(m.provider).toBe("openai");
-      expect(m.providerName).toBe("OpenAI");
-      expect(m.selectable).toBe(true);
-    }
-  });
+beforeEach(() => resetState());
+afterEach(() => resetState());
 
-  it("does NOT include gpt-5-codex (Codex CLI only)", () => {
-    expect(
-      OPENAI_AGENTS_MODELS.find((m) => m.id === "gpt-5-codex"),
-    ).toBeUndefined();
-  });
-});
+// ── resolveModel ────────────────────────────────────────────────────────────
 
 describe("openai-agents / resolveModel", () => {
-  it("returns exact match for a known model id", () => {
+  it("returns missing for an empty query", () => {
+    expect(resolveModel("").kind).toBe("missing");
+    expect(resolveModel("   ").kind).toBe("missing");
+  });
+
+  it("exact-matches an advertised id and surfaces its metadata", () => {
+    seedCatalog([
+      ["gpt-5.5", { contextWindow: 400_000, displayName: "GPT-5.5" }],
+    ]);
     const r = resolveModel("gpt-5.5");
     expect(r.kind).toBe("exact");
     if (r.kind !== "exact") return;
     expect(r.model.id).toBe("gpt-5.5");
+    expect(r.model.contextWindow).toBe(400_000);
+    expect(r.model.displayName).toBe("GPT-5.5");
+    expect(r.storedValue).toBe("gpt-5.5");
   });
 
-  it("returns missing for an empty query", () => {
-    expect(resolveModel("").kind).toBe("missing");
+  it("prefix-matches by id when unambiguous", () => {
+    seedCatalog([
+      ["gpt-5-mini", { contextWindow: 200_000 }],
+      ["o4-mini", { contextWindow: 128_000 }],
+    ]);
+    const r = resolveModel("gpt");
+    expect(r.kind).toBe("exact");
+    if (r.kind !== "exact") return;
+    expect(r.model.id).toBe("gpt-5-mini");
   });
 
-  it("returns missing for an unrecognised query", () => {
-    expect(resolveModel("totally-not-a-model").kind).toBe("missing");
-  });
-
-  it("returns ambiguous for a prefix that matches multiple", () => {
+  it("returns ambiguous when more than one entry shares a prefix and none is an exact match", () => {
+    seedCatalog([
+      ["gpt-5.5", {}],
+      ["gpt-5-mini", {}],
+    ]);
+    // "gpt-5" is a strict prefix of both ids but isn't an id itself,
+    // so the resolver can't disambiguate.
     const r = resolveModel("gpt-5");
-    // `gpt-5`, `gpt-5.5`, and `gpt-5-mini` all share the `gpt-5` prefix.
-    expect(["exact", "ambiguous"]).toContain(r.kind);
-    // `gpt-5` itself IS an exact id, so prefix match prefers the exact one.
-    // The handler-facing contract is that an unambiguous user query like
-    // `gpt-5` resolves cleanly to the exact id; we still want SOME match.
+    expect(r.kind).toBe("ambiguous");
+    if (r.kind !== "ambiguous") return;
+    expect(r.matches.map((m) => m.id).sort()).toEqual([
+      "gpt-5-mini",
+      "gpt-5.5",
+    ]);
+  });
+
+  it("prefers exact id match even when there are longer-id prefix candidates", () => {
+    seedCatalog([
+      ["gpt-5", {}],
+      ["gpt-5.5", {}],
+      ["gpt-5-mini", {}],
+    ]);
+    // "gpt-5" is exact for the first entry; the resolver short-circuits
+    // and doesn't go through the prefix ambiguity path.
+    const r = resolveModel("gpt-5");
+    expect(r.kind).toBe("exact");
+    if (r.kind !== "exact") return;
+    expect(r.model.id).toBe("gpt-5");
+  });
+
+  it("passes through unknown ids as bare passthrough models", () => {
+    seedCatalog([]);
+    const r = resolveModel("brand-new/release-2030");
+    expect(r.kind).toBe("exact");
+    if (r.kind !== "exact") return;
+    expect(r.model.id).toBe("brand-new/release-2030");
+    expect(r.model.displayName).toBe("brand-new/release-2030");
+    expect(r.model.contextWindow).toBeUndefined();
+    expect(r.model.provider).toBe("openai-compatible");
+  });
+
+  it("prefix-matches by display name when present", () => {
+    seedCatalog([
+      ["abc/owl-alpha", { displayName: "Owl Alpha", contextWindow: 1_000_000 }],
+    ]);
+    const r = resolveModel("owl");
+    expect(r.kind).toBe("exact");
+    if (r.kind !== "exact") return;
+    expect(r.model.id).toBe("abc/owl-alpha");
   });
 });
+
+// ── getModelInfo ────────────────────────────────────────────────────────────
 
 describe("openai-agents / getModelInfo", () => {
-  it("returns the model for a known id", () => {
-    expect(getModelInfo("gpt-5.5")?.id).toBe("gpt-5.5");
+  it("returns enriched info for a known id", () => {
+    seedCatalog([
+      ["gpt-5.5", { contextWindow: 400_000, displayName: "GPT-5.5" }],
+    ]);
+    const info = getModelInfo("gpt-5.5");
+    expect(info?.contextWindow).toBe(400_000);
+    expect(info?.displayName).toBe("GPT-5.5");
   });
 
-  it("returns undefined for unknown ids", () => {
-    expect(getModelInfo("missing-model")).toBeUndefined();
+  it("returns a bare passthrough for an unknown id (never undefined for non-empty)", () => {
+    seedCatalog([]);
+    const info = getModelInfo("unknown/model");
+    expect(info).toBeDefined();
+    expect(info?.id).toBe("unknown/model");
+    expect(info?.contextWindow).toBeUndefined();
+    expect(info?.free).toBeUndefined();
+  });
+
+  it("returns undefined for the empty string", () => {
+    expect(getModelInfo("")).toBeUndefined();
   });
 });
+
+// ── /settings presentation ──────────────────────────────────────────────────
 
 describe("openai-agents / getSettingsPresentation", () => {
-  it("returns one button per model with active marker on the current one", () => {
-    const pres = getSettingsPresentation("gpt-5");
-    expect(pres.modelButtons.length).toBe(OPENAI_AGENTS_MODELS.length);
-    const activeButton = pres.modelButtons.find((b) =>
-      b.callback_data.endsWith("gpt-5"),
+  it("marks the active model with a bullet and includes it first", () => {
+    seedCatalog([
+      ["gpt-5.5", { displayName: "GPT-5.5", contextWindow: 400_000 }],
+      ["gpt-5", { displayName: "GPT-5", contextWindow: 400_000 }],
+    ]);
+    const pres = getSettingsPresentation("gpt-5.5");
+    expect(pres.modelButtons[0].text).toContain("● ");
+    expect(pres.modelButtons[0].callback_data).toBe("settings:model:gpt-5.5");
+  });
+
+  it("caps the visible button list to a sensible number", () => {
+    const entries: Array<[string, EndpointModelCapabilities]> = [];
+    for (let i = 0; i < 50; i++) entries.push([`m${i}`, {}]);
+    seedCatalog(entries);
+    const pres = getSettingsPresentation("m0");
+    expect(pres.modelButtons.length).toBeLessThanOrEqual(12);
+    expect(pres.modelButtons.length).toBeGreaterThan(0);
+  });
+
+  it("prefers entries with known context windows over bare passthroughs", () => {
+    seedCatalog([
+      ["bare", {}],
+      ["enriched", { contextWindow: 128_000 }],
+    ]);
+    const pres = getSettingsPresentation("(unset)");
+    // The enriched entry should appear ahead of the bare one
+    const enrichedIdx = pres.modelButtons.findIndex((b) =>
+      b.callback_data.endsWith("enriched"),
     );
-    expect(activeButton?.text.startsWith("● ")).toBe(true);
+    const bareIdx = pres.modelButtons.findIndex((b) =>
+      b.callback_data.endsWith("bare"),
+    );
+    expect(enrichedIdx).toBeGreaterThanOrEqual(0);
+    expect(bareIdx).toBeGreaterThanOrEqual(0);
+    expect(enrichedIdx).toBeLessThan(bareIdx);
   });
 
-  it("uses the supplied callbackPrefix", () => {
-    const pres = getSettingsPresentation("gpt-5.5", "model:");
-    expect(pres.modelButtons[0].callback_data.startsWith("model:")).toBe(true);
+  it("formats context window and free flag in details when present", () => {
+    seedCatalog([["m", { contextWindow: 128_000, free: true }]]);
+    const pres = getSettingsPresentation("m");
+    expect(pres.modelDetails[0]).toContain("128k ctx");
+    expect(pres.modelDetails[0]).toContain("free");
   });
 });
 
-describe("openai-agents / getProviders + getProviderModels", () => {
-  it("returns OpenAI as the sole provider", () => {
+// ── providers ──────────────────────────────────────────────────────────────
+
+describe("openai-agents / providers", () => {
+  it("exposes a single endpoint-agnostic provider", () => {
+    seedCatalog([
+      ["m1", {}],
+      ["m2", {}],
+    ]);
     const providers = getProviders();
-    expect(providers.length).toBe(1);
+    expect(providers).toHaveLength(1);
     expect(providers[0].id).toBe("openai");
-    expect(providers[0].connected).toBe(true);
-    expect(providers[0].modelCount).toBe(OPENAI_AGENTS_MODELS.length);
+    expect(providers[0].modelCount).toBe(2);
   });
 
-  it("returns paginated models for openai provider", () => {
-    const page1 = getProviderModels("openai", 1, 2);
-    expect(page1.models.length).toBe(2);
-    expect(page1.total).toBe(OPENAI_AGENTS_MODELS.length);
+  it("paginates getProviderModels()", () => {
+    const entries: Array<[string, EndpointModelCapabilities]> = [];
+    for (let i = 0; i < 60; i++)
+      entries.push([`m${String(i).padStart(2, "0")}`, {}]);
+    seedCatalog(entries);
+    const page1 = getProviderModels("openai", 1, 50);
+    expect(page1.models.length).toBe(50);
+    expect(page1.total).toBe(60);
+    const page2 = getProviderModels("openai", 2, 50);
+    expect(page2.models.length).toBe(10);
   });
 
-  it("returns empty for unknown provider", () => {
-    expect(getProviderModels("anthropic").models).toEqual([]);
+  it("returns nothing for unknown providers", () => {
+    seedCatalog([["m", {}]]);
+    expect(getProviderModels("bogus").models).toEqual([]);
   });
 });
+
+// ── formatModelError ───────────────────────────────────────────────────────
 
 describe("openai-agents / formatModelError", () => {
-  it("describes ambiguous matches with backtick-quoted ids", () => {
-    const msg = formatModelError("g", {
+  it("lists the candidates on ambiguity", () => {
+    seedCatalog([
+      ["gpt-5", {}],
+      ["gpt-5.5", {}],
+    ]);
+    const msg = formatModelError("gpt-5", {
       kind: "ambiguous",
-      matches: OPENAI_AGENTS_MODELS.slice(0, 2),
+      matches: [
+        {
+          id: "gpt-5",
+          displayName: "x",
+          provider: "x",
+          providerName: "x",
+          selectable: true,
+          reasoning: false,
+        },
+        {
+          id: "gpt-5.5",
+          displayName: "x",
+          provider: "x",
+          providerName: "x",
+          selectable: true,
+          reasoning: false,
+        },
+      ],
     });
-    expect(msg).toContain("Multiple");
-    expect(msg).toContain("`");
+    expect(msg).toContain("gpt-5");
+    expect(msg).toContain("gpt-5.5");
+    expect(msg).toContain("Pick one");
   });
 
-  it("describes a missing query with the full catalog", () => {
-    const msg = formatModelError("nope", { kind: "missing" });
-    expect(msg).toContain("No OpenAI Agents model matches");
-    expect(msg).toContain("gpt-5.5");
+  it("returns the empty-query hint for `missing`", () => {
+    const msg = formatModelError("", { kind: "missing" });
+    expect(msg.toLowerCase()).toContain("no model id");
   });
 });
+
+// ── listModels filter ──────────────────────────────────────────────────────
 
 describe("openai-agents / listModels", () => {
-  it("returns all by default", () => {
-    const r = listModels();
-    expect(r.models.length).toBe(OPENAI_AGENTS_MODELS.length);
-    expect(r.total).toBe(OPENAI_AGENTS_MODELS.length);
+  it("returns the full catalog by default", () => {
+    seedCatalog([
+      ["m1", { free: true }],
+      ["m2", {}],
+      ["m3", { free: true }],
+    ]);
+    expect(listModels().models.length).toBe(3);
+    expect(listModels("all").models.length).toBe(3);
   });
 
-  it("returns nothing for `free` filter — no free OpenAI Agents models", () => {
+  it("returns only free-flagged models for the `free` filter", () => {
+    seedCatalog([
+      ["m-paid", {}],
+      ["m-free", { free: true }],
+    ]);
+    const free = listModels("free");
+    expect(free.models).toHaveLength(1);
+    expect(free.models[0].id).toBe("m-free");
+    expect(free.models[0].free).toBe(true);
+  });
+
+  it("returns an empty list when no entries are flagged free", () => {
+    seedCatalog([["m", {}]]);
     expect(listModels("free").models).toEqual([]);
-  });
-
-  it("returns all for the `all` filter", () => {
-    expect(listModels("all").models.length).toBe(OPENAI_AGENTS_MODELS.length);
   });
 });
 
-describe("openai-agents / custom endpoint (openaiBaseUrl) passthrough", () => {
+// ── env-var resolution ─────────────────────────────────────────────────────
+
+describe("openai-agents / env-var resolution", () => {
   const origTalonBase = process.env.TALON_AGENTS_URL;
   const origTalonKey = process.env.TALON_AGENTS_KEY;
   const origTalonMode = process.env.TALON_AGENTS_API_MODE;
@@ -164,73 +319,40 @@ describe("openai-agents / custom endpoint (openaiBaseUrl) passthrough", () => {
     else process.env.TALON_AGENTS_API_MODE = origTalonMode;
   });
 
-  function initWithBase(baseURL?: string, apiKey = "test-key") {
+  function init(cfg: { apiKey?: string; baseURL?: string }): void {
     delete process.env.TALON_AGENTS_URL;
     delete process.env.TALON_AGENTS_KEY;
     delete process.env.TALON_AGENTS_API_MODE;
     initOpenAIAgentsAgent(
       {
         model: "gpt-5.5",
-        openaiApiKey: apiKey,
-        ...(baseURL ? { openaiBaseUrl: baseURL } : {}),
+        ...(cfg.apiKey ? { openaiApiKey: cfg.apiKey } : {}),
+        ...(cfg.baseURL ? { openaiBaseUrl: cfg.baseURL } : {}),
       } as never,
       () => 12345,
       "telegram",
     );
   }
 
-  it("getOpenAIBaseUrl returns the configured baseURL", () => {
-    initWithBase("https://openrouter.ai/api/v1");
+  it("returns the configured baseURL", () => {
+    init({ apiKey: "k", baseURL: "https://openrouter.ai/api/v1" });
     expect(getOpenAIBaseUrl()).toBe("https://openrouter.ai/api/v1");
   });
 
-  it("getOpenAIBaseUrl returns undefined when no baseURL is set", () => {
-    initWithBase(undefined);
+  it("returns undefined when no baseURL is configured", () => {
+    init({ apiKey: "k" });
     expect(getOpenAIBaseUrl()).toBeUndefined();
   });
 
   it("TALON_AGENTS_URL env overrides config", () => {
-    initWithBase("https://config.example.com/v1");
+    init({ apiKey: "k", baseURL: "https://config.example.com/v1" });
     process.env.TALON_AGENTS_URL = "https://env.example.com/v1";
     expect(getOpenAIBaseUrl()).toBe("https://env.example.com/v1");
   });
 
-  it("resolveModel passes through unknown ids when a custom baseURL is set", () => {
-    initWithBase("https://openrouter.ai/api/v1");
-    const r = resolveModel("meta-llama/llama-3.3-70b-instruct");
-    expect(r.kind).toBe("exact");
-    if (r.kind !== "exact") return;
-    expect(r.model.id).toBe("meta-llama/llama-3.3-70b-instruct");
-    expect(r.model.provider).toBe("openai-compatible");
-  });
-
-  it("resolveModel still returns missing for unknown ids when no baseURL is set", () => {
-    initWithBase(undefined);
-    expect(resolveModel("meta-llama/llama-3.3-70b-instruct").kind).toBe(
-      "missing",
-    );
-  });
-
-  it("resolveModel still prefers exact catalog hits when a baseURL is set", () => {
-    initWithBase("https://openrouter.ai/api/v1");
-    const r = resolveModel("gpt-5.5");
-    expect(r.kind).toBe("exact");
-    if (r.kind !== "exact") return;
-    expect(r.model.id).toBe("gpt-5.5");
-    expect(r.model.provider).toBe("openai");
-  });
-
-  it("getModelInfo returns a synthetic entry for arbitrary ids when baseURL is set", () => {
-    initWithBase("https://openrouter.ai/api/v1");
-    const info = getModelInfo("qwen/qwen3-coder");
-    expect(info?.id).toBe("qwen/qwen3-coder");
-    expect(info?.displayName).toBe("qwen/qwen3-coder");
-  });
-
-  it("formatModelError points to direct-config when baseURL is set", () => {
-    initWithBase("https://openrouter.ai/api/v1");
-    const msg = formatModelError("typo-model", { kind: "missing" });
-    expect(msg).toContain("openaiBaseUrl");
-    expect(msg).toContain("talon.json");
+  it("TALON_AGENTS_KEY env overrides config", () => {
+    init({ apiKey: "config-key" });
+    process.env.TALON_AGENTS_KEY = "env-key";
+    expect(getOpenAIApiKey()).toBe("env-key");
   });
 });

--- a/src/__tests__/telegram-model-menu.test.ts
+++ b/src/__tests__/telegram-model-menu.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Tests for the `/model` UX layer (Telegram frontend):
+ *
+ *   - `parseModelCallback` — pure parser over the inline-button
+ *     callback-data grammar. Pinned because Telegram's 64-byte
+ *     callback_data limit + frontend dispatch correctness depend on
+ *     it staying in lockstep with the renderers.
+ *   - `buildModelMenuState` — pure async assembler that turns the
+ *     backend's `getSettingsPresentation` snapshot + chat-settings
+ *     into a `ModelMenuState` ready for rendering.
+ *   - `renderModelMenuKeyboard` / `renderModelMenuText` — the main
+ *     menu surface.
+ *   - `renderModelBrowseKeyboard` — the browse view (groups or
+ *     paginated models, with `← Back to menu` always present).
+ */
+import { describe, it, expect } from "vitest";
+import { parseModelCallback } from "../frontend/telegram/model-callbacks.js";
+import {
+  buildModelMenuState,
+  renderModelMenuKeyboard,
+  renderModelMenuText,
+  renderModelBrowseKeyboard,
+  type ModelMenuState,
+} from "../frontend/telegram/helpers.js";
+
+// ── parseModelCallback ─────────────────────────────────────────────────────
+
+describe("telegram /model — parseModelCallback", () => {
+  it("rejects non-model: callbacks as unknown", () => {
+    expect(parseModelCallback("settings:done").kind).toBe("unknown");
+    expect(parseModelCallback("pulse:on").kind).toBe("unknown");
+    expect(parseModelCallback("").kind).toBe("unknown");
+  });
+
+  it("parses one-word actions", () => {
+    expect(parseModelCallback("model:done").kind).toBe("done");
+    expect(parseModelCallback("model:noop").kind).toBe("noop");
+    expect(parseModelCallback("model:menu").kind).toBe("menu");
+    expect(parseModelCallback("model:browse").kind).toBe("browse");
+    expect(parseModelCallback("model:toggle-free").kind).toBe("toggle-free");
+    expect(parseModelCallback("model:reset").kind).toBe("reset");
+  });
+
+  it("parses provider drill with multi-segment provider ids", () => {
+    const out = parseModelCallback("model:nav:provider:aion-labs");
+    expect(out).toEqual({ kind: "nav-provider", provider: "aion-labs" });
+  });
+
+  it("parses back-to-providers", () => {
+    expect(parseModelCallback("model:nav:providers").kind).toBe(
+      "nav-back-to-providers",
+    );
+  });
+
+  it("parses nav:page with required filter and optional provider", () => {
+    expect(parseModelCallback("model:nav:page:3:all")).toEqual({
+      kind: "nav-page",
+      page: 3,
+      filter: "all",
+    });
+    expect(parseModelCallback("model:nav:page:2:free:openai")).toEqual({
+      kind: "nav-page",
+      page: 2,
+      filter: "free",
+      provider: "openai",
+    });
+  });
+
+  it("treats malformed nav payloads as unknown", () => {
+    expect(parseModelCallback("model:nav:page:NaN:all").kind).toBe("unknown");
+    expect(parseModelCallback("model:nav:page:1:bogus").kind).toBe("unknown");
+    expect(parseModelCallback("model:nav:page:0:all").kind).toBe("unknown");
+    expect(parseModelCallback("model:nav:provider:").kind).toBe("unknown");
+    expect(parseModelCallback("model:nav:filter:bogus").kind).toBe("unknown");
+    expect(parseModelCallback("model:nav:unknown-sub").kind).toBe("unknown");
+  });
+
+  it("parses a plain model id as a selection", () => {
+    expect(parseModelCallback("model:openrouter/owl-alpha")).toEqual({
+      kind: "select",
+      modelId: "openrouter/owl-alpha",
+    });
+  });
+
+  it("refuses to interpret stale picker-control payloads as model ids", () => {
+    // Earlier bot versions emitted ambiguous control payloads. The
+    // parser must never let `nav:...` end up as a selectable model id
+    // because that would persist into chat-settings on click.
+    expect(parseModelCallback("model:nav:filter:free").kind).not.toBe("select");
+    expect(parseModelCallback("model:nav:filter:free").kind).toBe("nav-filter");
+  });
+});
+
+// ── buildModelMenuState ────────────────────────────────────────────────────
+
+describe("telegram /model — buildModelMenuState", () => {
+  function stubBackend(
+    opts: {
+      freeCount?: number;
+      totalCount?: number;
+      statusLines?: string[];
+      display?: string;
+    } = {},
+  ) {
+    return {
+      fetchSnapshot: async () => ({
+        freeCount: opts.freeCount ?? 0,
+        totalCount: opts.totalCount ?? 0,
+        modelDetails: opts.statusLines ?? [],
+      }),
+      fetchActiveDisplay: async () => opts.display,
+    };
+  }
+
+  it("falls back to the raw model id when no display name is available", async () => {
+    const state = await buildModelMenuState({
+      chatId: "c1",
+      activeModel: "openrouter/owl-alpha",
+      defaultModel: "openrouter/owl-alpha",
+      freeOnly: false,
+      ...stubBackend(),
+    });
+    expect(state.activeDisplay).toBe("openrouter/owl-alpha");
+  });
+
+  it("marks hasOverride when the active model differs from the default", async () => {
+    const same = await buildModelMenuState({
+      chatId: "c",
+      activeModel: "m",
+      defaultModel: "m",
+      freeOnly: false,
+      ...stubBackend(),
+    });
+    expect(same.hasOverride).toBe(false);
+
+    const diff = await buildModelMenuState({
+      chatId: "c",
+      activeModel: "m",
+      defaultModel: "other",
+      freeOnly: false,
+      ...stubBackend(),
+    });
+    expect(diff.hasOverride).toBe(true);
+  });
+
+  it("shows the free toggle only when the backend reports free models", async () => {
+    const without = await buildModelMenuState({
+      chatId: "c",
+      activeModel: "m",
+      defaultModel: "m",
+      freeOnly: false,
+      ...stubBackend({ freeCount: 0, totalCount: 50 }),
+    });
+    expect(without.showFreeToggle).toBe(false);
+
+    const withFree = await buildModelMenuState({
+      chatId: "c",
+      activeModel: "m",
+      defaultModel: "m",
+      freeOnly: false,
+      ...stubBackend({ freeCount: 4, totalCount: 50 }),
+    });
+    expect(withFree.showFreeToggle).toBe(true);
+  });
+
+  it("recovers from snapshot-fetch failures with a safe empty state", async () => {
+    const state = await buildModelMenuState({
+      chatId: "c",
+      activeModel: "m",
+      defaultModel: "m",
+      freeOnly: false,
+      fetchSnapshot: async () => {
+        throw new Error("backend offline");
+      },
+      fetchActiveDisplay: async () => "Active",
+    });
+    expect(state.statusLines).toEqual([]);
+    expect(state.showFreeToggle).toBe(false);
+    expect(state.activeDisplay).toBe("Active");
+  });
+});
+
+// ── renderModelMenuKeyboard ────────────────────────────────────────────────
+
+function baseState(overrides: Partial<ModelMenuState> = {}): ModelMenuState {
+  return {
+    activeModel: "openrouter/owl-alpha",
+    activeDisplay: "Owl Alpha",
+    statusLines: ["356 models discovered via OpenAI Agents endpoint"],
+    hasOverride: false,
+    showFreeToggle: true,
+    freeOnly: false,
+    ...overrides,
+  };
+}
+
+function callbacks(
+  rows: ReadonlyArray<ReadonlyArray<{ callback_data: string }>>,
+): string[] {
+  return rows.flat().map((b) => b.callback_data);
+}
+
+describe("telegram /model — renderModelMenuKeyboard", () => {
+  it("always includes Browse", () => {
+    const rows = renderModelMenuKeyboard(baseState());
+    expect(callbacks(rows)).toContain("model:browse");
+  });
+
+  it("does NOT include a Done button — closing the picker requires deleting the message externally", () => {
+    const rows = renderModelMenuKeyboard(baseState({ hasOverride: true }));
+    expect(callbacks(rows)).not.toContain("model:done");
+  });
+
+  it("includes the free toggle when showFreeToggle is true", () => {
+    const off = renderModelMenuKeyboard(baseState({ freeOnly: false }));
+    const on = renderModelMenuKeyboard(baseState({ freeOnly: true }));
+    expect(callbacks(off)).toContain("model:toggle-free");
+    expect(callbacks(on)).toContain("model:toggle-free");
+    expect(
+      off.flat().find((b) => b.callback_data === "model:toggle-free")!.text,
+    ).toMatch(/OFF/i);
+    expect(
+      on.flat().find((b) => b.callback_data === "model:toggle-free")!.text,
+    ).toMatch(/ON/i);
+  });
+
+  it("omits the free toggle when the backend has no free models", () => {
+    const rows = renderModelMenuKeyboard(baseState({ showFreeToggle: false }));
+    expect(callbacks(rows)).not.toContain("model:toggle-free");
+  });
+
+  it("includes Reset only when there's a per-chat override", () => {
+    const without = renderModelMenuKeyboard(baseState({ hasOverride: false }));
+    const withOverride = renderModelMenuKeyboard(
+      baseState({ hasOverride: true }),
+    );
+    expect(callbacks(without)).not.toContain("model:reset");
+    expect(callbacks(withOverride)).toContain("model:reset");
+  });
+});
+
+describe("telegram /model — renderModelMenuText", () => {
+  it("contains the active display name and renders status lines plainly", () => {
+    const text = renderModelMenuText(
+      baseState({
+        activeDisplay: "Owl Alpha",
+        statusLines: ["356 models discovered"],
+      }),
+    );
+    expect(text).toContain("Owl Alpha");
+    expect(text).toContain("356 models discovered");
+  });
+
+  it("adds a filter hint when freeOnly is on", () => {
+    const off = renderModelMenuText(baseState({ freeOnly: false }));
+    const on = renderModelMenuText(baseState({ freeOnly: true }));
+    expect(off.toLowerCase()).not.toContain("filtering to free");
+    expect(on.toLowerCase()).toContain("free-tier");
+  });
+
+  it("does not advertise free filtering when the backend lacks free models", () => {
+    const text = renderModelMenuText(
+      baseState({ freeOnly: true, showFreeToggle: false }),
+    );
+    expect(text.toLowerCase()).not.toContain("free-tier");
+  });
+});
+
+// ── renderModelBrowseKeyboard ──────────────────────────────────────────────
+
+describe("telegram /model — renderModelBrowseKeyboard", () => {
+  it("always ends with a Back-to-menu row", () => {
+    const rows = renderModelBrowseKeyboard(
+      [{ text: "a", callback_data: "model:a" }],
+      {
+        page: 1,
+        totalPages: 1,
+        filter: "all",
+        freeCount: 0,
+        totalCount: 1,
+      },
+      "models",
+      undefined,
+      "model:menu",
+    );
+    const last = rows[rows.length - 1];
+    expect(last).toEqual([
+      { text: "← Back to menu", callback_data: "model:menu" },
+    ]);
+  });
+
+  it("renders no Prev/Next row when there's a single page", () => {
+    const rows = renderModelBrowseKeyboard(
+      [{ text: "a", callback_data: "model:a" }],
+      {
+        page: 1,
+        totalPages: 1,
+        filter: "all",
+        freeCount: 0,
+        totalCount: 1,
+      },
+      "models",
+      undefined,
+      "model:menu",
+    );
+    expect(callbacks(rows).some((cb) => cb.startsWith("model:nav:page:"))).toBe(
+      false,
+    );
+  });
+
+  it("renders Prev/Next page buttons when totalPages > 1", () => {
+    const rows = renderModelBrowseKeyboard(
+      [{ text: "a", callback_data: "model:a" }],
+      {
+        page: 2,
+        totalPages: 5,
+        filter: "all",
+        freeCount: 0,
+        totalCount: 40,
+      },
+      "models",
+      undefined,
+      "model:menu",
+    );
+    const cbs = callbacks(rows);
+    // Prev → page 1, Next → page 3
+    expect(cbs).toContain("model:nav:page:1:all");
+    expect(cbs).toContain("model:nav:page:3:all");
+  });
+
+  it("encodes the active provider into pagination data when drilled in", () => {
+    const rows = renderModelBrowseKeyboard(
+      [{ text: "a", callback_data: "model:a" }],
+      {
+        page: 1,
+        totalPages: 3,
+        filter: "all",
+        freeCount: 0,
+        totalCount: 24,
+      },
+      "models",
+      "anthropic",
+      "model:menu",
+    );
+    const cbs = callbacks(rows);
+    expect(cbs).toContain("model:nav:providers"); // back-to-groups button
+    expect(cbs).toContain("model:nav:page:2:all:anthropic");
+  });
+
+  it("does NOT render an inline filter chip row — the toggle lives on the main menu", () => {
+    const rows = renderModelBrowseKeyboard(
+      [{ text: "a", callback_data: "model:a" }],
+      {
+        page: 1,
+        totalPages: 1,
+        filter: "all",
+        freeCount: 8,
+        totalCount: 40,
+      },
+      "models",
+      undefined,
+      "model:menu",
+    );
+    expect(
+      callbacks(rows).some((cb) => cb.startsWith("model:nav:filter:")),
+    ).toBe(false);
+  });
+
+  it("respects Telegram's 64-byte callback_data limit on every button", () => {
+    const rows = renderModelBrowseKeyboard(
+      [
+        {
+          text: "x",
+          // Worst-case selection id we'd see from OpenRouter (≈48 chars
+          // including the `model:` prefix); still under 64 bytes.
+          callback_data: "model:openrouter/nousresearch/hermes-3-llama-3.1-405",
+        },
+      ],
+      {
+        page: 3,
+        totalPages: 99,
+        filter: "free",
+        freeCount: 100,
+        totalCount: 400,
+      },
+      "models",
+      "nousresearch",
+      "model:menu",
+    );
+    for (const b of rows.flat()) {
+      expect(Buffer.byteLength(b.callback_data, "utf8")).toBeLessThanOrEqual(
+        64,
+      );
+    }
+  });
+});

--- a/src/backend/claude-sdk/factory.ts
+++ b/src/backend/claude-sdk/factory.ts
@@ -46,8 +46,8 @@ const claudeSdkFactory: BackendFactory = {
       updateSystemPrompt: (prompt) => claudeUpdateSystemPrompt(prompt),
       resolveModel: (q) => modelProvider.resolveModel(q),
       getModelInfo: (id) => modelProvider.getModelInfo(id),
-      getSettingsPresentation: (m, prefix) =>
-        modelProvider.getSettingsPresentation(m, prefix),
+      getSettingsPresentation: (m, options) =>
+        modelProvider.getSettingsPresentation(m, options),
       getProviders: () => modelProvider.getProviders(),
       getProviderModels: (p, pg, ps) =>
         modelProvider.getProviderModels(p, pg, ps),

--- a/src/backend/claude-sdk/model-provider.ts
+++ b/src/backend/claude-sdk/model-provider.ts
@@ -18,6 +18,8 @@ import type {
   UnifiedModelResolution,
   UnifiedProviderInfo,
   ModelButton,
+  ModelPickerOptions,
+  ModelPickerResult,
 } from "../../core/types.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -111,11 +113,12 @@ export async function getModelInfo(
 
 export async function getSettingsPresentation(
   activeModel: string,
-  callbackPrefix = "settings:model:",
-): Promise<{ modelButtons: ModelButton[]; modelDetails: string[] }> {
-  const options = getUniqueModels();
+  options: ModelPickerOptions = {},
+): Promise<ModelPickerResult> {
+  const callbackPrefix = options.callbackPrefix ?? "settings:model:";
+  const models = getUniqueModels();
 
-  const modelButtons: ModelButton[] = options.map((m) => {
+  const modelButtons: ModelButton[] = models.map((m) => {
     const selected = isSelectedModel(activeModel, m.id);
     return {
       text: selected ? `\u2713 ${m.displayName}` : m.displayName,
@@ -123,7 +126,20 @@ export async function getSettingsPresentation(
     };
   });
 
-  return { modelButtons, modelDetails: [] };
+  // Claude SDK ships a small, curated set \u2014 pagination and the
+  // free-tier filter aren't meaningful here. We honour the contract
+  // by returning fixed metadata; the frontend won't render Prev/Next
+  // when totalPages === 1.
+  return {
+    modelButtons,
+    modelDetails: [],
+    view: "models",
+    page: 1,
+    totalPages: 1,
+    filter: "all",
+    freeCount: 0,
+    totalCount: models.length,
+  };
 }
 
 export async function getProviders(): Promise<UnifiedProviderInfo[]> {

--- a/src/backend/codex/factory.ts
+++ b/src/backend/codex/factory.ts
@@ -38,8 +38,8 @@ const codexFactory: BackendFactory = {
       query: (params) => codexHandleMessage(params),
       resolveModel: (q) => Promise.resolve(resolveModel(q)),
       getModelInfo: (id) => Promise.resolve(getModelInfo(id)),
-      getSettingsPresentation: (m, prefix) =>
-        Promise.resolve(getSettingsPresentation(m, prefix)),
+      getSettingsPresentation: (m, options) =>
+        Promise.resolve(getSettingsPresentation(m, options)),
       getProviders: () => Promise.resolve(getProviders()),
       getProviderModels: (p, pg, ps) =>
         Promise.resolve(getProviderModels(p, pg, ps)),

--- a/src/backend/codex/models.ts
+++ b/src/backend/codex/models.ts
@@ -17,6 +17,8 @@ import type {
   UnifiedModelResolution,
   UnifiedProviderInfo,
   ModelButton,
+  ModelPickerOptions,
+  ModelPickerResult,
 } from "../../core/types.js";
 
 /**
@@ -146,24 +148,41 @@ export function getModelInfo(id: string): UnifiedModelInfo | undefined {
   return CODEX_MODELS.find((m) => m.id === id);
 }
 
-/** Quick-pick buttons for the `/settings` model picker. */
+/**
+ * Quick-pick buttons for the `/settings` model picker. Codex ships a
+ * small fixed catalog so pagination + the free-tier filter are
+ * no-ops; we satisfy the contract by returning fixed metadata.
+ */
 export function getSettingsPresentation(
   activeModel: string,
-  callbackPrefix = "settings:model:",
-): { modelButtons: ModelButton[]; modelDetails: string[] } {
+  options: ModelPickerOptions = {},
+): ModelPickerResult {
+  const callbackPrefix = options.callbackPrefix ?? "settings:model:";
   const modelButtons: ModelButton[] = CODEX_MODELS.map((m) => ({
     text: `${m.id === activeModel ? "● " : ""}${m.displayName}`,
     callback_data: `${callbackPrefix}${m.id}`,
   }));
 
-  const modelDetails = CODEX_MODELS.map((m) => {
-    const flags: string[] = [];
-    if (m.reasoning) flags.push("reasoning");
-    if (m.contextWindow) flags.push(`${m.contextWindow / 1000}k ctx`);
-    return `**${m.displayName}** (${m.id}) — ${flags.join(" · ")}`;
-  });
+  const active = CODEX_MODELS.find((m) => m.id === activeModel);
+  const modelDetails: string[] = [];
+  if (active) {
+    const ctx = active.contextWindow
+      ? ` — ${Math.round(active.contextWindow / 1000)}k ctx`
+      : "";
+    modelDetails.push(`Active: ${active.displayName} (${active.id})${ctx}`);
+  }
+  modelDetails.push(`Backend: Codex — ${CODEX_MODELS.length} models`);
 
-  return { modelButtons, modelDetails };
+  return {
+    modelButtons,
+    modelDetails,
+    view: "models",
+    page: 1,
+    totalPages: 1,
+    filter: "all",
+    freeCount: 0,
+    totalCount: CODEX_MODELS.length,
+  };
 }
 
 /** List Codex's providers (one — OpenAI). */

--- a/src/backend/kilo/factory.ts
+++ b/src/backend/kilo/factory.ts
@@ -45,8 +45,25 @@ const kiloFactory: BackendFactory = {
       query: (params) => kiloHandleMessage(params),
       resolveModel: (q) => resolveModel(q),
       getModelInfo: (id) => getModelInfo(id),
-      getSettingsPresentation: (m, prefix) =>
-        getSettingsPresentation(m, prefix),
+      getSettingsPresentation: async (m, options) => {
+        // Kilo's existing helper returns legacy `{modelButtons,
+        // modelDetails}`. Wrap into the new ModelPickerResult shape;
+        // Kilo doesn't expose pagination or a free-tier filter so the
+        // result is always page 1 of 1 with filter "all".
+        const legacy = await getSettingsPresentation(
+          m,
+          options?.callbackPrefix,
+        );
+        return {
+          ...legacy,
+          view: "models" as const,
+          page: 1,
+          totalPages: 1,
+          filter: "all" as const,
+          freeCount: 0,
+          totalCount: legacy.modelButtons.length,
+        };
+      },
       getProviders: () => getProviders(),
       getProviderModels: (p, pg, ps) => getProviderModels(p, pg, ps),
       formatModelError: (q, r) => formatModelError(q, r),

--- a/src/backend/openai-agents/builtins.ts
+++ b/src/backend/openai-agents/builtins.ts
@@ -189,6 +189,13 @@ function runShell(
       child.kill("SIGKILL");
     }, timeoutMs);
     let timedOut = false;
+    child.on("error", (err) => {
+      // spawn failed (e.g. bash not in PATH on Windows). Resolve instead
+      // of letting Node emit an uncaught error — the tool returns the
+      // diagnostic so callers can surface it rather than crashing.
+      clearTimeout(killer);
+      resolveResult({ stdout, stderr: err.message, code: -1, timedOut: false });
+    });
     child.on("close", (code) => {
       clearTimeout(killer);
       resolveResult({ stdout, stderr, code: code ?? -1, timedOut });

--- a/src/backend/openai-agents/factory.ts
+++ b/src/backend/openai-agents/factory.ts
@@ -36,8 +36,8 @@ const openAIAgentsFactory: BackendFactory = {
       query: (params) => openAIAgentsHandleMessage(params),
       resolveModel: (q) => Promise.resolve(resolveModel(q)),
       getModelInfo: (id) => Promise.resolve(getModelInfo(id)),
-      getSettingsPresentation: (m, prefix) =>
-        Promise.resolve(getSettingsPresentation(m, prefix)),
+      getSettingsPresentation: (m, options) =>
+        Promise.resolve(getSettingsPresentation(m, options)),
       getProviders: () => Promise.resolve(getProviders()),
       getProviderModels: (p, pg, ps) =>
         Promise.resolve(getProviderModels(p, pg, ps)),

--- a/src/backend/openai-agents/index.ts
+++ b/src/backend/openai-agents/index.ts
@@ -12,7 +12,6 @@ export { initOpenAIAgentsAgent, getOpenAIApiKey } from "./init.js";
 export { handleMessage, getActiveAbort } from "./handler.js";
 export { resetState, getState } from "./state.js";
 export {
-  OPENAI_AGENTS_MODELS,
   resolveModel,
   getModelInfo,
   getSettingsPresentation,

--- a/src/backend/openai-agents/init.ts
+++ b/src/backend/openai-agents/init.ts
@@ -139,22 +139,22 @@ export function initOpenAIAgentsAgent(
     );
   }
 
-  // Fire-and-forget: enrich the in-memory model catalog with whatever
-  // the remote endpoint advertises via `GET /models`. Lets /status,
-  // /settings, and the model picker show real context windows for
-  // any OpenAI-compatible endpoint (OpenRouter, Ollama, LiteLLM,
-  // vLLM, Azure with deployments) without Talon having to maintain a
-  // per-provider catalog. No-op for the default OpenAI endpoint —
-  // its /models response doesn't include `context_length`, so the
-  // built-in OPENAI_AGENTS_MODELS catalog stays authoritative there.
-  if (baseURL) {
-    fetchEndpointModels(baseURL, apiKey).catch((err) => {
-      logDebug(
-        "agent",
-        `Endpoint model enrichment skipped: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    });
-  }
+  // Fire-and-forget: populate the in-memory model catalog from
+  // whatever the active endpoint advertises via `GET /models`. The
+  // backend is fully provider-agnostic — there's no hardcoded model
+  // list — so /status, /settings, and the model picker all read from
+  // this map. Runs against the default OpenAI endpoint too; OpenAI's
+  // /models response is sparse (no context_length) but at least lets
+  // us list discovered ids. Operators can still target any model id
+  // their endpoint accepts even if /models doesn't mention it —
+  // unknown ids fall through to a bare passthrough.
+  const effectiveBaseURL = baseURL ?? "https://api.openai.com/v1";
+  fetchEndpointModels(effectiveBaseURL, apiKey).catch((err) => {
+    logDebug(
+      "agent",
+      `Endpoint model enrichment skipped: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
 }
 
 // ── Endpoint model enrichment ───────────────────────────────────────────────
@@ -177,7 +177,7 @@ interface EndpointModelEntry {
  * and `pricing.prompt`, vLLM has just `context_length`, Ollama has
  * neither). We grab whatever's present and ignore the rest.
  */
-async function fetchEndpointModels(
+export async function fetchEndpointModels(
   baseURL: string,
   apiKey: string | undefined,
 ): Promise<void> {

--- a/src/backend/openai-agents/models.ts
+++ b/src/backend/openai-agents/models.ts
@@ -26,6 +26,8 @@ import type {
   UnifiedModelResolution,
   UnifiedProviderInfo,
   ModelButton,
+  ModelPickerOptions,
+  ModelPickerResult,
 } from "../../core/types.js";
 import { getState, type EndpointModelCapabilities } from "./state.js";
 
@@ -139,53 +141,187 @@ export function getModelInfo(id: string): UnifiedModelInfo | undefined {
 
 // ── /settings presentation ──────────────────────────────────────────────────
 
-const SETTINGS_PICKER_LIMIT = 12;
+const DEFAULT_PAGE_SIZE = 8;
+const MAX_PAGE_SIZE = 24;
+/**
+ * Catalog size beyond which we surface provider chips instead of a
+ * flat paginated model list. Matches openclaw's `PROVIDER_FILTER_THRESHOLD`
+ * (`/tmp/openclaw/src/flows/model-picker.ts`) so the UX scales the
+ * same way: small catalogs stay flat, large ones get a provider
+ * grouping step first.
+ */
+const PROVIDER_GROUP_THRESHOLD = 30;
 
 /**
- * Inline-button picker shown in /settings. The discovered catalog
- * can be huge (OpenRouter ships 350+ models); we cap the picker at
- * a handful for visibility and let operators set unlisted ids
- * directly in `talon.json` or via `/model <id>`.
+ * Inline-button picker for /settings. The picker is two-stage when
+ * the filtered catalog has more than `PROVIDER_GROUP_THRESHOLD`
+ * entries (typical for OpenRouter with 350+ models):
  *
- * Selection heuristic: prefer the active model, then anything with a
- * known context window (more useful than bare passthroughs), then
- * everything else. Stable id-sorted within each tier.
+ *   1. `view: "groups"` — provider chips (Anthropic, OpenAI, Google…).
+ *      Tapping one re-invokes with `options.provider` set.
+ *   2. `view: "models"` — that provider's models, paginated.
+ *
+ * Smaller catalogs (and any catalog drilled into a single provider)
+ * skip step 1 and render the model list directly. `modelDetails`
+ * carries only a backend-status line; the caller renders the active
+ * model header from its own data.
  */
 export function getSettingsPresentation(
   activeModel: string,
-  callbackPrefix = "settings:model:",
-): { modelButtons: ModelButton[]; modelDetails: string[] } {
-  const all = snapshot();
-  const active = all.find((m) => m.id === activeModel);
-
-  const enriched = all.filter(
-    (m) => m.id !== activeModel && m.contextWindow !== undefined,
+  options: ModelPickerOptions = {},
+): ModelPickerResult {
+  const callbackPrefix = options.callbackPrefix ?? "settings:model:";
+  const navPrefix = options.navCallbackPrefix ?? "settings:models";
+  const filter = options.filter ?? "all";
+  // Telegram's inline-button `callback_data` is capped at 64 bytes
+  // (https://core.telegram.org/bots/api#inlinekeyboardbutton). Other
+  // chat platforms (Discord, Slack) typically allow more, but 64 is
+  // the lowest common denominator so we treat it as the universal
+  // budget. Any model whose `<prefix><id>` payload would overflow is
+  // hidden from the button surface; operators can still target it
+  // via `/model <id>`.
+  const PLATFORM_CALLBACK_BUDGET = 64;
+  const callbackBudget = PLATFORM_CALLBACK_BUDGET - byteLen(callbackPrefix);
+  const pageSize = clamp(
+    options.pageSize ?? DEFAULT_PAGE_SIZE,
+    1,
+    MAX_PAGE_SIZE,
   );
-  const bare = all.filter(
-    (m) => m.id !== activeModel && m.contextWindow === undefined,
-  );
 
-  const ordered: UnifiedModelInfo[] = [];
-  if (active) ordered.push(active);
-  ordered.push(...enriched, ...bare);
-  const visible = ordered.slice(0, SETTINGS_PICKER_LIMIT);
+  const all = snapshot().filter((m) => byteLen(m.id) <= callbackBudget);
+  const filtered = filter === "free" ? all.filter((m) => m.free) : all;
+  const freeCount = all.reduce((n, m) => (m.free ? n + 1 : n), 0);
+
+  const modelDetails = buildStatusDetails(all);
+  const baseResult = {
+    modelDetails,
+    filter,
+    freeCount,
+    totalCount: all.length,
+  } as const;
+
+  // Group-view branch: only when no provider is selected AND the
+  // filtered catalog is big enough to benefit. Tapping a provider
+  // sends the same callbackPrefix scheme back, but with the prefix
+  // changed to a "drill" form (`settings:models:provider:<id>`)
+  // which the frontend recognises.
+  const useGroupView =
+    !options.provider && filtered.length > PROVIDER_GROUP_THRESHOLD;
+  if (useGroupView) {
+    const groups = groupByProvider(filtered);
+    const modelButtons: ModelButton[] = groups.map(({ provider, count }) => ({
+      text: `${humanizeProvider(provider)} (${count})`,
+      callback_data: `${navPrefix}:provider:${provider}`,
+    }));
+    return {
+      ...baseResult,
+      modelButtons,
+      view: "groups",
+      page: 1,
+      totalPages: 1,
+    };
+  }
+
+  // Model-view branch: either we drilled into a provider, the
+  // catalog is small enough not to need grouping, or the free
+  // filter has reduced it below the grouping threshold.
+  const scoped = options.provider
+    ? filtered.filter((m) => providerOf(m.id) === options.provider)
+    : filtered;
+  const totalPages = Math.max(1, Math.ceil(scoped.length / pageSize));
+  const page = clamp(options.page ?? 1, 1, totalPages);
+  const start = (page - 1) * pageSize;
+  const visible = scoped.slice(start, start + pageSize);
 
   const modelButtons: ModelButton[] = visible.map((m) => ({
-    text: `${m.id === activeModel ? "● " : ""}${m.displayName}`,
+    text: formatButtonLabel(m, m.id === activeModel),
     callback_data: `${callbackPrefix}${m.id}`,
   }));
 
-  const modelDetails = visible.map((m) => {
-    const flags: string[] = [];
-    if (m.reasoning) flags.push("reasoning");
-    if (m.contextWindow)
-      flags.push(`${Math.round(m.contextWindow / 1000)}k ctx`);
-    if (m.free) flags.push("free");
-    const tag = flags.length > 0 ? ` — ${flags.join(" · ")}` : "";
-    return `**${m.displayName}** (\`${m.id}\`)${tag}`;
-  });
+  return {
+    ...baseResult,
+    modelButtons,
+    view: "models",
+    page,
+    totalPages,
+    ...(options.provider ? { provider: options.provider } : {}),
+  };
+}
 
-  return { modelButtons, modelDetails };
+function providerOf(id: string): string {
+  // OpenRouter ids look like `vendor/model`. Some have a leading
+  // tilde (router shortcuts) — treat `~vendor/model` as `vendor`.
+  const stripped = id.startsWith("~") ? id.slice(1) : id;
+  const slash = stripped.indexOf("/");
+  return slash >= 0 ? stripped.slice(0, slash) : "openai";
+}
+
+function groupByProvider(
+  models: UnifiedModelInfo[],
+): Array<{ provider: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const m of models) {
+    const p = providerOf(m.id);
+    counts.set(p, (counts.get(p) ?? 0) + 1);
+  }
+  const groups = Array.from(counts, ([provider, count]) => ({
+    provider,
+    count,
+  }));
+  // Largest first — common providers (anthropic, openai, google)
+  // float to the top; long-tail providers fall after.
+  groups.sort(
+    (a, b) => b.count - a.count || a.provider.localeCompare(b.provider),
+  );
+  return groups;
+}
+
+function humanizeProvider(p: string): string {
+  // Title-case ids like "anthropic" → "Anthropic", "aion-labs" → "Aion Labs".
+  return p
+    .split(/[-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function buildStatusDetails(all: UnifiedModelInfo[]): string[] {
+  if (all.length === 0) return [];
+  const enriched = all.reduce(
+    (n, m) => (m.contextWindow !== undefined ? n + 1 : n),
+    0,
+  );
+  return [
+    `${all.length} model${all.length === 1 ? "" : "s"} discovered via OpenAI Agents endpoint` +
+      (enriched > 0 ? `, ${enriched} with context info` : ""),
+  ];
+}
+
+function formatButtonLabel(m: UnifiedModelInfo, isActive: boolean): string {
+  const prefix = isActive ? "● " : "";
+  // Strip vendor prefix (e.g. "openrouter/owl-alpha" → "owl-alpha") to
+  // keep button text short; full id is in the callback data anyway.
+  const slash = m.id.lastIndexOf("/");
+  const short = slash >= 0 ? m.id.slice(slash + 1) : m.id;
+  const ctx = m.contextWindow ? ` ${formatTokens(m.contextWindow)}` : "";
+  const free = m.free ? " ·🆓" : "";
+  return `${prefix}${short}${ctx}${free}`;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${Math.round(n / 1_000_000)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  if (Number.isNaN(n)) return lo;
+  return Math.min(hi, Math.max(lo, Math.floor(n)));
+}
+
+function byteLen(s: string): number {
+  // Telegram counts callback_data in UTF-8 bytes, not characters.
+  // Reuse Buffer to match server-side accounting exactly.
+  return Buffer.byteLength(s, "utf8");
 }
 
 // ── Provider / list ────────────────────────────────────────────────────────

--- a/src/backend/openai-agents/models.ts
+++ b/src/backend/openai-agents/models.ts
@@ -1,17 +1,24 @@
 /**
- * OpenAI Agents backend model catalog.
+ * OpenAI Agents backend model surface.
  *
- * The Agents SDK speaks to OpenAI's Responses (or Chat Completions)
- * API and accepts any model identifier the endpoint exposes. The
- * built-in catalog covers the OpenAI-native models; when a custom
- * `openaiBaseUrl` is configured (OpenRouter, Azure, Ollama, etc.),
- * arbitrary model ids are accepted as passthrough so users can target
- * e.g. `meta-llama/llama-3.3-70b-instruct` without us maintaining a
- * separate catalog per third-party provider.
+ * Design note: there is **no** hardcoded model catalog here. The
+ * Agents SDK speaks to any OpenAI-compatible endpoint (OpenAI itself,
+ * OpenRouter, Azure, Ollama, LiteLLM, vLLM, etc.), each of which
+ * advertises its own model set via `GET /models`. Maintaining a
+ * static list in Talon would either be wrong-by-default (the day
+ * OpenAI ships a new model) or wrong-by-provider (OpenRouter's 350+
+ * models, Ollama's user-installed models, Azure's deployment ids).
  *
- * Note: `gpt-5-codex` is intentionally NOT in this catalog. That
- * model is exposed via the Codex CLI only, not the public Responses
- * API. Users who want `gpt-5-codex` should use the `codex` backend.
+ * Instead, `init.ts#fetchEndpointModels` populates
+ * `state.endpointModels` at startup with whatever the active
+ * endpoint reports. Every public function in this file derives its
+ * answer from that map. If a query asks about a model the endpoint
+ * never mentioned, we still hand back a bare passthrough — the user
+ * (or `talon.json`) may know about ids the discovery call missed.
+ *
+ * Note: `gpt-5-codex` is intentionally NOT used here. That model is
+ * exposed via the Codex CLI only, not the public Responses API.
+ * Users who want `gpt-5-codex` should pick the `codex` backend.
  */
 
 import type {
@@ -20,21 +27,22 @@ import type {
   UnifiedProviderInfo,
   ModelButton,
 } from "../../core/types.js";
-import { getOpenAIBaseUrl } from "./init.js";
-import { getState } from "./state.js";
+import { getState, type EndpointModelCapabilities } from "./state.js";
+
+// ── Internal: id → ModelInfo projection ─────────────────────────────────────
 
 /**
- * Build a `UnifiedModelInfo` for an arbitrary model id when the
- * backend is talking to a custom OpenAI-compatible endpoint.
- *
- * If `init.ts`'s `fetchEndpointModels()` has finished, we enrich the
- * passthrough with whatever the endpoint advertised (real context
- * window, display name, free flag). Otherwise we fall back to a bare
- * passthrough — the id verbatim, no capabilities — so /status and
- * /settings stay rendererable even before the catalog fetch lands.
+ * Build a `UnifiedModelInfo` from a model id and its discovered
+ * capabilities. Capabilities are optional — when absent, the model
+ * is treated as a bare passthrough (id only, no context window, no
+ * free-pricing flag). The `provider` / `providerName` fields fall
+ * back to a generic "OpenAI-compatible endpoint" since this backend
+ * is by design provider-agnostic.
  */
-function makePassthroughModel(id: string): UnifiedModelInfo {
-  const caps = getState().endpointModels.get(id);
+function makeModelInfo(
+  id: string,
+  caps?: EndpointModelCapabilities,
+): UnifiedModelInfo {
   return {
     id,
     displayName: caps?.displayName ?? id,
@@ -47,127 +55,156 @@ function makePassthroughModel(id: string): UnifiedModelInfo {
   };
 }
 
-/** Models available through the OpenAI Agents SDK. */
-export const OPENAI_AGENTS_MODELS: UnifiedModelInfo[] = [
-  {
-    id: "gpt-5.5",
-    displayName: "GPT-5.5",
-    provider: "openai",
-    providerName: "OpenAI",
-    selectable: true,
-    reasoning: true,
-    contextWindow: 400_000,
-  },
-  {
-    id: "gpt-5",
-    displayName: "GPT-5",
-    provider: "openai",
-    providerName: "OpenAI",
-    selectable: true,
-    reasoning: true,
-    contextWindow: 400_000,
-  },
-  {
-    id: "gpt-5-mini",
-    displayName: "GPT-5 Mini",
-    provider: "openai",
-    providerName: "OpenAI",
-    selectable: true,
-    reasoning: true,
-    contextWindow: 400_000,
-  },
-  {
-    id: "o4-mini",
-    displayName: "o4-mini",
-    provider: "openai",
-    providerName: "OpenAI",
-    selectable: true,
-    reasoning: true,
-    contextWindow: 128_000,
-  },
-];
+/**
+ * Snapshot of the discovered catalog as a sorted list. Sorted by id
+ * for stable UI ordering; the underlying Map preserves insertion
+ * order from the `/models` response which is arbitrary across
+ * providers.
+ */
+function snapshot(): UnifiedModelInfo[] {
+  const out: UnifiedModelInfo[] = [];
+  for (const [id, caps] of getState().endpointModels) {
+    out.push(makeModelInfo(id, caps));
+  }
+  out.sort((a, b) => a.id.localeCompare(b.id));
+  return out;
+}
+
+// ── Resolution ──────────────────────────────────────────────────────────────
 
 /**
- * Resolve a user query against the catalog. Exact-id match first,
- * then case-insensitive prefix on id or display name; ambiguous when
- * multiple match.
+ * Resolve a user query against the discovered catalog.
  *
- * When a custom `openaiBaseUrl` is configured the catalog isn't
- * authoritative — anything the user types is passed through to the
- * endpoint verbatim. The prefix-matching pass still runs first so
- * `gpt-5` resolves cleanly on OpenAI-compatible proxies that happen
- * to mirror OpenAI's namespace.
+ *   1. Exact id match  — returned immediately.
+ *   2. Case-insensitive prefix match on id or display name —
+ *      returned when exactly one model matches; ambiguous when more
+ *      than one.
+ *   3. No match — accepted as a passthrough so operators can target
+ *      ids that the discovery call missed (e.g. brand-new releases,
+ *      private deployments, Ollama models added after Talon started).
+ *
+ * Returns `missing` only for an empty/whitespace query, since any
+ * non-empty id can be passed through.
  */
 export function resolveModel(query: string): UnifiedModelResolution {
   const q = query.trim();
   if (!q) return { kind: "missing" };
 
-  const exact = OPENAI_AGENTS_MODELS.find((m) => m.id === q);
-  if (exact) return { kind: "exact", model: exact, storedValue: exact.id };
+  const catalog = getState().endpointModels;
+
+  const exact = catalog.get(q);
+  if (exact !== undefined) {
+    return { kind: "exact", model: makeModelInfo(q, exact), storedValue: q };
+  }
 
   const qLower = q.toLowerCase();
-  const matches = OPENAI_AGENTS_MODELS.filter(
-    (m) =>
-      m.id.toLowerCase().startsWith(qLower) ||
-      m.displayName.toLowerCase().startsWith(qLower),
-  );
+  const matches: Array<{ id: string; caps: EndpointModelCapabilities }> = [];
+  for (const [id, caps] of catalog) {
+    const idMatch = id.toLowerCase().startsWith(qLower);
+    const nameMatch = (caps.displayName ?? "").toLowerCase().startsWith(qLower);
+    if (idMatch || nameMatch) matches.push({ id, caps });
+  }
 
   if (matches.length === 1) {
-    return { kind: "exact", model: matches[0], storedValue: matches[0].id };
+    const m = matches[0];
+    return {
+      kind: "exact",
+      model: makeModelInfo(m.id, m.caps),
+      storedValue: m.id,
+    };
   }
   if (matches.length > 1) {
-    return { kind: "ambiguous", matches };
+    return {
+      kind: "ambiguous",
+      matches: matches.map((m) => makeModelInfo(m.id, m.caps)),
+    };
   }
 
-  // No catalog hit. If a custom endpoint is configured, accept the
-  // raw id as a passthrough — third-party endpoints (OpenRouter,
-  // Azure, Ollama, LiteLLM) use namespaces we don't track.
-  if (getOpenAIBaseUrl()) {
-    const passthrough = makePassthroughModel(q);
-    return { kind: "exact", model: passthrough, storedValue: passthrough.id };
-  }
-
-  return { kind: "missing" };
+  // No catalog hit — fall through to a bare passthrough. The endpoint
+  // may legitimately accept ids it doesn't advertise.
+  return { kind: "exact", model: makeModelInfo(q), storedValue: q };
 }
 
-/** Look up a model by stored id. */
+/**
+ * Look up a model by stored id. Returns enriched metadata when the
+ * discovery call covered this id, otherwise a bare passthrough so
+ * /status and /settings can render something for unknown-but-valid
+ * ids instead of "unknown model".
+ */
 export function getModelInfo(id: string): UnifiedModelInfo | undefined {
-  const found = OPENAI_AGENTS_MODELS.find((m) => m.id === id);
-  if (found) return found;
-  // Custom-endpoint passthrough — surface the id back so /settings can
-  // render something instead of "unknown model".
-  if (getOpenAIBaseUrl()) return makePassthroughModel(id);
-  return undefined;
+  if (!id) return undefined;
+  const caps = getState().endpointModels.get(id);
+  return makeModelInfo(id, caps);
 }
 
-/** Quick-pick buttons for the `/settings` model picker. */
+// ── /settings presentation ──────────────────────────────────────────────────
+
+const SETTINGS_PICKER_LIMIT = 12;
+
+/**
+ * Inline-button picker shown in /settings. The discovered catalog
+ * can be huge (OpenRouter ships 350+ models); we cap the picker at
+ * a handful for visibility and let operators set unlisted ids
+ * directly in `talon.json` or via `/model <id>`.
+ *
+ * Selection heuristic: prefer the active model, then anything with a
+ * known context window (more useful than bare passthroughs), then
+ * everything else. Stable id-sorted within each tier.
+ */
 export function getSettingsPresentation(
   activeModel: string,
   callbackPrefix = "settings:model:",
 ): { modelButtons: ModelButton[]; modelDetails: string[] } {
-  const modelButtons: ModelButton[] = OPENAI_AGENTS_MODELS.map((m) => ({
+  const all = snapshot();
+  const active = all.find((m) => m.id === activeModel);
+
+  const enriched = all.filter(
+    (m) => m.id !== activeModel && m.contextWindow !== undefined,
+  );
+  const bare = all.filter(
+    (m) => m.id !== activeModel && m.contextWindow === undefined,
+  );
+
+  const ordered: UnifiedModelInfo[] = [];
+  if (active) ordered.push(active);
+  ordered.push(...enriched, ...bare);
+  const visible = ordered.slice(0, SETTINGS_PICKER_LIMIT);
+
+  const modelButtons: ModelButton[] = visible.map((m) => ({
     text: `${m.id === activeModel ? "● " : ""}${m.displayName}`,
     callback_data: `${callbackPrefix}${m.id}`,
   }));
 
-  const modelDetails = OPENAI_AGENTS_MODELS.map((m) => {
+  const modelDetails = visible.map((m) => {
     const flags: string[] = [];
     if (m.reasoning) flags.push("reasoning");
-    if (m.contextWindow) flags.push(`${m.contextWindow / 1000}k ctx`);
-    return `**${m.displayName}** (${m.id}) — ${flags.join(" · ")}`;
+    if (m.contextWindow)
+      flags.push(`${Math.round(m.contextWindow / 1000)}k ctx`);
+    if (m.free) flags.push("free");
+    const tag = flags.length > 0 ? ` — ${flags.join(" · ")}` : "";
+    return `**${m.displayName}** (\`${m.id}\`)${tag}`;
   });
 
   return { modelButtons, modelDetails };
 }
 
-/** OpenAI is the sole provider for this backend. */
+// ── Provider / list ────────────────────────────────────────────────────────
+
+/**
+ * A single "provider" entry covering whichever endpoint is currently
+ * configured. The backend stays provider-agnostic so we don't try to
+ * split this further by inferring from baseURL — operators who care
+ * see the actual endpoint url in `OpenAI Agents auth: ...` at
+ * startup.
+ */
 export function getProviders(): UnifiedProviderInfo[] {
+  const count = getState().endpointModels.size;
   return [
     {
       id: "openai",
-      name: "OpenAI",
+      name: "OpenAI Agents endpoint",
       connected: true,
-      modelCount: OPENAI_AGENTS_MODELS.length,
+      modelCount: count,
     },
   ];
 }
@@ -179,41 +216,12 @@ export function getProviderModels(
   pageSize = 50,
 ): { models: UnifiedModelInfo[]; total: number } {
   if (providerId !== "openai") return { models: [], total: 0 };
-  const merged = mergedCatalog();
+  const all = snapshot();
   const start = (page - 1) * pageSize;
   return {
-    models: merged.slice(start, start + pageSize),
-    total: merged.length,
+    models: all.slice(start, start + pageSize),
+    total: all.length,
   };
-}
-
-/**
- * Return the visible model catalog: the built-in OpenAI catalog plus
- * anything the remote endpoint advertised via `GET /models` (see
- * `init.ts#fetchEndpointModels`). Built-ins win for shared ids so we
- * don't trample the OpenAI display names with whatever raw id the
- * proxy returns.
- */
-function mergedCatalog(): UnifiedModelInfo[] {
-  const builtIns = new Map<string, UnifiedModelInfo>();
-  for (const m of OPENAI_AGENTS_MODELS) builtIns.set(m.id, m);
-
-  const endpoint = getState().endpointModels;
-  const out: UnifiedModelInfo[] = [...OPENAI_AGENTS_MODELS];
-  for (const [id, caps] of endpoint) {
-    if (builtIns.has(id)) continue;
-    out.push({
-      id,
-      displayName: caps.displayName ?? id,
-      provider: "openai-compatible",
-      providerName: "OpenAI-compatible endpoint",
-      selectable: true,
-      reasoning: false,
-      ...(caps.contextWindow ? { contextWindow: caps.contextWindow } : {}),
-      ...(caps.free ? { free: true } : {}),
-    });
-  }
-  return out;
 }
 
 /** Format a human-readable error for an unresolvable model query. */
@@ -225,16 +233,9 @@ export function formatModelError(
     const list = resolution.matches.map((m) => `\`${m.id}\``).join(", ");
     return `Multiple OpenAI Agents models match \`${query}\`: ${list}. Pick one.`;
   }
-  if (getOpenAIBaseUrl()) {
-    return (
-      `No catalog entry matches \`${query}\`. A custom \`openaiBaseUrl\` is set, ` +
-      `so any id your endpoint accepts is valid — set \`model\` directly in talon.json.`
-    );
-  }
-  return (
-    `No OpenAI Agents model matches \`${query}\`. ` +
-    `Available: ${OPENAI_AGENTS_MODELS.map((m) => m.id).join(", ")}.`
-  );
+  // `missing` only fires for empty queries since unknown non-empty
+  // ids resolve to a passthrough.
+  return `No model id supplied — provide one (e.g. \`gpt-5.5\`, \`openrouter/owl-alpha\`).`;
 }
 
 /** Filter the catalog by a coarse-grained tag. */
@@ -242,10 +243,10 @@ export function listModels(filter?: "free" | "all"): {
   models: UnifiedModelInfo[];
   total: number;
 } {
-  const merged = mergedCatalog();
+  const all = snapshot();
   if (filter === "free") {
-    const free = merged.filter((m) => m.free === true);
+    const free = all.filter((m) => m.free === true);
     return { models: free, total: free.length };
   }
-  return { models: merged, total: merged.length };
+  return { models: all, total: all.length };
 }

--- a/src/backend/opencode/factory.ts
+++ b/src/backend/opencode/factory.ts
@@ -40,8 +40,21 @@ const opencodeFactory: BackendFactory = {
       query: (params) => ocHandleMessage(params),
       resolveModel: (q) => resolveModel(q),
       getModelInfo: (id) => getModelInfo(id),
-      getSettingsPresentation: (m, prefix) =>
-        getSettingsPresentation(m, prefix),
+      getSettingsPresentation: async (m, options) => {
+        const legacy = await getSettingsPresentation(
+          m,
+          options?.callbackPrefix,
+        );
+        return {
+          ...legacy,
+          view: "models" as const,
+          page: 1,
+          totalPages: 1,
+          filter: "all" as const,
+          freeCount: 0,
+          totalCount: legacy.modelButtons.length,
+        };
+      },
       getProviders: () => getProviders(),
       getProviderModels: (p, pg, ps) => getProviderModels(p, pg, ps),
       formatModelError: (q, r) => formatModelError(q, r),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -67,6 +67,70 @@ export type UnifiedProviderInfo = {
 export type ModelButton = { text: string; callback_data: string };
 
 /**
+ * Options for `getSettingsPresentation()`. The picker has two
+ * navigational axes — *provider* (when a catalog is large enough to
+ * benefit from grouping) and *page within a provider*. Backends with
+ * small catalogs may ignore everything except `callbackPrefix`.
+ */
+export interface ModelPickerOptions {
+  /** Callback-data prefix used on each model button. Defaults to `settings:model:`. */
+  callbackPrefix?: string;
+  /**
+   * Callback-data prefix used for navigation buttons (provider drill,
+   * pagination, filter toggles). Defaults to `settings:models`. Must
+   * match the prefix the frontend's callback router decodes — for
+   * example `/model` uses `model:nav` so its router recognises
+   * `model:nav:provider:openai` as a drill action.
+   */
+  navCallbackPrefix?: string;
+  /** 1-indexed page within the current provider/filter. Defaults to 1. */
+  page?: number;
+  /** Buttons per page. Backends may clamp to a sensible range. */
+  pageSize?: number;
+  /** Filter the catalog before grouping/paginating. `free` keeps only free-tier models. */
+  filter?: "all" | "free";
+  /**
+   * When set, render that provider's models directly. When omitted
+   * and the filtered catalog is "large" (backend-defined threshold),
+   * the backend returns provider chips instead of model buttons —
+   * the frontend drills in by sending this option back.
+   */
+  provider?: string;
+}
+
+/**
+ * Result returned by `getSettingsPresentation()`. `view` tells the
+ * frontend whether `modelButtons` is a list of providers ("groups")
+ * or a list of models ("models"). The frontend reads `page` /
+ * `totalPages` / `freeCount` / `provider` to render the appropriate
+ * navigation controls.
+ */
+export interface ModelPickerResult {
+  /** Buttons to render. Interpretation depends on `view`. Empty for `menu`. */
+  modelButtons: ModelButton[];
+  /** Optional supplementary text (backend status, etc.). Plain text. */
+  modelDetails: string[];
+  /**
+   * Which axis the buttons represent:
+   *   - `groups`: provider chips (drill by tapping).
+   *   - `models`: the model list (paginated).
+   */
+  view: "groups" | "models";
+  /** Current 1-indexed page (always 1 for `groups`). */
+  page: number;
+  /** Total pages in the current view. */
+  totalPages: number;
+  /** The filter actually applied (normalised). */
+  filter: "all" | "free";
+  /** Total free-flagged models in the (unfiltered) catalog. */
+  freeCount: number;
+  /** Total models in the (unfiltered) catalog. */
+  totalCount: number;
+  /** When `view === "models"`, the provider the buttons belong to (if any). */
+  provider?: string;
+}
+
+/**
  * Parameters for one-shot agent runs (heartbeat, dream).
  *
  * Unlike `query()` which is tied to a chat session and history, this is a
@@ -111,14 +175,18 @@ export interface QueryBackend {
   resolveModel?(query: string): Promise<UnifiedModelResolution>;
   /** Get info for a model by its stored ID. */
   getModelInfo?(id: string): Promise<UnifiedModelInfo | undefined>;
-  /** Get quick-pick buttons for model selection. callbackPrefix defaults to "settings:model:". */
+  /**
+   * Get the quick-pick model picker for /settings. Backends with
+   * large catalogs (e.g. OpenRouter via openai-agents) should honour
+   * `options.page` / `options.filter` so the picker is browseable;
+   * small-catalog backends may ignore them and always return the
+   * full set on page 1. The frontend reads `page` / `totalPages` /
+   * `freeCount` off the result to render Prev/Next + filter chips.
+   */
   getSettingsPresentation?(
     activeModel: string,
-    callbackPrefix?: string,
-  ): Promise<{
-    modelButtons: ModelButton[];
-    modelDetails: string[];
-  }>;
+    options?: ModelPickerOptions,
+  ): Promise<ModelPickerResult>;
   /** List available providers. */
   getProviders?(): Promise<UnifiedProviderInfo[]>;
   /** List models for a given provider (paginated). */

--- a/src/frontend/discord/callbacks.ts
+++ b/src/frontend/discord/callbacks.ts
@@ -269,7 +269,9 @@ export async function handleComponentInteraction(
     const current = getChatSettings(chatId).model ?? config.model;
     const be = gateway?.backend;
     if (be?.getSettingsPresentation) {
-      const pres = await be.getSettingsPresentation(current, "model:");
+      const pres = await be.getSettingsPresentation(current, {
+        callbackPrefix: "model:",
+      });
       const modelInfo = await be.getModelInfo?.(current);
       const displayName = modelInfo?.displayName ?? current;
       const menu = new StringSelectMenuBuilder()
@@ -552,7 +554,9 @@ async function loadModelList(gateway: Gateway): Promise<string[]> {
   }
   const be = gateway?.backend;
   if (!be?.getSettingsPresentation) return [];
-  const pres = await be.getSettingsPresentation("", "model:");
+  const pres = await be.getSettingsPresentation("", {
+    callbackPrefix: "model:",
+  });
   const values = pres.modelButtons.map((b) =>
     b.callback_data.replace(/^model:/, ""),
   );

--- a/src/frontend/discord/commands.ts
+++ b/src/frontend/discord/commands.ts
@@ -675,7 +675,9 @@ async function handleModel(
       return;
     }
     if (be?.getSettingsPresentation) {
-      const pres = await be.getSettingsPresentation(activeModel, "model:");
+      const pres = await be.getSettingsPresentation(activeModel, {
+        callbackPrefix: "model:",
+      });
       const modelInfo = await be.getModelInfo?.(activeModel);
       const displayName =
         modelInfo?.displayName ?? formatModelLabel(activeModel);

--- a/src/frontend/telegram/callbacks.ts
+++ b/src/frontend/telegram/callbacks.ts
@@ -2,12 +2,14 @@
  * All callback_query handlers (settings panel, model/effort selectors, proactive toggle).
  */
 
-import type { Bot } from "grammy";
+import type { Bot, Context } from "grammy";
 import type { TalonConfig } from "../../util/config.js";
+import { logWarn } from "../../util/log.js";
 import {
   getChatSettings,
   setChatModel,
   setChatEffort,
+  setChatFreeOnly,
   resolveModelName,
   EFFORT_LEVELS,
   type EffortLevel,
@@ -23,8 +25,39 @@ import { escapeHtml } from "./formatting.js";
 import {
   renderSettingsText,
   renderSettingsKeyboard,
+  renderModelPickerControlRows,
+  renderModelMenuText,
+  renderModelMenuKeyboard,
+  renderModelBrowseKeyboard,
+  buildModelMenuState,
   type SettingsButton,
 } from "./helpers.js";
+import { parseModelCallback } from "./model-callbacks.js";
+
+/**
+ * Wrapper around `editMessageText` that swallows Telegram's
+ * "message is not modified" noise (we hit it whenever a user
+ * taps a button that doesn't actually change the rendered state)
+ * while still surfacing real failures to the operator log. Without
+ * this distinction, buttons silently fail to update and the symptom
+ * is "I clicked X and nothing happened".
+ */
+async function editOrIgnoreSame(
+  ctx: Context,
+  text: string,
+  inlineKeyboard: Array<Array<SettingsButton>>,
+): Promise<void> {
+  try {
+    await ctx.editMessageText(text, {
+      parse_mode: "HTML",
+      reply_markup: { inline_keyboard: inlineKeyboard },
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/message is not modified/i.test(msg)) return;
+    logWarn("bot", `editMessageText failed: ${msg}`);
+  }
+}
 
 export function registerCallbacks(
   bot: Bot,
@@ -37,7 +70,11 @@ export function registerCallbacks(
     const data = ctx.callbackQuery.data;
     const cid = String(ctx.chat?.id ?? ctx.from.id);
 
-    // Handle unified /settings callbacks
+    // Handle /settings callbacks (effort, pulse, done). Model selection
+    // is intentionally NOT here — that lives entirely under /model now.
+    // Legacy `settings:model:*` and `settings:models:*` callbacks from
+    // old messages are silently dismissed so stale buttons don't fire
+    // the model dispatcher path.
     if (data.startsWith("settings:")) {
       const parts = data.split(":");
       if (!parts[1]) {
@@ -47,42 +84,30 @@ export function registerCallbacks(
       const category = parts[1];
       const value = parts[2] ?? "";
 
-      if (category === "done") {
-        await ctx.answerCallbackQuery({ text: "Done" });
-        try {
-          await ctx.deleteMessage();
-        } catch {
-          // might not have permission to delete
-        }
+      if (category === "noop") {
+        await ctx.answerCallbackQuery();
         return;
       }
 
-      if (category === "model") {
-        if (value === "reset") {
-          setChatModel(cid, undefined);
-        } else if (gateway?.backend?.resolveModel) {
-          const resolution = await gateway.backend.resolveModel(value);
-          if (resolution.kind !== "exact") {
-            await ctx.answerCallbackQuery({ text: "Model is unavailable" });
-            return;
-          }
-          if (!resolution.model.selectable) {
-            await ctx.answerCallbackQuery({
-              text: resolution.model.unavailableReason ?? "Unavailable",
-            });
-            return;
-          }
-          setChatModel(cid, resolution.storedValue);
-        } else {
-          setChatModel(cid, resolveModelName(value));
-        }
-        const settingsModel = getChatSettings(cid).model ?? config.model;
-        const settingsModelInfo =
-          await gateway?.backend?.getModelInfo?.(settingsModel);
+      // Stale `settings:done` payloads from older bot versions that
+      // shipped a Done button. Quietly ack — the user can dismiss the
+      // message via Telegram's UI now.
+      if (category === "done") {
+        await ctx.answerCallbackQuery();
+        return;
+      }
+
+      // Stale model-picker callbacks (`settings:model:*`, `settings:models:*`)
+      // emitted by older Talon builds. Quietly ack — the user can re-open
+      // /model to get the current picker.
+      if (category === "model" || category === "models") {
         await ctx.answerCallbackQuery({
-          text: `Model: ${settingsModelInfo?.displayName ?? settingsModel}`,
+          text: "Picker moved — use /model",
         });
-      } else if (category === "effort") {
+        return;
+      }
+
+      if (category === "effort") {
         if (value === "adaptive") {
           setChatEffort(cid, undefined);
         } else if (EFFORT_LEVELS.includes(value as EffortLevel)) {
@@ -105,15 +130,6 @@ export function registerCallbacks(
       const activeModel = chatSets.model ?? config.model;
       const effortName = chatSets.effort ?? "adaptive";
       const pulseOn = isPulseEnabled(cid);
-      let modelDetails: Array<string> | undefined;
-      let modelButtons: Array<SettingsButton> | undefined;
-
-      if (gateway?.backend?.getSettingsPresentation) {
-        const presentation =
-          await gateway.backend.getSettingsPresentation(activeModel);
-        modelDetails = presentation.modelDetails;
-        modelButtons = presentation.modelButtons;
-      }
 
       try {
         await ctx.editMessageText(
@@ -122,7 +138,6 @@ export function registerCallbacks(
             effortName,
             pulseOn,
             chatSets.pulseIntervalMs,
-            modelDetails,
           ),
           {
             parse_mode: "HTML",
@@ -131,7 +146,6 @@ export function registerCallbacks(
                 activeModel,
                 effortName,
                 pulseOn,
-                modelButtons,
               ),
             },
           },
@@ -231,51 +245,171 @@ export function registerCallbacks(
       return;
     }
 
-    // Handle model callbacks (from /model quick-pick buttons)
+    // Handle /model callbacks via the pure parser. The dispatch
+    // below stays narrow — each branch mutates at most one piece of
+    // chat-settings state, then either re-renders the main menu or
+    // the browse view. Everything routes through the same two
+    // renderers so the UX stays consistent regardless of entry path.
     if (data.startsWith("model:")) {
-      const model = data.slice(6);
-      if (model === "reset") {
-        setChatModel(cid, undefined);
-        await ctx.answerCallbackQuery({
-          text: `Model: ${config.model} (default)`,
-        });
-      } else if (gateway?.backend?.resolveModel) {
-        const resolution = await gateway.backend.resolveModel(model);
-        if (resolution.kind === "exact" && resolution.model.selectable) {
-          setChatModel(cid, resolution.storedValue);
-          await ctx.answerCallbackQuery({
-            text: `Model: ${resolution.model.displayName}`,
-          });
-        } else {
-          await ctx.answerCallbackQuery({ text: "Model is unavailable" });
-          return;
-        }
-      } else {
-        setChatModel(cid, resolveModelName(model));
-        await ctx.answerCallbackQuery({
-          text: `Model: ${getChatSettings(cid).model ?? config.model}`,
-        });
-      }
-      // Refresh the model picker buttons
-      const current = getChatSettings(cid).model ?? config.model;
-      const be = gateway?.backend;
-      if (be?.getSettingsPresentation) {
-        const pres = await be.getSettingsPresentation(current, "model:");
-        const modelInfo = await be.getModelInfo?.(current);
-        const displayName = modelInfo?.displayName ?? current;
-        const rows: Array<Array<{ text: string; callback_data: string }>> = [];
-        for (let i = 0; i < pres.modelButtons.length; i += 2) {
-          rows.push(pres.modelButtons.slice(i, i + 2));
-        }
+      const action = parseModelCallback(data);
+
+      // Acknowledge fast (within Telegram's 30s window) so the user
+      // doesn't see a perpetual loading spinner.
+      if (action.kind === "done") {
+        await ctx.answerCallbackQuery({ text: "Done" });
         try {
-          await ctx.editMessageText(
-            `<b>Model:</b> <code>${escapeHtml(displayName)}</code>`,
-            { parse_mode: "HTML", reply_markup: { inline_keyboard: rows } },
-          );
+          await ctx.deleteMessage();
         } catch {
-          /* message unchanged */
+          /* might lack delete permission */
         }
+        return;
       }
+      if (action.kind === "noop" || action.kind === "unknown") {
+        await ctx.answerCallbackQuery();
+        return;
+      }
+
+      const be = gateway?.backend;
+
+      // State-mutating actions.
+      let toast: string | undefined;
+      let viewAfter: "menu" | "browse" = "menu";
+      let browsePage: number | undefined;
+      let browseFilter: "all" | "free" | undefined;
+      let browseProvider: string | undefined;
+      let browseBackToGroups = false;
+
+      if (action.kind === "select") {
+        if (be?.resolveModel) {
+          const resolution = await be.resolveModel(action.modelId);
+          if (resolution.kind !== "exact" || !resolution.model.selectable) {
+            await ctx.answerCallbackQuery({
+              text:
+                resolution.kind === "exact"
+                  ? (resolution.model.unavailableReason ?? "Unavailable")
+                  : "Model is unavailable",
+            });
+            return;
+          }
+          setChatModel(cid, resolution.storedValue);
+          toast = `Model: ${resolution.model.displayName}`;
+        } else {
+          setChatModel(cid, resolveModelName(action.modelId));
+          toast = `Model: ${getChatSettings(cid).model ?? config.model}`;
+        }
+      } else if (action.kind === "reset") {
+        setChatModel(cid, undefined);
+        toast = `Model reset to default`;
+      } else if (action.kind === "toggle-free") {
+        const next = !getChatSettings(cid).freeOnly;
+        setChatFreeOnly(cid, next ? true : undefined);
+        toast = `Free only: ${next ? "on" : "off"}`;
+      } else if (action.kind === "menu") {
+        viewAfter = "menu";
+      } else if (action.kind === "browse") {
+        viewAfter = "browse";
+      } else if (action.kind === "nav-back-to-providers") {
+        viewAfter = "browse";
+        browseBackToGroups = true;
+        browsePage = 1;
+      } else if (action.kind === "nav-provider") {
+        viewAfter = "browse";
+        browseProvider = action.provider;
+        browsePage = 1;
+      } else if (action.kind === "nav-page") {
+        viewAfter = "browse";
+        browsePage = action.page;
+        browseFilter = action.filter;
+        browseProvider = action.provider;
+      } else if (action.kind === "nav-filter") {
+        // Legacy support — current UX promotes free-toggle on the main
+        // menu, but a `model:nav:filter:*` payload from an old message
+        // still routes to the browse view with that filter applied.
+        viewAfter = "browse";
+        browseFilter = action.filter;
+        browsePage = 1;
+      }
+
+      // Selection / reset / toggle confirmations toast briefly.
+      if (toast !== undefined) {
+        await ctx.answerCallbackQuery({ text: toast });
+      } else {
+        await ctx.answerCallbackQuery();
+      }
+
+      // Re-render the message in the appropriate view.
+      const currentModel = getChatSettings(cid).model ?? config.model;
+      const freeOnly = getChatSettings(cid).freeOnly === true;
+
+      if (!be?.getSettingsPresentation) return;
+
+      if (viewAfter === "menu") {
+        const state = await buildModelMenuState({
+          chatId: cid,
+          activeModel: currentModel,
+          defaultModel: config.model,
+          freeOnly,
+          fetchSnapshot: async () => {
+            const pres = await be.getSettingsPresentation!(currentModel, {
+              callbackPrefix: "model:",
+              navCallbackPrefix: "model:nav",
+              filter: freeOnly ? "free" : "all",
+            });
+            return {
+              freeCount: pres.freeCount,
+              totalCount: pres.totalCount,
+              modelDetails: pres.modelDetails,
+            };
+          },
+          fetchActiveDisplay: async () =>
+            (await be.getModelInfo?.(currentModel))?.displayName,
+        });
+        await editOrIgnoreSame(
+          ctx,
+          renderModelMenuText(state),
+          renderModelMenuKeyboard(state),
+        );
+        return;
+      }
+
+      // browse view — fetch picker with chat's freeOnly applied as filter
+      const filter: "all" | "free" =
+        browseFilter ?? (freeOnly ? "free" : "all");
+      const pres = await be.getSettingsPresentation(currentModel, {
+        callbackPrefix: "model:",
+        navCallbackPrefix: "model:nav",
+        filter,
+        ...(browsePage !== undefined ? { page: browsePage } : {}),
+        ...(browseProvider !== undefined && !browseBackToGroups
+          ? { provider: browseProvider }
+          : {}),
+      });
+      const modelInfo = await be.getModelInfo?.(currentModel);
+      const displayName = modelInfo?.displayName ?? currentModel;
+      const lines = [
+        `<b>Model:</b> <code>${escapeHtml(displayName)}</code>`,
+        ...pres.modelDetails.map(escapeHtml),
+        ...(filter === "free" && pres.freeCount > 0
+          ? ["<i>Filter: free-tier only.</i>"]
+          : []),
+      ];
+      await editOrIgnoreSame(
+        ctx,
+        lines.join("\n"),
+        renderModelBrowseKeyboard(
+          pres.modelButtons,
+          {
+            page: pres.page,
+            totalPages: pres.totalPages,
+            filter: pres.filter,
+            freeCount: pres.freeCount,
+            totalCount: pres.totalCount,
+          },
+          pres.view,
+          pres.provider,
+          "model:menu",
+        ),
+      );
       return;
     }
 

--- a/src/frontend/telegram/commands.ts
+++ b/src/frontend/telegram/commands.ts
@@ -43,6 +43,9 @@ import {
   renderMetricsMessages,
   renderSettingsText,
   renderSettingsKeyboard,
+  renderModelMenuText,
+  renderModelMenuKeyboard,
+  buildModelMenuState,
   type SettingsButton,
 } from "./helpers.js";
 import { handleAdminCommand } from "./admin.js";
@@ -208,20 +211,33 @@ export function registerCommands(
         );
         return;
       }
-      // Show current model + quick-pick buttons via backend
+      // Render the main /model menu. Browsing the catalog happens
+      // behind the "Browse models" button — see callbacks.ts.
       if (be?.getSettingsPresentation) {
-        const pres = await be.getSettingsPresentation(activeModel, "model:");
-        const rows = chunkButtons(pres.modelButtons);
-        const modelInfo = await be.getModelInfo?.(activeModel);
-        const displayName =
-          modelInfo?.displayName ?? formatModelLabel(activeModel);
-        const lines = [
-          `<b>Model:</b> <code>${escapeHtml(displayName)}</code>`,
-          ...pres.modelDetails.map(escapeHtml),
-        ];
-        await ctx.reply(lines.join("\n"), {
+        const freeOnly = getChatSettings(cid).freeOnly === true;
+        const state = await buildModelMenuState({
+          chatId: cid,
+          activeModel,
+          defaultModel: config.model,
+          freeOnly,
+          fetchSnapshot: async () => {
+            const pres = await be.getSettingsPresentation!(activeModel, {
+              callbackPrefix: "model:",
+              navCallbackPrefix: "model:nav",
+              filter: freeOnly ? "free" : "all",
+            });
+            return {
+              freeCount: pres.freeCount,
+              totalCount: pres.totalCount,
+              modelDetails: pres.modelDetails,
+            };
+          },
+          fetchActiveDisplay: async () =>
+            (await be.getModelInfo?.(activeModel))?.displayName,
+        });
+        await ctx.reply(renderModelMenuText(state), {
           parse_mode: "HTML",
-          reply_markup: { inline_keyboard: rows },
+          reply_markup: { inline_keyboard: renderModelMenuKeyboard(state) },
         });
       } else {
         await ctx.reply(
@@ -426,23 +442,15 @@ export function registerCommands(
     const activeModel = chatSets.model ?? config.model;
     const effortName = chatSets.effort ?? "adaptive";
     const pulseOn = isPulseEnabled(cid);
-    let modelDetails: Array<string> | undefined;
-    let modelButtons: Array<SettingsButton> | undefined;
 
-    if (gateway?.backend?.getSettingsPresentation) {
-      const presentation =
-        await gateway.backend.getSettingsPresentation(activeModel);
-      modelDetails = presentation.modelDetails;
-      modelButtons = presentation.modelButtons;
-    }
-
+    // /settings is for Talon-level toggles only: effort, pulse, etc.
+    // Model selection lives entirely under /model — no picker here.
     await ctx.reply(
       renderSettingsText(
         activeModel,
         effortName,
         pulseOn,
         chatSets.pulseIntervalMs,
-        modelDetails,
       ),
       {
         parse_mode: "HTML",
@@ -451,7 +459,6 @@ export function registerCommands(
             activeModel,
             effortName,
             pulseOn,
-            modelButtons,
           ),
         },
       },

--- a/src/frontend/telegram/helpers.ts
+++ b/src/frontend/telegram/helpers.ts
@@ -219,11 +219,222 @@ export function isSelectedModel(
 
 export type SettingsButton = { text: string; callback_data: string };
 
+/**
+ * Optional pager metadata supplied by the backend for the model
+ * picker. When present, callers add a filter row (when `freeCount > 0`)
+ * and a Prev / page / Next row (when `totalPages > 1`). Backends with
+ * small fixed catalogs may omit this entirely.
+ */
+export interface SettingsPager {
+  page: number;
+  totalPages: number;
+  filter: "all" | "free";
+  freeCount: number;
+  totalCount: number;
+}
+
+/**
+ * Build the pager + filter button rows for a model picker. Shared by
+ * `/settings` and the standalone `/model` command. `navPrefix` is the
+ * callback-data prefix used for filter and pagination buttons —
+ * `/settings` uses `settings:models` (so its handler sees
+ * `settings:models:page:N:F`), `/model` uses `model:nav` (so its
+ * handler sees `model:nav:page:N:F`). A `noopData` sentinel is the
+ * callback for disabled-edge buttons (Telegram requires every inline
+ * button to carry callback data).
+ */
+export function renderModelPickerControlRows(
+  pager: SettingsPager,
+  navPrefix: string,
+  noopData: string,
+  view: "models" | "groups" = "models",
+  activeProvider?: string,
+): Array<Array<SettingsButton>> {
+  const rows: Array<Array<SettingsButton>> = [];
+  // When showing one provider's models, offer an explicit way back to
+  // the provider list. Encoded as `…:providers` so the callback
+  // handler knows to drop the `provider` option on re-render.
+  if (view === "models" && activeProvider) {
+    rows.push([
+      {
+        text: `← Providers`,
+        callback_data: `${navPrefix}:providers`,
+      },
+    ]);
+  }
+  if (pager.totalPages > 1) {
+    const prev = Math.max(1, pager.page - 1);
+    const next = Math.min(pager.totalPages, pager.page + 1);
+    const providerSuffix = activeProvider ? `:${activeProvider}` : "";
+    rows.push([
+      {
+        text: pager.page > 1 ? "← Prev" : "·",
+        callback_data:
+          pager.page > 1
+            ? `${navPrefix}:page:${prev}:${pager.filter}${providerSuffix}`
+            : noopData,
+      },
+      {
+        text: `${pager.page} / ${pager.totalPages}`,
+        callback_data: noopData,
+      },
+      {
+        text: pager.page < pager.totalPages ? "Next →" : "·",
+        callback_data:
+          pager.page < pager.totalPages
+            ? `${navPrefix}:page:${next}:${pager.filter}${providerSuffix}`
+            : noopData,
+      },
+    ]);
+  }
+  return rows;
+}
+
+// ── /model main-menu + browse view ──────────────────────────────────────────
+//
+// /model has two screens:
+//
+//   1. Main menu (`model:menu` callback path) — shows current model +
+//      toggles. Free-only toggle persists into chat-settings, so the
+//      preference survives bot restarts. "Browse models" drills into
+//      screen 2.
+//   2. Browse (`model:nav:*` callback path) — provider chips → models
+//      with pagination and a "← Back to menu" return button.
+//
+// All Telegram inline buttons here use callback data ≤ 64 bytes as
+// required by https://core.telegram.org/bots/api#inlinekeyboardbutton.
+
+export interface ModelMenuState {
+  activeModel: string;
+  /** Human-readable active model name (display) */
+  activeDisplay: string;
+  /** Active model status line(s) shown above the buttons. */
+  statusLines: string[];
+  /** Whether this chat has a per-chat model override (vs falling back to config default). */
+  hasOverride: boolean;
+  /** Whether the backend reports any free-tier models — controls visibility of the Free toggle. */
+  showFreeToggle: boolean;
+  /** Current persisted free-only setting for this chat. */
+  freeOnly: boolean;
+}
+
+/** Inputs needed to build a `ModelMenuState`. Pure-function shape so tests can stub everything. */
+export interface BuildModelMenuStateArgs {
+  chatId: string;
+  activeModel: string;
+  defaultModel: string;
+  freeOnly: boolean;
+  /**
+   * Backend hook to fetch a passive snapshot of the catalog. We only
+   * read `freeCount`, `totalCount`, and `modelDetails` for the body
+   * status line — never render `modelButtons` from this call.
+   */
+  fetchSnapshot: () => Promise<{
+    freeCount: number;
+    totalCount: number;
+    modelDetails: string[];
+  }>;
+  /** Resolve display name for the active model. Falls back to the raw id. */
+  fetchActiveDisplay: () => Promise<string | undefined>;
+}
+
+export async function buildModelMenuState(
+  args: BuildModelMenuStateArgs,
+): Promise<ModelMenuState> {
+  const [snapshot, display] = await Promise.all([
+    args.fetchSnapshot().catch(() => ({
+      freeCount: 0,
+      totalCount: 0,
+      modelDetails: [],
+    })),
+    args.fetchActiveDisplay().catch(() => undefined),
+  ]);
+
+  return {
+    activeModel: args.activeModel,
+    activeDisplay: display ?? args.activeModel,
+    statusLines: snapshot.modelDetails.slice(),
+    hasOverride: args.activeModel !== args.defaultModel,
+    showFreeToggle: snapshot.freeCount > 0,
+    freeOnly: args.freeOnly,
+  };
+}
+
+/** Build the main-menu inline keyboard for `/model`. */
+export function renderModelMenuKeyboard(
+  state: ModelMenuState,
+): Array<Array<SettingsButton>> {
+  const rows: Array<Array<SettingsButton>> = [];
+
+  rows.push([{ text: "Browse models", callback_data: "model:browse" }]);
+
+  if (state.showFreeToggle) {
+    rows.push([
+      {
+        text: state.freeOnly ? "Free only: ON" : "Free only: OFF",
+        callback_data: "model:toggle-free",
+      },
+    ]);
+  }
+
+  if (state.hasOverride) {
+    rows.push([{ text: "Reset to default", callback_data: "model:reset" }]);
+  }
+
+  return rows;
+}
+
+/** Format the body text of the `/model` main menu. */
+export function renderModelMenuText(state: ModelMenuState): string {
+  const lines: string[] = [
+    `<b>Model:</b> <code>${state.activeDisplay}</code>`,
+    ...state.statusLines.map((l) => l),
+  ];
+  if (state.freeOnly && state.showFreeToggle) {
+    lines.push("<i>Filtering to free-tier models when browsing.</i>");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Build the inline keyboard for the /model "browse" screen (provider
+ * groups OR a paginated model list). `backToMenuData` is the callback
+ * sent when the user wants to return to the main menu.
+ */
+export function renderModelBrowseKeyboard(
+  modelButtons: Array<SettingsButton>,
+  pager: SettingsPager,
+  view: "models" | "groups",
+  activeProvider: string | undefined,
+  backToMenuData: string,
+): Array<Array<SettingsButton>> {
+  const cols = 2;
+  const modelRows: Array<Array<SettingsButton>> = [];
+  for (let i = 0; i < modelButtons.length; i += cols) {
+    modelRows.push(modelButtons.slice(i, i + cols));
+  }
+  const controlRows = renderModelPickerControlRows(
+    pager,
+    "model:nav",
+    "model:noop",
+    view,
+    activeProvider,
+  );
+  return [
+    ...modelRows,
+    ...controlRows,
+    [{ text: "← Back to menu", callback_data: backToMenuData }],
+  ];
+}
+
 export function renderSettingsKeyboard(
   model: string,
   effort: string,
   proactive: boolean,
   modelButtons?: Array<SettingsButton>,
+  pager?: SettingsPager,
+  view: "models" | "groups" = "models",
+  activeProvider?: string,
 ): Array<Array<SettingsButton>> {
   const selectedButtons = modelButtons?.length
     ? modelButtons
@@ -238,8 +449,20 @@ export function renderSettingsKeyboard(
   for (let i = 0; i < selectedButtons.length; i += cols) {
     modelRows.push(selectedButtons.slice(i, i + cols));
   }
+
+  const controlRows = pager
+    ? renderModelPickerControlRows(
+        pager,
+        "settings:models",
+        "settings:noop",
+        view,
+        activeProvider,
+      )
+    : [];
+
   return [
     ...modelRows,
+    ...controlRows,
     [
       {
         text: effort === "low" ? "\u2713 Low" : "Low",
@@ -263,7 +486,6 @@ export function renderSettingsKeyboard(
         text: proactive ? "Pulse: ON" : "Pulse: OFF",
         callback_data: `settings:proactive:${proactive ? "off" : "on"}`,
       },
-      { text: "Done", callback_data: "settings:done" },
     ],
   ];
 }

--- a/src/frontend/telegram/model-callbacks.ts
+++ b/src/frontend/telegram/model-callbacks.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure parser + types for `/model` inline-button callback data.
+ *
+ * Centralising this here keeps the dispatch in `callbacks.ts` thin
+ * and gives tests a side-effect-free entry point — no Telegram
+ * context, no chat-settings storage, no backend calls. The
+ * grammar:
+ *
+ *   model:done                         — close (delete message)
+ *   model:noop                         — ack-and-drop (page indicator)
+ *   model:menu                         — re-render main menu
+ *   model:browse                       — drill into browse view
+ *   model:toggle-free                  — flip persisted freeOnly
+ *   model:reset                        — clear per-chat model override
+ *   model:nav:provider:<provider>      — drill into one provider
+ *   model:nav:providers                — back to provider list
+ *   model:nav:filter:<all|free>        — change filter (legacy; toggle owns it now)
+ *   model:nav:page:<N>:<filter>:<P?>   — navigate to a page
+ *   model:<id>                         — select that model
+ *
+ * Telegram Bot API limit: 1–64 bytes per callback_data
+ * (https://core.telegram.org/bots/api#inlinekeyboardbutton). The
+ * grammar above keeps the prefix short so 40+-char model ids still
+ * fit.
+ */
+
+export type ModelCallback =
+  | { kind: "done" }
+  | { kind: "noop" }
+  | { kind: "menu" }
+  | { kind: "browse" }
+  | { kind: "toggle-free" }
+  | { kind: "reset" }
+  | { kind: "nav-provider"; provider: string }
+  | { kind: "nav-back-to-providers" }
+  | { kind: "nav-filter"; filter: "all" | "free" }
+  | {
+      kind: "nav-page";
+      page: number;
+      filter: "all" | "free";
+      provider?: string;
+    }
+  | { kind: "select"; modelId: string }
+  | { kind: "unknown" };
+
+const FILTERS = new Set(["all", "free"]);
+
+export function parseModelCallback(data: string): ModelCallback {
+  if (!data.startsWith("model:")) return { kind: "unknown" };
+  const rest = data.slice("model:".length);
+
+  if (rest === "done") return { kind: "done" };
+  if (rest === "noop") return { kind: "noop" };
+  if (rest === "menu") return { kind: "menu" };
+  if (rest === "browse") return { kind: "browse" };
+  if (rest === "toggle-free") return { kind: "toggle-free" };
+  if (rest === "reset") return { kind: "reset" };
+
+  if (rest.startsWith("nav:")) {
+    const parts = rest.split(":");
+    // parts[0] === "nav", parts[1] === <sub>, parts[2...] === args
+    const sub = parts[1];
+    if (sub === "providers") return { kind: "nav-back-to-providers" };
+    if (sub === "provider") {
+      const provider = parts.slice(2).join(":");
+      if (!provider) return { kind: "unknown" };
+      return { kind: "nav-provider", provider };
+    }
+    if (sub === "filter") {
+      const f = parts[2];
+      if (f && FILTERS.has(f))
+        return { kind: "nav-filter", filter: f as "all" | "free" };
+      return { kind: "unknown" };
+    }
+    if (sub === "page") {
+      const n = Number(parts[2]);
+      if (!Number.isFinite(n) || n < 1) return { kind: "unknown" };
+      const f = parts[3];
+      if (!f || !FILTERS.has(f)) return { kind: "unknown" };
+      const provider = parts[4];
+      return {
+        kind: "nav-page",
+        page: Math.floor(n),
+        filter: f as "all" | "free",
+        ...(provider ? { provider } : {}),
+      };
+    }
+    return { kind: "unknown" };
+  }
+
+  // Anything else under `model:` is a model id selection. Reject ids
+  // that look like control payloads from older bot versions so they
+  // can't be persisted as a real model.
+  if (rest.startsWith("nav") || rest === "" || rest.includes(":nav:")) {
+    return { kind: "unknown" };
+  }
+  return { kind: "select", modelId: rest };
+}

--- a/src/storage/chat-settings.ts
+++ b/src/storage/chat-settings.ts
@@ -24,6 +24,12 @@ export type ChatSettings = {
   pulseIntervalMs?: number;
   /** Last message ID checked by pulse (persisted to avoid reprocessing on restart). */
   pulseLastCheckMsgId?: number;
+  /**
+   * When true, the model picker filters to free-tier models by default.
+   * Only meaningful for backends that report free-tier metadata (currently
+   * `openai-agents` against OpenRouter); other backends ignore the flag.
+   */
+  freeOnly?: boolean;
 };
 
 const STORE_FILE = files.chatSettings;
@@ -169,6 +175,18 @@ export function setChatEffort(
     store[chatId].effort = effort;
   } else {
     delete store[chatId].effort;
+    cleanupEmpty(chatId);
+  }
+  dirty = true;
+  save();
+}
+
+export function setChatFreeOnly(chatId: string, on: boolean | undefined): void {
+  if (!store[chatId]) store[chatId] = {};
+  if (on) {
+    store[chatId].freeOnly = true;
+  } else {
+    delete store[chatId].freeOnly;
     cleanupEmpty(chatId);
   }
   dirty = true;


### PR DESCRIPTION
## Summary

Overhauls the model picker UX end-to-end. Three branches of work in the one PR because they're entangled:

1. **Backend: dynamic catalog.** Drop the hardcoded `OPENAI_AGENTS_MODELS` constant. The picker now derives every answer from whatever `state.endpointModels` reports — populated at init from the active endpoint's `GET /models`. Works against OpenAI, OpenRouter, Ollama, vLLM, LiteLLM, anything OpenAI-compatible.
2. **Frontend: decouple `/settings` from `/model`.** `/settings` is Talon-level toggles only (Effort + Pulse). `/model` is a dedicated two-screen picker: main menu (active model + status + "Browse models" + persisted "Free only" toggle + "Reset to default") and browse view (provider chips when catalog > 30, else a paginated model list, always with "← Back to menu"). No more "Done" buttons.
3. **Robustness:** pure callback parser, byte-budget guard on Telegram's 64-byte `callback_data` limit, diagnostic `editMessageText` wrapper, persisted `freeOnly` setting, stale-callback dismissal.

## Bugs fixed along the way

| Symptom | Cause | Fix |
|---|---|---|
| `BUTTON_DATA_INVALID` from Telegram when Free filter on | `cognitivecomputations/dolphin-mistral-24b-venice-edition:free` (61 chars) overflowed the 64-byte `callback_data` limit | Filter offending ids out of the picker (still selectable via `/model <id>`) |
| Bot persisted `model = "nav:filter:free"` from a filter chip click on an older version | Picker control payloads were ambiguous with model ids in the callback handler | Pure typed parser (`parseModelCallback`); control payloads can't decay to selections |
| `/model` reply re-rendered as `/settings` panel | Shared `getSettingsPresentation` + shared callback prefix routed cross-command | Separate `navCallbackPrefix` per entry path; `/settings` no longer touches model state |
| Buttons "silently did nothing" | `editMessageText` errors swallowed by `try/catch {}` | `editOrIgnoreSame` wrapper logs everything except Telegram's "message is not modified" noise |
| Provider drill emitted bad callback data | `derivePagerPrefix` produced `models:provider:openai` for `/model` (no `model:` prefix → not matched) | Explicit `navCallbackPrefix` option, no derivation |

## Backend compatibility

`getSettingsPresentation` signature changed from `(activeModel, callbackPrefix?)` to `(activeModel, options?)` with the new `ModelPickerResult` shape. All five backends updated:

- `openai-agents` — full impl (groups + pagination + free filter)
- `codex` / `claude-sdk` — return `view: "models"` with their fixed catalog; pagination + free filter no-op
- `kilo` / `opencode` — wrap their legacy `{modelButtons, modelDetails}` output with the new metadata fields

## Tests

| Suite | Count | Coverage |
|---|---|---|
| `openai-agents-builtins.test.ts` | 20 | Read/Write/Edit/Bash/Glob/Grep against a real temp dir |
| `openai-agents-enrichment.test.ts` | 15 | `fetchEndpointModels` against stubbed fetch (OpenRouter / vLLM / OpenAI / malformed shapes, auth header, failure paths) |
| `openai-agents-models.test.ts` | 32 | Resolver paths, picker view selection, pagination clamping, free filter, callback-byte budget, drill behavior |
| `openai-agents-backend.test.ts` | 8 | Constants, state, factory |
| `telegram-model-menu.test.ts` | 25 | `parseModelCallback` grammar, `buildModelMenuState`, menu/browse keyboard renderers, 64-byte invariant |

Total: **100 tests** (up from 8). `npm run typecheck` and `npm run format:check` clean.

## Manual test plan

- [x] `/settings` shows Effort + Pulse only
- [x] `/model` shows main menu with active model + Browse + Free toggle + Reset
- [x] Free toggle persists across `/restart`
- [x] Browse with 356-model OpenRouter catalog drills into provider groups
- [x] Tapping a provider drills into that provider's paginated models
- [x] Tapping `← Back to menu` returns to the main menu
- [x] Stale `settings:models:*` callbacks from old bot versions show a "Picker moved" toast instead of dispatching a turn
- [x] No `BUTTON_DATA_INVALID` errors with Free filter on

🤖 Generated with [Claude Code](https://claude.com/claude-code)