### PR TITLE
fix: four bugs in agy/antigravity/codex backends

### DIFF
--- a/src/backend/agy/handler.ts
+++ b/src/backend/agy/handler.ts
@@ -41,6 +41,7 @@ import { AGY_LABEL } from "./constants.js";
 export async function handleMessage(params: QueryParams): Promise<QueryResult> {
   const { chatId, text, senderName, isGroup, messageId } = params;
   const session = getSession(chatId);
+  const previousTurns = session.turns;
   const config = loadConfig();
   const turnStarted = Date.now();
 
@@ -107,8 +108,8 @@ export async function handleMessage(params: QueryParams): Promise<QueryResult> {
   });
 
   incrementTurns(chatId);
-  if (session.turns === 0 && finalText.length > 0) {
-    const name = extractSessionName(finalText);
+  if (previousTurns === 0 && text.length > 0) {
+    const name = extractSessionName(text);
     if (name) setSessionName(chatId, name);
   }
   recordUsage(chatId, {

--- a/src/backend/antigravity/python-bridge.ts
+++ b/src/backend/antigravity/python-bridge.ts
@@ -317,6 +317,12 @@ export class AntigravityBridge {
       if (!this.ready && this.readyReject) {
         const msg = `bridge ready handshake timed out (60s) — is google-antigravity installed and GEMINI_API_KEY valid? venv=${pythonPath}`;
         this.readyReject(new Error(msg));
+        // Kill the subprocess so it doesn't run indefinitely as an orphan.
+        // The bridge won't be registered in state.bridges (start() throws),
+        // so nothing else will clean it up. Mirrors the protocol-version-
+        // mismatch path which also calls this.proc?.kill().
+        this.dead = true;
+        this.proc?.kill("SIGTERM");
       }
     }, 60_000);
 

--- a/src/backend/codex/discovery.ts
+++ b/src/backend/codex/discovery.ts
@@ -126,7 +126,9 @@ export function isCodexCompatibleModel(id: string): boolean {
     return false;
   }
   // Positive prefixes for chat-capable / reasoning models.
-  if (/^(gpt-[3-9]|o[3-9]|chatgpt-)/.test(lower)) return true;
+  // `o[1-9]` covers o1, o1-mini, o1-preview, o2, o3, o4 … — the
+  // original `o[3-9]` accidentally dropped the o1/o2 families.
+  if (/^(gpt-[3-9]|o[1-9]|chatgpt-)/.test(lower)) return true;
   return false;
 }
 

--- a/src/backend/codex/handler.ts
+++ b/src/backend/codex/handler.ts
@@ -494,13 +494,20 @@ export async function handleMessage(
       // saying "not supported when using Codex with a ChatGPT account".
       // Check both the captured event-stream message and the thrown
       // error — Codex SDK surfaces it via both channels.
+      // Only pass a thread ID to probeUsageExhausted when we have the
+      // ID from the CURRENT run (resolvedThreadId). Falling back to
+      // session.sessionId (the previous run's thread) can produce a
+      // false-positive CodexUsageExhaustedError: if the previous
+      // session's rollout shows has_credits:false, probeUsageExhausted
+      // returns "exhausted" even though the current failure is unrelated
+      // (transient network error, rate-limit, etc.).
       const fallback = await maybeFallbackForChatGptMismatch(
         `${turnFailedError ?? ""} ${errMsg(err)}`,
         activeModel,
         params,
         _retried,
         chatId,
-        resolvedThreadId ?? session.sessionId,
+        resolvedThreadId,
       );
       if (fallback) return fallback;
 


### PR DESCRIPTION
## Summary

Code review of the antigravity / agy / codex additions on this branch surfaced four bugs, fixed here.

---

### Bug 1 — agy session name is never set (`src/backend/agy/handler.ts`)

`getSession` returns the **same mutable object** stored in `sessions[chatId]`. After `incrementTurns(chatId)` at line 109 mutated `session.turns` to 1, the guard `if (session.turns === 0)` at line 110 was always false → `setSessionName` was never called → every agy chat shows as "untitled" forever.

A second issue in the same block: the name was extracted from `finalText` (the model's response) instead of `text` (the user's first message). Every other backend — claude-sdk:314, codex:614, antigravity:231 — uses the user's text.

**Fix:** capture `previousTurns = session.turns` before `incrementTurns`, check `previousTurns === 0`, and pass `text`.

---

### Bug 2 — Python bridge subprocess leaked on 60-second ready timeout (`src/backend/antigravity/python-bridge.ts`)

The ready-handshake timeout called `this.readyReject(err)` (rejecting the promise and causing `start()` to throw) but never `this.proc?.kill()`. Since a timed-out bridge is never registered in `state.bridges`, nothing else could clean it up. The spawned Python process (and the bridge object held alive by its `proc.on('exit')` listener) would run indefinitely.

The protocol-version-mismatch path at line 350 already correctly calls `this.proc?.kill()`. The timeout path now does too, and sets `this.dead = true` to prevent any further command writes.

---

### Bug 3 — Stale thread ID can cause false-positive `CodexUsageExhaustedError` (`src/backend/codex/handler.ts`)

`probeUsageExhausted` was called with `resolvedThreadId ?? session.sessionId`. When the Codex SDK throws before emitting `thread.started`, `resolvedThreadId` is `undefined` and the **previous run's** thread ID is used instead. If that older session's rollout JSONL happens to show `has_credits: false`, `probeUsageExhausted` returns `"exhausted"` and throws `CodexUsageExhaustedError` — masking the real current failure (transient error, rate-limit, wrong config, etc.) and skipping the model-fallback that might have succeeded.

**Fix:** pass only `resolvedThreadId`. When it is `undefined`, `probeUsageExhausted` returns `"unknown"`, which correctly falls back to the oauth-incompat heuristic.

---

### Bug 4 — `isCodexCompatibleModel` silently drops o1/o2 families (`src/backend/codex/discovery.ts`)

The positive filter used `o[3-9]`, which matches o3, o4, … but **not** o1, o1-mini, o1-preview, or o2. Operators whose API key grants access to these models would find them missing from the `/model` picker with no warning.

**Fix:** change to `o[1-9]`.

---

## Unresolved (noted for follow-up)

One additional race is documented but **not fixed here** because the correct solution requires a Python-side change:

> `bridge.abort(turnId)` fires in `onToolCall` — which arrives before the MCP HTTP call for `end_turn`/`send` has completed. Python's asyncio task can be cancelled at an `await` inside the MCP call, potentially dropping the delivery. `hadBridgeDelivery` is then set `true`, suppressing the text fallback → silent response.

The safest fix would be to trigger `abort` in `onToolResult` (after the MCP round-trip is confirmed) or to have the Python bridge drain the current MCP call before honouring a cancellation. Leaving a tracking comment for the next iteration.

## Test plan

- [ ] Start an agy chat and verify the session is named from the first user message
- [ ] Verify antigravity bridge startup failure (invalid key / missing venv) doesn't leave zombie Python processes (check `ps aux`)
- [ ] With a ChatGPT-OAuth Codex credential and a fresh chat that has never started a thread, send a message on an api-key-only model and confirm the error is the oauth-incompat fallback, not a spurious `CodexUsageExhaustedError`
- [ ] With an api-key Codex credential, open the `/model` picker and confirm o1-mini / o1-preview appear (if the key has access)

https://claude.ai/code/session_01RBBwsTLZwcMwzxCu3Wn5H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBBwsTLZwcMwzxCu3Wn5H1)_