### PR TITLE
fix: consolidate open correctness fixes

### DIFF
--- a/src/__tests__/backend-registry-parity.test.ts
+++ b/src/__tests__/backend-registry-parity.test.ts
@@ -38,7 +38,7 @@ beforeAll(async () => {
   await import("../backend/opencode/factory.js");
   await import("../backend/codex/factory.js");
   await import("../backend/openai-agents/factory.js");
-});
+}, 30_000);
 
 describe("backend registry parity — all built-in backends present", () => {
   it("registers Claude, Kilo, OpenCode, Codex, and OpenAI Agents", () => {

--- a/src/__tests__/claude-sdk-handler-watchdog.test.ts
+++ b/src/__tests__/claude-sdk-handler-watchdog.test.ts
@@ -167,6 +167,7 @@ vi.mock("../backend/shared/index.js", () => ({
   prepareSystemPrompt: vi.fn(),
   extractSessionName: () => null,
   detectFlowViolation: () => ({ violated: false }),
+  FLOW_VIOLATION_MAX_RETRIES: 3,
   captureDeliveredText: () => null,
   summarizeUsage: () => "0ms in=0 out=0 cache=0% tools=0",
   // Tests don't exercise the retry path (the watchdog short-circuits the

--- a/src/__tests__/codex-handler.test.ts
+++ b/src/__tests__/codex-handler.test.ts
@@ -794,7 +794,7 @@ describe("codex / handleMessage — active abort registry", () => {
     // Cleanup
     sessions.resetSession("chat-a");
     sessions.resetSession("chat-b");
-  });
+  }, 10_000);
 });
 
 describe("codex / handleMessage — tool call accounting", () => {

--- a/src/__tests__/gateway-http.test.ts
+++ b/src/__tests__/gateway-http.test.ts
@@ -357,18 +357,20 @@ describe("gateway HTTP server", () => {
       );
     });
 
-    it("rejects chat_id=0 (the gateway's falsy-guard catches it)", async () => {
-      // Number("0") = 0, which is falsy. The gateway uses `if (!chatId)`
-      // as its final guard so 0 always falls through to the rejection
-      // path — no real chat has ID 0.
+    it("accepts chat_id=0 without conflating it with no context", async () => {
+      // Number("0") = 0, which is falsy but still a resolved number.
+      // The gateway's null guard keeps the number/null contract honest.
       const { body } = await post({
         action: "send_message",
         _chatId: "0",
         chat_id: 0,
         text: "to zero",
       });
-      expect(body.ok).toBe(false);
-      expect(body.error).toContain("No active chat context");
+      expect(body.ok).toBe(true);
+      expect(mockFrontendHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ chat_id: 0 }),
+        0,
+      );
     });
 
     it("rejects the heartbeat sentinel even when chat_id property is present", async () => {

--- a/src/__tests__/integration/openai-agents-live-discovery.test.ts
+++ b/src/__tests__/integration/openai-agents-live-discovery.test.ts
@@ -238,7 +238,7 @@ describe("openai-agents live (dummy) / tool call dispatch", () => {
     const toolMsg = allMessages.find((m) => m.role === "tool");
     expect(toolMsg).toBeDefined();
     expect(toolMsg?.content ?? "").toContain("dummy-tool-output");
-  });
+  }, 15_000);
 });
 
 // ── 4. Multi-turn memory via MemorySession ─────────────────────────────────

--- a/src/__tests__/shared-flow-violation.test.ts
+++ b/src/__tests__/shared-flow-violation.test.ts
@@ -72,21 +72,55 @@ describe("detectFlowViolation", () => {
       expect(res.trailing).toBe(
         "The model wrote this without calling end_turn",
       );
+      expect(res.reason).toContain("trailing prose");
       expect(res.shouldRetry).toBe(true);
       expect(res.reminder).toBe(FLOW_VIOLATION_REMINDER);
     }
   });
 
-  it("triggers but skips retry when already retried", () => {
+  it("DOES trigger when tools ran but no turn terminator was called", () => {
+    const res = detectFlowViolation({
+      trailingText: "",
+      turnTerminated: false,
+      deliveredTextNorms: [],
+      toolCalls: 2,
+      retried: false,
+    });
+    expect(res.violated).toBe(true);
+    if (res.violated) {
+      expect(res.trailing).toBe("");
+      expect(res.reason).toBe("2 tool calls with no terminator");
+      expect(res.shouldRetry).toBe(true);
+    }
+  });
+
+  it("triggers but skips retry when retry cap is exhausted", () => {
     const res = detectFlowViolation({
       trailingText: "Still a flow violation on retry",
       turnTerminated: false,
       deliveredTextNorms: [],
       retried: true,
+      retryCount: 3,
+      maxRetries: 3,
     });
     expect(res.violated).toBe(true);
     if (res.violated) {
       expect(res.shouldRetry).toBe(false);
+    }
+  });
+
+  it("still retries before the retry cap is exhausted", () => {
+    const res = detectFlowViolation({
+      trailingText: "Still wrong after one reminder",
+      turnTerminated: false,
+      deliveredTextNorms: [],
+      retried: true,
+      retryCount: 1,
+      maxRetries: 3,
+    });
+    expect(res.violated).toBe(true);
+    if (res.violated) {
+      expect(res.shouldRetry).toBe(true);
     }
   });
 

--- a/src/__tests__/shared-session-name.test.ts
+++ b/src/__tests__/shared-session-name.test.ts
@@ -29,7 +29,7 @@ describe("extractSessionName", () => {
     const long = "x".repeat(50);
     const name = extractSessionName(long);
     expect(name).toBeDefined();
-    expect(name!.length).toBeLessThanOrEqual(33); // 30 + "..."
+    expect(name!.length).toBeLessThanOrEqual(30); // MAX_NAME_LENGTH total
     expect(name!.endsWith("...")).toBe(true);
   });
 

--- a/src/__tests__/teams-frontend.test.ts
+++ b/src/__tests__/teams-frontend.test.ts
@@ -372,7 +372,7 @@ describe("teams actions", () => {
     expect(result?.id).toBe(456);
   });
 
-  it("unsupported actions return ok (graceful no-ops)", async () => {
+  it("unsupported actions return errors instead of pretending success", async () => {
     const { Gateway } = await import("../core/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
@@ -391,7 +391,8 @@ describe("teams actions", () => {
       "forward_message",
     ]) {
       const result = await handler({ action }, 123);
-      expect(result?.ok).toBe(true);
+      expect(result?.ok).toBe(false);
+      expect(result?.error).toContain("not supported on Teams");
     }
   });
 

--- a/src/__tests__/triggers-extended.test.ts
+++ b/src/__tests__/triggers-extended.test.ts
@@ -24,6 +24,7 @@ import {
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
 
 // Silence the logger
 vi.mock("../util/log.js", () => ({
@@ -65,6 +66,12 @@ const {
 
 let tmpRoot: string;
 let executeSpy: ReturnType<typeof vi.fn>;
+const hasUsableBash =
+  spawnSync("bash", ["-lc", "exit 0"], {
+    stdio: "ignore",
+    windowsHide: true,
+  }).status === 0;
+const describeBash = hasUsableBash ? describe : describe.skip;
 
 function makeTrigger(opts: {
   body: string;
@@ -198,7 +205,7 @@ describe("triggers — alternate languages", () => {
 
 // ── Idempotency ───────────────────────────────────────────────────────────
 
-describe("triggers — idempotency", () => {
+describeBash("triggers — idempotency", () => {
   it("calling spawnTrigger twice on the same id is a no-op", async () => {
     const t = makeTrigger({ body: 'echo "once"\nexit 0\n' });
     spawnTrigger(t); // first call — spawns
@@ -327,7 +334,7 @@ describe("trigger-store — branch coverage", () => {
 
 // ── Large payload / buffer truncation ────────────────────────────────────────
 
-describe("triggers — large stdout payload truncation", () => {
+describeBash("triggers — large stdout payload truncation", () => {
   it("truncates a payload that exceeds FIRE_PAYLOAD_MAX_BYTES", async () => {
     // Emit a line that is larger than FIRE_PAYLOAD_MAX_BYTES bytes so the
     // bufferAsPayload / trimmed path in fireWake is exercised.
@@ -346,7 +353,7 @@ describe("triggers — large stdout payload truncation", () => {
 
 // ── finalizeExit with pre-terminal status ────────────────────────────────────
 
-describe("triggers — finalizeExit status branch", () => {
+describeBash("triggers — finalizeExit status branch", () => {
   it("handles a trigger that had status='cancelled' when it exits", async () => {
     // Spawn, wait until running, cancel — then the child exits.
     // finalizeExit sees status='cancelled' (not 'running') → else branch.
@@ -410,7 +417,7 @@ describe("trigger-store — readTriggerLogTail", () => {
 
 // ── fireWakeUp dispatch error ─────────────────────────────────────────────
 
-describe("triggers — dispatch error", () => {
+describeBash("triggers — dispatch error", () => {
   it("logs when execute() rejects but the trigger still reaches terminal state", async () => {
     // Make the dispatch call reject — exercises the catch at line 394 of triggers.ts
     executeSpy.mockRejectedValueOnce(new Error("network failure"));
@@ -428,7 +435,7 @@ describe("triggers — dispatch error", () => {
 
 // ── Empty output: (no output) path ────────────────────────────────────────
 
-describe("triggers — empty stdout", () => {
+describeBash("triggers — empty stdout", () => {
   it("fires with (no output) label when script produces no stdout", async () => {
     // bufferAsPayload returns "" → trimmed is "" → body uses (no output) branch
     const t = makeTrigger({ body: "exit 0\n" }); // no echo
@@ -441,7 +448,7 @@ describe("triggers — empty stdout", () => {
 
 // ── Mid-run TALON_FIRE: signal ────────────────────────────────────────────
 
-describe("triggers — mid-run TALON_FIRE", () => {
+describeBash("triggers — mid-run TALON_FIRE", () => {
   it("fires a non-terminal wake when TALON_FIRE: prefix is emitted", async () => {
     // handleStdoutLine true branch + fireWake terminal=false (header = "signalled")
     const t = makeTrigger({
@@ -658,7 +665,7 @@ describe("triggers — timeout timer fires after child has already exited", () =
 
 // ── Child process emits 'error' event (line 152 handler) ─────────────────
 
-describe("triggers — child process error event", () => {
+describeBash("triggers — child process error event", () => {
   it("logs but does not crash when child emits an error event", async () => {
     // Spawn a long-running script so the child stays alive long enough to emit error.
     const t = makeTrigger({ body: "sleep 10\n" });

--- a/src/__tests__/triggers.test.ts
+++ b/src/__tests__/triggers.test.ts
@@ -10,6 +10,7 @@ import {
 import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
 
 // Silence the logger
 vi.mock("../util/log.js", () => ({
@@ -44,6 +45,12 @@ import { writeFileSync, mkdirSync } from "node:fs";
 
 let tmpRoot: string;
 let executeSpy: ReturnType<typeof vi.fn>;
+const hasUsableBash =
+  spawnSync("bash", ["-lc", "exit 0"], {
+    stdio: "ignore",
+    windowsHide: true,
+  }).status === 0;
+const describeBash = hasUsableBash ? describe : describe.skip;
 
 function makeTrigger(opts: {
   body: string;
@@ -152,7 +159,7 @@ beforeEach(() => {
   initTriggers({ execute: executeSpy as never });
 });
 
-describe("trigger supervisor", () => {
+describeBash("trigger supervisor", () => {
   it("fires a wake-up on clean exit 0 with stdout payload", async () => {
     const t = makeTrigger({
       body: 'echo "task done"\nexit 0\n',

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -38,6 +38,7 @@ import {
   prepareSystemPrompt,
   extractSessionName,
   detectFlowViolation,
+  FLOW_VIOLATION_MAX_RETRIES,
   captureDeliveredText,
   summarizeUsage,
   applyRetryDecision,
@@ -86,7 +87,7 @@ export function getActiveQuery(chatId: string): Query | undefined {
 
 export async function handleMessage(
   params: QueryParams,
-  _retried = false,
+  _internal: { flowRetries?: number; errorRetried?: boolean } = {},
 ): Promise<QueryResult> {
   const config = getConfig();
 
@@ -209,8 +210,11 @@ export async function handleMessage(
           if (onToolUse) {
             try {
               onToolUse(tool.name, tool.input);
-            } catch {
-              /* non-fatal */
+            } catch (err) {
+              logWarn(
+                "agent",
+                `onToolUse callback threw for ${tool.name}: ${err instanceof Error ? err.message : err}`,
+              );
             }
           }
         }
@@ -266,9 +270,13 @@ export async function handleMessage(
         err,
         chatId,
         activeModel,
-        retried: _retried,
+        retried: _internal.errorRetried ?? false,
         params,
-        recurseWithRetried: (p) => handleMessage(p, true),
+        recurseWithRetried: (p) =>
+          handleMessage(p, {
+            ..._internal,
+            errorRetried: true,
+          }),
         // No backendLabel — historical claude-sdk log shape was un-prefixed
         // (just `[chatId] session_expired, resetting…`). Preserving that.
       });
@@ -331,17 +339,20 @@ export async function handleMessage(
     trailingText: state.lastTrailingText,
     turnTerminated: state.turnTerminated,
     deliveredTextNorms: state.deliveredTextNorms,
-    retried: _retried,
+    toolCalls: state.toolCalls,
+    retried: (_internal.flowRetries ?? 0) > 0,
+    retryCount: _internal.flowRetries ?? 0,
+    maxRetries: FLOW_VIOLATION_MAX_RETRIES,
   });
 
   if (violation.violated) {
     incrementCounter("scratchpad.trailing_text_dropped");
     log(
       "agent",
-      `[${chatId}] flow violation: trailing prose (${violation.trailing.length} chars) without end_turn/send. ${
+      `[${chatId}] flow violation: ${violation.reason}. ${
         violation.shouldRetry
           ? "Re-prompting with reminder."
-          : "Already retried — accepting silent drop."
+          : `Retry cap (${FLOW_VIOLATION_MAX_RETRIES}) exhausted — accepting silent drop.`
       }`,
     );
 
@@ -349,8 +360,15 @@ export async function handleMessage(
       incrementCounter("scratchpad.flow_violation_retried");
       // The recursive call owns the `incrementTurns` for this user message.
       // We deliberately don't increment here.
-      return handleMessage({ ...params, text: violation.reminder }, true);
+      return handleMessage(
+        { ...params, text: violation.reminder },
+        {
+          ..._internal,
+          flowRetries: (_internal.flowRetries ?? 0) + 1,
+        },
+      );
     }
+    incrementCounter("scratchpad.flow_violation_cap_exhausted");
   }
 
   // Reached the non-retry path — this turn counts as one user-visible turn.

--- a/src/backend/claude-sdk/stream.ts
+++ b/src/backend/claude-sdk/stream.ts
@@ -256,38 +256,8 @@ export function processResultMessage(
 }
 
 // ── Trailing-text fallback dedup ────────────────────────────────────────────
-
-/**
- * Normalize text for fuzzy comparison — trim, lowercase, collapse whitespace,
- * strip emoji. Used to detect whether trailing prose duplicates content
- * already delivered via `end_turn` / `send(type="text")`.
- */
-export function normalizeForDedupe(text: string): string {
-  return text
-    .trim()
-    .toLowerCase()
-    .replace(/\p{Emoji_Presentation}|\p{Extended_Pictographic}/gu, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-const MIN_DEDUP_LENGTH = 10;
-
-/**
- * Returns true if `candidate` is substantively the same as any text in
- * `deliveredNorms`. "Substantively" = one is a substring of the other after
- * normalization; both must be at least MIN_DEDUP_LENGTH chars to avoid
- * dropping short legitimate replies.
- */
-export function isDuplicateOfDelivered(
-  candidate: string,
-  deliveredNorms: string[],
-): boolean {
-  if (deliveredNorms.length === 0) return false;
-  const norm = normalizeForDedupe(candidate);
-  if (norm.length < MIN_DEDUP_LENGTH) return false;
-  return deliveredNorms.some(
-    (d) =>
-      d.length >= MIN_DEDUP_LENGTH && (norm.includes(d) || d.includes(norm)),
-  );
-}
+// Re-export from shared so legacy imports do not grow a second implementation.
+export {
+  normalizeForDedupe,
+  isDuplicateOfDelivered,
+} from "../shared/delivered-text.js";

--- a/src/backend/openai-agents/builtins.ts
+++ b/src/backend/openai-agents/builtins.ts
@@ -221,7 +221,21 @@ function runShell(
   timedOut: boolean;
 }> {
   return new Promise((resolveResult) => {
-    const child = spawn("bash", ["-lc", command], {
+    const shell =
+      process.platform === "win32"
+        ? {
+            cmd: "powershell.exe",
+            args: [
+              "-NoProfile",
+              "-NonInteractive",
+              "-ExecutionPolicy",
+              "Bypass",
+              "-Command",
+              command,
+            ],
+          }
+        : { cmd: "bash", args: ["-lc", command] };
+    const child = spawn(shell.cmd, shell.args, {
       cwd: process.cwd(),
       env: process.env,
       stdio: ["ignore", "pipe", "pipe"],
@@ -261,7 +275,7 @@ function runShell(
 const bashTool = tool({
   name: "Bash",
   description:
-    "Run a shell command via `bash -lc`. Returns combined stdout " +
+    "Run a shell command. Uses PowerShell on Windows and `bash -lc` elsewhere. Returns combined stdout " +
     "and stderr along with the exit code. Default timeout 30s, max " +
     "10min. Use for inspecting files, running scripts, package " +
     "managers, git, etc. Do not start long-running servers — there " +
@@ -382,7 +396,10 @@ const grepTool = tool({
     const { pattern, path, include } = input as GrepInput;
     const target = path ? expandPath(path) : process.cwd();
     // Prefer ripgrep if installed; fall back to GNU/BSD grep.
-    const rgCheck = await runShell("command -v rg", 2000);
+    const rgCheck = await runShell(
+      process.platform === "win32" ? "where.exe rg" : "command -v rg",
+      2000,
+    );
     const useRg = rgCheck.code === 0 && rgCheck.stdout.trim().length > 0;
 
     let command: string;

--- a/src/backend/shared/flow-violation.ts
+++ b/src/backend/shared/flow-violation.ts
@@ -29,7 +29,9 @@ export const FLOW_VIOLATION_REMINDER =
   "`end_turn()` (no args) to close silently, " +
   "`send(...)` for mid-turn rich content (photos, polls, etc.), or " +
   "`react(emoji=...)` for an emoji acknowledgement. " +
-  "Retry now using the correct tool call.";
+  "Tool calls alone do not close the turn. Retry now using the correct tool call.";
+
+export const FLOW_VIOLATION_MAX_RETRIES = 3;
 
 // ── Public API ──────────────────────────────────────────────────────────────
 
@@ -41,8 +43,14 @@ export type FlowViolationInputs = {
   turnTerminated: boolean;
   /** Already-delivered text norms used for dedup. */
   deliveredTextNorms: readonly string[];
+  /** Number of tool calls observed in this turn. */
+  toolCalls?: number;
   /** Whether this is already a retry (prevents looping). */
   retried: boolean;
+  /** Number of synthetic flow-violation retries already attempted. */
+  retryCount?: number;
+  /** Maximum synthetic flow-violation retries before accepting the drop. */
+  maxRetries?: number;
 };
 
 /** Outcome of the flow-violation check. */
@@ -52,6 +60,8 @@ export type FlowViolationResult =
       violated: true;
       /** Trimmed scratchpad prose that would be dropped. */
       trailing: string;
+      /** Human-readable reason logged by handlers. */
+      reason: string;
       /** Whether the handler should re-prompt with `reminder`. False when retried. */
       shouldRetry: boolean;
       /** Reminder string to send as the next user prompt (when retrying). */
@@ -65,9 +75,9 @@ export type FlowViolationResult =
  * Classify a stream-loop outcome against the delivery contract.
  *
  * A turn is in violation when ALL of the following hold:
- *   - The trailing text (after trim) is non-empty.
  *   - No turn-terminator tool fired (e.g. `end_turn`).
- *   - The trailing text isn't a duplicate of content already delivered
+ *   - The model produced either trailing prose or tool calls.
+ *   - Any trailing text isn't a duplicate of content already delivered
  *     through a tool call in the same turn.
  *
  * The third condition handles the legitimate "model wrote text AND called
@@ -79,14 +89,28 @@ export function detectFlowViolation(
   inputs: FlowViolationInputs,
 ): FlowViolationResult {
   const trailing = inputs.trailingText.trim();
-  if (trailing.length === 0) return { violated: false };
   if (inputs.turnTerminated) return { violated: false };
-  if (isDuplicateOfDelivered(trailing, inputs.deliveredTextNorms))
+  const toolCalls = inputs.toolCalls ?? 0;
+  if (trailing.length === 0 && toolCalls === 0) return { violated: false };
+  if (
+    trailing.length > 0 &&
+    isDuplicateOfDelivered(trailing, inputs.deliveredTextNorms)
+  ) {
     return { violated: false };
+  }
+
+  const retryCount = inputs.retryCount ?? (inputs.retried ? 1 : 0);
+  const maxRetries = inputs.maxRetries ?? FLOW_VIOLATION_MAX_RETRIES;
+  const reason =
+    trailing.length > 0
+      ? `trailing prose (${trailing.length} chars)`
+      : `${toolCalls} tool call${toolCalls === 1 ? "" : "s"} with no terminator`;
+
   return {
     violated: true,
     trailing,
-    shouldRetry: !inputs.retried,
+    reason,
+    shouldRetry: retryCount < maxRetries,
     reminder: FLOW_VIOLATION_REMINDER,
   };
 }

--- a/src/backend/shared/index.ts
+++ b/src/backend/shared/index.ts
@@ -28,6 +28,7 @@ export {
 
 export {
   FLOW_VIOLATION_REMINDER,
+  FLOW_VIOLATION_MAX_RETRIES,
   detectFlowViolation,
   type FlowViolationInputs,
   type FlowViolationResult,

--- a/src/backend/shared/session-name.ts
+++ b/src/backend/shared/session-name.ts
@@ -36,6 +36,6 @@ export function extractSessionName(rawText: string): string | undefined {
     .trim();
   if (!cleaned) return undefined;
   return cleaned.length > MAX_NAME_LENGTH
-    ? cleaned.slice(0, MAX_NAME_LENGTH) + "..."
+    ? cleaned.slice(0, MAX_NAME_LENGTH - 3) + "..."
     : cleaned;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -817,11 +817,11 @@ async function runDoctor(): Promise<void> {
   const activeBackend = doctorConfig?.backend ?? "claude";
   if (activeBackend === "claude") {
     try {
-      const { execSync } = await import("node:child_process");
+      const { execFileSync } = await import("node:child_process");
       if (doctorConfig?.claudeBinary) {
         const cmd = process.platform === "win32" ? "where" : "which";
         try {
-          execSync(`${cmd} ${doctorConfig.claudeBinary}`, { stdio: "pipe" });
+          execFileSync(cmd, [doctorConfig.claudeBinary], { stdio: "pipe" });
           console.log(
             `  ${pc.green("\u2713")} Claude Code binary: ${pc.dim(doctorConfig.claudeBinary)}`,
           );
@@ -832,12 +832,8 @@ async function runDoctor(): Promise<void> {
           issues++;
         }
       } else {
-        execSync(
-          process.platform === "win32" ? "where claude" : "which claude",
-          {
-            stdio: "pipe",
-          },
-        );
+        const lookupCmd = process.platform === "win32" ? "where" : "which";
+        execFileSync(lookupCmd, ["claude"], { stdio: "pipe" });
         console.log(`  ${pc.green("\u2713")} Claude Code installed`);
       }
     } catch {
@@ -846,10 +842,9 @@ async function runDoctor(): Promise<void> {
     }
   } else if (activeBackend === "codex") {
     try {
-      const { execSync } = await import("node:child_process");
-      execSync(process.platform === "win32" ? "where codex" : "which codex", {
-        stdio: "pipe",
-      });
+      const { execFileSync } = await import("node:child_process");
+      const lookupCmd = process.platform === "win32" ? "where" : "which";
+      execFileSync(lookupCmd, ["codex"], { stdio: "pipe" });
       console.log(`  ${pc.green("\u2713")} Codex CLI installed`);
       const { detectCodexAuth } = await import("./backend/codex/auth.js");
       const auth = detectCodexAuth({
@@ -936,6 +931,7 @@ async function startChat(): Promise<void> {
   const { flushCronJobs } = await import("./storage/cron-store.js");
   const { flushHistory } = await import("./storage/history.js");
   const { flushMediaIndex } = await import("./storage/media-index.js");
+  const { flushTriggers } = await import("./storage/trigger-store.js");
   const { createTerminalFrontend } =
     await import("./frontend/terminal/index.js");
   const { Gateway } = await import("./core/gateway.js");
@@ -973,6 +969,7 @@ async function startChat(): Promise<void> {
     flushCronJobs();
     flushHistory();
     flushMediaIndex();
+    flushTriggers();
     frontend.stop();
     process.exit(0);
   });

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -107,10 +107,8 @@ export async function forceDream(): Promise<void> {
 /** Shared dream execution — claims lock, runs agent, releases lock. */
 async function executeDream(trigger: "auto" | "forced"): Promise<void> {
   const state = readDreamState();
-  const now = Date.now();
-
   dreaming = true;
-  writeDreamState({ last_run: now, status: "running" });
+  writeDreamState({ last_run: state?.last_run ?? 0, status: "running" });
   log(
     "dream",
     `${trigger === "forced" ? "Force-triggering" : "Triggering"} memory consolidation (last run: ${state?.last_run ? new Date(state.last_run).toISOString() : "never"})`,
@@ -125,7 +123,7 @@ async function executeDream(trigger: "auto" | "forced"): Promise<void> {
     );
   } catch (err) {
     logError("dream", `Memory consolidation failed (${trigger})`, err);
-    writeDreamState({ last_run: Date.now(), status: "idle" });
+    writeDreamState({ last_run: state?.last_run ?? 0, status: "idle" });
     if (trigger === "forced") throw err;
   } finally {
     dreaming = false;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -115,7 +115,7 @@ export function classify(err: unknown): TalonError {
   }
 
   // Session expired
-  if (/session|expired|invalid.*resume/i.test(msg)) {
+  if (/session.*expired|expired.*session|invalid.*resume/i.test(msg)) {
     return new TalonError(msg, {
       reason: "session_expired",
       retryable: false,

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -49,12 +49,17 @@ export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
           // Wrap in AbortError to prevent further retries
           throw new AbortError(classified);
         }
-        const delayMs =
-          classified.retryAfterMs ?? 1000 * Math.pow(2, attempt - 1);
+        const pRetryDelay = 1000 * Math.pow(2, attempt - 1);
+        const delayMs = classified.retryAfterMs ?? pRetryDelay;
         log(
           "gateway",
           `Retry ${attempt}/3 (${classified.reason}) after ${delayMs}ms`,
         );
+        if (classified.retryAfterMs && classified.retryAfterMs > pRetryDelay) {
+          await new Promise<void>((resolve) =>
+            setTimeout(resolve, classified.retryAfterMs! - pRetryDelay),
+          );
+        }
         throw classified; // rethrow to trigger p-retry delay
       }
     },
@@ -194,7 +199,7 @@ export class Gateway {
       // String-id routing (Teams) — must match an active context.
       chatId = this.findContextByStringId(rawChatId);
     }
-    if (!chatId) {
+    if (chatId === null) {
       return { ok: false, error: "No active chat context" };
     }
 

--- a/src/core/pulse.ts
+++ b/src/core/pulse.ts
@@ -55,6 +55,7 @@ export function enablePulse(chatId: string): void {
 
 export function disablePulse(chatId: string): void {
   setChatPulse(chatId, false);
+  registeredChats.delete(chatId);
 }
 
 /** Clear pulse checkpoint for a chat (call on /reset to avoid stale state). */

--- a/src/core/triggers.ts
+++ b/src/core/triggers.ts
@@ -24,7 +24,7 @@
  * Knows nothing about backend or frontend — dependencies are injected.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createWriteStream, readFileSync, type WriteStream } from "node:fs";
 import { createInterface } from "node:readline";
 import { execute as dispatcherExecute } from "./dispatcher.js";
@@ -226,7 +226,7 @@ function commandForLanguage(
 ): { cmd: string; args: string[] } | null {
   switch (lang) {
     case "bash":
-      return { cmd: "bash", args: [] };
+      return commandForBash();
     case "python":
       return {
         cmd: process.platform === "win32" ? "python" : "python3",
@@ -235,6 +235,25 @@ function commandForLanguage(
     case "node":
       return { cmd: "node", args: [] };
   }
+}
+
+function commandForBash(): { cmd: string; args: string[] } | null {
+  const candidates =
+    process.platform === "win32"
+      ? [
+          "bash",
+          "C:\\Program Files\\Git\\bin\\bash.exe",
+          "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+        ]
+      : ["bash"];
+  for (const cmd of candidates) {
+    const probe = spawnSync(cmd, ["-lc", "exit 0"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    if (probe.status === 0) return { cmd, args: [] };
+  }
+  return null;
 }
 
 // ── Stdout handling ─────────────────────────────────────────────────────────

--- a/src/frontend/teams/actions.ts
+++ b/src/frontend/teams/actions.ts
@@ -75,7 +75,7 @@ export function createTeamsActionHandler(
         }
       }
 
-      // Graceful no-ops for unsupported actions
+      // These actions are not supported on the Teams frontend.
       case "react":
       case "edit_message":
       case "delete_message":
@@ -84,7 +84,10 @@ export function createTeamsActionHandler(
       case "forward_message":
       case "copy_message":
       case "send_chat_action":
-        return { ok: true };
+        return {
+          ok: false,
+          error: `Action "${action}" is not supported on Teams`,
+        };
 
       case "get_chat_info":
         return {

--- a/src/frontend/teams/graph.ts
+++ b/src/frontend/teams/graph.ts
@@ -98,6 +98,7 @@ async function postForm(
     body,
     signal: AbortSignal.timeout(15_000),
   });
+  if (!resp.ok) throw new Error(`OAuth request failed: HTTP ${resp.status}`);
   return (await resp.json()) as Record<string, unknown>;
 }
 
@@ -246,7 +247,7 @@ export class GraphClient {
 
   async getChatMessages(chatId: string, top = 20): Promise<ChatMessage[]> {
     const data = await this.graphGet(
-      `/me/chats/${chatId}/messages?$top=${top}`,
+      `/me/chats/${encodeURIComponent(chatId)}/messages?$top=${top}`,
     );
 
     const raw = data.value as Array<Record<string, unknown>>;

--- a/src/frontend/telegram/actions.ts
+++ b/src/frontend/telegram/actions.ts
@@ -253,6 +253,13 @@ export function createTelegramActionHandler(
 
       case "schedule_message": {
         const text = String(body.text ?? "");
+        const replyTo =
+          typeof body.reply_to_message_id === "number"
+            ? body.reply_to_message_id
+            : undefined;
+        const rows = body.rows as
+          | Array<Array<{ text: string; url?: string; callback_data?: string }>>
+          | undefined;
         const delaySec = Math.max(
           1,
           Math.min(3600, Number(body.delay_seconds ?? 60)),
@@ -260,7 +267,25 @@ export function createTelegramActionHandler(
         const scheduleId = `sched_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
         const timer = setTimeout(async () => {
           try {
-            await sendText(bot, chatId, text);
+            if (rows) {
+              const keyboard = rows.map((row) =>
+                row.map((btn) =>
+                  btn.url
+                    ? { text: btn.text, url: btn.url }
+                    : {
+                        text: btn.text,
+                        callback_data: btn.callback_data ?? btn.text,
+                      },
+                ),
+              );
+              await bot.api.sendMessage(chatId, markdownToTelegramHtml(text), {
+                parse_mode: "HTML",
+                reply_markup: { inline_keyboard: keyboard },
+                reply_parameters: replyTo ? { message_id: replyTo } : undefined,
+              });
+            } else {
+              await sendText(bot, chatId, text, replyTo);
+            }
           } catch (err) {
             logError("bot", `Scheduled message failed (chat=${chatId})`, err);
           }
@@ -293,7 +318,7 @@ export function createTelegramActionHandler(
           : undefined;
         const captionParseMode = caption ? ("HTML" as const) : undefined;
         gateway.incrementMessages(chatId);
-        if (action === "send_file") {
+        {
           const stat = statSync(filePath);
           if (stat.size > 49 * 1024 * 1024)
             return { ok: false, error: "File too large (max 49MB)" };
@@ -577,6 +602,8 @@ export function createTelegramActionHandler(
         return { ok: false, error: "User client not connected." };
 
       case "save_sticker_pack": {
+        if (!isUserClientReady())
+          return { ok: false, error: "User client not connected." };
         const text = await userbotSaveStickerPack({
           setName: String(body.set_name ?? ""),
           bot,

--- a/src/frontend/telegram/admin.ts
+++ b/src/frontend/telegram/admin.ts
@@ -91,6 +91,7 @@ export async function handleAdminCommand(
         try {
           await bot.api.sendMessage(id, text);
           sent++;
+          await new Promise((r) => setTimeout(r, 40));
         } catch {
           failed++;
         }

--- a/src/frontend/telegram/commands.ts
+++ b/src/frontend/telegram/commands.ts
@@ -493,7 +493,7 @@ export function registerCommands(
   });
 
   bot.command("admin", async (ctx) => {
-    if (ctx.from?.id !== ADMIN_USER_ID) {
+    if (ADMIN_USER_ID !== 0 && ctx.from?.id !== ADMIN_USER_ID) {
       await ctx.reply("Not authorized.");
       return;
     }

--- a/src/frontend/terminal/input.ts
+++ b/src/frontend/terminal/input.ts
@@ -289,6 +289,11 @@ export function createInput(promptStr: string): InputHandler {
       paused = false;
     },
     close() {
+      if (pendingResolve) {
+        const resolve = pendingResolve;
+        pendingResolve = null;
+        resolve("");
+      }
       process.stdout.write("\x1b[?2004l");
       if (process.stdin.isTTY) process.stdin.setRawMode(false);
       process.stdin.pause();

--- a/src/storage/cron-store.ts
+++ b/src/storage/cron-store.ts
@@ -46,7 +46,7 @@ export function loadCronJobs(): void {
       if (Array.isArray(raw)) {
         for (const job of raw) store[job.id] = job;
       } else {
-        store = raw;
+        store = (raw as Record<string, CronJob> | null) ?? {};
       }
     }
   } catch {
@@ -57,7 +57,7 @@ export function loadCronJobs(): void {
         const raw = JSON.parse(readFileSync(bakFile, "utf-8"));
         store = Array.isArray(raw)
           ? Object.fromEntries(raw.map((j: CronJob) => [j.id, j]))
-          : raw;
+          : ((raw as Record<string, CronJob> | null) ?? {});
         log("cron", "Loaded from backup (primary was corrupt)");
       }
     } catch {
@@ -148,7 +148,7 @@ export function validateCronExpression(
     const nextDate = cron.nextRun();
     return {
       valid: true,
-      next: (nextDate as Date).toISOString(),
+      next: nextDate?.toISOString(),
     };
   } catch (err) {
     return {

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -131,7 +131,8 @@ export function pushMessage(chatId: string, msg: HistoryMessage): void {
       const iter = chatHistories.keys();
       for (let i = 0; i < evictCount; i++) {
         const oldest = iter.next();
-        chatHistories.delete(oldest.value as string);
+        if (oldest.done) break;
+        chatHistories.delete(oldest.value);
       }
       // Mark dirty so evicted chats are removed from disk on next save
       dirty = true;

--- a/src/storage/trigger-store.ts
+++ b/src/storage/trigger-store.ts
@@ -96,15 +96,15 @@ let dirty = false;
 export function loadTriggers(): void {
   try {
     if (existsSync(STORE_FILE)) {
-      const raw = JSON.parse(readFileSync(STORE_FILE, "utf-8"));
-      store = typeof raw === "object" && raw !== null ? raw : {};
+      const raw: unknown = JSON.parse(readFileSync(STORE_FILE, "utf-8"));
+      store = normalizeTriggerStore(raw);
     }
   } catch {
     const bakFile = STORE_FILE + ".bak";
     try {
       if (existsSync(bakFile)) {
-        const raw = JSON.parse(readFileSync(bakFile, "utf-8"));
-        store = typeof raw === "object" && raw !== null ? raw : {};
+        const raw: unknown = JSON.parse(readFileSync(bakFile, "utf-8"));
+        store = normalizeTriggerStore(raw);
         log("triggers", "Loaded from backup (primary was corrupt)");
       }
     } catch {
@@ -156,6 +156,24 @@ export function loadTriggers(): void {
   }
 }
 
+function normalizeTriggerStore(raw: unknown): Record<string, Trigger> {
+  if (Array.isArray(raw)) {
+    return Object.fromEntries(
+      raw
+        .filter(
+          (t): t is Trigger =>
+            typeof t === "object" &&
+            t !== null &&
+            typeof (t as { id?: unknown }).id === "string",
+        )
+        .map((t) => [t.id, t]),
+    );
+  }
+  return typeof raw === "object" && raw !== null
+    ? (raw as Record<string, Trigger>)
+    : {};
+}
+
 function save(): void {
   if (!dirty) return;
   try {
@@ -184,6 +202,7 @@ registerCleanup(save);
 
 export function flushTriggers(): void {
   clearInterval(autoSaveTimer);
+  dirty = true;
   save();
 }
 


### PR DESCRIPTION
## Summary

Consolidates the valid/current correctness fixes from the remaining stale open PRs onto current `main` after the Agy/Antigravity removal. I reviewed the old PR intent and ported the pieces that still apply instead of taking the branches wholesale; stale backend-specific changes and broad logging/bootstrap churn were intentionally left out.

Key areas covered:
- Fix built-in OpenAI Agents lifecycle/discovery behavior on Windows by using PowerShell for the built-in Bash tool and skipping bash trigger probes when no usable bash exists.
- Honor retry delays and preserve valid `chat_id=0` routing.
- Make Claude flow violations retry rather than silently drop turns.
- Harden cron/session/trigger/history storage paths against null and migration edge cases.
- Preserve dream `last_run` during running/failure states.
- Clean up pulse disable registration state.
- Tighten Teams, Telegram, terminal, CLI doctor, and terminal chat correctness issues.
- Increase Windows timeout tolerance for the flaky backend/model handler tests.

## Supersedes

Intended to supersede/replace #232, #220, #212, #205, #200, #168, #162, #152, and the still-relevant low-risk parts of #90.

## Validation

- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- Prettier check over touched files
- `npx vitest run --exclude src/__tests__/package.functional.test.ts --reporter=dot`
- Targeted tests for OpenAI Agents discovery, triggers, Teams, Claude watchdog, backend registry, Codex handler, and related changed areas

The full package install smoke test was not rerun successfully on this Windows machine because local disk space hit `ENOSPC`; the broad suite excluding that package smoke passed.