### PR TITLE
fix: five correctness bugs from deep code review

### DIFF
--- a/src/__tests__/triggers-extended.test.ts
+++ b/src/__tests__/triggers-extended.test.ts
@@ -272,7 +272,11 @@ describe("triggers — resumeAfterRestart", () => {
     expect(call.prompt).toMatch(/terminated/);
   });
 
-  it("does NOT fire for a trigger that already fired", async () => {
+  it("fires for a trigger that had mid-run TALON_FIRE: events but was then terminated", async () => {
+    // A long-running watcher may have emitted TALON_FIRE: signals (setting
+    // lastFireAt) but was still running when Talon restarted. The bot received
+    // earlier fire events but never received the terminal "terminated" wake —
+    // it must get one on restart so it knows the trigger was killed.
     const id = generateTriggerId();
     const t: Trigger = {
       id,
@@ -287,12 +291,15 @@ describe("triggers — resumeAfterRestart", () => {
       endedAt: Date.now() - 5_000,
       timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
       fireCount: 1,
-      lastFireAt: Date.now() - 6_000, // has already fired → condition excludes it
+      lastFireAt: Date.now() - 6_000,
     };
     addTrigger(t);
 
     await resumeAfterRestart();
-    expect(executeSpy).not.toHaveBeenCalled();
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    const call = executeSpy.mock.calls[0][0];
+    expect(call.chatId).toBe("chat-resume2");
+    expect(call.prompt).toMatch(/terminated/);
   });
 
   it("does NOT fire for an old terminated trigger (>5 min ago)", async () => {

--- a/src/core/cron.ts
+++ b/src/core/cron.ts
@@ -136,7 +136,7 @@ async function withTimeout<T>(
   ms: number,
   label: string,
 ): Promise<T> {
-  let timer: ReturnType<typeof setTimeout>;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(
       () => reject(new Error(`${label} timed out after ${ms}ms`)),
@@ -146,7 +146,7 @@ async function withTimeout<T>(
   try {
     return await Promise.race([promise, timeout]);
   } finally {
-    clearTimeout(timer!);
+    clearTimeout(timer);
   }
 }
 

--- a/src/core/triggers.ts
+++ b/src/core/triggers.ts
@@ -562,10 +562,14 @@ export async function resumeAfterRestart(): Promise<void> {
     }
     if (
       t.status === "terminated" &&
-      t.lastFireAt === undefined &&
       t.endedAt &&
       Date.now() - t.endedAt < 5 * 60_000
     ) {
+      // Fire for all recently-terminated triggers regardless of whether they
+      // had previously sent mid-run TALON_FIRE: wakes. A long-running watcher
+      // that emitted fires before being killed by a restart still needs a
+      // terminal "terminated" notification — omitting it silently hides the
+      // trigger's death from the bot.
       await fireWake(t.id, "terminated", t.lastError, /* terminal */ true);
     }
   }

--- a/src/frontend/telegram/formatting.ts
+++ b/src/frontend/telegram/formatting.ts
@@ -80,11 +80,14 @@ export function markdownToTelegramHtml(text: string): string {
   );
   // Italic: _text_ (surrounded by non-word or start/end)
   processed = processed.replace(/(?<!\w)_(.+?)_(?!\w)/g, "<i>$1</i>");
-  // Links: [text](url) — only allow safe URL schemes; escape the URL to
-  // prevent HTML attribute injection (e.g. href="url" onmouseover="x")
+  // Links: [text](url) — only allow safe URL schemes.
+  // NOTE: `url` is already HTML-escaped from step 3 (the global entity-escape
+  // pass ran over the entire text including link targets). Re-applying
+  // escapeHtml here would double-encode `&` as `&amp;amp;`, breaking any URL
+  // that contains query-string parameters (e.g. `?a=1&b=2`).
   processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) =>
     /^https?:\/\//i.test(url)
-      ? `<a href="${escapeHtml(url)}">${text}</a>`
+      ? `<a href="${url}">${text}</a>`
       : text,
   );
   // Strikethrough: ~~text~~

--- a/src/frontend/telegram/formatting.ts
+++ b/src/frontend/telegram/formatting.ts
@@ -86,9 +86,7 @@ export function markdownToTelegramHtml(text: string): string {
   // escapeHtml here would double-encode `&` as `&amp;amp;`, breaking any URL
   // that contains query-string parameters (e.g. `?a=1&b=2`).
   processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) =>
-    /^https?:\/\//i.test(url)
-      ? `<a href="${url}">${text}</a>`
-      : text,
+    /^https?:\/\//i.test(url) ? `<a href="${url}">${text}</a>` : text,
   );
   // Strikethrough: ~~text~~
   processed = processed.replace(/~~(.+?)~~/g, "<s>$1</s>");

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -47,11 +47,21 @@ let dirty = false;
 export function loadHistory(): void {
   try {
     if (existsSync(STORE_FILE)) {
-      const raw = JSON.parse(readFileSync(STORE_FILE, "utf-8")) as Record<
-        string,
-        HistoryMessage[]
-      >;
+      const parsed: unknown = JSON.parse(readFileSync(STORE_FILE, "utf-8"));
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        logError(
+          "history",
+          "History file has unexpected format — starting fresh",
+        );
+        return;
+      }
+      const raw = parsed as Record<string, HistoryMessage[]>;
       for (const [chatId, messages] of Object.entries(raw)) {
+        if (!Array.isArray(messages)) continue;
         // Only load recent messages (cap per chat)
         const trimmed = messages.slice(-MAX_HISTORY_PER_CHAT);
         chatHistories.set(chatId, trimmed);

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -68,7 +68,20 @@ function ensureDir(): void {
 export function loadSessions(): void {
   try {
     if (existsSync(STORE_FILE)) {
-      store = JSON.parse(readFileSync(STORE_FILE, "utf-8"));
+      const parsed: unknown = JSON.parse(readFileSync(STORE_FILE, "utf-8"));
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        logError(
+          "sessions",
+          "Session file has unexpected format — starting fresh",
+        );
+        store = {};
+        return;
+      }
+      store = parsed as SessionStore;
     }
   } catch {
     // Primary file corrupt — try backup


### PR DESCRIPTION
## Summary

Deep audit of the codebase identified five distinct bugs spanning formatting, storage, scheduling, and trigger lifecycle. All are confirmed, all tests pass (2828 ✓, 34 skipped — same as `main`).

---

### Bug 1 — Double HTML-escaping of URLs in `markdownToTelegramHtml` (`formatting.ts`)

**Symptom:** Any Markdown link whose URL contains `&` (e.g. query-string parameters) is rendered broken in Telegram. `[Click here](https://example.com?a=1&b=2)` produces `href="…?a=1&amp;amp;b=2"` instead of the correct `href="…?a=1&amp;b=2"`.

**Root cause:** The function has a deliberate step 3 that HTML-escapes the *entire* working string (plain text segments between code-block / inline-code placeholders), including Markdown link syntax. By the time step 4 processes `[text](url)`, the `url` capture group already contains `&amp;` from step 3. The call `escapeHtml(url)` then escapes *that*, yielding `&amp;amp;`.

**Fix:** Replace `escapeHtml(url)` with just `url` in the link-replacement regex handler. The URL is already safely escaped from step 3.

---

### Bug 2 — Missing termination wake for triggers that previously fired (`triggers.ts`)

**Symptom:** A long-running watcher that sent mid-run `TALON_FIRE:` signals and was subsequently killed by a Talon restart never receives a terminal "terminated" wake notification. The bot silently loses awareness that the trigger was killed.

**Root cause:** `resumeAfterRestart()` had the condition `t.lastFireAt === undefined`, which excluded any trigger that had ever called `fireWake` (i.e. sent a `TALON_FIRE:` event). The intent was to avoid redundant wakes, but the effect is that mid-run multi-event triggers disappear silently on restart.

**Fix:** Remove the `t.lastFireAt === undefined` guard. All recently-terminated triggers (within the 5-minute window) now receive a restart wake. The test description and assertion updated to match the correct behaviour.

---

### Bug 3 — Session store crashes on malformed JSON (`sessions.ts`)

**Symptom:** If `sessions.json` contains valid JSON that is not a plain object (e.g. `null`, `[]`, a number), the process crashes with an uncaught `TypeError: Cannot read properties of null` at the first `store[chatId]` access in `getSession()`.

**Root cause:** `loadSessions()` did `store = JSON.parse(...)` with no type guard. `JSON.parse` succeeds and assigns `null` (or an array, etc.) to `store`, and Node does not catch this until the next message is processed.

**Fix:** Validate the parsed value is a plain non-null non-array object; if not, log a warning and reset to `{}`.

---

### Bug 4 — History store crashes on malformed JSON (`history.ts`)

**Symptom:** Same class of crash as Bug 3. If `history.json` contains a non-object at the top level, `Object.entries(raw)` throws `TypeError` and the entire process crashes on the next history write.

**Fix:** Same pattern — validate the deserialized value before iterating. Additionally added a per-entry `Array.isArray(messages)` guard so one malformed chat cannot abort loading for all other chats.

---

### Bug 5 — `withTimeout` uses non-null assertion on a possibly-uninitialized variable (`cron.ts`)

**Symptom:** `let timer: ReturnType<typeof setTimeout>` is declared without an initializer, then referenced as `clearTimeout(timer!)` in the `finally` block. TypeScript strict mode emits a diagnostic here. While the runtime works (the `new Promise` callback assigns `timer` synchronously), the `!` assertion hides any future refactoring that might break this guarantee.

**Fix:** Declare `timer` as `ReturnType<typeof setTimeout> | undefined` and call `clearTimeout(timer)` unconditionally (which is a no-op when `undefined`).

---

## Test plan

- [x] `npm test` — 2828 tests pass, 34 skipped (no regressions)
- [x] `triggers-extended.test.ts` — updated to assert the new correct restart-wake behaviour
- [x] TypeScript strict types remain clean (no `timer!` assertion, proper union type)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LaNH9PYx6XiPxGwE1bg9pL)_