### PR TITLE
fix: four correctness bugs from deep code review

### DIFF
--- a/src/backend/codex/handler.ts
+++ b/src/backend/codex/handler.ts
@@ -281,12 +281,15 @@ async function maybeFallbackForChatGptMismatch(
         : ``),
   );
   resetSession(chatId);
-  const originalModel = getChatSettings(chatId).model;
   setChatModel(chatId, fallbackModel);
   try {
     return await handleMessage(params, true);
   } finally {
-    setChatModel(chatId, originalModel);
+    // Restore the model that was active before the fallback. `activeModel`
+    // is always a non-undefined string, so this avoids the
+    // `setChatModel(chatId, undefined)` "reset everything" path that would
+    // wipe the entire modelByBackend map for migrated chats.
+    setChatModel(chatId, activeModel);
   }
 }
 

--- a/src/backend/shared/handle-retry.ts
+++ b/src/backend/shared/handle-retry.ts
@@ -26,7 +26,7 @@ import type { QueryParams, QueryResult } from "../../core/types.js";
 import { classify, type TalonError } from "../../core/errors.js";
 import { logWarn } from "../../util/log.js";
 import { incrementCounter } from "../../util/metrics.js";
-import { getChatSettings, setChatModel } from "../../storage/chat-settings.js";
+import { setChatModel } from "../../storage/chat-settings.js";
 import { resetSession } from "../../storage/sessions.js";
 import { classifyRetry } from "./model-retry.js";
 
@@ -128,12 +128,15 @@ export async function applyRetryDecision(
       `[${chatId}] ${classified.reason}, falling back to ${decision.fallbackModelId}`,
     );
     resetSession(chatId);
-    const originalModel = getChatSettings(chatId).model;
     setChatModel(chatId, decision.fallbackModelId);
     try {
       return { retry: await recurseWithRetried(params), classified };
     } finally {
-      setChatModel(chatId, originalModel);
+      // Restore the model that was active before the fallback. `activeModel`
+      // is always a non-undefined string, so this avoids the
+      // `setChatModel(chatId, undefined)` "reset everything" path that would
+      // wipe the entire modelByBackend map for migrated chats.
+      setChatModel(chatId, activeModel);
     }
   }
 

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -200,7 +200,15 @@ export async function initBackendAndDispatcher(
       }
     }
 
-    const currentModel = getAllChatSettings()[cid]?.model;
+    // After migrateLegacyModelField, the canonical model lives in
+    // modelByBackend[boundBackend], not in the legacy .model field. Check
+    // both so pre-migration chats (if any) and post-migration chats are
+    // both validated.
+    const latestSettings = getAllChatSettings()[cid];
+    const boundBackendId = latestSettings?.backend ?? config.backend;
+    const currentModel =
+      latestSettings?.modelByBackend?.[boundBackendId] ??
+      latestSettings?.model;
     if (currentModel) {
       const be = getBackendForChat(cid);
       try {

--- a/src/util/mcp-launcher.mjs
+++ b/src/util/mcp-launcher.mjs
@@ -67,16 +67,15 @@ process.stdin.pipe(child.stdin);
 // Tolerant MCP clients (e.g. the claude binary) see exactly what they
 // did before — this is a no-op for clean servers.
 {
-  // Quick discriminator: a JSON-RPC line must start with `{` (objects).
-  // The MCP spec permits array batches (`[`) but our plugins only emit
-  // objects, and several plugins log lines that START with `[` (e.g.
-  // tailscale-mcp's `[ISO-timestamp] [INFO] …`). Restrict to `{` and
-  // verify it's parseable JSON before forwarding, so a stray
-  // `{ tip: "..." }` shell-style line that isn't valid JSON still
-  // goes to stderr.
+  // Quick discriminator: a JSON-RPC line must start with `{` (object) or
+  // `[` (batch array). Several plugins log lines starting with `[` (e.g.
+  // tailscale-mcp's `[ISO-timestamp] [INFO] …`), but those are not valid
+  // JSON — requiring a successful JSON.parse before forwarding ensures they
+  // still go to stderr. Accepting `[` is necessary for servers that send
+  // JSON-RPC batch responses per the MCP spec.
   const looksJson = (line) => {
     const s = line.trimStart();
-    if (s.length === 0 || s[0] !== "{") return false;
+    if (s.length === 0 || (s[0] !== "{" && s[0] !== "[")) return false;
     try {
       JSON.parse(s);
       return true;


### PR DESCRIPTION
## Summary

Deep review of the recent model-resolver / per-backend storage changes found four confirmed bugs. All are fixed in this PR.

---

### Bug 1 — `handle-retry`: fallback-model restore nukes `modelByBackend` for migrated chats

**File:** `src/backend/shared/handle-retry.ts:131`

```ts
// before
const originalModel = getChatSettings(chatId).model;   // ← undefined post-migration
setChatModel(chatId, decision.fallbackModelId);
try { ... } finally {
  setChatModel(chatId, originalModel);  // ← setChatModel(cid, undefined) = wipe everything
}
```

`migrateLegacyModelField` (called at boot) moves all model values out of the legacy `settings.model` field into `modelByBackend[backendId]` and clears `settings.model`. So `getChatSettings(chatId).model` is `undefined` for every migrated chat. `setChatModel(chatId, undefined)` triggers the "reset everything" branch that deletes the entire `modelByBackend` map, permanently clearing all per-backend overrides.

**Fix:** restore `activeModel` (already in scope as a parameter — it's the model that was running when the error fired) instead of reading the now-empty legacy field.

---

### Bug 2 — `codex/handler`: same destroy-on-restore in `maybeFallbackForChatGptMismatch`

**File:** `src/backend/codex/handler.ts:284`

Identical pattern: `getChatSettings(chatId).model` is read to save `originalModel`, then restored via `setChatModel(chatId, originalModel)` in `finally`. Post-migration this calls `setChatModel(chatId, undefined)` and wipes `modelByBackend`.

**Fix:** use the `activeModel` parameter (already passed to `maybeFallbackForChatGptMismatch`).

---

### Bug 3 — `bootstrap`: per-chat model validation is a no-op for all migrated chats

**File:** `src/bootstrap.ts:203`

```ts
migrateLegacyModelField(config.backend, ...);  // clears settings.model → moves to modelByBackend
// ...
const currentModel = getAllChatSettings()[cid]?.model;  // always undefined post-migration
if (currentModel) { /* validate — never reached */ }
```

The validation loop is meant to evict stale model IDs at startup, but reads the legacy field that was just cleared by `migrateLegacyModelField`. Stale model IDs in `modelByBackend` were never evicted, causing every subsequent turn on a removed/renamed model to fail.

**Fix:** resolve the current model from `modelByBackend[boundBackend]` first, falling back to the legacy `.model` field so pre-migration entries are still covered.

---

### Bug 4 — `mcp-launcher`: JSON-RPC batch responses silently discarded to stderr

**File:** `src/util/mcp-launcher.mjs:77`

```js
const looksJson = (line) => {
  const s = line.trimStart();
  if (s.length === 0 || s[0] !== "{") return false;  // ← rejects '[' entirely
  ...
};
```

The MCP spec permits batch responses as JSON arrays (`[{...}]`). The filter rejects any line whose first character is not `{`, so batch responses are silently rerouted to stderr and the caller never receives the result — RPC calls using batch protocol hang or time out with no error surfaced.

The stated reason for the `{`-only restriction was to filter out plugin log lines like `[ISO-timestamp] [INFO] …`. But those lines are not parseable JSON and already fail the `JSON.parse` check — accepting `[` with the same parse-verification step rejects the noisy log lines while correctly forwarding valid batch arrays.

**Fix:** change the discriminator to `s[0] !== "{" && s[0] !== "["`.

---

## Additional findings (not fixed here, need discussion)

- **`src/backend/claude-sdk/handler.ts:90`** — Separate `flowRetries` / `errorRetried` counters are now independent; a single user message can accumulate up to 4 API calls (1 error retry + 3 flow retries) vs the old combined cap of 2. Worth deciding whether a combined ceiling should be added.
- **`src/backend/codex/discovery.ts:123`** — `isCodexCompatibleModel` rejects any model whose ID contains the substring `search`, which would also exclude a future model named e.g. `gpt-5-research-preview`. Consider anchoring the exclusion regex.

## Test plan

- [ ] Trigger a Codex ChatGPT OAuth mismatch error on a chat that has a per-backend model override; confirm the override survives the retry instead of being wiped.
- [ ] Trigger a `fallback_model` retry path in any backend (e.g. kilo/opencode context-length); confirm `modelByBackend` is intact after the retry.
- [ ] Boot Talon with a chat store that has a stale/removed model in `modelByBackend`; confirm the startup log reports the invalid model and resets it.
- [ ] Connect an MCP server that sends batch JSON-RPC responses; confirm they are forwarded to stdout rather than stderr.

https://claude.ai/code/session_01XCciyFoGCgmjTUicZer2ev

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCciyFoGCgmjTUicZer2ev)_