### PR TITLE
fix(agent-runtime): three correctness bugs in adapter and legacy-bridge

### DIFF
--- a/src/core/agent-runtime/adapter.ts
+++ b/src/core/agent-runtime/adapter.ts
@@ -147,17 +147,21 @@ export function adaptQueryBackend(
       }
     : undefined;
 
-  const sessions: SessionBackend | undefined =
-    legacy.resetChat || legacy.warmSession
-      ? {
-          resetChat(chatId) {
-            return legacy.resetChat?.(chatId);
-          },
-          warmSession: legacy.warmSession
-            ? (chatId) => legacy.warmSession!(chatId)
-            : undefined,
-        }
-      : undefined;
+  // Only advertise session support when resetChat is actually implemented.
+  // warmSession is a cold-start optimisation hint that can only be meaningful
+  // alongside reset support — advertising sessions: true with a no-op resetChat
+  // (because only warmSession was defined) misleads callers into believing they
+  // can reset the session when they actually cannot.
+  const sessions: SessionBackend | undefined = legacy.resetChat
+    ? {
+        resetChat(chatId) {
+          return legacy.resetChat!(chatId);
+        },
+        warmSession: legacy.warmSession
+          ? (chatId) => legacy.warmSession!(chatId)
+          : undefined,
+      }
+    : undefined;
 
   const tools: ToolRuntime | undefined = legacy.refreshMcpServers
     ? {

--- a/src/core/agent-runtime/legacy-bridge.ts
+++ b/src/core/agent-runtime/legacy-bridge.ts
@@ -128,6 +128,23 @@ export async function pipeEventsToCallbacks(
         break;
       }
       case "tool_call": {
+        if (
+          !isPlainObject(event.input) &&
+          event.input !== undefined &&
+          event.input !== null
+        ) {
+          // The legacy onToolUse contract requires Record<string, unknown>, so
+          // non-plain-object inputs (e.g. arrays emitted by Phase 3 backends)
+          // cannot be forwarded verbatim. Log the data loss so operators can
+          // diagnose if a tool receives empty args when it shouldn't.
+          const typeLabel = Array.isArray(event.input)
+            ? "array"
+            : typeof event.input;
+          console.warn(
+            `[legacy-bridge] tool_call "${event.name}": input is ${typeLabel}, ` +
+              `not a plain object — bridging to {} (legacy onToolUse accepts only Record<string, unknown>).`,
+          );
+        }
         const input = isPlainObject(event.input)
           ? (event.input as Record<string, unknown>)
           : {};
@@ -178,7 +195,6 @@ export async function reduceEventsToResult(
   let usage = emptyUsage();
   let modelId: string | undefined;
   let durationMs = 0;
-  let saw = false;
 
   for await (const event of stream) {
     switch (event.type) {
@@ -193,7 +209,6 @@ export async function reduceEventsToResult(
         if (event.usage.modelId) modelId = event.usage.modelId;
         break;
       case "completed":
-        saw = true;
         if (event.result) {
           return event.result;
         }
@@ -205,10 +220,11 @@ export async function reduceEventsToResult(
     }
   }
 
-  // No completed event seen — synthesise from observed deltas.
-  // Phase 3.x backends should always emit `completed`; falling
-  // through here means the stream ended on a non-terminator,
-  // which is a backend contract violation but not catastrophic.
+  // Stream ended without a `completed` terminator, OR the `completed`
+  // event carried no result. Phase 3.x backends should always emit
+  // `completed` with a result; falling through here means the stream
+  // ended on a non-terminator, which is a backend contract violation
+  // but not catastrophic — synthesise from observed deltas.
   return {
     text,
     durationMs,


### PR DESCRIPTION
## Summary

Deep code review of the `main...HEAD` diff surfaced three correctness bugs in the new `agent-runtime` infrastructure (Phase 1–2). All are in code that has **no production callers yet**, which means they would have silently shipped as-is into Phase 3+ without being caught by tests. All 2990 tests pass before and after this fix.

---

## Bug 1 — `adapter.ts`: `sessions` capability falsely advertised when only `warmSession` is defined

**File:** `src/core/agent-runtime/adapter.ts`

**Root cause:**

```ts
// BEFORE (buggy)
const sessions: SessionBackend | undefined =
  legacy.resetChat || legacy.warmSession  // ← OR: too broad
    ? {
        resetChat(chatId) {
          return legacy.resetChat?.(chatId);  // ← silent no-op when resetChat is undefined
        },
        ...
      }
    : undefined;
```

If a legacy backend defined only `warmSession` (no `resetChat`), the adapter would:
1. Set `capabilities.sessions = true`
2. Provide a `sessions.resetChat()` method that calls `legacy.resetChat?.()` — which returns `undefined` and does nothing

Callers checking `backend.capabilities.sessions` would believe the backend supports session reset, call `sessions.resetChat(chatId)`, and silently get a no-op. No error, no log, no reset.

**Fix:** Guard session object creation on `legacy.resetChat` being defined. `warmSession` is still forwarded when both are present.

```ts
// AFTER (fixed)
const sessions: SessionBackend | undefined = legacy.resetChat  // ← AND: precise
  ? {
      resetChat(chatId) {
        return legacy.resetChat!(chatId);  // ← non-null assertion safe; guarded above
      },
      warmSession: legacy.warmSession
        ? (chatId) => legacy.warmSession!(chatId)
        : undefined,
    }
  : undefined;
```

---

## Bug 2 — `legacy-bridge.ts`: non-plain-object tool inputs silently discarded

**File:** `src/core/agent-runtime/legacy-bridge.ts`

**Root cause:**

The `tool_call` event in `events.ts` types `input` as `unknown` — valid values include arrays and other non-plain objects. The legacy `onToolUse` callback requires `Record<string, unknown>`, so the bridge must convert. The old code silently replaced any non-plain-object input with `{}`:

```ts
// BEFORE (buggy)
const input = isPlainObject(event.input)
  ? (event.input as Record<string, unknown>)
  : {};  // ← array inputs become {}, data gone, no warning
callbacks.onToolUse?.(event.name, input);
```

A Phase 3 backend emitting `{ type: "tool_call", name: "write_file", input: ["a", "b"] }` would silently have `["a", "b"]` replaced with `{}` before reaching `onToolUse`. The tool would receive empty arguments.

**Fix:** Add a `console.warn` when data loss occurs, so operators can identify backends producing array-shaped tool inputs before the bridge strips them.

```ts
// AFTER (fixed)
if (!isPlainObject(event.input) && event.input !== undefined && event.input !== null) {
  const typeLabel = Array.isArray(event.input) ? "array" : typeof event.input;
  console.warn(
    `[legacy-bridge] tool_call "${event.name}": input is ${typeLabel}, ` +
      `not a plain object — bridging to {} ...`,
  );
}
const input = isPlainObject(event.input)
  ? (event.input as Record<string, unknown>)
  : {};
callbacks.onToolUse?.(event.name, input);
```

---

## Bug 3 — `legacy-bridge.ts`: dead-code `saw` variable in `reduceEventsToResult`

**File:** `src/core/agent-runtime/legacy-bridge.ts`

**Root cause:**

```ts
// BEFORE (buggy)
let saw = false;
...
case "completed":
  saw = true;
  if (event.result) { return event.result; }
  break;
...
return {
  text, durationMs, usage,
  ...(modelId ? { modelId } : {}),
  // saw === false means we hit the silent-stream path
  ...(saw ? {} : {}),   // ← BOTH branches spread {}.  saw has zero effect.
};
```

`...(saw ? {} : {})` always spreads an empty object. The `saw` flag was computed correctly (set `true` when a `completed` event with a falsy result was seen) but **had no effect on the returned value**. The comment claimed it distinguished a "silent-stream path" — but both paths produced identical output. This is dead code that would mislead any future engineer extending `reduceEventsToResult`.

**Fix:** Remove the `saw` variable and its meaningless spread; clarify the comment.

```ts
// AFTER (fixed)
// (no saw variable)
return {
  text, durationMs, usage,
  ...(modelId ? { modelId } : {}),
  // Stream ended without a completed terminator, or completed carried no
  // result — synthesise from observed deltas.
};
```

---

## Test results

```
Test Files  130 passed | 7 skipped (137)
     Tests  2990 passed | 41 skipped (3031)
```

https://claude.ai/code/session_01Ddo8qvtcTtq5NVU4SkwCCP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ddo8qvtcTtq5NVU4SkwCCP)_