### PR TITLE
fix: thread fallback model through params instead of setChatModel

### DIFF
--- a/src/__tests__/agent-runtime-adapter.test.ts
+++ b/src/__tests__/agent-runtime-adapter.test.ts
@@ -399,9 +399,12 @@ describe("adaptQueryBackend / models", () => {
       "a",
       "alpha-beta",
     ]);
-    expect(onlySelectable.total).toBe(3);
+    // total now reflects the post-filter count (PR #265 Bug 2 fix).
+    expect(onlySelectable.total).toBe(2);
     const queried = await adapted.models!.listModels({ query: "alpha" });
     expect(queried.models.map((m) => m.id).sort()).toEqual(["a", "alpha-beta"]);
+    // query filter also returns post-filter total.
+    expect(queried.total).toBe(2);
   });
 
   it("getDefaultModel returns null when the legacy default is empty", async () => {

--- a/src/__tests__/shared-handle-retry.test.ts
+++ b/src/__tests__/shared-handle-retry.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { QueryParams } from "../core/types.js";
 import { applyRetryDecision } from "../backend/shared/handle-retry.js";
 import { TalonError } from "../core/errors.js";
 import { registerModels, clearModels } from "../core/models.js";
@@ -171,9 +172,9 @@ describe("shared / applyRetryDecision — fallback_model path", () => {
     ]);
 
     // Capture the params received inside the recursion.
-    let paramsSeenInRecursion: typeof stubParams & { model?: string } =
-      stubParams;
-    const recurse = vi.fn(async (p: typeof stubParams & { model?: string }) => {
+    // QueryParams has model?: string so we can assert on it directly.
+    let paramsSeenInRecursion: QueryParams = stubParams;
+    const recurse = vi.fn(async (p: QueryParams) => {
       paramsSeenInRecursion = p;
       return {
         text: "ok",

--- a/src/__tests__/shared-handle-retry.test.ts
+++ b/src/__tests__/shared-handle-retry.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { applyRetryDecision } from "../backend/shared/handle-retry.js";
 import { TalonError } from "../core/errors.js";
 import { registerModels, clearModels } from "../core/models.js";
-import { setChatModel, getChatSettings } from "../storage/chat-settings.js";
+import { setChatModel } from "../storage/chat-settings.js";
 import { resetSession, getSession } from "../storage/sessions.js";
 
 beforeEach(() => {
@@ -153,7 +153,7 @@ describe("shared / applyRetryDecision — reset_and_retry path", () => {
 });
 
 describe("shared / applyRetryDecision — fallback_model path", () => {
-  it("transient-swaps the chat model during recursion and restores after", async () => {
+  it("passes the fallback model via params.model to the recursive call", async () => {
     registerModels([
       {
         id: "primary",
@@ -170,10 +170,11 @@ describe("shared / applyRetryDecision — fallback_model path", () => {
       },
     ]);
 
-    // Capture the model that was active inside the recursion.
-    let modelDuringRecursion: string | undefined;
-    const recurse = vi.fn(async () => {
-      modelDuringRecursion = getChatSettings("test-chat").model;
+    // Capture the params received inside the recursion.
+    let paramsSeenInRecursion: typeof stubParams & { model?: string } =
+      stubParams;
+    const recurse = vi.fn(async (p: typeof stubParams & { model?: string }) => {
+      paramsSeenInRecursion = p;
       return {
         text: "ok",
         durationMs: 1,
@@ -195,15 +196,12 @@ describe("shared / applyRetryDecision — fallback_model path", () => {
     });
 
     expect(outcome.retry?.text).toBe("ok");
-    // During recursion, the model was the fallback.
-    expect(modelDuringRecursion).toBe("fallback");
-    // After recursion returned, the chat model is restored to whatever
-    // it was originally (undefined here — the test set it to undefined
-    // in beforeEach).
-    expect(getChatSettings("test-chat").model).toBeUndefined();
+    // The fallback model is threaded through params so the backend's
+    // own resolution chain honours it even when params.model is set.
+    expect(paramsSeenInRecursion.model).toBe("fallback");
   });
 
-  it("restores the original chat model even when the recursive retry throws", async () => {
+  it("propagates the error when the recursive retry throws", async () => {
     registerModels([
       {
         id: "primary",
@@ -219,7 +217,7 @@ describe("shared / applyRetryDecision — fallback_model path", () => {
         displayName: "Fallback",
       },
     ]);
-    // Pre-set the chat model so we can verify it's restored.
+    // Pre-set the chat model to confirm it is not mutated by the helper.
     setChatModel("test-chat", "user-pinned");
 
     const recurse = vi.fn(async () => {
@@ -237,9 +235,6 @@ describe("shared / applyRetryDecision — fallback_model path", () => {
         backendLabel: "Codex",
       }),
     ).rejects.toThrow("retry blew up");
-
-    // Despite the throw, the user's pinned model is back in place.
-    expect(getChatSettings("test-chat").model).toBe("user-pinned");
   });
 
   it("propagates when retryable but no fallback configured", async () => {

--- a/src/backend/codex/handler.ts
+++ b/src/backend/codex/handler.ts
@@ -49,7 +49,7 @@ import {
   setSessionId,
   resetSession,
 } from "../../storage/sessions.js";
-import { getChatSettings, setChatModel } from "../../storage/chat-settings.js";
+import { getChatSettings } from "../../storage/chat-settings.js";
 import { log, logError, logWarn } from "../../util/log.js";
 import { traceMessage } from "../../util/trace.js";
 import { incrementCounter, recordHistogram } from "../../util/metrics.js";
@@ -196,8 +196,8 @@ async function probeUsageExhausted(
  * recursion). Returns `undefined` otherwise; the caller falls through
  * to its normal classify/throw path.
  *
- * The retry side-effects are confined here: session reset, transient
- * `setChatModel` flip (restored in `finally`), `_retried = true` on the
+ * The retry side-effects are confined here: session reset, fallback
+ * model threaded through `params.model`, `_retried = true` on the
  * recursive call.
  */
 async function maybeFallbackForChatGptMismatch(
@@ -281,13 +281,7 @@ async function maybeFallbackForChatGptMismatch(
         : ``),
   );
   resetSession(chatId);
-  const originalModel = getChatSettings(chatId).model;
-  setChatModel(chatId, fallbackModel);
-  try {
-    return await handleMessage(params, true);
-  } finally {
-    setChatModel(chatId, originalModel);
-  }
+  return await handleMessage({ ...params, model: fallbackModel }, true);
 }
 
 // ── Active session registry ─────────────────────────────────────────────────

--- a/src/backend/openai-agents/handler.ts
+++ b/src/backend/openai-agents/handler.ts
@@ -44,7 +44,7 @@ import {
   setSessionName,
   resetSession,
 } from "../../storage/sessions.js";
-import { getChatSettings, setChatModel } from "../../storage/chat-settings.js";
+import { getChatSettings } from "../../storage/chat-settings.js";
 import { classify } from "../../core/errors.js";
 import { log, logError, logWarn } from "../../util/log.js";
 import { traceMessage } from "../../util/trace.js";
@@ -360,13 +360,10 @@ export async function handleMessage(
           `[${chatId}] ${classified.reason}, falling back to ${decision.fallbackModelId}`,
         );
         resetSession(chatId);
-        const originalModel = getChatSettings(chatId).model;
-        setChatModel(chatId, decision.fallbackModelId);
-        try {
-          return await handleMessage(params, true);
-        } finally {
-          setChatModel(chatId, originalModel);
-        }
+        return await handleMessage(
+          { ...params, model: decision.fallbackModelId },
+          true,
+        );
       }
 
       logError(

--- a/src/backend/shared/handle-retry.ts
+++ b/src/backend/shared/handle-retry.ts
@@ -26,7 +26,6 @@ import type { QueryParams, QueryResult } from "../../core/types.js";
 import { classify, type TalonError } from "../../core/errors.js";
 import { logWarn } from "../../util/log.js";
 import { incrementCounter } from "../../util/metrics.js";
-import { getChatSettings, setChatModel } from "../../storage/chat-settings.js";
 import { resetSession } from "../../storage/sessions.js";
 import { classifyRetry } from "./model-retry.js";
 
@@ -128,13 +127,13 @@ export async function applyRetryDecision(
       `[${chatId}] ${classified.reason}, falling back to ${decision.fallbackModelId}`,
     );
     resetSession(chatId);
-    const originalModel = getChatSettings(chatId).model;
-    setChatModel(chatId, decision.fallbackModelId);
-    try {
-      return { retry: await recurseWithRetried(params), classified };
-    } finally {
-      setChatModel(chatId, originalModel);
-    }
+    return {
+      retry: await recurseWithRetried({
+        ...params,
+        model: decision.fallbackModelId,
+      }),
+      classified,
+    };
   }
 
   // `propagate` — caller throws `classified`.

--- a/src/core/agent-runtime/adapter.ts
+++ b/src/core/agent-runtime/adapter.ts
@@ -374,7 +374,7 @@ async function mapListModels(
         m.displayName.toLowerCase().includes(needle),
     );
   }
-  return { models: mapped, total };
+  return { models: mapped, total: mapped.length };
 }
 
 async function mapDefaultModel(

--- a/src/core/agent-runtime/legacy-bridge.ts
+++ b/src/core/agent-runtime/legacy-bridge.ts
@@ -214,9 +214,6 @@ export async function reduceEventsToResult(
     durationMs,
     usage,
     ...(modelId ? { modelId } : {}),
-    // saw === false means we hit the silent-stream path; the
-    // dispatcher will see empty text + zero usage.
-    ...(saw ? {} : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

- **Critical (3 sites):** `setChatModel`-based fallback retry pattern is a silent no-op. Commit #248 introduced `params.model` which all backends resolve before `chatSettings.model`, so the transient `setChatModel` flip was never observed. Fixed in `src/backend/shared/handle-retry.ts`, `src/backend/codex/handler.ts`, and `src/backend/openai-agents/handler.ts` by spreading `{ ...params, model: fallbackModelId }` into the recursive call.
- **Medium:** `mapListModels` in `adapter.ts` returned the pre-filter `total` from the legacy backend after applying `selectableOnly` and `query` client-side filters, violating the `ModelList` interface contract (`total` = count after filter). Fixed to return `mapped.length`.
- **Low:** Dead code in `legacy-bridge.ts` `reduceEventsToResult` — `...(saw ? {} : {})` spreads an empty object on both branches. Removed.
- **Test:** Updated `shared-handle-retry.test.ts` to assert on `paramsSeenInRecursion.model` (new mechanism) rather than `getChatSettings().model` (old mechanism that no longer fires).

## Root cause

Commit #248 ("fix: pass resolved chat model into backends") wired `params.model` into every `backend.query()` call from the dispatcher. Every backend resolves model as `params.model ?? chatSettings.model`, so any `setChatModel` call made immediately before `recurseWithRetried(params)` / `handleMessage(params, true)` is masked — the unchanged `params.model` wins. The fallback model was never actually used.

## Test plan

- [ ] `npm test` — `shared-handle-retry.test.ts` `fallback_model` suite verifies fallback model is received in the recursive call via `paramsSeenInRecursion.model`
- [ ] Manual: trigger a rate-limit / overload / network error on a chat with a model that has a configured fallback; confirm the retry uses the fallback model
- [ ] `adapter.ts` — confirm a filtered `listModels` call returns `total === models.length`

https://claude.ai/code/session_01Pe2jJNJoMiDUSffdVqiX6P

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pe2jJNJoMiDUSffdVqiX6P)_