### PR TITLE
fix: 19 correctness bugs from deep codebase review

### DIFF
--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -322,8 +322,10 @@ export async function handleMessage(
     numApiCalls: state.numApiCalls,
   });
 
-  // Set a descriptive session name from the first message
-  if (session.turns === 0 && text) {
+  // Set a descriptive session name from the first message.
+  // Guard against flow-violation retries, which pass the reminder text as
+  // `text` — we only want the original user message, not the synthetic prompt.
+  if (session.turns === 0 && text && !_internal.flowRetries) {
     const name = extractSessionName(text);
     if (name) setSessionName(chatId, name);
   }

--- a/src/backend/claude-sdk/stream.ts
+++ b/src/backend/claude-sdk/stream.ts
@@ -125,7 +125,8 @@ export function processStreamDelta(
   const delta = deltaEvent.delta;
 
   if (delta.type === "thinking_delta") {
-    state.currentThinkingText += (delta as { thinking?: string }).thinking ?? "";
+    state.currentThinkingText +=
+      (delta as { thinking?: string }).thinking ?? "";
     const now = Date.now();
     if (now - state.lastStreamUpdate >= STREAM_INTERVAL) {
       state.lastStreamUpdate = now;

--- a/src/backend/claude-sdk/stream.ts
+++ b/src/backend/claude-sdk/stream.ts
@@ -23,6 +23,7 @@ import { log } from "../../util/log.js";
 /** Mutable state accumulated while iterating the SDK message stream. */
 export type StreamState = {
   currentBlockText: string;
+  currentThinkingText: string;
   allResponseText: string;
   newSessionId: string | undefined;
   toolCalls: number;
@@ -66,6 +67,7 @@ export type StreamState = {
 export function createStreamState(): StreamState {
   return {
     currentBlockText: "",
+    currentThinkingText: "",
     allResponseText: "",
     newSessionId: undefined,
     toolCalls: 0,
@@ -123,10 +125,11 @@ export function processStreamDelta(
   const delta = deltaEvent.delta;
 
   if (delta.type === "thinking_delta") {
+    state.currentThinkingText += (delta as { thinking?: string }).thinking ?? "";
     const now = Date.now();
     if (now - state.lastStreamUpdate >= STREAM_INTERVAL) {
       state.lastStreamUpdate = now;
-      onStreamDelta(state.currentBlockText, "thinking");
+      onStreamDelta(state.currentThinkingText, "thinking");
     }
   } else if (delta.type === "text_delta") {
     state.currentBlockText += delta.text;

--- a/src/backend/kilo/handler.ts
+++ b/src/backend/kilo/handler.ts
@@ -28,6 +28,7 @@ import {
   getSession,
   incrementTurns,
   recordUsage,
+  setSessionId,
   setSessionName,
 } from "../../storage/sessions.js";
 import { getChatSettings } from "../../storage/chat-settings.js";
@@ -246,7 +247,6 @@ export async function handleMessage(
     const stored = getSession(chatId).sessionId;
     if (stored !== state.newSessionId) {
       // Defer to the storage helper to keep its invariants.
-      const { setSessionId } = await import("../../storage/sessions.js");
       setSessionId(chatId, state.newSessionId);
     }
   }

--- a/src/backend/kilo/models.ts
+++ b/src/backend/kilo/models.ts
@@ -258,8 +258,7 @@ function isFreeModel(model: {
   const id = model.id.toLowerCase();
   const name = model.name.toLowerCase();
   return (
-    model.costInput === 0 ||
-    model.costOutput === 0 ||
+    (model.costInput === 0 && model.costOutput === 0) ||
     id.includes("free") ||
     name.includes("free")
   );

--- a/src/backend/openai-agents/discovery.ts
+++ b/src/backend/openai-agents/discovery.ts
@@ -100,9 +100,6 @@ export function startDiscovery(
   if (state.discoveryPromise) return state.discoveryPromise;
 
   const promise = fetchEndpointModels(baseURL, apiKey)
-    .then(() => {
-      state.discoveryAt = Date.now();
-    })
     .catch((err) => {
       logDebug(
         "agent",
@@ -110,6 +107,9 @@ export function startDiscovery(
       );
     })
     .finally(() => {
+      // Mark discovery attempted regardless of success or failure so callers
+      // don't spin-wait on repeated awaitDiscovery() calls when unreachable.
+      state.discoveryAt = Date.now();
       // Clear the promise reference so a subsequent `refreshDiscovery`
       // can kick off a new fetch instead of being short-circuited.
       if (state.discoveryPromise === promise) {

--- a/src/backend/opencode/handler.ts
+++ b/src/backend/opencode/handler.ts
@@ -30,6 +30,7 @@ import {
   getSession,
   incrementTurns,
   recordUsage,
+  setSessionId,
   setSessionName,
 } from "../../storage/sessions.js";
 import { getChatSettings } from "../../storage/chat-settings.js";
@@ -255,7 +256,6 @@ export async function handleMessage(
   if (state.newSessionId) {
     const stored = getSession(chatId).sessionId;
     if (stored !== state.newSessionId) {
-      const { setSessionId } = await import("../../storage/sessions.js");
       setSessionId(chatId, state.newSessionId);
     }
   }

--- a/src/backend/opencode/model-provider.ts
+++ b/src/backend/opencode/model-provider.ts
@@ -129,12 +129,12 @@ export async function getProviders(): Promise<UnifiedProviderInfo[]> {
 
 export async function getProviderModels(
   providerId: string,
-  page = 0,
+  page = 1,
   pageSize = 8,
 ): Promise<{ models: UnifiedModelInfo[]; total: number }> {
   const catalog = await getOpenCodeModelCatalog();
   const filtered = catalog.models.filter((m) => m.providerID === providerId);
-  const start = page * pageSize;
+  const start = (page - 1) * pageSize;
   const slice = filtered.slice(start, start + pageSize);
   return {
     models: slice.map(toUnifiedModelInfo),

--- a/src/backend/remote-server/lifecycle.ts
+++ b/src/backend/remote-server/lifecycle.ts
@@ -152,7 +152,9 @@ async function reuseExistingServer<TClient extends RemoteAgentClient>(
 ): Promise<TClient | null> {
   const { state, createClient, healthPath } = inputs;
   try {
-    const response = await fetch(`${state.baseUrl}${healthPath}`);
+    const response = await fetch(`${state.baseUrl}${healthPath}`, {
+      signal: AbortSignal.timeout(5_000),
+    });
     if (!response.ok) return null;
     const client = createClient(state.baseUrl);
     log("agent", `Reusing ${state.label} server at ${state.baseUrl}`);

--- a/src/backend/remote-server/session-helpers.ts
+++ b/src/backend/remote-server/session-helpers.ts
@@ -342,10 +342,10 @@ export async function listSessionMessages(
   const seenMessageIds = new Set<string>();
 
   for (const message of page) {
-    const messageId = (message as Record<string, unknown>)?.info as
+    const messageInfo = (message as Record<string, unknown>)?.info as
       | { id?: string }
       | undefined;
-    const id = messageId?.id;
+    const id = messageInfo?.id;
     if (id && seenMessageIds.has(id)) continue;
     if (id) seenMessageIds.add(id);
     messages.push(message);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -122,6 +122,7 @@ function isConfigured(config: Config): boolean {
     if (fe === "telegram") return !!config.botToken;
     if (fe === "terminal") return true;
     if (fe === "teams") return !!config.teamsWebhookUrl;
+    if (fe === "discord") return !!config.discord?.botToken;
     return false;
   });
 }

--- a/src/core/cron.ts
+++ b/src/core/cron.ts
@@ -118,7 +118,7 @@ function isDue(job: CronJob, now: Date): boolean {
   } catch (err) {
     if (!warnedBadSchedule.has(job.id)) {
       if (warnedBadSchedule.size >= MAX_WARNED_SCHEDULES)
-        warnedBadSchedule.clear();
+        warnedBadSchedule.delete(warnedBadSchedule.values().next().value!);
       warnedBadSchedule.add(job.id);
       logWarn(
         "cron",

--- a/src/core/dream.ts
+++ b/src/core/dream.ts
@@ -36,6 +36,7 @@ export type DreamState = {
 const DREAM_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
 const DREAM_STATE_FILE = pathFiles.dreamState;
 const DREAM_TIMEOUT_MS = 10 * 60 * 1000; // 10-minute max
+const DREAM_ABORT_GRACE_MS = 30 * 1000; // max wait for backend to honour abort
 const DREAM_LOGS_DIR = resolve(dirs.logs, "dreams");
 
 // ── State ────────────────────────────────────────────────────────────────────
@@ -259,9 +260,22 @@ If commands fail, log the error and continue — this stage is optional.`
       dreamLogFile,
       `\n---\n**Dream FAILED at ${new Date().toISOString()}:** ${err}\n`,
     );
-    // On timeout, wait for the agent to actually finish before releasing the
-    // dreaming lock to prevent overlapping dream runs
-    await agentPromise.catch(() => {});
+    // Give the backend a bounded grace window to honour the abort signal.
+    // Never wait indefinitely — a backend that ignores abort would otherwise
+    // hold the `dreaming` lock forever, silently killing the dream loop.
+    const settled = await Promise.race([
+      agentPromise.catch(() => "settled" as const),
+      new Promise<"timed_out">((resolve) => {
+        const t = setTimeout(() => resolve("timed_out"), DREAM_ABORT_GRACE_MS);
+        t.unref();
+      }),
+    ]);
+    if (settled === "timed_out") {
+      logWarn(
+        "dream",
+        `Backend ignored abort after ${DREAM_ABORT_GRACE_MS}ms — releasing dreaming lock`,
+      );
+    }
     throw err;
   } finally {
     if (timeoutHandle) clearTimeout(timeoutHandle);

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -124,7 +124,7 @@ export function classify(err: unknown): TalonError {
   }
 
   // Context length / overflow
-  if (/context.*length|too.*long|token.*limit|overflow/i.test(msg)) {
+  if (/context.{0,10}length|too.{0,10}long|token.{0,10}limit|context.{0,10}overflow/i.test(msg)) {
     return new TalonError(msg, {
       reason: "context_length",
       retryable: false,

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -124,7 +124,11 @@ export function classify(err: unknown): TalonError {
   }
 
   // Context length / overflow
-  if (/context.{0,10}length|too.{0,10}long|token.{0,10}limit|context.{0,10}overflow/i.test(msg)) {
+  if (
+    /context.{0,10}length|too.{0,10}long|token.{0,10}limit|context.{0,10}overflow/i.test(
+      msg,
+    )
+  ) {
     return new TalonError(msg, {
       reason: "context_length",
       retryable: false,

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -192,7 +192,7 @@ export class Gateway {
     ) {
       // Explicit-routing branch: caller provided chat_id, trust it.
       chatId = numericId;
-    } else if (!isNaN(numericId) && this.chatContexts.has(numericId)) {
+    } else if (rawChatId !== "" && !isNaN(numericId) && this.chatContexts.has(numericId)) {
       // Chat-mode branch: ambient _chatId must match an active context.
       chatId = numericId;
     } else {

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -192,7 +192,11 @@ export class Gateway {
     ) {
       // Explicit-routing branch: caller provided chat_id, trust it.
       chatId = numericId;
-    } else if (rawChatId !== "" && !isNaN(numericId) && this.chatContexts.has(numericId)) {
+    } else if (
+      rawChatId !== "" &&
+      !isNaN(numericId) &&
+      this.chatContexts.has(numericId)
+    ) {
       // Chat-mode branch: ambient _chatId must match an active context.
       chatId = numericId;
     } else {

--- a/src/core/triggers.ts
+++ b/src/core/triggers.ts
@@ -237,7 +237,11 @@ function commandForLanguage(
   }
 }
 
+let _bashCommand: { cmd: string; args: string[] } | null | undefined =
+  undefined;
+
 function commandForBash(): { cmd: string; args: string[] } | null {
+  if (_bashCommand !== undefined) return _bashCommand;
   const candidates =
     process.platform === "win32"
       ? [
@@ -251,8 +255,12 @@ function commandForBash(): { cmd: string; args: string[] } | null {
       stdio: "ignore",
       windowsHide: true,
     });
-    if (probe.status === 0) return { cmd, args: [] };
+    if (probe.status === 0) {
+      _bashCommand = { cmd, args: [] };
+      return _bashCommand;
+    }
   }
+  _bashCommand = null;
   return null;
 }
 

--- a/src/frontend/discord/actions.ts
+++ b/src/frontend/discord/actions.ts
@@ -196,10 +196,10 @@ export function createDiscordActionHandler(client: Client, gateway: Gateway) {
 
       case "edit_message": {
         const text = String(body.text ?? "");
-        if (text.length > DISCORD_MAX_TEXT * 2) {
+        if (text.length > DISCORD_MAX_TEXT) {
           return {
             ok: false,
-            error: `Edit text too long (max ${DISCORD_MAX_TEXT * 2})`,
+            error: `Edit text too long (max ${DISCORD_MAX_TEXT})`,
           };
         }
         const messageId = String(body.message_id ?? "");

--- a/src/frontend/telegram/callbacks.ts
+++ b/src/frontend/telegram/callbacks.ts
@@ -124,7 +124,7 @@ export function registerCallbacks(
 
   bot.on("callback_query:data", async (ctx) => {
     const data = ctx.callbackQuery.data;
-    const cid = String(ctx.chat?.id ?? ctx.from.id);
+    const cid = String(ctx.chat?.id ?? ctx.from?.id);
 
     // Handle /settings callbacks (effort, pulse, done). Model selection
     // is intentionally NOT here — that lives entirely under /model now.

--- a/src/frontend/telegram/formatting.ts
+++ b/src/frontend/telegram/formatting.ts
@@ -84,7 +84,7 @@ export function markdownToTelegramHtml(text: string): string {
   // prevent HTML attribute injection (e.g. href="url" onmouseover="x")
   processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) =>
     /^https?:\/\//i.test(url)
-      ? `<a href="${escapeHtml(url)}">${text}</a>`
+      ? `<a href="${escapeHtml(url)}">${escapeHtml(text)}</a>`
       : text,
   );
   // Strikethrough: ~~text~~

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -156,6 +156,7 @@ export function getSession(chatId: string): SessionState {
     session.usage.lastResponseMs = 0;
   if (
     session.usage.fastestResponseMs === undefined ||
+    session.usage.fastestResponseMs === null ||
     session.usage.fastestResponseMs === 0
   )
     session.usage.fastestResponseMs = Infinity;


### PR DESCRIPTION
## Summary

Deep review of the full codebase (all ~250 source files) by six parallel static-analysis passes surfaced 19 confirmed bugs. All are fixed here; all 2998 tests pass after.

---

## Critical / High

### `sessions.ts` — `fastestResponseMs` permanently stuck at `null` after restart
`Infinity` serialises to `null` in JSON (`JSON.stringify({x: Infinity})` → `{"x":null}`). The migration guard at startup only checked `=== undefined` and `=== 0`, so after any process restart `fastestResponseMs` was loaded as `null` and stayed there forever — `durationMs < null` is always `false` in JS. Added `=== null` to the guard.

### `claude-sdk/stream.ts` — `thinking_delta` callback passed response text, not thinking text
`onStreamDelta(state.currentBlockText, "thinking")` fired with `currentBlockText` — which accumulates *response* text deltas, not thinking deltas. Thinking content was silently dropped. Added a `currentThinkingText` field to `StreamState`, accumulate `thinking_delta.thinking` into it, and pass that to the callback.

### `claude-sdk/handler.ts` — session name overwritten with flow-violation reminder on first retry
`session.turns === 0` is still `true` on the first flow-violation retry (because `incrementTurns` hasn't fired yet). The recursive call passes `text: violation.reminder`, so `extractSessionName(violation.reminder)` would produce a session name like `"[FLOW VIOLATION] Your previous..."`. Guard with `!_internal.flowRetries`.

### `kilo/models.ts` — `isFreeModel` uses `||` instead of `&&` for cost check
```ts
// BEFORE (bug): a model with costInput=0 but costOutput=$5 is labelled free
model.costInput === 0 || model.costOutput === 0
// AFTER (fix):
(model.costInput === 0 && model.costOutput === 0)
```

### `openai-agents/discovery.ts` — `discoveryAt` not set on failed discovery
`state.discoveryAt = Date.now()` was only in the `.then()` path. On a network failure, `discoveryAt` stayed `null`, causing `hasAttemptedDiscovery()` to return `false` on every subsequent call and `awaitDiscovery()` to incur a 3-second soft timeout on every model-picker open when the endpoint is unreachable. Moved to `.finally()`.

### `telegram/callbacks.ts` — `ctx.from.id` crashes on channel post callbacks
Channel posts have no `from` field — `ctx.from` is `undefined` for them. Added optional chaining: `ctx.from?.id`.

### `telegram/formatting.ts` — Markdown link label not HTML-escaped
```ts
// BEFORE (bug): [<b>bold</b>](url) → <a href="…"><b>bold</b></a>  (HTML injection)
`<a href="${escapeHtml(url)}">${text}</a>`
// AFTER (fix):
`<a href="${escapeHtml(url)}">${escapeHtml(text)}</a>`
```

---

## Medium

### `discord/actions.ts` — `edit_message` guard allowed 4000-char edits
The early-rejection guard compared against `DISCORD_MAX_TEXT * 2` (4000), but Discord's API limit for edits is `DISCORD_MAX_TEXT` (2000). Text between 2001–4000 chars passed the guard but was silently truncated at the send step. Changed the guard to `DISCORD_MAX_TEXT`.

### `cli.ts` — `isConfigured` always returned `false` for Discord frontend
```ts
// BEFORE: default case catches Discord → always returns false
return false;
// AFTER:
if (fe === "discord") return !!config.discord?.botToken;
return false;
```

### `errors.ts` — bare `overflow` regex too broad
`/overflow/i` matched `Maximum call stack size exceeded`, numeric overflow, buffer overflows, etc., silently misclassifying them as non-retryable `context_length` errors and suppressing retries that might otherwise succeed. Tightened to `context.{0,10}overflow` so only context-related overflow messages match.

### `cron.ts` — `warnedBadSchedule.clear()` caused a re-warning burst at the cap
When the 200-entry cap was hit, `clear()` removed all entries. On the very next tick, every previously-warned job was no longer in the set and re-logged a warning — producing a burst of 200 log lines. Now evicts only the oldest entry via `Set` insertion-order iteration.

### `gateway.ts` — `Number("") === 0` could match chat context 0
When `_chatId` is absent, `rawChatId = ""` and `Number("") === 0`. `!isNaN(0)` is `true`, so if any chat with numeric ID `0` ever appeared in `chatContexts`, a bare tool call with no `_chatId` would route to it. The explicit-routing branch already guards with `rawChatId !== ""`; added the same guard to the ambient-context branch.

### `dream.ts` — `dreaming` lock held forever if backend ignores abort signal
`await agentPromise.catch(() => {})` with no timeout meant a backend that ignored its abort signal would block `executeDream` indefinitely. Since `dreaming = false` is in `executeDream`'s `finally` block, it would never reset, silently killing all future dream runs until a process restart. Added a `DREAM_ABORT_GRACE_MS` (30 s) bounded wait, mirroring the pattern in `heartbeat.ts`.

### `remote-server/lifecycle.ts` — health-check `fetch` had no timeout
A server that accepted TCP connections but never sent an HTTP response would stall `reuseExistingServer` — and therefore `ensureRemoteServer`, called on every chat turn — indefinitely. Added `AbortSignal.timeout(5_000)`.

### `opencode/model-provider.ts` — `getProviderModels` was 0-indexed while all other backends use 1-indexed
`page = 0` with `start = page * pageSize` meant a caller passing `page=1` (the standard from other backends) skipped the first `pageSize` models entirely. Changed to `page = 1` / `start = (page - 1) * pageSize`.

---

## Low

### `triggers.ts` — `commandForBash()` re-probed bash on every trigger spawn
`spawnSync(cmd, ["-lc", "exit 0"])` was called synchronously on the hot path of every bash trigger invocation. The result is the same every time (bash either exists or it doesn't). Cached it in a module-level variable after the first probe.

### `kilo/handler.ts` / `opencode/handler.ts` — redundant dynamic `import()` of `setSessionId`
Both files already statically import from `../../storage/sessions.js`. `setSessionId` was the one export not included in the static import, causing a `await import(...)` at runtime. Added `setSessionId` to the static import and removed the dynamic call.

### `remote-server/session-helpers.ts` — confusing variable name `messageId` for the info blob
The intermediate variable was named `messageId` but held `message.info` (the whole info object). Renamed to `messageInfo` to match what it actually holds and eliminate a misleading hint that it contained just an ID.

---

## Test plan

- [x] `npm test` — 2998 tests pass, 34 skipped (same skipped count as `main`)
- [x] `npm run typecheck` — clean

https://claude.ai/code/session_01M8utiWqUBerWtQ45jdeXgH

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8utiWqUBerWtQ45jdeXgH)_