### PR TITLE
fix: four correctness bugs (history namespace, cron double-fire, gateway crash, orphaned comment)

### DIFF
--- a/src/core/cron.ts
+++ b/src/core/cron.ts
@@ -52,6 +52,11 @@ export function stopCronTimer(): void {
 
 // ── Core ─────────────────────────────────────────────────────────────────────
 
+// Job IDs currently executing. Prevents a long-running "query" job from being
+// dispatched a second time by the next 60-second tick before recordCronRun()
+// has had a chance to update lastRunAt.
+const runningJobs = new Set<string>();
+
 async function runCronTick(): Promise<void> {
   if (!deps) return;
   if (getActiveCount() > 10) return; // safety valve — don't pile on if heavily loaded
@@ -61,9 +66,11 @@ async function runCronTick(): Promise<void> {
 
   for (const job of jobs) {
     if (!job.enabled) continue;
+    if (runningJobs.has(job.id)) continue; // already in-flight this tick or a previous one
     if (!isDue(job, now)) continue;
     if (getActiveCount() > 10) break;
 
+    runningJobs.add(job.id);
     try {
       log(
         "cron",
@@ -78,6 +85,8 @@ async function runCronTick(): Promise<void> {
       log("cron", `Executed "${job.name}" [${job.id}] in chat ${job.chatId}`);
     } catch (err) {
       logError("cron", `Job "${job.name}" [${job.id}] failed`, err);
+    } finally {
+      runningJobs.delete(job.id);
     }
   }
 }
@@ -155,8 +164,7 @@ async function executeJob(job: CronJob): Promise<void> {
 
   const numericChatId = Number(job.chatId);
   if (!Number.isFinite(numericChatId)) {
-    logError("cron", `Invalid chatId for job "${job.name}": ${job.chatId}`);
-    return;
+    throw new Error(`Invalid chatId for job "${job.name}": ${job.chatId}`);
   }
 
   if (job.type === "message") {

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -342,6 +342,14 @@ export class Gateway {
               ? (addr as { port: number }).port
               : p;
           log("gateway", `Action gateway on :${this.port}`);
+          // Replace the one-shot startup error listener with a persistent
+          // handler. Without this, once the `once("error")` from port-binding
+          // fires (and auto-removes itself), any subsequent server-level error
+          // has no listener and crashes the process via uncaught 'error' event.
+          httpServer.removeAllListeners("error");
+          httpServer.on("error", (err) =>
+            logError("gateway", "HTTP server error", err),
+          );
           resolve(this.port);
         });
       };

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -77,7 +77,7 @@ export function loadHistory(): void {
       /* backup also corrupt */
     }
     logError(
-      "sessions",
+      "history",
       "History data corrupt and no valid backup — starting fresh",
     );
   }

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -117,8 +117,6 @@ function saveSessions(): void {
 // Auto-save every 10 seconds if dirty
 const autoSaveTimer = setInterval(saveSessions, 10_000);
 
-// Periodic stale session pruning (every hour)
-
 const emptyUsage = (): SessionUsage => ({
   totalInputTokens: 0,
   totalOutputTokens: 0,


### PR DESCRIPTION
## Summary

Deep code review of the full repository surfaced four concrete bugs. All 3032 tests pass and `tsc --noEmit` is clean.

---

### Bug 1 — Wrong log namespace in `history.ts` (typo)

**File:** `src/storage/history.ts:79`

```ts
// before
logError("sessions", "History data corrupt and no valid backup — starting fresh");

// after
logError("history",  "History data corrupt and no valid backup — starting fresh");
```

The corrupt-history fallback path logged under the `"sessions"` namespace instead of `"history"`, making it invisible when filtering logs by module.

---

### Bug 2 — `cron.ts`: invalid `chatId` silently marks job as successful

**File:** `src/core/cron.ts:153-165`

`executeJob` returned early (no throw) when `Number(job.chatId)` is `NaN`. Because `runCronTick` calls `recordCronRun(job.id)` only after `await executeJob(job)` returns *without throwing*, the failed job had its `lastRunAt` timestamp updated as if it ran successfully. The error was swallowed after the first log line, with no way to distinguish a config error from a real run.

Fix: replace `return` with `throw new Error(...)` so the outer `catch` block receives the error and `recordCronRun` is never called.

---

### Bug 3 — `cron.ts`: no in-flight guard → double-dispatch of long-running jobs

**File:** `src/core/cron.ts`

The `setInterval` tick fires every 60 seconds. "Query"-type jobs run through the dispatcher and can take up to 10 minutes (the `withTimeout` cap). `recordCronRun` — which updates `lastRunAt` — is only called *after* the job completes. The `isDue` guard checks `lastRunAt < 55s ago`, so the same job was eligible to be dispatched again on the very next tick while it was still running.

Fix: add a `runningJobs: Set<string>` that is populated before `await executeJob(job)` and cleared in `finally`, skipping any job already in-flight.

---

### Bug 4 — `gateway.ts`: HTTP server left with no error handler after startup

**File:** `src/core/gateway.ts:318-346`

The port-binding loop registers `httpServer.once("error", ...)` to catch `EADDRINUSE` and retry on the next port. `once` auto-removes the listener after it fires. After `listen()` succeeds and the promise resolves, that `once` listener is still attached (it hasn't fired yet), but there is no *persistent* `on("error")` handler. The first server-level error fires the `once` handler (calling `reject` — a no-op since the promise already resolved) and removes it. Any *subsequent* server-level error then has zero listeners, emitting an unhandled `'error'` event and crashing the Node process.

Fix: in the `listen()` success callback, call `removeAllListeners("error")` and install a permanent `on("error", ...)` logger.

---

### Bug 5 — `sessions.ts`: orphaned comment with no implementation

**File:** `src/storage/sessions.ts:120`

```ts
// Periodic stale session pruning (every hour)
```

No timer, no function, no implementation anywhere in the file. The comment was a leftover from a planned feature that was never built, describing behaviour that does not exist. Removed to avoid misleading future readers.

## Test plan

- [x] `npx vitest run` — 2998 tests pass, 34 skipped, 0 failures
- [x] `npx tsc --noEmit` — zero type errors
- [ ] Manual: create a cron job with an invalid chatId, confirm it logs an error and `lastRunAt` is *not* updated
- [ ] Manual: verify gateway starts and any post-startup server error is logged rather than crashing

https://claude.ai/code/session_01VsKcpE1wKoEdCkbaMrXQ1m

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsKcpE1wKoEdCkbaMrXQ1m)_