### PR TITLE
fix: four correctness bugs (history logger, formatting $-patterns, stream blockText, cron timer)

### DIFF
--- a/src/backend/claude-sdk/stream.ts
+++ b/src/backend/claude-sdk/stream.ts
@@ -186,9 +186,12 @@ export function processAssistantMessage(
       if (blockText.trim()) {
         progressTexts.push(blockText.trim());
         state.allResponseText += blockText;
-        blockText = "";
-        state.currentBlockText = "";
       }
+      // Always reset — skipping the reset when blockText is whitespace-only
+      // causes that whitespace to leak into the next text block's accumulation,
+      // corrupting subsequent progress text and the final trailing-text value.
+      blockText = "";
+      state.currentBlockText = "";
     }
   }
 

--- a/src/core/cron.ts
+++ b/src/core/cron.ts
@@ -136,7 +136,7 @@ async function withTimeout<T>(
   ms: number,
   label: string,
 ): Promise<T> {
-  let timer: ReturnType<typeof setTimeout>;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(
       () => reject(new Error(`${label} timed out after ${ms}ms`)),
@@ -146,7 +146,7 @@ async function withTimeout<T>(
   try {
     return await Promise.race([promise, timeout]);
   } finally {
-    clearTimeout(timer!);
+    clearTimeout(timer);
   }
 }
 

--- a/src/frontend/telegram/formatting.ts
+++ b/src/frontend/telegram/formatting.ts
@@ -91,13 +91,19 @@ export function markdownToTelegramHtml(text: string): string {
   processed = processed.replace(/~~(.+?)~~/g, "<s>$1</s>");
 
   // Step 5: Restore inline code spans.
+  // Use a function replacement to prevent JS from interpreting `$&`, `$1`,
+  // etc. in the replacement string as special patterns — user code can
+  // legitimately contain dollar-sign sequences that would otherwise expand
+  // incorrectly (e.g. `$&` would be replaced by the matched placeholder text).
   for (let i = 0; i < inlineCode.length; i++) {
-    processed = processed.replace(`\x00INLINECODE${i}\x00`, inlineCode[i]);
+    const html = inlineCode[i];
+    processed = processed.replace(`\x00INLINECODE${i}\x00`, () => html);
   }
 
   // Step 6: Restore fenced code blocks.
   for (let i = 0; i < codeBlocks.length; i++) {
-    processed = processed.replace(`\x00CODEBLOCK${i}\x00`, codeBlocks[i]);
+    const html = codeBlocks[i];
+    processed = processed.replace(`\x00CODEBLOCK${i}\x00`, () => html);
   }
 
   return processed;

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -77,7 +77,7 @@ export function loadHistory(): void {
       /* backup also corrupt */
     }
     logError(
-      "sessions",
+      "history",
       "History data corrupt and no valid backup — starting fresh",
     );
   }


### PR DESCRIPTION
## Summary

Deep review of the codebase found four concrete correctness bugs. All 131 test files pass after the fixes (3032 tests total, 34 skipped).

---

### Bug 1 — `history.ts`: wrong component name in `logError` (minor)

**File:** `src/storage/history.ts:80`

The corrupt-and-no-backup error path in `loadHistory()` logged under `"sessions"` instead of `"history"`. When filtering structured logs by component name, these errors were invisible.

```diff
-logError("sessions", "History data corrupt and no valid backup — starting fresh");
+logError("history", "History data corrupt and no valid backup — starting fresh");
```

---

### Bug 2 — `formatting.ts`: `$`-pattern expansion corrupts placeholder restoration (correctness)

**File:** `src/frontend/telegram/formatting.ts`, steps 5 & 6

`String.prototype.replace(string, string)` processes special replacement patterns in its second argument even when the first argument is a plain string (not a regex). Sequences like `$&`, `$'`, `` $` ``, `$1`, `$$` have defined meanings:

- `$&` → expands to the matched substring (i.e., the placeholder itself)
- `$$` → expands to a literal `$`
- `$'` → expands to the portion of the string after the match
- `` $` `` → expands to the portion before the match

If a user's inline code or code block contains any of these sequences (completely valid code in many languages), the placeholder is restored incorrectly. For example, a message containing `` `$&` `` would render as `<code>\x00INLINECODE0\x00</code>` — the raw placeholder — instead of `<code>$&</code>`.

**Fix:** pass a function as the replacement argument, which opts out of pattern expansion entirely.

```diff
-processed = processed.replace(`\x00INLINECODE${i}\x00`, inlineCode[i]);
+const html = inlineCode[i];
+processed = processed.replace(`\x00INLINECODE${i}\x00`, () => html);
```

Same fix applied to the code-block restoration loop.

---

### Bug 3 — `stream.ts`: `blockText` not cleared after whitespace-only pre-tool text (correctness)

**File:** `src/backend/claude-sdk/stream.ts`, `processAssistantMessage`

When a `tool_use` block is preceded by only whitespace (e.g. a blank line), `blockText.trim()` is falsy so the guard body never runs — but **`blockText` itself was never reset**. The whitespace from before the tool call leaked into the next text block's accumulation.

For a content array `[text("  \n"), tool_use(foo), text("hello")]`:

- **Before fix:** `state.currentBlockText = "  \nhello"`, `trailingText = "  \nhello"`
- **After fix:** `state.currentBlockText = "hello"`, `trailingText = "hello"`

The extraneous leading whitespace polluted `state.allResponseText` (used for tracing) and `state.lastTrailingText` (used for flow-violation detection), making internal diagnostics inaccurate.

**Fix:** unconditionally reset `blockText` and `state.currentBlockText` after every `tool_use` block.

```diff
+if (blockText.trim()) {
+  progressTexts.push(blockText.trim());
+  state.allResponseText += blockText;
+}
+// Always reset — skipping the reset when blockText is whitespace-only
+// causes that whitespace to leak into the next text block's accumulation.
 blockText = "";
 state.currentBlockText = "";
```

---

### Bug 4 — `cron.ts`: `!` non-null assertion on uninitialised `timer` variable (type safety)

**File:** `src/core/cron.ts`, `withTimeout`

`timer` was declared as `ReturnType<typeof setTimeout>` (no initial value) and then referenced as `timer!` in the `finally` block, bypassing TypeScript's definite-assignment check. While safe at runtime (the `Promise` constructor executes its callback synchronously so `timer` is always assigned before `finally` runs), the pattern suppresses a legitimate TypeScript safety check and makes intent unclear.

**Fix:** declare as `| undefined` and drop the assertion — `clearTimeout(undefined)` is a documented no-op.

```diff
-let timer: ReturnType<typeof setTimeout>;
+let timer: ReturnType<typeof setTimeout> | undefined;
 ...
-clearTimeout(timer!);
+clearTimeout(timer);
```

---

## Test plan

- [x] `npm test` — 131 test files, 2998 tests passed, 34 skipped (integration tests requiring live auth)
- [x] Targeted the four changed files; no new test failures introduced

https://claude.ai/code/session_01PJEo7gdoy1TSFQv6sMV4md

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJEo7gdoy1TSFQv6sMV4md)_