### PR TITLE
fix(claude-sdk): detect Fable and show both 1M/non-1M variants

### DIFF
--- a/src/__tests__/chat-settings.test.ts
+++ b/src/__tests__/chat-settings.test.ts
@@ -40,13 +40,12 @@ const { registerClaudeModelsStatic, CLAUDE_MODELS_STATIC } =
   await import("../backend/claude-sdk/models.js");
 registerClaudeModelsStatic(CLAUDE_MODELS_STATIC);
 
-// convertSdkModels collapses base + 1M variants into a single canonical ID
-// per family+version, preferring the 1M variant (and "default" when the SDK
-// marks one canonical). So sonnet/sonnet[1m] → "default", opus/opus[1m] →
-// "opus[1m]", and plain "haiku" stays.
+// convertSdkModels surfaces base and 1M variants separately, collapsing only
+// true duplicates. The bare family aliases resolve to the *base* entry: the
+// SDK marks base Sonnet as "default", base Opus stays "opus", "haiku" stays.
 const SDK_MODEL_IDS = {
   sonnet: "default",
-  opus: "opus[1m]",
+  opus: "opus",
   haiku: "haiku",
 } as const;
 

--- a/src/__tests__/claude-sdk-models.test.ts
+++ b/src/__tests__/claude-sdk-models.test.ts
@@ -2,9 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSupportedModels = vi.fn();
 
+// The mock forwards the seed model (options.model) to mockSupportedModels so
+// tests can simulate the binary's per-seed echo behaviour. Tests using
+// mockResolvedValue ignore the arg and return the same list for every seed.
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
-  query: vi.fn(() => ({
-    supportedModels: mockSupportedModels,
+  query: vi.fn((opts) => ({
+    supportedModels: () => mockSupportedModels(opts?.options?.model),
     [Symbol.asyncIterator]() {
       return {
         next: async () => ({ done: true, value: undefined }),
@@ -58,40 +61,97 @@ describe("registerClaudeModels", () => {
     clearModels();
   });
 
-  it("collapses family+version duplicates (base + 1M + claude-*) into a single canonical entry", async () => {
+  it("surfaces base and 1M variants separately while collapsing true duplicates", async () => {
     const { registerClaudeModels } =
       await import("../backend/claude-sdk/models.js");
     const { getModels, resolveModelId } = await import("../core/models.js");
 
     await registerClaudeModels({ model: "default" });
 
-    // sonnet, sonnet[1m], claude-sonnet-4-6 all share family+version and
-    // collapse into "default" (the SDK's recommended canonical). opus/opus[1m]
-    // collapse into opus[1m] (1M-preferred since no "default" exists for that
-    // family). haiku stands alone.
+    // Base sonnet ("default") and sonnet[1m] are distinct context sizes, so
+    // both surface. The longhand `claude-sonnet-4-6` is a true duplicate of the
+    // base and collapses into "default". opus/opus[1m] likewise both surface.
     const anthropicModels = getModels("anthropic");
     expect(anthropicModels.map((model) => model.id)).toEqual([
       "default",
+      "sonnet[1m]",
+      "opus",
       "opus[1m]",
       "haiku",
     ]);
 
-    expect(
-      anthropicModels.find((model) => model.id === "default")?.displayName,
-    ).toBe("Sonnet 4.6");
-    expect(
-      anthropicModels.find((model) => model.id === "opus[1m]")?.displayName,
-    ).toBe("Opus 4.6");
-    expect(
-      anthropicModels.find((model) => model.id === "haiku")?.displayName,
-    ).toBe("Haiku 4.5");
+    const byId = (id: string) =>
+      anthropicModels.find((model) => model.id === id);
+    expect(byId("default")?.displayName).toBe("Sonnet 4.6");
+    expect(byId("sonnet[1m]")?.displayName).toBe("Sonnet 4.6 (1M context)");
+    expect(byId("opus")?.displayName).toBe("Opus 4.6");
+    expect(byId("opus[1m]")?.displayName).toBe("Opus 4.6 (1M context)");
+    expect(byId("haiku")?.displayName).toBe("Haiku 4.5");
 
+    // Bare aliases resolve to the base entry; [1m] aliases to the 1M entry.
     expect(resolveModelId("sonnet")).toBe("default");
-    expect(resolveModelId("sonnet[1m]")).toBe("default");
     expect(resolveModelId("claude-sonnet-4-6")).toBe("default");
-    expect(resolveModelId("claude-sonnet-4-6[1m]")).toBe("default");
-    expect(resolveModelId("opus")).toBe("opus[1m]");
-    expect(resolveModelId("claude-opus-4-6")).toBe("opus[1m]");
+    expect(resolveModelId("sonnet[1m]")).toBe("sonnet[1m]");
+    expect(resolveModelId("claude-sonnet-4-6[1m]")).toBe("sonnet[1m]");
+    expect(resolveModelId("opus")).toBe("opus");
+    expect(resolveModelId("claude-opus-4-6")).toBe("opus");
+    expect(resolveModelId("opus[1m]")).toBe("opus[1m]");
+    expect(resolveModelId("claude-opus-4-6[1m]")).toBe("opus[1m]");
+  });
+
+  it("resolves family aliases for a model shipped only as a 1M variant (Fable)", async () => {
+    // Mirrors real SDK output: Fable is advertised solely as
+    // `claude-fable-5[1m]` with no base (non-1M) entry, and a bare
+    // `displayName: "Fable"` whose version lives only in the description.
+    mockSupportedModels.mockResolvedValue([
+      {
+        value: "default",
+        displayName: "Default (recommended)",
+        description: "Opus 4.7 with 1M context · Most capable for complex work",
+      },
+      {
+        value: "sonnet",
+        displayName: "Sonnet",
+        description: "Sonnet 4.6 · Best for everyday tasks",
+      },
+      {
+        value: "sonnet[1m]",
+        displayName: "Sonnet (1M context)",
+        description: "Sonnet 4.6 with 1M context · $3/$15 per Mtok",
+      },
+      {
+        value: "haiku",
+        displayName: "Haiku",
+        description: "Haiku 4.5 · Fastest for quick answers",
+      },
+      {
+        value: "claude-fable-5[1m]",
+        displayName: "Fable",
+        description:
+          "Fable 5 · Most capable for your hardest and longest-running tasks",
+      },
+    ]);
+
+    const { registerClaudeModels } =
+      await import("../backend/claude-sdk/models.js");
+    const { getModels, resolveModelId } = await import("../core/models.js");
+
+    await registerClaudeModels({ model: "default" });
+
+    const fable = getModels("anthropic").find((m) =>
+      m.id.startsWith("claude-fable-5"),
+    );
+    expect(fable, "Fable should be discovered").toBeDefined();
+    expect(fable?.id).toBe("claude-fable-5[1m]");
+    expect(fable?.displayName).toBe("Fable 5 (1M context)");
+
+    // The bug: with no base variant, the bare family aliases were never
+    // generated, so "/model fable" (and the version forms) failed to resolve.
+    expect(resolveModelId("fable")).toBe("claude-fable-5[1m]");
+    expect(resolveModelId("fable-5")).toBe("claude-fable-5[1m]");
+    expect(resolveModelId("fable[1m]")).toBe("claude-fable-5[1m]");
+    expect(resolveModelId("claude-fable-5")).toBe("claude-fable-5[1m]");
+    expect(resolveModelId("claude-fable-5[1m]")).toBe("claude-fable-5[1m]");
   });
 
   it("derives compatibility aliases from SDK metadata instead of hardcoded versions", async () => {
@@ -138,9 +198,86 @@ describe("registerClaudeModels", () => {
 
     expect(resolveModelId("claude-sonnet-5-0")).toBe("default");
     expect(resolveModelId("claude-sonnet-4-6")).toBe("default");
-    expect(resolveModelId("claude-opus-5-0")).toBe("opus[1m]");
-    expect(resolveModelId("claude-opus-4-6")).toBe("opus[1m]");
+    expect(resolveModelId("claude-opus-5-0")).toBe("opus");
+    expect(resolveModelId("claude-opus-4-6")).toBe("opus");
     expect(resolveModelId("claude-haiku-5-0")).toBe("haiku");
     expect(resolveModelId("claude-haiku-4-5")).toBe("haiku");
+  });
+
+  it("unions probes across family seeds so base and 1M variants both surface", async () => {
+    // Simulate the real binary: a base set that echoes only the *requested*
+    // model's context variant. A single "default" probe shows opus only as the
+    // 1M `default`; the base opus surfaces only when probing the "opus" seed.
+    // Unrecognised seeds come back as "Custom model" passthrough junk.
+    const BASE = [
+      {
+        value: "sonnet",
+        displayName: "Sonnet",
+        description: "Sonnet 4.6 · Best for everyday tasks",
+      },
+      {
+        value: "sonnet[1m]",
+        displayName: "Sonnet (1M context)",
+        description: "Sonnet 4.6 with 1M context",
+      },
+      {
+        value: "haiku",
+        displayName: "Haiku",
+        description: "Haiku 4.5 · Fastest for quick answers",
+      },
+    ];
+    const ECHO: Record<string, { value: string; description: string }> = {
+      default: {
+        value: "default",
+        description: "Opus 4.7 with 1M context · Most capable for complex work",
+      },
+      opus: {
+        value: "opus",
+        description: "Opus 4.7 · Most capable for complex work",
+      },
+      sonnet: {
+        value: "sonnet",
+        description: "Sonnet 4.6 · Best for everyday tasks",
+      },
+      haiku: {
+        value: "haiku",
+        description: "Haiku 4.5 · Fastest for quick answers",
+      },
+    };
+    mockSupportedModels.mockImplementation((seed?: string) => {
+      const echo = ECHO[seed ?? ""] ?? {
+        value: seed ?? "unknown",
+        description: "Custom model",
+      };
+      return Promise.resolve([
+        ...BASE,
+        {
+          value: echo.value,
+          displayName: echo.value,
+          description: echo.description,
+        },
+      ]);
+    });
+
+    const { registerClaudeModels } =
+      await import("../backend/claude-sdk/models.js");
+    const { getModels, resolveModelId } = await import("../core/models.js");
+
+    await registerClaudeModels({ model: "default" });
+
+    const ids = getModels("anthropic").map((m) => m.id);
+    // The "opus" seed probe reveals base opus; "default" carries opus 1M.
+    expect(ids).toContain("opus");
+    expect(ids).toContain("default");
+    expect(ids).toContain("sonnet");
+    expect(ids).toContain("sonnet[1m]");
+
+    // Both opus context sizes resolve, to distinct entries.
+    expect(resolveModelId("opus")).toBe("opus");
+    expect(resolveModelId("opus[1m]")).toBe("default");
+
+    // No "Custom model" passthrough junk leaked into the registry.
+    const descriptions = getModels("anthropic").map((m) => m.description);
+    expect(descriptions).not.toContain("Custom model");
   });
 });

--- a/src/__tests__/fuzz.test.ts
+++ b/src/__tests__/fuzz.test.ts
@@ -333,13 +333,13 @@ describe("fuzz: resolveModelName()", () => {
   it("known aliases resolve to the expected SDK model IDs", () => {
     const aliasMappings = [
       ["sonnet", "default"],
-      ["opus", "opus[1m]"],
+      ["opus", "opus"],
       ["haiku", "haiku"],
       ["sonnet-4.6", "default"],
-      ["opus-4.6", "opus[1m]"],
+      ["opus-4.6", "opus"],
       ["haiku-4.5", "haiku"],
       ["sonnet-4-6", "default"],
-      ["opus-4-6", "opus[1m]"],
+      ["opus-4-6", "opus"],
       ["haiku-4-5", "haiku"],
     ] as const;
     fc.assert(

--- a/src/backend/claude-sdk/model-provider.ts
+++ b/src/backend/claude-sdk/model-provider.ts
@@ -39,7 +39,11 @@ function toUnified(model: ModelInfo): UnifiedModelInfo {
   };
 }
 
-/** De-duplicate models by displayName (1M variants share a label with their base). */
+/**
+ * De-duplicate models by displayName. Base and 1M variants carry distinct
+ * labels ("Sonnet 4.6" vs "Sonnet 4.6 (1M context)"), so both survive here;
+ * this only guards against accidental collisions.
+ */
 function getUniqueModels(): ModelInfo[] {
   const options: ModelInfo[] = [];
   const seenKeys = new Set<string>();

--- a/src/backend/claude-sdk/models.ts
+++ b/src/backend/claude-sdk/models.ts
@@ -67,9 +67,10 @@ function toDisplayFamilyName(family: string): string {
 }
 
 /**
- * Synthesize a clean label like "Sonnet 4.6" from parsed identity. Base and
- * 1M variants share a label because the variant-merge step hides the base
- * behind the 1M one — what we surface is effectively the 1M model.
+ * Synthesize a clean label like "Sonnet 4.6" (or "Sonnet 4.6 (1M context)")
+ * from parsed identity. Base and 1M variants get distinct labels so the picker
+ * can list both — the de-dup by display name in the model provider relies on
+ * this distinction to keep both entries.
  */
 function deriveDisplayName(
   identity: ParsedModelIdentity,
@@ -78,7 +79,8 @@ function deriveDisplayName(
   if (!identity.family) return fallback;
   const family = toDisplayFamilyName(identity.family);
   const version = identity.version ? ` ${identity.version}` : "";
-  return `${family}${version}`;
+  const suffix = identity.isOneMillion ? " (1M context)" : "";
+  return `${family}${version}${suffix}`;
 }
 
 function stripOneMillionSuffix(value: string): string {
@@ -139,6 +141,20 @@ function parseClaudeId(
   };
 }
 
+/**
+ * Detect whether a model is a 1M-context variant. The SDK signals this in two
+ * ways: the canonical `[1m]` value suffix (e.g. `claude-sonnet-4-6[1m]`), or —
+ * for the recommended `default` alias — only in prose ("…with 1M context…").
+ * Catching both keeps a description-only 1M model from masquerading as a
+ * separate base entry alongside its longhand `[1m]` duplicate.
+ */
+function detectOneMillion(model: SdkModelInfo): boolean {
+  if (model.value.endsWith("[1m]")) return true;
+  const text =
+    `${model.description ?? ""} ${model.displayName ?? ""}`.toLowerCase();
+  return /\b1m\b/.test(text) && text.includes("context");
+}
+
 function describeSdkModel(model: SdkModelInfo): ParsedModelIdentity {
   const textIdentity = parseFamilyAndVersionFromTexts([
     model.description,
@@ -155,7 +171,7 @@ function describeSdkModel(model: SdkModelInfo): ParsedModelIdentity {
     claudeId:
       claudeIdentity.claudeId ??
       (family && version ? `claude-${family}-${toDashVersion(version)}` : null),
-    isOneMillion: model.value.endsWith("[1m]"),
+    isOneMillion: detectOneMillion(model),
   };
 }
 
@@ -166,61 +182,76 @@ function buildFamilyKey(identity: ParsedModelIdentity): string | null {
 }
 
 /**
- * Variant key collapses base and 1M variants of the same family+version into
- * a single bucket. The priority function picks the 1M entry as canonical, so
- * users see one "Sonnet 4.6" option (backed by sonnet[1m]) rather than two.
+ * Variant key groups only *true* duplicates — same family, version, AND
+ * context size. Base and 1M variants of one family+version land in separate
+ * buckets so both surface in the picker, while redundant longhand ids (e.g.
+ * `claude-opus-4-7[1m]` next to the `default` it mirrors) still collapse.
  */
 function buildVariantKey(identity: ParsedModelIdentity): string | null {
-  return buildFamilyKey(identity);
+  const familyKey = buildFamilyKey(identity);
+  if (!familyKey) return null;
+  return `${familyKey}:${identity.isOneMillion ? "1m" : "base"}`;
 }
 
-function appendOneMillionSuffix(alias: string, isOneMillion: boolean): string {
-  return isOneMillion ? `${alias}[1m]` : alias;
-}
+type AliasFormOptions = {
+  /** Emit bare, unsuffixed forms ("fable", "fable-5", "claude-fable-5"). */
+  includeBare: boolean;
+  /** Emit `[1m]`-suffixed forms ("fable[1m]", "claude-fable-5[1m]"). */
+  include1m: boolean;
+};
 
-function buildGeneratedAliases(identity: ParsedModelIdentity): string[] {
+/**
+ * Generate resolution aliases for a model's identity.
+ *
+ * The caller decides which forms this entry owns:
+ *  - A base entry owns the bare forms ("sonnet", "sonnet-4-6", …).
+ *  - A 1M entry owns the `[1m]` forms; it additionally claims the bare forms
+ *    only when no base sibling exists (e.g. Fable, shipped solely as
+ *    `claude-fable-5[1m]`, must still resolve from "fable").
+ *
+ * Stems come from the family, the family+version (dot and dash spellings),
+ * and the canonical claude-id, so both "fable-5" and "claude-fable-5" resolve.
+ */
+function buildGeneratedAliases(
+  identity: ParsedModelIdentity,
+  { includeBare, include1m }: AliasFormOptions,
+): string[] {
   if (!identity.family) return [];
 
-  const aliases = [
-    appendOneMillionSuffix(identity.family, identity.isOneMillion),
-  ];
+  const stems = [identity.family];
 
   if (identity.version) {
-    aliases.push(
-      appendOneMillionSuffix(
-        `${identity.family}-${identity.version}`,
-        identity.isOneMillion,
-      ),
-      appendOneMillionSuffix(
-        `${identity.family}-${toDashVersion(identity.version)}`,
-        identity.isOneMillion,
-      ),
+    stems.push(
+      `${identity.family}-${identity.version}`,
+      `${identity.family}-${toDashVersion(identity.version)}`,
     );
   }
 
   if (identity.claudeId) {
-    aliases.push(
-      appendOneMillionSuffix(identity.claudeId, identity.isOneMillion),
-    );
+    stems.push(identity.claudeId);
+  }
+
+  const aliases: string[] = [];
+  for (const stem of stems) {
+    if (includeBare) aliases.push(stem);
+    if (include1m) aliases.push(`${stem}[1m]`);
   }
 
   return aliases;
 }
 
 /**
- * Lower number = higher priority when picking a canonical ID among variants
- * sharing a family+version:
+ * Lower number = higher priority when choosing a canonical id among *true
+ * duplicates* (records sharing family + version + context size):
  *   0 — "default"                      (SDK-recommended canonical)
- *   1 — 1M variant, non-claude-prefix  (e.g. sonnet[1m])
- *   2 — base variant, non-claude       (e.g. sonnet)
- *   3 — claude-prefixed (legacy)       (e.g. claude-sonnet-4-6[1m])
+ *   1 — short non-claude-prefixed      (e.g. sonnet, sonnet[1m])
+ *   2 — claude-prefixed (legacy)       (e.g. claude-sonnet-4-6[1m])
+ * The short alias wins over the longhand `claude-*` id so picker callbacks and
+ * stored values stay compact.
  */
 function getPreferredModelPriority(record: SdkModelRecord): number {
   if (record.value === "default") return 0;
-  const isClaudePrefixed = record.value.startsWith("claude-");
-  if (record.identity.isOneMillion && !isClaudePrefixed) return 1;
-  if (!isClaudePrefixed) return 2;
-  return 3;
+  return record.value.startsWith("claude-") ? 2 : 1;
 }
 
 function buildSdkModelRecords(sdkModels: SdkModelInfo[]): SdkModelRecord[] {
@@ -234,32 +265,6 @@ function buildSdkModelRecords(sdkModels: SdkModelInfo[]): SdkModelRecord[] {
       variantKey: buildVariantKey(identity),
     };
   });
-}
-
-function buildPreferredCanonicalIds(
-  records: readonly SdkModelRecord[],
-): Map<string, string> {
-  const grouped = new Map<string, SdkModelRecord[]>();
-
-  for (const record of records) {
-    if (!record.variantKey) continue;
-    const variants = grouped.get(record.variantKey) ?? [];
-    variants.push(record);
-    grouped.set(record.variantKey, variants);
-  }
-
-  const preferred = new Map<string, string>();
-  for (const [variantKey, variants] of grouped) {
-    const canonical = [...variants].sort((left, right) => {
-      const priorityDelta =
-        getPreferredModelPriority(left) - getPreferredModelPriority(right);
-      if (priorityDelta !== 0) return priorityDelta;
-      return left.index - right.index;
-    })[0];
-    if (canonical) preferred.set(variantKey, canonical.value);
-  }
-
-  return preferred;
 }
 
 function mergeAliases(...lists: readonly string[][]): string[] {
@@ -276,30 +281,6 @@ function mergeAliases(...lists: readonly string[][]): string[] {
   }
 
   return aliases;
-}
-
-function buildHiddenModelAliases(
-  records: readonly SdkModelRecord[],
-  preferredCanonicalIds: ReadonlyMap<string, string>,
-): Map<string, string[]> {
-  const hiddenAliases = new Map<string, string[]>();
-
-  for (const record of records) {
-    if (!record.variantKey) continue;
-    const preferredId = preferredCanonicalIds.get(record.variantKey);
-    if (!preferredId || preferredId === record.value) continue;
-
-    hiddenAliases.set(
-      preferredId,
-      mergeAliases(
-        hiddenAliases.get(preferredId) ?? [],
-        [record.value],
-        buildGeneratedAliases(record.identity),
-      ),
-    );
-  }
-
-  return hiddenAliases;
 }
 
 // ── SDK → registry conversion ───────────────────────────────────────────────
@@ -321,106 +302,170 @@ function extractSdkReasoningLevels(model: SdkModelInfo) {
 }
 
 /**
+ * Group records into variant buckets and pick the canonical record for each.
+ * Records without a parseable identity become their own singleton bucket so
+ * they still surface (keyed by value to stay unique).
+ */
+function groupVariants(
+  records: readonly SdkModelRecord[],
+): Map<string, SdkModelRecord[]> {
+  const groups = new Map<string, SdkModelRecord[]>();
+  for (const record of records) {
+    const key = record.variantKey ?? `raw:${record.value}`;
+    const bucket = groups.get(key) ?? [];
+    bucket.push(record);
+    groups.set(key, bucket);
+  }
+  return groups;
+}
+
+function pickCanonical(bucket: readonly SdkModelRecord[]): SdkModelRecord {
+  return [...bucket].sort((left, right) => {
+    const priorityDelta =
+      getPreferredModelPriority(left) - getPreferredModelPriority(right);
+    if (priorityDelta !== 0) return priorityDelta;
+    return left.index - right.index;
+  })[0]!;
+}
+
+/**
+ * Assign a best-effort fallback (used on overload/timeout) to every model
+ * except the last:
+ *  - A 1M variant prefers its base sibling of the same family+version.
+ *  - Otherwise a model falls back to the next model in SDK order.
+ */
+function assignFallbacks(
+  models: ModelInfo[],
+  recordByValue: ReadonlyMap<string, SdkModelRecord>,
+): void {
+  const baseByFamily = new Map<string, string>();
+  for (const model of models) {
+    const rec = recordByValue.get(model.id);
+    if (rec && !rec.identity.isOneMillion && rec.familyKey) {
+      baseByFamily.set(rec.familyKey, model.id);
+    }
+  }
+
+  models.forEach((model, index) => {
+    const rec = recordByValue.get(model.id);
+    if (rec?.identity.isOneMillion && rec.familyKey) {
+      const baseSibling = baseByFamily.get(rec.familyKey);
+      if (baseSibling && baseSibling !== model.id) {
+        model.fallback = baseSibling;
+        return;
+      }
+    }
+    if (index < models.length - 1) {
+      model.fallback = models[index + 1]!.id;
+    }
+  });
+}
+
+/**
  * Convert SDK ModelInfo to our registry format.
- * Keeps SDK model IDs/display names intact while deriving compatibility aliases
- * and duplicate collapsing from the SDK metadata instead of hardcoded versions.
+ *
+ * Base and 1M variants of the same family+version each surface as their own
+ * selectable entry (so the picker shows both), while true duplicates — the
+ * same model exposed under multiple ids, e.g. the recommended `default` and
+ * the longhand `claude-opus-4-7[1m]` it mirrors — collapse into one canonical
+ * entry that absorbs the others' aliases. Display names, aliases, and the
+ * fallback chain are all derived from SDK metadata, never hardcoded versions.
  */
 function convertSdkModels(sdkModels: SdkModelInfo[]): ModelInfo[] {
   const records = buildSdkModelRecords(sdkModels);
-  const preferredCanonicalIds = buildPreferredCanonicalIds(records);
-  const hiddenModelAliases = buildHiddenModelAliases(
-    records,
-    preferredCanonicalIds,
-  );
-  const hiddenModels = new Set(
-    records
-      .filter(
-        (record) =>
-          !!record.variantKey &&
-          preferredCanonicalIds.get(record.variantKey) !== undefined &&
-          preferredCanonicalIds.get(record.variantKey) !== record.value,
-      )
-      .map((record) => record.value),
-  );
+  const groups = groupVariants(records);
+
+  // One canonical per variant bucket, ordered by SDK position so the registry
+  // preserves the SDK's ordering.
+  const canonicals = [...groups.values()]
+    .map(pickCanonical)
+    .sort((a, b) => a.index - b.index);
+
+  // Which family+version pairs have a base (non-1M) canonical? A 1M entry only
+  // claims the bare family aliases when there is no base sibling to own them.
+  const baseFamilyVersions = new Set<string>();
+  for (const canonical of canonicals) {
+    if (!canonical.identity.isOneMillion && canonical.familyKey) {
+      baseFamilyVersions.add(canonical.familyKey);
+    }
+  }
 
   const usedKeys = new Set<string>();
+  const recordByValue = new Map<string, SdkModelRecord>();
   const models: ModelInfo[] = [];
 
-  for (const record of records) {
-    if (hiddenModels.has(record.value)) continue;
+  for (const canonical of canonicals) {
+    const groupKey = canonical.variantKey ?? `raw:${canonical.value}`;
+    const bucket = groups.get(groupKey)!;
+    const { identity } = canonical;
 
-    const canonicalKey = record.value.toLowerCase();
-    if (usedKeys.has(canonicalKey)) continue;
+    const hasBaseSibling = identity.isOneMillion
+      ? !!canonical.familyKey && baseFamilyVersions.has(canonical.familyKey)
+      : true;
+    const aliasForms: AliasFormOptions = {
+      includeBare: !identity.isOneMillion || !hasBaseSibling,
+      include1m: identity.isOneMillion,
+    };
 
+    // Aliases come from every record the canonical absorbs (its own value plus
+    // each duplicate's value and generated forms), so legacy ids keep resolving.
+    const canonicalKey = canonical.value.toLowerCase();
     const aliases = mergeAliases(
-      buildGeneratedAliases(record.identity),
-      hiddenModelAliases.get(record.value) ?? [],
+      ...bucket.map((record) => [
+        record.value,
+        ...buildGeneratedAliases(record.identity, aliasForms),
+      ]),
     )
       .filter((alias) => alias.toLowerCase() !== canonicalKey)
       .filter((alias) => !usedKeys.has(alias.toLowerCase()));
 
     usedKeys.add(canonicalKey);
-    for (const alias of aliases) {
-      usedKeys.add(alias.toLowerCase());
-    }
+    for (const alias of aliases) usedKeys.add(alias.toLowerCase());
 
+    recordByValue.set(canonical.value, canonical);
     models.push({
-      id: record.value,
-      displayName: deriveDisplayName(record.identity, record.displayName),
-      description: record.description,
+      id: canonical.value,
+      displayName: deriveDisplayName(identity, canonical.displayName),
+      description: canonical.description,
       aliases,
       provider: "anthropic",
-      supportedReasoningLevels: extractSdkReasoningLevels(record),
+      supportedReasoningLevels: extractSdkReasoningLevels(canonical),
     });
   }
 
-  // Assign fallback chain from SDK order (single pass, O(1) lookups):
-  // - 1M variants fall back to their base family model
-  // - Base models fall back to the next base model in SDK order
-  const recordById = new Map(records.map((r) => [r.value, r]));
-  const baseByFamily = new Map<string, string>();
-  const baseModels: ModelInfo[] = [];
-
-  for (const model of models) {
-    if (model.id.endsWith("[1m]")) continue;
-    const rec = recordById.get(model.id);
-    if (rec?.familyKey) baseByFamily.set(rec.familyKey, model.id);
-    baseModels.push(model);
-  }
-
-  const baseIndex = new Map(baseModels.map((m, i) => [m.id, i]));
-
-  for (const model of models) {
-    const rec = recordById.get(model.id);
-    if (model.id.endsWith("[1m]") && rec?.familyKey) {
-      model.fallback = baseByFamily.get(rec.familyKey);
-    } else {
-      const idx = baseIndex.get(model.id);
-      if (idx !== undefined && idx < baseModels.length - 1) {
-        model.fallback = baseModels[idx + 1]!.id;
-      }
-    }
-  }
-
+  assignFallbacks(models, recordByValue);
   return models;
 }
 
 // ── Public API ──────────────────────────────────────────────────────────────
 
-/**
- * Discover available models from the Claude Agent SDK and register them.
- *
- * Spawns a throwaway SDK subprocess, calls supportedModels(), converts the
- * results to our registry format, and registers them. Throws on failure —
- * if the SDK can't provide models, Talon cannot function.
- */
-export async function registerClaudeModels(sdkOptions: {
-  model: string;
+type ProbeOptions = {
   cwd?: string;
   permissionMode?: string;
   allowDangerouslySkipPermissions?: boolean;
   pathToClaudeCodeExecutable?: string;
-}): Promise<void> {
+};
+
+const DISCOVERY_TIMEOUT_MS = 15_000;
+const MAX_DISCOVERY_SEEDS = 8;
+
+/**
+ * The `claude` binary returns "Custom model" for a `model` it doesn't
+ * recognise — it echoes the requested id straight back as a passthrough entry
+ * with no real metadata. We drop those (except the user's own configured
+ * model) so seed probing doesn't pollute the registry with junk families.
+ */
+const CUSTOM_MODEL_DESCRIPTION = "custom model";
+
+/**
+ * Spawn a throwaway SDK subprocess seeded with `seedModel` and return its
+ * `supportedModels()` list. The binary always echoes the requested model into
+ * the list, so the seed controls which models surface beyond the base set.
+ */
+async function probeSupportedModels(
+  seedModel: string,
+  probeOptions: ProbeOptions,
+): Promise<SdkModelInfo[]> {
   const abort = new AbortController();
   let drainPromise: Promise<void> | undefined;
 
@@ -436,7 +481,8 @@ export async function registerClaudeModels(sdkOptions: {
     const q = query({
       prompt: neverYield(),
       options: {
-        ...sdkOptions,
+        ...probeOptions,
+        model: seedModel,
         abortController: abort,
       } as Parameters<typeof query>[0]["options"],
     });
@@ -454,36 +500,115 @@ export async function registerClaudeModels(sdkOptions: {
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(
-        () => reject(new Error("model discovery timed out after 15s")),
-        15_000,
+        () =>
+          reject(
+            new Error(
+              `model discovery timed out after 15s (seed "${seedModel}")`,
+            ),
+          ),
+        DISCOVERY_TIMEOUT_MS,
       );
     });
 
-    let sdkModels: SdkModelInfo[];
     try {
-      sdkModels = await Promise.race([q.supportedModels(), timeout]);
+      return await Promise.race([q.supportedModels(), timeout]);
     } finally {
       if (timeoutId !== undefined) clearTimeout(timeoutId);
+      abort.abort();
+      await drainPromise.catch(() => {});
     }
+  } catch (err) {
+    abort.abort();
+    if (drainPromise) await drainPromise.catch(() => {});
+    throw err;
+  }
+}
 
-    if (sdkModels.length === 0) {
+/**
+ * Merge probe results into one list, first-occurrence-wins by value, dropping
+ * unrecognised "Custom model" passthrough echoes (but always keeping the user's
+ * configured model even if the binary treats it as custom).
+ */
+function unionSdkModels(
+  lists: readonly SdkModelInfo[][],
+  configuredModel: string,
+): SdkModelInfo[] {
+  const byValue = new Map<string, SdkModelInfo>();
+  for (const list of lists) {
+    for (const model of list) {
+      if (byValue.has(model.value)) continue;
+      const isPassthroughJunk =
+        (model.description ?? "").trim().toLowerCase() ===
+          CUSTOM_MODEL_DESCRIPTION && model.value !== configuredModel;
+      if (isPassthroughJunk) continue;
+      byValue.set(model.value, model);
+    }
+  }
+  return [...byValue.values()];
+}
+
+/**
+ * Discover available models from the Claude Agent SDK and register them.
+ *
+ * Discovery is a union of probes. The binary only echoes the *requested* model
+ * (and a small base set) from `supportedModels()`, so a single probe misses
+ * the base-vs-1M counterpart of most families. We therefore probe the
+ * configured model first (mandatory — guarantees the user's choice is always
+ * discoverable), then best-effort re-probe each real family alias it revealed,
+ * and union the results so the picker reliably lists both context sizes of
+ * every family. Throws only if the mandatory first probe fails — if the SDK
+ * can't provide models, Talon cannot function.
+ */
+export async function registerClaudeModels(sdkOptions: {
+  model: string;
+  cwd?: string;
+  permissionMode?: string;
+  allowDangerouslySkipPermissions?: boolean;
+  pathToClaudeCodeExecutable?: string;
+}): Promise<void> {
+  const { model: configuredModel, ...probeOptions } = sdkOptions;
+
+  try {
+    // Pass 1 (mandatory): the configured model is always echoed back.
+    const primary = await probeSupportedModels(configuredModel, probeOptions);
+    if (primary.length === 0) {
       throw new Error("SDK returned empty model list");
     }
 
-    const models = convertSdkModels(sdkModels);
+    // Pass 2 (best-effort): re-probe each real family alias from pass 1 to coax
+    // out the context variants the first probe didn't echo. Bare family aliases
+    // (e.g. "opus") return real metadata; unrecognised ones come back as
+    // "Custom model" and are filtered by unionSdkModels.
+    const seeds = new Set<string>();
+    for (const model of primary) {
+      const { family } = describeSdkModel(model);
+      if (family && family !== "default") seeds.add(family);
+    }
+    seeds.delete(configuredModel);
+
+    const seedList = [...seeds].slice(0, MAX_DISCOVERY_SEEDS);
+    const secondary = await Promise.allSettled(
+      seedList.map((seed) => probeSupportedModels(seed, probeOptions)),
+    );
+    const extraLists = secondary
+      .filter(
+        (result): result is PromiseFulfilledResult<SdkModelInfo[]> =>
+          result.status === "fulfilled",
+      )
+      .map((result) => result.value);
+
+    const union = unionSdkModels([primary, ...extraLists], configuredModel);
+    const models = convertSdkModels(union);
     clearModelsByProvider("anthropic");
     registerProviderPrefix("claude-");
     registerModels(models);
     log(
       "agent",
-      `Discovered ${models.length} models from SDK: ${models.map((m) => m.id).join(", ")}`,
+      `Discovered ${models.length} models from SDK ` +
+        `(${1 + extraLists.length}/${1 + seedList.length} probes): ` +
+        models.map((m) => m.id).join(", "),
     );
-
-    abort.abort();
-    await drainPromise;
   } catch (err) {
-    abort.abort();
-    if (drainPromise) await drainPromise.catch(() => {});
     const msg = err instanceof Error ? err.message : String(err);
     logError("agent", `Fatal: model discovery failed — ${msg}`);
     throw new Error(


### PR DESCRIPTION
## Summary

Fixes dynamic model discovery for the Claude SDK backend, which wasn't detecting **Fable 5** and collapsed 1M/non-1M variants into a single picker entry.

Fable is the trigger case: the SDK ships it **only** as `claude-fable-5[1m]` (no base variant). Three latent issues surfaced from that:

1. **1M-only models had no bare aliases** — `/model fable`, `fable-5`, and `claude-fable-5` all failed to resolve; only the `[1m]` forms worked.
2. **Base and 1M variants were collapsed** into one picker entry, so you couldn't choose between e.g. *Sonnet 4.6* and its 1M-context variant.
3. **A single discovery probe under-reports** — `supportedModels()` only echoes the *requested* model plus a small base set, so probing with the configured model surfaced just one context size per family.

## Changes

- **Aliases** (`buildGeneratedAliases`): always emit bare forms, plus `[1m]` forms for 1M variants. A 1M-only family (Fable) also claims the bare aliases so it resolves from `fable`.
- **Variant grouping**: keys on family + version + **context size**, so base and 1M surface as distinct entries (`Sonnet 4.6` vs `Sonnet 4.6 (1M context)`) while genuine duplicates (`claude-opus-4-7[1m]` mirroring `default`) still collapse. 1M detection also reads the description, so the description-only-1M `default` alias merges with its longhand duplicate instead of duplicating.
- **Union discovery** (`registerClaudeModels`): probe the configured model (mandatory), then best-effort re-probe each real family alias it reveals, unioning results and filtering `"Custom model"` passthrough echoes. This reliably lists both context sizes of every family.

## Testing

- New/updated unit tests in `claude-sdk-models.test.ts` covering: base + 1M shown separately, true-duplicate collapse, Fable (1M-only) alias resolution, and union-across-seeds discovery. Updated `chat-settings` / `fuzz` expectations (bare `opus` now resolves to the base entry, not `opus[1m]`).
- `typecheck`, `oxlint`, `knip` clean (only a pre-existing `require-yield` warning on the unchanged `neverYield` generator).
- Verified end-to-end against the **real Claude Code binary**: discovery lists *Opus 4.7*, *Opus 4.7 (1M context)*, *Sonnet 4.6*, and *Sonnet 4.6 (1M context)* as separate selectable entries; Fable resolves correctly when advertised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)