### PR TITLE
fix: three correctness bugs from deep code review

### DIFF
--- a/src/core/gateway-actions.ts
+++ b/src/core/gateway-actions.ts
@@ -135,10 +135,11 @@ export async function handleSharedAction(
         // The Content-Length header is advisory but saves bandwidth when present.
         const MAX_BYTES = 20 * 1024 * 1024; // 20 MB
         const contentLength = resp.headers.get("content-length");
-        if (contentLength && Number(contentLength) > MAX_BYTES) {
+        const contentLengthNum = contentLength ? parseInt(contentLength, 10) : NaN;
+        if (Number.isFinite(contentLengthNum) && contentLengthNum > MAX_BYTES) {
           return {
             ok: false,
-            error: `File too large (${(Number(contentLength) / 1024 / 1024).toFixed(0)}MB, max 20MB)`,
+            error: `File too large (${(contentLengthNum / 1024 / 1024).toFixed(0)}MB, max 20MB)`,
           };
         }
 

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -51,10 +51,16 @@ export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
           throw new AbortError(classified);
         }
         const pRetryDelay = 1000 * Math.pow(2, attempt - 1);
-        const delayMs = classified.retryAfterMs ?? pRetryDelay;
+        // Total wait = p-retry's own backoff plus any extra needed to honour
+        // the server-requested Retry-After.  When retryAfterMs < pRetryDelay
+        // p-retry's delay is already sufficient and no extra sleep is needed.
+        const totalDelayMs = Math.max(
+          pRetryDelay,
+          classified.retryAfterMs ?? pRetryDelay,
+        );
         log(
           "gateway",
-          `Retry ${attempt}/3 (${classified.reason}) after ${delayMs}ms`,
+          `Retry ${attempt}/3 (${classified.reason}) after ${totalDelayMs}ms`,
         );
         if (classified.retryAfterMs && classified.retryAfterMs > pRetryDelay) {
           await new Promise<void>((resolve) =>

--- a/src/storage/daily-log.ts
+++ b/src/storage/daily-log.ts
@@ -40,7 +40,7 @@ export function appendDailyLog(
     ensureLogsDir();
     const now = new Date();
     const dateStr = now.toISOString().slice(0, 10); // YYYY-MM-DD
-    const timeStr = now.toTimeString().slice(0, 5); // HH:MM
+    const timeStr = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
     const logFile = resolve(LOGS_DIR, `${dateStr}.md`);
 
     const label = formatLabel(chatName, chatContext);
@@ -64,7 +64,7 @@ export function appendDailyLogResponse(
     ensureLogsDir();
     const now = new Date();
     const dateStr = now.toISOString().slice(0, 10); // YYYY-MM-DD
-    const timeStr = now.toTimeString().slice(0, 5); // HH:MM
+    const timeStr = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
     const logFile = resolve(LOGS_DIR, `${dateStr}.md`);
 
     const label = chatContext?.chatTitle


### PR DESCRIPTION
## Summary

Deep review of the entire codebase (176 source files, ~46k lines). Three confirmed correctness bugs are fixed here. All 2909 unit tests pass.

---

### Bug 1 — `daily-log.ts`: `toTimeString().slice(0, 5)` is implementation-defined (`src/storage/daily-log.ts` lines 43 & 67)

**Problem:** `Date.prototype.toTimeString()` format is implementation-defined per the ECMAScript spec (MDN: *"The format of the string may vary between implementations"*). The code assumed the string always begins with `HH:MM`, which holds true in V8/Node.js today but is not guaranteed. On a non-V8 runtime or after an engine update, this would silently produce incorrect timestamps in daily log files.

**Fix:** Replace both occurrences with explicit `padStart(2, "0")` construction, which is spec-guaranteed on all engines:
```ts
// before
const timeStr = now.toTimeString().slice(0, 5);
// after
const timeStr = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
```

---

### Bug 2 — `gateway-actions.ts`: Malformed `Content-Length` bypasses the early-rejection size check (`src/core/gateway-actions.ts` line 138)

**Problem:** The early size check for fetched URLs used `Number(contentLength)`:
```ts
if (contentLength && Number(contentLength) > MAX_BYTES) { ... }
```
`Number("20971520abc")` → `NaN`. `NaN > MAX_BYTES` → `false`. A malformed or attacker-controlled `Content-Length` header therefore **silently bypasses the early-rejection optimisation**. The secondary check (`buffer.length > MAX_BYTES`, line 151) still catches oversized bodies after download, so this is not a security bypass of the ultimate guard — but it defeats the purpose of the early check: saving bandwidth by refusing before the download starts, and surfacing a clear "File too large" error with a KB count.

**Fix:** Validate with `parseInt(..., 10)` + `Number.isFinite()`:
```ts
const contentLengthNum = contentLength ? parseInt(contentLength, 10) : NaN;
if (Number.isFinite(contentLengthNum) && contentLengthNum > MAX_BYTES) { ... }
```

---

### Bug 3 — `gateway.ts` `withRetry`: Log message reports wrong expected delay when `retryAfterMs ≤ pRetryDelay` (`src/core/gateway.ts` lines 53–63)

**Problem:** The retry log said `"Retry N/3 after ${delayMs}ms"` where `delayMs = classified.retryAfterMs ?? pRetryDelay`. When a server returns a `Retry-After` value that is *less than* p-retry's exponential backoff (e.g. server says 500 ms, but p-retry would wait 1000 ms), no extra `setTimeout` is added (the condition `retryAfterMs > pRetryDelay` is false) — so the actual total wait is `pRetryDelay`. The log was reporting `500ms` while the actual wait was `1000ms`, making retry diagnostics misleading for operators.

**Fix:** Compute and log `Math.max(pRetryDelay, classified.retryAfterMs ?? pRetryDelay)` as `totalDelayMs`:
```ts
const totalDelayMs = Math.max(pRetryDelay, classified.retryAfterMs ?? pRetryDelay);
log("gateway", `Retry ${attempt}/3 (${classified.reason}) after ${totalDelayMs}ms`);
```

---

## Other findings (no code changes needed)

The review surfaced several other areas worth noting. None required changes because the code is correct on close reading, but they may be worth documenting for future maintainers:

| Area | Finding | Verdict |
|------|---------|---------|
| `sessions.ts` — `store.update(() => undefined)` pattern | Mutations happen via the reference returned by `store.get()` rather than inside the closure. Works because `JsonStore.get()` returns the live `#value` reference, not a copy. | Correct but unconventional — reliance on `JsonStore` internals. |
| `claude-sdk/stream.ts` — local `StreamState` vs shared interface | The claude-sdk's local `StreamState` lacks `hadBridgeDelivery`. The handler doesn't call the shared `recordToolUse` and manages `turnTerminated` / `deliveredTextNorms` directly. | Not a bug — the claude-sdk backend doesn't use `delivery.ts`, only Kilo/OpenCode/Codex/OpenAI-Agents do, and those call `recordToolUse` correctly. |
| `dispatcher.ts` — `chatChains` atomicity | The review flagged a "race" in the get/set pair, but JS is single-threaded — no `await` exists between the `get` and `set`, making the operation atomic in practice. | Not a bug. |
| `cron-store.ts` — `runCount \|\| 0` vs `?? 0` | `(0 \|\| 0) + 1` and `(0 ?? 0) + 1` both equal `1`; the behaviour is identical for all possible `runCount` values. | Not a bug. |
| `gateway.ts` — `removeAllListeners("error")` | Inside the `listen` success callback, `removeAllListeners` removes the startup `once("error")` listener and replaces it with a persistent one. Inside the `once("error")` handler, `once` already removed the listener before invoking it, so the explicit `removeAllListeners` is a no-op — harmless cleanup. | Correct; the inline comment explains the intent. |

## Test plan

- [x] All 2909 unit tests pass (`vitest run`)
- [x] Diff reviewed — changes are minimal and localised to the three identified lines

https://claude.ai/code/session_01V456Y9FcXuMBDgcsE6cf1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01V456Y9FcXuMBDgcsE6cf1b)_