### PR TITLE
Prompt architecture overhaul, shared backend metrics, and core restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ index.ts                    Composition root
   |   +-- background/       Agents that run without a user message:
   |   |                     heartbeat, dream, pulse, cron, triggers
   |   +-- tools/            MCP tool definitions + spawn/env contract
-  |   +-- gateway.ts        HTTP bridge for MCP tool calls
-  |   +-- dispatcher.ts     Per-chat serial, cross-chat parallel execution
+  |   +-- engine/           Message flow: dispatcher (per-chat serial,
+  |   |                     cross-chat parallel), HTTP gateway for MCP
+  |   |                     tool calls, backend lifecycle controller
   |   +-- plugin.ts         Plugin loader, registry, hot-reload
   |
   +-- backend/
@@ -82,6 +83,7 @@ index.ts                    Composition root
   |   +-- openai-agents/    OpenAI Agents SDK backend (Responses API)
   |
   +-- frontend/
+  |   +-- shared/           Cross-frontend presentation helpers
   |   +-- telegram/         Grammy bot + GramJS userbot
   |   +-- discord/          discord.js v14
   |   +-- teams/            Bot Framework + Graph API

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Backends](https://img.shields.io/badge/backends-Claude_%7C_Kilo_%7C_OpenCode_%7C_Codex-D97706)](#backends)
+[![Backends](https://img.shields.io/badge/backends-Claude_%7C_Kilo_%7C_OpenCode_%7C_Codex_%7C_OpenAI_Agents-D97706)](#backends)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/dylanneve1/talon/actions/workflows/ci.yml/badge.svg)](https://github.com/dylanneve1/talon/actions/workflows/ci.yml)
 
-Multi-platform agentic AI harness. Runs on **Telegram**, **Discord**, **Microsoft Teams**, and the **Terminal**, with a pluggable backend (**Claude Agent SDK**, **Kilo**, **OpenCode**, or **Codex**) and full tool access through MCP.
+Multi-platform agentic AI harness. Runs on **Telegram**, **Discord**, **Microsoft Teams**, and the **Terminal**, with a pluggable backend (**Claude Agent SDK**, **Kilo**, **OpenCode**, **Codex**, or **OpenAI Agents**) and full tool access through MCP.
 
 ---
 
@@ -15,7 +15,7 @@ Multi-platform agentic AI harness. Runs on **Telegram**, **Discord**, **Microsof
 |                       |                                                                                                                                              |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Multi-frontend**    | Telegram (Grammy + GramJS userbot), Discord (discord.js), Microsoft Teams (Bot Framework), Terminal with live tool visibility                |
-| **Pluggable backend** | Claude Agent SDK, Kilo, OpenCode, Codex — selectable per-process via `backend` config. Streaming, model fallback, context-overflow recovery. |
+| **Pluggable backend** | Claude Agent SDK, Kilo, OpenCode, Codex, OpenAI Agents — selectable per-process via `backend` config. Streaming, model fallback, context-overflow recovery. |
 | **MCP tools**         | Messaging, media, history, search, web fetch, cron jobs, triggers, stickers, file system, admin controls                                     |
 | **Plugins**           | Hot-reloadable plugin system. Built-in: GitHub, MemPalace, Playwright, Brave Search                                                          |
 | **Background agents** | Heartbeat (periodic maintenance) and Dream (memory consolidation + diary) — backend-agnostic                                                 |
@@ -57,27 +57,29 @@ npx talon chat        # terminal chat mode
 index.ts                    Composition root
   |
   +-- core/                 Platform-agnostic engine
-  |   +-- models.ts         Model registry (dynamic backend discovery)
+  |   +-- agent-runtime/    Backend capability interfaces, events, stores
+  |   +-- models/           Model layer: catalog, per-chat active model,
+  |   |                     reasoning-effort vocabulary
+  |   +-- prompt/           System-prompt assembly + prompts/system templates
+  |   +-- background/       Agents that run without a user message:
+  |   |                     heartbeat, dream, pulse, cron, triggers
+  |   +-- tools/            MCP tool definitions + spawn/env contract
   |   +-- gateway.ts        HTTP bridge for MCP tool calls
   |   +-- dispatcher.ts     Per-chat serial, cross-chat parallel execution
   |   +-- plugin.ts         Plugin loader, registry, hot-reload
-  |   +-- heartbeat.ts      Periodic background agent
-  |   +-- dream.ts          Memory consolidation agent
-  |   +-- pulse.ts          Conversation-aware group engagement
-  |   +-- cron.ts           Persistent scheduled jobs
-  |   +-- triggers.ts       Self-authored watcher scripts
-  |   +-- tools/            MCP tool definitions
   |
   +-- backend/
   |   +-- registry.ts       Bootstrap-decoupled backend lookup
   |   +-- shared/           Cross-backend helpers (stream state, flow violation,
-  |   |                     prompt format, model retry, system prompt, usage)
+  |   |                     delivery contract, metrics, prompt format,
+  |   |                     model retry, system prompt, usage)
   |   +-- remote-server/    Shared infrastructure for agent-server backends
   |   |                     (MCP registration, sessions, providers, lifecycle)
   |   +-- claude-sdk/       Claude Agent SDK (in-process MCP, hooks)
   |   +-- kilo/             Kilo HTTP server backend (streaming via SSE)
   |   +-- opencode/         OpenCode HTTP server backend
   |   +-- codex/            Codex CLI backend (`@openai/codex-sdk`)
+  |   +-- openai-agents/    OpenAI Agents SDK backend (Responses API)
   |
   +-- frontend/
   |   +-- telegram/         Grammy bot + GramJS userbot
@@ -90,13 +92,15 @@ index.ts                    Composition root
   +-- util/                 Config, logging, workspace, paths, time
 ```
 
-**Dependency rule:** `core/` imports nothing from `frontend/` or `backend/`. Frontends and backends depend on core types, never on each other. All four backends (Claude SDK, Kilo, OpenCode, Codex) implement the same `QueryBackend` interface in `core/types.ts`. Kilo and OpenCode additionally share the `remote-server/` infrastructure because they wrap forks of the same upstream HTTP agent server.
+**Dependency rule:** `core/` imports nothing from `frontend/` or `backend/`. Frontends and backends depend on core types, never on each other. All five backends (Claude SDK, Kilo, OpenCode, Codex, OpenAI Agents) implement the same `Backend` capability interface from `core/agent-runtime/capabilities.ts`. Kilo and OpenCode additionally share the `remote-server/` infrastructure because they wrap forks of the same upstream HTTP agent server.
+
+**Prompts:** everything the model reads at session start is assembled by `core/prompt/` from the files in `prompts/` — see [prompts/README.md](prompts/README.md) for the assembly order, file ownership (user-editable vs package-owned templates), and the per-backend delivery contracts.
 
 ---
 
 ## Backends
 
-Select via the `backend` field in `~/.talon/config.json`. All backends implement the same `QueryBackend` interface — heartbeat, dream, and chat handlers are backend-agnostic.
+Select via the `backend` field in `~/.talon/config.json`. All backends implement the same `Backend` capability interface — heartbeat, dream, and chat handlers are backend-agnostic.
 
 | Backend    | `backend` value | Transport                                       | Notes                                                                                                                                                                                                            |
 | ---------- | --------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -104,6 +108,7 @@ Select via the `backend` field in `~/.talon/config.json`. All backends implement
 | Kilo       | `"kilo"`        | Local HTTP server via `@kilocode/sdk`           | SSE-streamed turns. Routes to many model providers via Kilo's auth.                                                                                                                                              |
 | OpenCode   | `"opencode"`    | Local HTTP server via `@opencode-ai/sdk`        | SSE-streamed turns; same MCP and session shape as Kilo (upstream fork).                                                                                                                                          |
 | Codex      | `"codex"`       | Per-turn subprocess via `@openai/codex-sdk`     | Requires the `codex` CLI from `@openai/codex` and Codex auth (`codex login`, `CODEX_API_KEY`, `TALON_CODEX_KEY`, or `codexApiKey`). MCP servers configured via TOML overrides at thread start. |
+| OpenAI Agents | `"openai-agents"` | In-process via `@openai/agents` | Responses API (or any OpenAI-compatible endpoint via `TALON_AGENTS_URL` / `openaiBaseUrl`). Persistent per-chat MCP bundles. |
 
 The Kilo and OpenCode backends share infrastructure (`backend/remote-server/`) since the upstream HTTP API is the same; each backend supplies its own SDK client, port, and delivery suffix. Codex is its own integration on top of the Codex CLI's JSONL event stream.
 
@@ -247,7 +252,7 @@ Config file: `~/.talon/config.json`
 | Field                      | Default      | Description                                                                                                             |
 | -------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | `frontend`                 | `"telegram"` | `"telegram"`, `"discord"`, `"teams"`, `"terminal"`, or an array                                                         |
-| `backend`                  | `"claude"`   | `"claude"`, `"kilo"`, `"opencode"`, or `"codex"`                                                                        |
+| `backend`                  | `"claude"`   | `"claude"`, `"kilo"`, `"opencode"`, `"codex"`, or `"openai-agents"`                                                     |
 | `botToken`                 | ---          | Telegram bot token                                                                                                      |
 | `model`                    | `"default"`  | Default model. Interpretation depends on the active backend.                                                            |
 | `codexApiKey`              | ---          | Codex-only OpenAI API key. Prefer this over `openaiApiKey` for Codex API-key auth. `codex login` takes precedence over shared `openaiApiKey`. |
@@ -258,6 +263,8 @@ Config file: `~/.talon/config.json`
 | `braveApiKey`              | ---          | Brave Search API key                                                                                                    |
 | `timezone`                 | ---          | IANA timezone (e.g. `"Europe/London"`)                                                                                  |
 | `plugins`                  | `[]`         | External plugin packages                                                                                                |
+| `disabledToolTags`         | ---          | Hide whole tool groups from the model (e.g. `["stickers", "web"]`) — each registered tool costs context tokens per session |
+| `disabledTools`            | ---          | Hide individual tools by name (`end_turn` cannot be disabled)                                                           |
 | `adminUserId`              | ---          | Telegram user ID for `/admin` commands                                                                                  |
 | `allowedUsers`             | ---          | Whitelist of Telegram user IDs                                                                                          |
 | `apiId` / `apiHash`        | ---          | Telegram API credentials for full message history                                                                       |

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -2,19 +2,20 @@
 
 Talon's `core/` is backend-agnostic. The active model provider is
 selected via `backend` in `~/.talon/config.json`, and every backend
-implements the same `QueryBackend` interface from
-[`src/core/types.ts`](../src/core/types.ts). Heartbeat, dream,
-`/model`, `/settings`, `/status`, plugin hot-reload, etc. work
-identically against any backend.
+composes the same `Backend` capability interface from
+[`src/core/agent-runtime/capabilities.ts`](../src/core/agent-runtime/capabilities.ts).
+Heartbeat, dream, `/model`, `/settings`, `/status`, plugin hot-reload,
+etc. work identically against any backend.
 
 ## Available backends
 
-| `backend` value | Label     | SDK                              | Transport                                     |
-| --------------- | --------- | -------------------------------- | --------------------------------------------- |
-| `"claude"`      | Anthropic | `@anthropic-ai/claude-agent-sdk` | Per-query subprocess (the `claude` CLI)       |
-| `"kilo"`        | Kilo      | `@kilocode/sdk`                  | Local HTTP server (one process, SSE-streamed) |
-| `"opencode"`    | OpenCode  | `@opencode-ai/sdk`               | Local HTTP server (one process, SSE-streamed) |
-| `"codex"`       | Codex     | `@openai/codex-sdk`              | Per-turn subprocess (the `codex` CLI)         |
+| `backend` value    | Label         | SDK                              | Transport                                     |
+| ------------------ | ------------- | -------------------------------- | --------------------------------------------- |
+| `"claude"`         | Anthropic     | `@anthropic-ai/claude-agent-sdk` | Per-query subprocess (the `claude` CLI)       |
+| `"kilo"`           | Kilo          | `@kilocode/sdk`                  | Local HTTP server (one process, SSE-streamed) |
+| `"opencode"`       | OpenCode      | `@opencode-ai/sdk`               | Local HTTP server (one process, SSE-streamed) |
+| `"codex"`          | Codex         | `@openai/codex-sdk`              | Per-turn subprocess (the `codex` CLI)         |
+| `"openai-agents"`  | OpenAI Agents | `@openai/agents`                 | In-process (Responses API or any OpenAI-compatible endpoint) |
 
 ## Shared infrastructure
 
@@ -26,11 +27,19 @@ Every backend uses these:
   delivered-text norms, synthetic-error markers.
 - `delivery.ts` — `routeDelivery` decides between
   `tool` / `synthetic-error` / `text-part` / `empty` at end of turn.
+- `delivery-contract.ts` — per-backend response-flow contract built
+  from `prompts/system/contract-*.md` templates, plus the
+  frontend-aware flow-violation reminder and first-turn nudge.
 - `flow-violation.ts` — detect trailing prose without delivery tool
   call, build the synthetic re-prompt.
+- `metrics.ts` — the shared metric vocabulary (`tool_calls.*`,
+  `queries_total`, per-turn histograms, `backend.<id>.*` dimensions).
+  Backends never call `incrementCounter` for these directly.
 - `prompt-format.ts` — `[YYYY-MM-DD HH:MM:SS] [Name] [msg_id:N]`
   prefix on user prompts.
-- `system-prompt.ts` — first-turn rebuild + per-backend suffix join.
+- `system-prompt.ts` — per-session frozen prompt snapshots +
+  per-backend suffix join (assembly itself lives in `core/prompt/`).
+- `frontends.ts` — `nonTerminalFrontends` config normaliser.
 - `model-retry.ts` — classify retryable errors into reset / fallback /
   bubble decisions.
 - `session-name.ts` — first-message → short session title.
@@ -60,36 +69,33 @@ server, so their MCP / session / provider plumbing is shared:
 Codex and Claude SDK don't use this — they wrap different transport
 shapes.
 
-## QueryBackend interface
+## The Backend capability interface
 
-Every backend's `factory.init()` returns one of these from
-`core/types.ts`:
+Every backend's factory composes a `Backend` object via
+`composeBackend(...)` from
+`core/agent-runtime/capabilities.ts`. Capabilities are explicit
+slots, not optional methods on a fat interface — consumers read
+presence directly (`backend.chat?.…`) and degrade gracefully when a
+slot is absent:
 
 ```typescript
-interface QueryBackend {
-  query(params: QueryParams): Promise<QueryResult>;        // required
-  warmSession?(chatId: string): Promise<void>;             // Claude-only
-  updateSystemPrompt?(prompt: string): void;               // Claude-only
-  refreshMcpServers?(chatId: string): Promise<...>;        // Claude-only
-  resolveModel?(query: string): Promise<UnifiedModelResolution>;
-  getModelInfo?(id: string): Promise<UnifiedModelInfo | undefined>;
-  getSettingsPresentation?(activeModel: string, callbackPrefix?: string):
-    Promise<{ modelButtons: ModelButton[]; modelDetails: string[] }>;
-  getProviders?(): Promise<UnifiedProviderInfo[]>;
-  getProviderModels?(providerId: string, page?: number, pageSize?: number):
-    Promise<{ models: UnifiedModelInfo[]; total: number }>;
-  formatModelError?(query: string, resolution: UnifiedModelResolution): string;
-  getSessionSnapshot?(sessionId: string): Promise<...>;     // /status
-  listModels?(filter?: "free" | "all"): Promise<...>;
-  runOneShotAgent?(params: OneShotAgentParams): Promise<void>;
-  evictOrphanSubprocesses?(contextLabel: string): Promise<...>;  // Claude-only
-  backendLabel?: string;
+interface Backend {
+  id: BackendId;
+  label: string;
+  cacheMetrics: CacheMetricsSupport;
+  chat?: ChatBackend;          // runChatTurn → AsyncIterable<AgentEvent>
+  background?: BackgroundRunner; // runOneShotAgent (heartbeat / dream / triggers)
+  models?: ModelCatalog;       // resolution core + optional picker surface
+  sessions?: SessionBackend;   // resetChat / warmSession
+  tools?: ToolRuntime;         // refreshTools (plugin hot-reload)
+  usage?: UsageTelemetry;      // getSessionSnapshot (/status enrichment)
+  control?: SystemControl;     // updateSystemPrompt
 }
 ```
 
-`runOneShotAgent` is what makes heartbeat + dream work across all
-backends — each backend's `one-shot.ts` translates the runtime
-events into Markdown-flavoured run-log entries.
+`background.runOneShotAgent` is what makes heartbeat + dream work
+across all backends — each backend's `one-shot.ts` translates the
+runtime events into Markdown-flavoured run-log entries.
 
 ## Backend-specific notes
 
@@ -147,9 +153,9 @@ keep OpenAI-compatible endpoint credentials without hijacking Codex.
    - `index.ts` — barrel.
 
 2. The factory's `init` is called once at startup and returns a
-   `QueryBackend` instance. Wire in as many of the optional methods
-   as your SDK supports; `core/` falls back gracefully when methods
-   are missing.
+   `Backend` composed via `composeBackend(...)`. Wire in as many of
+   the capability slots as your SDK supports; `core/` falls back
+   gracefully when a slot is missing.
 
 3. Add `await import("./backend/<name>/factory.js");` to
    `bootstrap.ts`'s factory-loading block.
@@ -166,8 +172,8 @@ keep OpenAI-compatible endpoint credentials without hijacking Codex.
 7. Add tests:
    - Unit tests for backend-specific helpers (`models.ts`,
      `mcp-config.ts`, etc.).
-   - A factory wiring test (mock the SDK, assert the returned
-     QueryBackend has the expected methods).
+   - A factory wiring test (mock the SDK, assert the composed
+     `Backend` has the expected capability slots).
    - If you wrap a CLI: a Docker harness under `docker/<name>-test/`
      for live verification.
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -65,6 +65,8 @@ server, so their MCP / session / provider plumbing is shared:
 - `providers.ts` — `resolveProviderID` walking the provider catalog.
 - `events.ts` — SSE event processor (`processStreamEvent`,
   `finalizePartsIntoState`).
+- `one-shot.ts` — shared heartbeat/dream runner; each backend binds
+  its server bootstrap, model-selection parser, and delivery suffix.
 
 Codex and Claude SDK don't use this — they wrap different transport
 shapes.

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -72,7 +72,8 @@ contradictions between backends.
 
 `heartbeat.md` and `dream.md` are not part of the chat system prompt — they
 are standalone prompts for the background heartbeat and memory-consolidation
-(dream) agents, loaded by `src/core/heartbeat.ts` / `src/core/dream.ts`.
+(dream) agents, loaded by `src/core/background/heartbeat.ts` /
+`src/core/background/dream.ts`.
 
 ## Token budget
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -10,17 +10,17 @@ dividers, split into a **static** prefix (stable for a session's lifetime,
 eligible for provider prompt caching) and a **dynamic** tail (volatile,
 placed after the cache boundary):
 
-| # | Section | Source | Part |
-|---|---------|--------|------|
-| 1 | Identity | `identity.md` + `~/.talon/workspace/identity.md` | static |
-| 2 | Core behaviour | `custom.md` (replaces `base.md` when present) | static |
-| 3 | Frontend capabilities | `<frontend>.md` (telegram / discord / teams / terminal) | static |
-| 4 | Persistent memory | `system/persistent-memory.md` wrapping `memory/memory.md`, size-capped | static |
-| 5 | Capability docs | `system/workspace.md`, `system/cron.md`, `system/triggers.md` | static |
-| 6 | Plugin additions | each plugin's `systemPrompt()` contribution | static |
-| 7 | **Delivery contract** | `system/contract-*.md`, appended by the **backend** as its suffix | static (tail) |
-| 8 | Daily-memory pointer | `system/daily-memory.md` (names today's file) | dynamic |
-| 9 | Workspace listing | generated tree of `~/.talon/workspace/` | dynamic |
+| #   | Section               | Source                                                                 | Part          |
+| --- | --------------------- | ---------------------------------------------------------------------- | ------------- |
+| 1   | Identity              | `identity.md` + `~/.talon/workspace/identity.md`                       | static        |
+| 2   | Core behaviour        | `custom.md` (replaces `base.md` when present)                          | static        |
+| 3   | Frontend capabilities | `<frontend>.md` (telegram / discord / teams / terminal)                | static        |
+| 4   | Persistent memory     | `system/persistent-memory.md` wrapping `memory/memory.md`, size-capped | static        |
+| 5   | Capability docs       | `system/workspace.md`, `system/cron.md`, `system/triggers.md`          | static        |
+| 6   | Plugin additions      | each plugin's `systemPrompt()` contribution                            | static        |
+| 7   | **Delivery contract** | `system/contract-*.md`, appended by the **backend** as its suffix      | static (tail) |
+| 8   | Daily-memory pointer  | `system/daily-memory.md` (names today's file)                          | dynamic       |
+| 9   | Workspace listing     | generated tree of `~/.talon/workspace/`                                | dynamic       |
 
 The delivery contract is deliberately LAST in the static prefix: it is the
 one section the model must not miss, and the end of the prompt is the

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,82 @@
+# Talon prompt architecture
+
+Everything the model reads at session start is assembled from the files in
+this directory by `src/core/prompt/assemble.ts`. This README is the map.
+
+## Assembly order
+
+The system prompt is an ordered list of markdown sections joined by `---`
+dividers, split into a **static** prefix (stable for a session's lifetime,
+eligible for provider prompt caching) and a **dynamic** tail (volatile,
+placed after the cache boundary):
+
+| # | Section | Source | Part |
+|---|---------|--------|------|
+| 1 | Identity | `identity.md` + `~/.talon/workspace/identity.md` | static |
+| 2 | Core behaviour | `custom.md` (replaces `base.md` when present) | static |
+| 3 | Frontend capabilities | `<frontend>.md` (telegram / discord / teams / terminal) | static |
+| 4 | Persistent memory | `system/persistent-memory.md` wrapping `memory/memory.md`, size-capped | static |
+| 5 | Capability docs | `system/workspace.md`, `system/cron.md`, `system/triggers.md` | static |
+| 6 | Plugin additions | each plugin's `systemPrompt()` contribution | static |
+| 7 | **Delivery contract** | `system/contract-*.md`, appended by the **backend** as its suffix | static (tail) |
+| 8 | Daily-memory pointer | `system/daily-memory.md` (names today's file) | dynamic |
+| 9 | Workspace listing | generated tree of `~/.talon/workspace/` | dynamic |
+
+The delivery contract is deliberately LAST in the static prefix: it is the
+one section the model must not miss, and the end of the prompt is the
+highest-salience position.
+
+## File ownership — two kinds of prompt files
+
+**User-editable prompts** (everything at the top level of this directory:
+`identity.md`, `base.md`, `custom.md`, `telegram.md`, `discord.md`,
+`teams.md`, `terminal.md`, `heartbeat.md`, `dream.md`, `mempalace.md`) are
+seeded once into `~/.talon/prompts/` on first run and read from there.
+User edits always win; package updates never overwrite them.
+
+**System templates** (`system/*.md`) are read directly from the package and
+are NOT seeded. They document runtime behaviour that is versioned with the
+code — delivery tool names, flow enforcement, trigger limits. A stale
+seeded copy would silently describe a contract the code no longer
+implements, so these are not user-customisable.
+
+Templates support a minimal syntax (`src/core/prompt/templates.ts`):
+`{{var}}` substitution and `{{#if var}}…{{/if}}` conditionals. Nothing else.
+
+## The delivery contract (response flow)
+
+How a reply reaches the user is a property of the **backend**, not the
+frontend, so it never belongs in the frontend `.md` files:
+
+- `system/contract-tool-only.md` — claude-sdk, openai-agents. The output
+  stream is private scratchpad; replies MUST go through a delivery tool
+  (`end_turn` / `send` / `react`). A prose-only turn triggers one
+  `[FLOW VIOLATION]` re-prompt, then a silent drop.
+- `system/contract-text-or-tools.md` — codex, kilo. Plain assistant text
+  is the reply; delivery tools add targeting / rich content.
+- opencode keeps a custom text-preferred override in its server module.
+
+The delivery TOOL NAMES are per-frontend (`end_turn`/`send`/`react` on
+telegram & discord, `end_turn`/`send_message` on teams) and are injected
+into the templates by `src/backend/shared/delivery-contract.ts`, which is
+also where the frontend-aware `[FLOW VIOLATION]` reminder and the
+first-turn nudge (appended to the turn-0 user message) are built.
+
+When editing frontend `.md` files, describe what the frontend can DO
+(tools, formatting, culture); never re-state how replies are delivered —
+the contract section wins, and duplicated contract text has already caused
+contradictions between backends.
+
+## Task prompts
+
+`heartbeat.md` and `dream.md` are not part of the chat system prompt — they
+are standalone prompts for the background heartbeat and memory-consolidation
+(dream) agents, loaded by `src/core/heartbeat.ts` / `src/core/dream.ts`.
+
+## Token budget
+
+The static prompt is read on EVERY session: every sentence must earn its
+tokens. Per-tool parameter details and examples belong in the MCP tool
+descriptions (which the model also has in context), not here. The memory
+section is capped (`MEMORY_INJECT_MAX_CHARS`) and the workspace listing
+collapses directories with more than 8 entries.

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -54,7 +54,8 @@ frontend, so it never belongs in the frontend `.md` files:
   `[FLOW VIOLATION]` re-prompt, then a silent drop.
 - `system/contract-text-or-tools.md` — codex, kilo. Plain assistant text
   is the reply; delivery tools add targeting / rich content.
-- opencode keeps a custom text-preferred override in its server module.
+- `system/contract-text-preferred.md` — opencode. Plain text is the
+  normal route; tools only for genuine side effects.
 
 The delivery TOOL NAMES are per-frontend (`end_turn`/`send`/`react` on
 telegram & discord, `end_turn`/`send_message` on teams) and are injected

--- a/prompts/discord.md
+++ b/prompts/discord.md
@@ -2,28 +2,11 @@
 
 In servers (guilds), you'll see messages prefixed with [Name]: — use their name naturally. In DMs, just one user.
 
-### CRITICAL: Message delivery
+How replies are delivered (end_turn / send / react and what counts as a valid turn) is defined in the **Response flow** section at the end of these instructions — that contract wins over anything here.
 
-ALL messages to the user MUST be sent using the `send` tool. Your plain text output is **private** — the user never sees it, only you. Think of it as an internal scratchpad: jot a brief note to yourself if useful (a sentence or two — what you did, what you noticed, a reminder), but keep it short since nobody reads it. The only way to reach the user is the `send` tool.
+### Tools
 
-### The `send` tool
-
-One tool for everything. Set `type` to choose what to send:
-
-- `send(type="text", text="Hello!")` — send a message
-- `send(type="text", text="Hey", reply_to="123456789012345678")` — reply to a specific message (Discord IDs are strings)
-- `send(type="text", text="Pick", buttons=[[{"text":"A","callback_data":"a","style":"primary"}]])` — with buttons
-- `send(type="text", text="Reminder", delay_seconds=60)` — schedule for later
-- `send(type="photo", file_path="img.jpg", caption="Look!")` — send an image
-- `send(type="file", file_path="report.pdf")` — send a document
-- `send(type="video", file_path="clip.mp4")` — send a video
-- `send(type="voice", file_path="audio.ogg")` — send an audio attachment
-- `send(type="poll", question="Best?", options=["A","B","C"])` — create a poll
-- `send(type="dice")` — roll dice
-- `send(type="location", latitude=37.77, longitude=-122.42)` — share a Google Maps location link
-- `send(type="contact", phone_number="+1234", first_name="John")` — share a contact card
-
-ALL types support `reply_to` to reply to a specific message.
+Your registered tool list covers the full Discord surface — rich sends (images, files, polls, scheduled messages), reactions, message management (edit/delete/pin), chat history and search, member info. Tool descriptions carry the parameters and examples; don't guess capabilities, check the list.
 
 ### Discord-specific
 
@@ -32,18 +15,7 @@ ALL types support `reply_to` to reply to a specific message.
 - **Markdown is native:** `**bold**`, `*italic*`, `` `code` ``, ` ```fenced``` `, `# headings`, `> quotes`, `||spoilers||`, `[links](url)`. Discord renders these without translation.
 - **Mentions:** the bot is configured to suppress all mentions (`@everyone`, `@here`, role/user pings) so you can't accidentally ping anyone. Don't worry about escaping.
 - **Message limit:** 2000 chars per message. Long messages are auto-chunked at paragraph breaks.
-
-### Other tools
-
-- `react(message_id, emoji)` — react to a message (unicode emoji only on Discord; custom emojis need `<:name:id>` format)
-- `edit_message(message_id, text)` — edit a sent message (max 2000 chars)
-- `delete_message(message_id)` — delete a message
-- `pin_message(message_id)` / `unpin_message()` — pin/unpin
-- `read_chat_history(limit)` — read past messages from this channel
-- `search_chat_history(query)` — search recent messages by keyword
-- `list_chat_members()` — list members in this server (guild only)
-- `get_member_info(user_id)` — detailed user info
-- `online_count()` — approximate online member count
+- **Reactions:** unicode emoji only; custom emojis need `<:name:id>` format.
 
 ### Message IDs
 
@@ -51,15 +23,7 @@ The user's message ID is in the prompt as msg_id:N (Discord snowflake string). U
 
 ### Choosing not to respond
 
-You don't HAVE to respond to every message. If a message doesn't need a response:
-
-- React with an emoji using the `react` tool — preferred way to acknowledge without replying.
-- Or simply don't call `send` and skip it entirely.
-- In servers, prefer reactions over replies for simple acknowledgements.
-
-### Reactions
-
-Use naturally: 👍 ❤️ 🔥 😂 🎉 👀 💯. React AND reply when both feel right.
+You don't HAVE to respond to every message. To acknowledge without replying, `react` with an emoji — in servers this is PREFERRED over replies for simple acknowledgements. Use reactions naturally: 👍 ❤️ 🔥 😂 🎉 👀 💯. React AND reply when both feel right.
 
 ### Buttons & Components
 

--- a/prompts/system/contract-text-or-tools.md
+++ b/prompts/system/contract-text-or-tools.md
@@ -1,0 +1,8 @@
+## Response flow
+
+Two ways to deliver a reply — pick whichever fits:
+
+- **Plain text** — your assistant text is the reply. Just answer normally. (Reasoning content stays private.)
+- **Delivery tools** — `{{end_turn}}(text="...")` for targeted/threaded replies, `{{send}}(...)` for rich content (photos, polls, files){{#if react}}, or `{{react}}(emoji="...")` for emoji acknowledgements{{/if}}. Use these when you need reply targeting, buttons, attachments, or multiple bubbles.
+
+If you call a delivery tool, don't also repeat the same text in plain output — commit to one route.

--- a/prompts/system/contract-text-preferred.md
+++ b/prompts/system/contract-text-preferred.md
@@ -1,0 +1,5 @@
+## Response flow
+
+- Return your normal user-facing reply as plain assistant text — that IS the message.
+- Do not rely on the `{{send}}` tool for ordinary replies.
+- Use tools only when they are genuinely needed for side effects or extra capabilities (rich content, reply targeting, reactions).

--- a/prompts/system/contract-tool-only.md
+++ b/prompts/system/contract-tool-only.md
@@ -1,0 +1,10 @@
+## Response flow — READ FIRST, applies to every turn
+
+Your output stream (prose like this) is **private scratchpad** — the user NEVER sees it. There is no plain-text fallback. The only ways content reaches the user:
+
+- `{{end_turn}}(text="...")` — deliver your final reply and close the turn. **This is how you answer.** Use it even for the simplest "hello" reply.
+- `{{end_turn}}()` (no args) — close the turn silently and deliberately.
+- `{{send}}(...)` — mid-turn / rich content (photos, files, polls, multi-message). Does NOT close the turn; follow with `{{end_turn}}`.{{#if react}}
+- `{{react}}(message_id, emoji)` — emoji reaction; often the right way to acknowledge without replying. Pair with `{{end_turn}}()` to close cleanly.{{/if}}
+
+**Every turn — including the very first turn of a session — must end with `{{end_turn}}`.** Prose written without a delivery tool is dropped, and the system re-prompts you with a [FLOW VIOLATION] reminder, burning 2x tokens. Write your reply directly inside `{{end_turn}}(text=...)` the first time.

--- a/prompts/system/cron.md
+++ b/prompts/system/cron.md
@@ -1,0 +1,3 @@
+## Scheduled jobs (cron)
+
+Persistent recurring tasks that survive restarts: `create_cron_job`, `list_cron_jobs`, `edit_cron_job`, `delete_cron_job`. Two job types: `message` sends text directly at the scheduled time; `query` runs a full agent prompt with tool access. Use cron for calendar-driven schedules ("every Monday at 9 AM").

--- a/prompts/system/daily-memory.md
+++ b/prompts/system/daily-memory.md
@@ -1,0 +1,3 @@
+## Daily Memory
+
+Your daily notes are stored in `{{daily_dir}}/`. Today's file is `{{today}}.md`. Use the Read tool to check recent daily notes when you need context from previous days.

--- a/prompts/system/persistent-memory.md
+++ b/prompts/system/persistent-memory.md
@@ -1,0 +1,8 @@
+## Persistent Memory
+
+The following is your memory file. Reference it naturally. Update it via the Write tool when you learn important new information.
+File: ~/.talon/workspace/memory/memory.md
+
+{{content}}{{#if truncated}}
+
+…(memory file truncated here to keep session start lean — Read the file above for the rest){{/if}}

--- a/prompts/system/triggers.md
+++ b/prompts/system/triggers.md
@@ -1,0 +1,5 @@
+## Triggers (long-running watcher scripts)
+
+For condition-driven wake-ups where a calendar schedule doesn't fit ("wake me when this PR merges", "alert if BTC moves >5%"): write a watcher script with `trigger_create` (bash / python / node). It runs as a supervised subprocess and wakes you on events — the tool description documents the stdout protocol and examples. Manage with `trigger_list`, `trigger_logs`, `trigger_cancel`, `trigger_delete`.
+
+Rule of thumb: calendar-driven and recurring → cron; condition-driven or multi-event watching → trigger. Limits: 5 active triggers per chat, and triggers do NOT survive a Talon restart — recreate them when `trigger_list` shows status "terminated".

--- a/prompts/system/workspace.md
+++ b/prompts/system/workspace.md
@@ -1,0 +1,9 @@
+## Workspace
+
+You have a workspace directory at `~/.talon/workspace/`. This is your home — organize it however you want.
+
+- `memory/memory.md` — your persistent memory file. Update it (Write tool) when you learn important things.
+- `memory/daily/YYYY-MM-DD.md` — your daily notes: observations, learnings, corrections, follow-ups. Keep entries concise.
+- `logs/` — daily interaction logs, written automatically.
+- `uploads/` — files users send you (photos, docs, voice) land here.
+- Everything else is yours to create and organize as you see fit.

--- a/prompts/teams.md
+++ b/prompts/teams.md
@@ -3,25 +3,22 @@
 You are running in a Microsoft Teams group chat via Power Automate webhooks + Graph API.
 Messages arrive as `[SenderName]: message text`. Use names naturally.
 
-### CRITICAL: Message delivery
+How replies are delivered (end_turn / send_message and what counts as a valid turn) is defined in the **Response flow** section at the end of these instructions — that contract wins over anything here.
 
-ALL messages to the user MUST be sent using the `send_message` tool. Your plain text output is **private** — the user never sees it, only you. Think of it as an internal scratchpad: jot a brief note to yourself if useful (a sentence or two — what you did, what you noticed, a reminder), but keep it short since nobody reads it. The only way to reach the user is the `send_message` tool.
+### Messaging tools
 
-### The `send_message` tool
-
-- `send_message(text="Hello!")` — send a message
+- `send_message(text="Hello!")` — send a message mid-turn
 - `send_message_with_buttons(text="Pick", rows=[[{"text":"Docs","url":"https://..."}]])` — with link buttons
 
 ### Other tools
 
 - `web_search(query)` — search the web
 - `fetch_url(url)` — fetch & parse a URL
-- `create_cron_job` / `list_cron_jobs` / `edit_cron_job` / `delete_cron_job` — scheduled jobs
 - `get_chat_info()` — info about the current chat
 
 ### Choosing not to respond
 
-You don't have to respond to every message. If a message doesn't need a response, simply don't call `send_message`.
+You don't have to respond to every message. If a message doesn't need a response, close the turn silently with `end_turn()`.
 
 ### Limitations
 

--- a/prompts/telegram.md
+++ b/prompts/telegram.md
@@ -2,66 +2,11 @@
 
 In groups, you'll see messages prefixed with [Name]: — use their name naturally.
 
-### Response flow — IMPORTANT
+How replies are delivered (end_turn / send / react and what counts as a valid turn) is defined in the **Response flow** section at the end of these instructions — that contract wins over anything here.
 
-Your output stream (this prose right here) is **private scratchpad**. The user never sees it. The ONLY ways for content to reach the user are:
+### Tools
 
-- **`end_turn(text=...)`** — the canonical way to deliver your final reply. Closes the turn. Optional `reply_to` for threaded replies, optional `buttons` for inline keyboards.
-- **`end_turn()`** with no args — explicit silent close. Use this when you've done what you needed to (e.g. reacted with an emoji, ran a tool that didn't need a reply) and want to make it clear that the silence is intentional.
-- **`send(...)`** — for mid-turn rich content (photos, polls, voice, stickers, scheduled messages, multi-message responses, multi-target). Does NOT close the turn — typically followed by `end_turn(...)` or `end_turn()`.
-- **`react(message_id, emoji)`** — emoji reaction on a message. Often the right response to acknowledge without replying. Pair with `end_turn()` to close cleanly.
-
-**There is no fallback.** Prose written without an `end_turn` / `send` call is scratchpad — dropped. If you write a thoughtful response in your output stream and forget to wrap it in `end_turn(text=...)`, the user sees nothing. Get into the habit of ending every turn with one of the closing options above.
-
-Doing nothing — no tool call at all — is also a valid silent close (the model genuinely had nothing to do), but `end_turn()` makes the intent explicit and is preferred when the silence is deliberate.
-
-**Flow enforcement:** if you produce trailing prose without calling `end_turn` / `send`, the system will re-prompt you ONCE with a `[FLOW VIOLATION]` reminder in the same session. You'll see your broken turn in history and get a fresh turn to redo it correctly. Burns 2x the tokens for that exchange, so just call `end_turn` the first time.
-
-### When to use `send` vs `end_turn`
-
-- **`end_turn`** = the final reply that ends your turn. Plain text + optional reply_to + optional buttons. The closer.
-- **`send`** = anything richer or anything mid-turn: photos, polls, voice, scheduled messages, stickers, locations, dice, contacts, multi-message responses, replies to other chats.
-
-For a plain text final reply, prefer `end_turn(text=...)` over `send(type="text", text=...)`. They reach the same delivery path, but the name makes the intent unambiguous.
-
-### The `send` tool (rich content)
-
-One tool, set `type` to choose what to send:
-
-- `send(type="text", text="Hello!")` — plain text (use end_turn instead for final reply)
-- `send(type="text", text="Hey", reply_to=12345)` — reply to a specific message
-- `send(type="text", text="Pick", buttons=[[{"text":"A","callback_data":"a"}]])` — with buttons
-- `send(type="text", text="Reminder", delay_seconds=60)` — schedule for later
-- `send(type="photo", file_path="img.jpg", caption="Look!")` — send a photo
-- `send(type="file", file_path="report.pdf")` — send a document
-- `send(type="video", file_path="clip.mp4")` — send a video
-- `send(type="voice", file_path="audio.ogg")` — send a voice message
-- `send(type="sticker", file_id="CAACAgI...")` — send a sticker
-- `send(type="poll", question="Best?", options=["A","B","C"])` — create a poll
-- `send(type="dice")` — roll dice
-- `send(type="location", latitude=37.77, longitude=-122.42)` — send location
-- `send(type="contact", phone_number="+1234", first_name="John")` — share contact
-
-ALL types support `reply_to` to reply to a specific message.
-
-### Other tools
-
-- `react(message_id, emoji)` — react to a message
-- `edit_message(message_id, text)` — edit a sent message
-- `delete_message(message_id)` — delete a message
-- `forward_message(message_id)` — forward a message
-- `pin_message(message_id)` / `unpin_message()` — pin/unpin
-- `read_chat_history(limit, before)` — read past messages
-- `search_chat_history(query)` — search by keyword
-- `download_media(message_id)` — download a photo/file/video from any message to workspace
-- `list_chat_members()` — list members with IDs
-- `get_member_info(user_id)` — detailed user info
-- `online_count()` — how many members are online/recently active
-- `get_pinned_messages()` — list pinned messages
-- `get_sticker_pack(set_name)` — browse stickers in a pack
-- `save_sticker_pack(set_name)` — save a pack to workspace for quick reuse
-- `download_sticker(file_id)` — download a sticker image to view it
-- `list_media(limit)` — list recent photos/files in this chat
+Your registered tool list covers the full Telegram surface — rich sends (photos, files, polls, voice, stickers, scheduled messages), reactions, message management (edit/delete/pin/forward), chat history and search, media download, member info. Tool descriptions carry the parameters and examples; don't guess capabilities, check the list.
 
 ### Message IDs
 
@@ -69,15 +14,7 @@ The user's message ID is in the prompt as [msg_id:N]. Use with `reply_to` and `r
 
 ### Choosing not to respond
 
-You don't HAVE to respond to every message. If a message doesn't need a response:
-
-- React with an emoji using the `react` tool — this is the PREFERRED way to acknowledge without replying.
-- Or call `end_turn()` with no args to end the turn silently.
-- In groups, prefer reactions over replies for simple acknowledgements.
-
-### Reactions
-
-Use naturally: 👍 ❤️ 🔥 😂 🎉 👀 💯. React AND reply when both feel right.
+You don't HAVE to respond to every message. To acknowledge without replying, `react` with an emoji — in groups this is PREFERRED over replies for simple acknowledgements. Use reactions naturally: 👍 ❤️ 🔥 😂 🎉 👀 💯. React AND reply when both feel right.
 
 ### Buttons
 
@@ -96,9 +33,7 @@ Use stickers like a human would — they're part of Telegram culture:
 
 - When users send stickers, their set_name is captured. Use `save_sticker_pack` to save packs you like.
 - Once saved, read `~/.talon/workspace/stickers/<set_name>.json` to find stickers by emoji and send them with `send(type="sticker", file_id="...")`.
-- Send stickers to express emotions, reactions, or just for fun. Don't overuse them.
-- You can `download_sticker` to actually see what a sticker looks like before sending it.
-- Build up a collection of favorite packs over time.
+- Send stickers to express emotions or reactions; `download_sticker` lets you see one before sending. Don't overuse them.
 - You can create and manage sticker packs with `create_sticker_set`, `add_sticker_to_set`, etc.
 
 ### Style

--- a/src/__tests__/active-model.test.ts
+++ b/src/__tests__/active-model.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the active-model resolver (`src/core/active-model.ts`).
+ * Tests for the active-model resolver (`src/core/models/active-model.ts`).
  *
  * The resolver is the central read path for "what model is this chat
  * running on?". Each test pins one branch of the 5-step chain so
@@ -57,7 +57,7 @@ const {
   getActiveModelForChat,
   describeActiveModelSource,
   getModelByBackendSnapshot,
-} = await import("../core/active-model.js");
+} = await import("../core/models/active-model.js");
 const {
   setChatModelForBackend,
   setChatBackend,

--- a/src/__tests__/backend-controller.test.ts
+++ b/src/__tests__/backend-controller.test.ts
@@ -27,7 +27,7 @@ import {
   cleanupBackendController,
   resetBackendControllerForTest,
   clearBackendChangeListenersForTest,
-} from "../core/backend-controller.js";
+} from "../core/engine/backend-controller.js";
 
 function makeStubBackend(label: string): Backend {
   return stubBackend({

--- a/src/__tests__/backend-pool.test.ts
+++ b/src/__tests__/backend-pool.test.ts
@@ -27,7 +27,7 @@ import {
   cleanupBackendPool,
   resetBackendPoolForTest,
   clearBackendChangeListenersForTest,
-} from "../core/backend-controller.js";
+} from "../core/engine/backend-controller.js";
 
 function makeStubBackend(label: string): Backend {
   return stubBackend({
@@ -327,7 +327,7 @@ describe("backend pool — multi-role bindings", () => {
     );
     // initBackendPool isn't imported with a side door here, so reach
     // via the existing helpers — same exports.
-    const ctrl = await import("../core/backend-controller.js");
+    const ctrl = await import("../core/engine/backend-controller.js");
 
     await ctrl.initBackendPool(configFor("alpha"), STUB_CTX);
     // Chat A pins beta as an override; pool now has 2 instances.
@@ -357,7 +357,7 @@ describe("backend pool — multi-role bindings", () => {
     registerBackend(
       makeFactory("gamma", "Gamma", { cleanupSpy: (id) => cleanups.push(id) }),
     );
-    const ctrl = await import("../core/backend-controller.js");
+    const ctrl = await import("../core/engine/backend-controller.js");
 
     await ctrl.initBackendPool(configFor("alpha"), STUB_CTX);
     await ctrl.rebindChat("chat-A", "beta", configFor("alpha"));
@@ -382,7 +382,7 @@ describe("backend pool — multi-role bindings", () => {
 
   it("releaseChat on an unbound chat is a no-op", async () => {
     registerBackend(makeFactory("alpha", "Alpha"));
-    const ctrl = await import("../core/backend-controller.js");
+    const ctrl = await import("../core/engine/backend-controller.js");
     await ctrl.initBackendPool(configFor("alpha"), STUB_CTX);
 
     // Doesn't throw, doesn't break the pool.

--- a/src/__tests__/claude-sdk-handler-watchdog.test.ts
+++ b/src/__tests__/claude-sdk-handler-watchdog.test.ts
@@ -254,7 +254,7 @@ describe("Claude SDK chat handler — post-result watchdog", () => {
     // — `vi.resetModules()` above ensures we get a fresh module per test.
     vi.stubEnv("TALON_SDK_POST_RESULT_GRACE_MS", "50");
 
-    const { clearModels, registerModels } = await import("../core/models.js");
+    const { clearModels, registerModels } = await import("../core/models/catalog.js");
     clearModels();
     registerModels([
       {

--- a/src/__tests__/claude-sdk-handler-watchdog.test.ts
+++ b/src/__tests__/claude-sdk-handler-watchdog.test.ts
@@ -254,7 +254,8 @@ describe("Claude SDK chat handler — post-result watchdog", () => {
     // — `vi.resetModules()` above ensures we get a fresh module per test.
     vi.stubEnv("TALON_SDK_POST_RESULT_GRACE_MS", "50");
 
-    const { clearModels, registerModels } = await import("../core/models/catalog.js");
+    const { clearModels, registerModels } =
+      await import("../core/models/catalog.js");
     clearModels();
     registerModels([
       {

--- a/src/__tests__/claude-sdk-handler-watchdog.test.ts
+++ b/src/__tests__/claude-sdk-handler-watchdog.test.ts
@@ -174,6 +174,12 @@ vi.mock("../backend/shared/index.js", () => ({
   FLOW_VIOLATION_MAX_RETRIES: 3,
   captureDeliveredText: () => null,
   summarizeUsage: () => "0ms in=0 out=0 cache=0% tools=0",
+  buildDeliveryContract: () => "",
+  buildFlowViolationReminder: () => "",
+  buildFirstTurnReminder: () => "",
+  recordToolCall: vi.fn(),
+  recordTurnMetrics: vi.fn(),
+  recordFlowViolation: vi.fn(),
   // Tests don't exercise the retry path (the watchdog short-circuits the
   // catch block when it fires). Stub returns the no-retry shape so the
   // handler's `if (outcome.retry) return outcome.retry` falls through to

--- a/src/__tests__/claude-sdk-models.test.ts
+++ b/src/__tests__/claude-sdk-models.test.ts
@@ -64,7 +64,8 @@ describe("registerClaudeModels", () => {
   it("surfaces base and 1M variants separately while collapsing true duplicates", async () => {
     const { registerClaudeModels } =
       await import("../backend/claude-sdk/models.js");
-    const { getModels, resolveModelId } = await import("../core/models/catalog.js");
+    const { getModels, resolveModelId } =
+      await import("../core/models/catalog.js");
 
     await registerClaudeModels({ model: "default" });
 
@@ -134,7 +135,8 @@ describe("registerClaudeModels", () => {
 
     const { registerClaudeModels } =
       await import("../backend/claude-sdk/models.js");
-    const { getModels, resolveModelId } = await import("../core/models/catalog.js");
+    const { getModels, resolveModelId } =
+      await import("../core/models/catalog.js");
 
     await registerClaudeModels({ model: "default" });
 
@@ -261,7 +263,8 @@ describe("registerClaudeModels", () => {
 
     const { registerClaudeModels } =
       await import("../backend/claude-sdk/models.js");
-    const { getModels, resolveModelId } = await import("../core/models/catalog.js");
+    const { getModels, resolveModelId } =
+      await import("../core/models/catalog.js");
 
     await registerClaudeModels({ model: "default" });
 

--- a/src/__tests__/claude-sdk-models.test.ts
+++ b/src/__tests__/claude-sdk-models.test.ts
@@ -57,14 +57,14 @@ describe("registerClaudeModels", () => {
     vi.clearAllMocks();
     mockSupportedModels.mockResolvedValue(sdkModels);
 
-    const { clearModels } = await import("../core/models.js");
+    const { clearModels } = await import("../core/models/catalog.js");
     clearModels();
   });
 
   it("surfaces base and 1M variants separately while collapsing true duplicates", async () => {
     const { registerClaudeModels } =
       await import("../backend/claude-sdk/models.js");
-    const { getModels, resolveModelId } = await import("../core/models.js");
+    const { getModels, resolveModelId } = await import("../core/models/catalog.js");
 
     await registerClaudeModels({ model: "default" });
 
@@ -134,7 +134,7 @@ describe("registerClaudeModels", () => {
 
     const { registerClaudeModels } =
       await import("../backend/claude-sdk/models.js");
-    const { getModels, resolveModelId } = await import("../core/models.js");
+    const { getModels, resolveModelId } = await import("../core/models/catalog.js");
 
     await registerClaudeModels({ model: "default" });
 
@@ -192,7 +192,7 @@ describe("registerClaudeModels", () => {
 
     const { registerClaudeModels } =
       await import("../backend/claude-sdk/models.js");
-    const { resolveModelId } = await import("../core/models.js");
+    const { resolveModelId } = await import("../core/models/catalog.js");
 
     await registerClaudeModels({ model: "default" });
 
@@ -261,7 +261,7 @@ describe("registerClaudeModels", () => {
 
     const { registerClaudeModels } =
       await import("../backend/claude-sdk/models.js");
-    const { getModels, resolveModelId } = await import("../core/models.js");
+    const { getModels, resolveModelId } = await import("../core/models/catalog.js");
 
     await registerClaudeModels({ model: "default" });
 

--- a/src/__tests__/claude-sdk-options.test.ts
+++ b/src/__tests__/claude-sdk-options.test.ts
@@ -46,7 +46,8 @@ describe("buildSdkOptions", () => {
     });
     mockGetBridgePort.mockReturnValue(19876);
 
-    const { clearModels, registerModels } = await import("../core/models/catalog.js");
+    const { clearModels, registerModels } =
+      await import("../core/models/catalog.js");
     clearModels();
     registerModels([
       {

--- a/src/__tests__/claude-sdk-options.test.ts
+++ b/src/__tests__/claude-sdk-options.test.ts
@@ -46,7 +46,7 @@ describe("buildSdkOptions", () => {
     });
     mockGetBridgePort.mockReturnValue(19876);
 
-    const { clearModels, registerModels } = await import("../core/models.js");
+    const { clearModels, registerModels } = await import("../core/models/catalog.js");
     clearModels();
     registerModels([
       {

--- a/src/__tests__/codex-backend.test.ts
+++ b/src/__tests__/codex-backend.test.ts
@@ -41,7 +41,7 @@ describe("codex / constants", () => {
     expect(CODEX_SYSTEM_PROMPT_SUFFIX).toContain("end_turn");
     expect(CODEX_SYSTEM_PROMPT_SUFFIX).toContain("send");
     expect(CODEX_SYSTEM_PROMPT_SUFFIX).toContain("react");
-    expect(CODEX_SYSTEM_PROMPT_SUFFIX).toContain("Codex Delivery");
+    expect(CODEX_SYSTEM_PROMPT_SUFFIX).toContain("Response flow");
   });
 });
 

--- a/src/__tests__/codex-handler.test.ts
+++ b/src/__tests__/codex-handler.test.ts
@@ -316,13 +316,13 @@ describe("codex / handleMessage — happy path", () => {
 
     expect(sessions.getSession("test-chat").usage.numApiCalls).toBe(2);
     const metrics = getMetrics();
-    expect(metrics.counters["codex.api_calls_total"]).toBe(2);
-    expect(metrics.counters["codex.turns_total"]).toBe(1);
-    expect(metrics.histograms["codex.api_calls_per_turn"]).toMatchObject({
+    expect(metrics.counters["api_calls_total"]).toBe(2);
+    expect(metrics.counters["backend.codex.queries"]).toBe(1);
+    expect(metrics.histograms["api_calls_per_turn"]).toMatchObject({
       count: 1,
       p50: 2,
     });
-    expect(metrics.histograms["codex.tool_calls_per_turn"]).toMatchObject({
+    expect(metrics.histograms["tool_calls_per_turn"]).toMatchObject({
       count: 1,
       p50: 0,
     });
@@ -763,11 +763,11 @@ describe("codex / handleMessage — tool use", () => {
     expect(tools[0].input).toEqual({ emoji: "🔥" });
 
     const metrics = getMetrics();
-    expect(metrics.counters["codex.tool_calls_total"]).toBe(1);
-    expect(metrics.counters["codex.tool_calls.react"]).toBe(1);
+    expect(metrics.counters["backend.codex.tool_calls"]).toBe(1);
     expect(metrics.counters["tool_calls.react"]).toBe(1);
-    expect(metrics.counters["codex.turns_with_tools_total"]).toBe(1);
-    expect(metrics.histograms["codex.tool_calls_per_turn"]).toMatchObject({
+    expect(metrics.counters["tool_calls.react"]).toBe(1);
+    expect(metrics.counters["turns_with_tools_total"]).toBe(1);
+    expect(metrics.histograms["tool_calls_per_turn"]).toMatchObject({
       count: 1,
       p50: 1,
     });
@@ -1492,13 +1492,13 @@ describe("codex / handleMessage — non-MCP items", () => {
     ]);
 
     const metrics = getMetrics();
-    expect(metrics.counters["codex.tool_calls_total"]).toBe(4);
-    expect(metrics.counters["codex.tool_calls.command_execution"]).toBe(1);
-    expect(metrics.counters["codex.tool_calls.file_change"]).toBe(1);
-    expect(metrics.counters["codex.tool_calls.web_search"]).toBe(1);
-    expect(metrics.counters["codex.tool_calls.image_generation"]).toBe(1);
-    expect(metrics.counters["codex.turns_with_tools_total"]).toBe(1);
-    expect(metrics.histograms["codex.tool_calls_per_turn"]).toMatchObject({
+    expect(metrics.counters["backend.codex.tool_calls"]).toBe(4);
+    expect(metrics.counters["tool_calls.command_execution"]).toBe(1);
+    expect(metrics.counters["tool_calls.file_change"]).toBe(1);
+    expect(metrics.counters["tool_calls.web_search"]).toBe(1);
+    expect(metrics.counters["tool_calls.image_generation"]).toBe(1);
+    expect(metrics.counters["turns_with_tools_total"]).toBe(1);
+    expect(metrics.histograms["tool_calls_per_turn"]).toMatchObject({
       count: 1,
       p50: 4,
     });

--- a/src/__tests__/codex-handler.test.ts
+++ b/src/__tests__/codex-handler.test.ts
@@ -395,7 +395,7 @@ describe("codex / handleMessage — happy path", () => {
 
     const sentInput = MOCK_RUN_STREAMED_CALLS[0].input;
     // System prompt is prepended (with Codex suffix added by prepareSystemPrompt)
-    expect(sentInput).toMatch(/Codex Delivery/);
+    expect(sentInput).toMatch(/Response flow/);
     expect(sentInput).toContain("First message");
   });
 });

--- a/src/__tests__/codex-handler.test.ts
+++ b/src/__tests__/codex-handler.test.ts
@@ -112,7 +112,7 @@ const { initCodexAgent } = await import("../backend/codex/init.js");
 const { resetState } = await import("../backend/codex/state.js");
 const sessions = await import("../storage/sessions.js");
 const chatSettings = await import("../storage/chat-settings.js");
-const coreModels = await import("../core/models.js");
+const coreModels = await import("../core/models/catalog.js");
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -513,9 +513,8 @@ describe("config", () => {
       mockFs({ frontend: "terminal" }, { "memory.md": bigMemory });
 
       const { loadConfig } = await import("../util/config.js");
-      const { MEMORY_INJECT_MAX_CHARS } = await import(
-        "../core/prompt/assemble.js"
-      );
+      const { MEMORY_INJECT_MAX_CHARS } =
+        await import("../core/prompt/assemble.js");
       const config = loadConfig();
       expect(config.systemPrompt).toContain("Persistent Memory");
       expect(config.systemPrompt).toContain("truncated");
@@ -523,9 +522,7 @@ describe("config", () => {
       const memorySection = config.systemPrompt
         .split("Persistent Memory")[1]
         .split("---")[0];
-      expect(memorySection.length).toBeLessThan(
-        MEMORY_INJECT_MAX_CHARS + 500,
-      );
+      expect(memorySection.length).toBeLessThan(MEMORY_INJECT_MAX_CHARS + 500);
     });
 
     it("includes workspace file listing when files exist", async () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+// Real fs, bound before any vi.doMock("node:fs") below: package-owned
+// system templates (prompts/system/*.md) are part of the code under
+// test, so the mock delegates those reads to the real filesystem.
+import { readFileSync as realReadFileSync } from "node:fs";
 
 vi.mock("write-file-atomic", () => ({
   default: { sync: vi.fn() },
 }));
+
+const isSystemTemplatePath = (path: string): boolean =>
+  /prompts[\\/]system[\\/].*\.md$/.test(path);
 
 describe("config", () => {
   beforeEach(() => {
@@ -76,6 +83,8 @@ describe("config", () => {
         return false;
       }),
       readFileSync: vi.fn((path: string) => {
+        if (typeof path === "string" && isSystemTemplatePath(path))
+          return realReadFileSync(path, "utf-8");
         if (path.includes("config.json") || path.includes("talon.json"))
           return JSON.stringify(configJson ?? {});
         for (const [key, val] of Object.entries(promptFiles)) {
@@ -387,7 +396,7 @@ describe("config", () => {
       expect(parts.staticText).toContain("I am Talon.");
       expect(parts.staticText).toContain("Be helpful.");
       expect(parts.staticText).toContain("User prefers dark mode.");
-      expect(parts.staticText).toContain("Cron Jobs");
+      expect(parts.staticText).toContain("Scheduled jobs (cron)");
 
       // Volatile content must NOT pollute the static prefix.
       expect(parts.staticText).not.toContain("Daily Memory");
@@ -419,7 +428,7 @@ describe("config", () => {
       const { loadConfig } = await import("../util/config.js");
       const config = loadConfig();
       expect(config.systemPrompt).toContain("workspace");
-      expect(config.systemPrompt).toContain("Cron Jobs");
+      expect(config.systemPrompt).toContain("Scheduled jobs (cron)");
     });
 
     it("loads terminal.md prompt for terminal frontend", async () => {
@@ -496,6 +505,27 @@ describe("config", () => {
       const config = loadConfig();
       expect(config.systemPrompt).toContain("Persistent Memory");
       expect(config.systemPrompt).toContain("User prefers dark mode.");
+    });
+
+    it("caps oversized memory.md and appends a truncation pointer", async () => {
+      const line = "remembered fact about the user\n";
+      const bigMemory = line.repeat(600); // ~19k chars > MEMORY_INJECT_MAX_CHARS
+      mockFs({ frontend: "terminal" }, { "memory.md": bigMemory });
+
+      const { loadConfig } = await import("../util/config.js");
+      const { MEMORY_INJECT_MAX_CHARS } = await import(
+        "../core/prompt/assemble.js"
+      );
+      const config = loadConfig();
+      expect(config.systemPrompt).toContain("Persistent Memory");
+      expect(config.systemPrompt).toContain("truncated");
+      // The whole prompt stays bounded: memory contributes at most the cap.
+      const memorySection = config.systemPrompt
+        .split("Persistent Memory")[1]
+        .split("---")[0];
+      expect(memorySection.length).toBeLessThan(
+        MEMORY_INJECT_MAX_CHARS + 500,
+      );
     });
 
     it("includes workspace file listing when files exist", async () => {

--- a/src/__tests__/delivery-contract.test.ts
+++ b/src/__tests__/delivery-contract.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Delivery-contract builders + system-template renderer.
+ *
+ * The contract bodies live in prompts/system/contract-*.md (package-
+ * owned templates); these tests exercise the real files — a template
+ * regression (renamed variable, broken conditional) should fail here.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildDeliveryContract,
+  buildFlowViolationReminder,
+  buildFirstTurnReminder,
+  deliveryToolsForFrontend,
+  registerFrontendDeliveryTools,
+} from "../backend/shared/delivery-contract.js";
+import { renderTemplate } from "../core/prompt/templates.js";
+import { detectFlowViolation } from "../backend/shared/flow-violation.js";
+
+describe("renderTemplate", () => {
+  it("substitutes variables and drops unknowns", () => {
+    expect(renderTemplate("a {{x}} b {{y}}", { x: "1" })).toBe("a 1 b ");
+  });
+
+  it("keeps {{#if}} blocks only when the variable is non-empty", () => {
+    const t = "start{{#if flag}} kept{{/if}} end";
+    expect(renderTemplate(t, { flag: "yes" })).toBe("start kept end");
+    expect(renderTemplate(t, {})).toBe("start end");
+    expect(renderTemplate(t, { flag: "" })).toBe("start end");
+  });
+});
+
+describe("buildDeliveryContract", () => {
+  it("tool-only contract names the frontend's tools (telegram)", () => {
+    const c = buildDeliveryContract("tool-only", "telegram");
+    expect(c).toContain("Response flow");
+    expect(c).toContain("end_turn");
+    expect(c).toContain("send");
+    expect(c).toContain("react");
+    expect(c).toContain("private scratchpad");
+    expect(c).toContain("FLOW VIOLATION");
+  });
+
+  it("teams gets send_message and no react bullet", () => {
+    const c = buildDeliveryContract("tool-only", "teams");
+    expect(c).toContain("send_message");
+    expect(c).not.toContain("react(");
+  });
+
+  it("text-or-tools contract allows plain text", () => {
+    const c = buildDeliveryContract("text-or-tools", "telegram");
+    expect(c).toContain("Plain text");
+    expect(c).toContain("end_turn");
+    expect(c).not.toContain("FLOW VIOLATION");
+  });
+
+  it("unknown frontends fall back to default tool names", () => {
+    expect(deliveryToolsForFrontend("nope").endTurn).toBe("end_turn");
+    const c = buildDeliveryContract("tool-only", "nope");
+    expect(c).toContain("end_turn");
+  });
+
+  it("registerFrontendDeliveryTools extends the registry", () => {
+    registerFrontendDeliveryTools("matrix", {
+      endTurn: "finish_turn",
+      send: "post",
+    });
+    const c = buildDeliveryContract("tool-only", "matrix");
+    expect(c).toContain("finish_turn");
+    expect(c).toContain("post");
+    expect(buildFlowViolationReminder("matrix")).toContain("finish_turn");
+  });
+});
+
+describe("frontend-aware reminders", () => {
+  it("flow-violation reminder uses the frontend's tool names", () => {
+    expect(buildFlowViolationReminder("teams")).toContain("send_message");
+    expect(buildFlowViolationReminder("teams")).not.toContain("react");
+    expect(buildFlowViolationReminder("telegram")).toContain("react");
+  });
+
+  it("first-turn reminder is a single bracketed line", () => {
+    const r = buildFirstTurnReminder("telegram");
+    expect(r.startsWith("[")).toBe(true);
+    expect(r.endsWith("]")).toBe(true);
+    expect(r).toContain("end_turn");
+    expect(r).not.toContain("\n");
+  });
+
+  it("detectFlowViolation ships a caller-supplied reminder", () => {
+    const result = detectFlowViolation({
+      trailingText: "dropped prose",
+      turnTerminated: false,
+      deliveredTextNorms: [],
+      retried: false,
+      reminder: buildFlowViolationReminder("teams"),
+    });
+    expect(result.violated).toBe(true);
+    if (result.violated) {
+      expect(result.reminder).toContain("send_message");
+    }
+  });
+});

--- a/src/__tests__/delivery-contract.test.ts
+++ b/src/__tests__/delivery-contract.test.ts
@@ -54,6 +54,13 @@ describe("buildDeliveryContract", () => {
     expect(c).not.toContain("FLOW VIOLATION");
   });
 
+  it("text-preferred contract steers away from tools for plain replies", () => {
+    const c = buildDeliveryContract("text-preferred", "telegram");
+    expect(c).toContain("plain assistant text");
+    expect(c).toContain("send");
+    expect(c).not.toContain("FLOW VIOLATION");
+  });
+
   it("unknown frontends fall back to default tool names", () => {
     expect(deliveryToolsForFrontend("nope").endTurn).toBe("end_turn");
     const c = buildDeliveryContract("tool-only", "nope");

--- a/src/__tests__/dispatcher.test.ts
+++ b/src/__tests__/dispatcher.test.ts
@@ -447,7 +447,7 @@ describe("typing indicator — non-Error throws", () => {
       logWarn: vi.fn(),
       logError: vi.fn(),
     }));
-    vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
+    vi.doMock("../core/background/dream.js", () => ({ maybeStartDream: vi.fn() }));
 
     const { initDispatcher, execute } = await import("../core/dispatcher.js");
     const logWarn = (await import("../util/log.js")).logWarn as ReturnType<
@@ -499,7 +499,7 @@ describe("typing indicator — non-Error throws", () => {
       logWarn: vi.fn(),
       logError: vi.fn(),
     }));
-    vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
+    vi.doMock("../core/background/dream.js", () => ({ maybeStartDream: vi.fn() }));
 
     const { initDispatcher, execute } = await import("../core/dispatcher.js");
     const logWarn = (await import("../util/log.js")).logWarn as ReturnType<
@@ -574,7 +574,7 @@ describe("dispatcher — uninitialized guard", () => {
       logWarn: vi.fn(),
       logError: vi.fn(),
     }));
-    vi.doMock("../core/dream.js", () => ({ maybeStartDream: vi.fn() }));
+    vi.doMock("../core/background/dream.js", () => ({ maybeStartDream: vi.fn() }));
 
     const { execute } = await import("../core/dispatcher.js");
     // deps is null because initDispatcher was never called in this fresh module

--- a/src/__tests__/dispatcher.test.ts
+++ b/src/__tests__/dispatcher.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { initDispatcher, execute, getActiveCount } from "../core/dispatcher.js";
+import {
+  initDispatcher,
+  execute,
+  getActiveCount,
+} from "../core/engine/dispatcher.js";
 import type { ContextManager } from "../core/types.js";
 import {
   stubBackend,
@@ -451,7 +455,8 @@ describe("typing indicator — non-Error throws", () => {
       maybeStartDream: vi.fn(),
     }));
 
-    const { initDispatcher, execute } = await import("../core/dispatcher.js");
+    const { initDispatcher, execute } =
+      await import("../core/engine/dispatcher.js");
     const logWarn = (await import("../util/log.js")).logWarn as ReturnType<
       typeof vi.fn
     >;
@@ -505,7 +510,8 @@ describe("typing indicator — non-Error throws", () => {
       maybeStartDream: vi.fn(),
     }));
 
-    const { initDispatcher, execute } = await import("../core/dispatcher.js");
+    const { initDispatcher, execute } =
+      await import("../core/engine/dispatcher.js");
     const logWarn = (await import("../util/log.js")).logWarn as ReturnType<
       typeof vi.fn
     >;
@@ -582,7 +588,7 @@ describe("dispatcher — uninitialized guard", () => {
       maybeStartDream: vi.fn(),
     }));
 
-    const { execute } = await import("../core/dispatcher.js");
+    const { execute } = await import("../core/engine/dispatcher.js");
     // deps is null because initDispatcher was never called in this fresh module
     await expect(
       execute({

--- a/src/__tests__/dispatcher.test.ts
+++ b/src/__tests__/dispatcher.test.ts
@@ -447,7 +447,9 @@ describe("typing indicator — non-Error throws", () => {
       logWarn: vi.fn(),
       logError: vi.fn(),
     }));
-    vi.doMock("../core/background/dream.js", () => ({ maybeStartDream: vi.fn() }));
+    vi.doMock("../core/background/dream.js", () => ({
+      maybeStartDream: vi.fn(),
+    }));
 
     const { initDispatcher, execute } = await import("../core/dispatcher.js");
     const logWarn = (await import("../util/log.js")).logWarn as ReturnType<
@@ -499,7 +501,9 @@ describe("typing indicator — non-Error throws", () => {
       logWarn: vi.fn(),
       logError: vi.fn(),
     }));
-    vi.doMock("../core/background/dream.js", () => ({ maybeStartDream: vi.fn() }));
+    vi.doMock("../core/background/dream.js", () => ({
+      maybeStartDream: vi.fn(),
+    }));
 
     const { initDispatcher, execute } = await import("../core/dispatcher.js");
     const logWarn = (await import("../util/log.js")).logWarn as ReturnType<
@@ -574,7 +578,9 @@ describe("dispatcher — uninitialized guard", () => {
       logWarn: vi.fn(),
       logError: vi.fn(),
     }));
-    vi.doMock("../core/background/dream.js", () => ({ maybeStartDream: vi.fn() }));
+    vi.doMock("../core/background/dream.js", () => ({
+      maybeStartDream: vi.fn(),
+    }));
 
     const { execute } = await import("../core/dispatcher.js");
     // deps is null because initDispatcher was never called in this fresh module

--- a/src/__tests__/dream.test.ts
+++ b/src/__tests__/dream.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for src/core/dream.ts
+ * Tests for src/core/background/dream.ts
  *
  * Covers: initDream, maybeStartDream (guard paths), forceDream (concurrency),
  * state persistence, prompt template / mempalace gating, and timeout handling.
@@ -70,7 +70,7 @@ function makeMockBackend(): Backend {
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 const { initDream, maybeStartDream, forceDream } =
-  await import("../core/dream.js");
+  await import("../core/background/dream.js");
 
 beforeEach(() => {
   runOneShotAgentMock.mockReset();
@@ -224,7 +224,7 @@ describe("readDreamState — edge cases", () => {
 });
 
 describe("dream timeout", () => {
-  let mod: typeof import("../core/dream.js");
+  let mod: typeof import("../core/background/dream.js");
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let timeoutRunOneShotMock: any;
 
@@ -259,7 +259,7 @@ describe("dream timeout", () => {
       },
     }));
     timeoutRunOneShotMock = vi.fn();
-    mod = await import("../core/dream.js");
+    mod = await import("../core/background/dream.js");
     mod.initDream({
       model: "claude-sonnet-4-6",
       getBackend: () =>

--- a/src/__tests__/fuzz.test.ts
+++ b/src/__tests__/fuzz.test.ts
@@ -47,7 +47,8 @@ vi.mock("../storage/cron-store.js", () => ({
 
 const { classify, TalonError } = await import("../core/errors.js");
 await import("../storage/cron-store.js");
-const { handleSharedAction } = await import("../core/gateway-actions.js");
+const { handleSharedAction } =
+  await import("../core/engine/gateway-actions.js");
 const { resolveModelName } = await import("../storage/chat-settings.js");
 const { registerClaudeModelsStatic, CLAUDE_MODELS_STATIC } =
   await import("../backend/claude-sdk/models.js");

--- a/src/__tests__/gateway-actions.test.ts
+++ b/src/__tests__/gateway-actions.test.ts
@@ -64,7 +64,8 @@ vi.mock("node:fs", () => ({
   readFileSync: vi.fn(),
 }));
 
-const { handleSharedAction } = await import("../core/gateway-actions.js");
+const { handleSharedAction } =
+  await import("../core/engine/gateway-actions.js");
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/src/__tests__/gateway-context.test.ts
+++ b/src/__tests__/gateway-context.test.ts
@@ -7,11 +7,11 @@ vi.mock("../util/log.js", () => ({
   logDebug: vi.fn(),
 }));
 
-vi.mock("../core/gateway-actions.js", () => ({
+vi.mock("../core/engine/gateway-actions.js", () => ({
   handleSharedAction: vi.fn(async () => null),
 }));
 
-import { Gateway } from "../core/gateway.js";
+import { Gateway } from "../core/engine/gateway.js";
 
 describe("gateway per-chat context", () => {
   let gateway: Gateway;

--- a/src/__tests__/gateway-http.test.ts
+++ b/src/__tests__/gateway-http.test.ts
@@ -32,7 +32,7 @@ vi.mock("../storage/sessions.js", () => ({
   getActiveSessionCount: vi.fn(() => 0),
 }));
 
-vi.mock("../core/dispatcher.js", () => ({
+vi.mock("../core/engine/dispatcher.js", () => ({
   getActiveCount: vi.fn(() => 0),
 }));
 
@@ -55,7 +55,7 @@ vi.mock("write-file-atomic", () => ({
   default: { sync: vi.fn() },
 }));
 
-import { Gateway } from "../core/gateway.js";
+import { Gateway } from "../core/engine/gateway.js";
 
 let gateway: Gateway;
 let port: number;

--- a/src/__tests__/gateway-retry.test.ts
+++ b/src/__tests__/gateway-retry.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for withRetry() exported from src/core/gateway.ts
+ * Tests for withRetry() exported from src/core/engine/gateway.ts
  *
  * withRetry wraps p-retry.  We mock p-retry so that:
  *   - The mock immediately drives the retry loop deterministically (no real
@@ -27,7 +27,7 @@ vi.mock("../util/log.js", () => ({
   logDebug: vi.fn(),
 }));
 
-vi.mock("../core/dispatcher.js", () => ({
+vi.mock("../core/engine/dispatcher.js", () => ({
   getActiveCount: vi.fn(() => 0),
 }));
 
@@ -44,7 +44,7 @@ vi.mock("../storage/sessions.js", () => ({
   getActiveSessionCount: vi.fn(() => 0),
 }));
 
-vi.mock("../core/gateway-actions.js", () => ({
+vi.mock("../core/engine/gateway-actions.js", () => ({
   handleSharedAction: vi.fn(async () => null),
 }));
 
@@ -71,7 +71,7 @@ vi.mock("write-file-atomic", () => ({
 
 // ── Dynamic import ─────────────────────────────────────────────────────────
 
-const { withRetry } = await import("../core/gateway.js");
+const { withRetry } = await import("../core/engine/gateway.js");
 import { TalonError, classify } from "../core/errors.js";
 
 // ── helpers ────────────────────────────────────────────────────────────────

--- a/src/__tests__/gateway-withRetry-extended.test.ts
+++ b/src/__tests__/gateway-withRetry-extended.test.ts
@@ -28,7 +28,7 @@ vi.mock("../util/log.js", () => ({
   logDebug: vi.fn(),
 }));
 
-vi.mock("../core/gateway-actions.js", () => ({
+vi.mock("../core/engine/gateway-actions.js", () => ({
   handleSharedAction: vi.fn(async () => null),
 }));
 
@@ -36,7 +36,7 @@ vi.mock("../core/plugin.js", () => ({
   handlePluginAction: vi.fn(async () => null),
 }));
 
-vi.mock("../core/dispatcher.js", () => ({
+vi.mock("../core/engine/dispatcher.js", () => ({
   getActiveCount: vi.fn(() => 0),
 }));
 
@@ -55,7 +55,7 @@ vi.mock("../storage/sessions.js", () => ({
 
 // ── Subject under test ────────────────────────────────────────────────────────
 
-import { Gateway } from "../core/gateway.js";
+import { Gateway } from "../core/engine/gateway.js";
 
 // ── Test suite ────────────────────────────────────────────────────────────────
 

--- a/src/__tests__/handlers-stream.test.ts
+++ b/src/__tests__/handlers-stream.test.ts
@@ -15,7 +15,7 @@ vi.mock("../util/log.js", () => ({
   logDebug: vi.fn(),
 }));
 
-vi.mock("../core/dispatcher.js", () => ({
+vi.mock("../core/engine/dispatcher.js", () => ({
   execute: vi.fn(),
 }));
 
@@ -135,7 +135,7 @@ describe("createStreamCallbacks — onStreamDelta streaming disabled path", () =
       config: unknown,
     ) => Promise<void>;
 
-    const dispatcher = await import("../core/dispatcher.js");
+    const dispatcher = await import("../core/engine/dispatcher.js");
     executeMock = dispatcher.execute as ReturnType<typeof vi.fn>;
 
     const log = await import("../util/log.js");

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const executeMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../core/dispatcher.js", () => ({
+vi.mock("../core/engine/dispatcher.js", () => ({
   execute: executeMock,
 }));
 vi.mock("../storage/daily-log.js", () => ({

--- a/src/__tests__/heartbeat.test.ts
+++ b/src/__tests__/heartbeat.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for src/core/heartbeat.ts
+ * Tests for src/core/background/heartbeat.ts
  *
  * Covers: initHeartbeat, startHeartbeatTimer (double-start guard),
  * forceHeartbeat (concurrency guard), state persistence semantics
@@ -95,7 +95,7 @@ const {
   getHeartbeatStatus,
   awaitCurrentRun,
   buildHeartbeatSystemPrompt,
-} = await import("../core/heartbeat.js");
+} = await import("../core/background/heartbeat.js");
 
 describe("initHeartbeat", () => {
   it("accepts a config object without throwing", () => {
@@ -554,7 +554,7 @@ describe("heartbeat eviction (timeout + abort + delegation)", () => {
       termed: 0,
       killed: 0,
     }));
-    evictionMod = await import("../core/heartbeat.js");
+    evictionMod = await import("../core/background/heartbeat.js");
     evictionMod.initHeartbeat({
       model: "claude-sonnet-4-6",
       getBackend: () =>

--- a/src/__tests__/heartbeat.test.ts
+++ b/src/__tests__/heartbeat.test.ts
@@ -493,68 +493,40 @@ describe("awaitCurrentRun", () => {
 // to the backend.
 
 describe("heartbeat eviction (timeout + abort + delegation)", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let evictionMod: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let evictionRunOneShotMock: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let evictionEvictMock: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let evictionWriteAtomicMock: any;
+  // Uses the file-level hoisted mocks and the top-level module import,
+  // exactly like every other suite in this file. The suite previously
+  // re-mocked node:fs / paths / write-file-atomic via vi.resetModules()
+  // + vi.doMock() and a fresh dynamic import — needed only because the
+  // heartbeat timeout env vars were read at module load. That pattern
+  // raced vitest's module registry (the fresh import intermittently saw
+  // the REAL fs or a stale mock instance) and made this suite flaky.
+  // heartbeat.ts now reads TALON_HEARTBEAT_TIMEOUT_MS / _ABORT_GRACE_MS
+  // per run, so no re-import is needed.
+  const evictionRunOneShotMock = runOneShotAgentMock;
+  const evictionEvictMock = evictOrphanSubprocessesMock;
+  const evictionWriteAtomicMock = writeAtomicSyncMock;
+  const evictionMod = { forceHeartbeat, initHeartbeat };
 
-  beforeEach(async () => {
+  beforeEach(() => {
     process.env.TALON_HEARTBEAT_TIMEOUT_MS = "50";
     process.env.TALON_HEARTBEAT_ABORT_GRACE_MS = "50";
-    vi.resetModules();
 
-    vi.doMock("../util/log.js", () => ({
-      log: vi.fn(),
-      logError: vi.fn(),
-      logWarn: vi.fn(),
-    }));
-    vi.doMock("node:fs", () => ({
-      existsSync: () => false,
-      readFileSync: (filePath: string) => {
-        const p = String(filePath).replace(/\\/g, "/");
-        if (p.endsWith("/heartbeat.md"))
-          return "heartbeat prompt {{workspace}} {{logsDir}} {{lastRunIso}} {{memoryFile}} {{instructionsFile}} {{runCount}} {{intervalMinutes}}";
-        return "null";
-      },
-      mkdirSync: vi.fn(),
-    }));
-    vi.doMock("node:fs/promises", () => ({
-      appendFile: vi.fn(async () => {}),
-      mkdir: vi.fn(async () => undefined),
-    }));
-    evictionWriteAtomicMock = vi.fn();
-    vi.doMock("write-file-atomic", () => ({
-      default: { sync: evictionWriteAtomicMock },
-    }));
-    vi.doMock("../util/paths.js", () => ({
-      files: {
-        heartbeatState: "/fake/.talon/workspace/memory/heartbeat_state.json",
-        dreamState: "/fake/.talon/workspace/memory/dream_state.json",
-        memory: "/fake/.talon/workspace/memory/memory.md",
-        log: "/fake/.talon/talon.log",
-      },
-      dirs: {
-        root: "/fake/.talon",
-        logs: "/fake/.talon/workspace/logs",
-        workspace: "/fake/.talon/workspace",
-        data: "/fake/.talon/data",
-        memory: "/fake/.talon/workspace/memory",
-        dailyMemory: "/fake/.talon/workspace/memory/daily",
-        prompts: "/fake/.talon/prompts",
-      },
-    }));
-
-    evictionRunOneShotMock = vi.fn();
-    evictionEvictMock = vi.fn(async () => ({
+    existsSyncMock.mockImplementation(() => false);
+    readFileSyncMock.mockImplementation(((filePath: string) => {
+      const p = String(filePath).replace(/\\/g, "/");
+      if (p.endsWith("/heartbeat.md"))
+        return "heartbeat prompt {{workspace}} {{logsDir}} {{lastRunIso}} {{memoryFile}} {{instructionsFile}} {{runCount}} {{intervalMinutes}}";
+      return "null";
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any);
+    evictionWriteAtomicMock.mockClear();
+    evictionRunOneShotMock.mockReset();
+    evictionEvictMock.mockReset();
+    evictionEvictMock.mockImplementation(async () => ({
       found: 0,
       termed: 0,
       killed: 0,
     }));
-    evictionMod = await import("../core/background/heartbeat.js");
     evictionMod.initHeartbeat({
       model: "claude-sonnet-4-6",
       getBackend: () =>
@@ -569,11 +541,6 @@ describe("heartbeat eviction (timeout + abort + delegation)", () => {
   afterEach(() => {
     delete process.env.TALON_HEARTBEAT_TIMEOUT_MS;
     delete process.env.TALON_HEARTBEAT_ABORT_GRACE_MS;
-    vi.doUnmock("../util/log.js");
-    vi.doUnmock("node:fs");
-    vi.doUnmock("node:fs/promises");
-    vi.doUnmock("write-file-atomic");
-    vi.doUnmock("../util/paths.js");
   });
 
   it("calls AbortController.abort() when the agent hangs past the timeout", async () => {
@@ -687,7 +654,7 @@ describe("heartbeat eviction (timeout + abort + delegation)", () => {
     // Find the final state write (status: "idle" — the one written in the
     // catch path; the initial "running" write happens before the timeout).
     const idleWrites = evictionWriteAtomicMock.mock.calls
-      .map((c: [string, string]) => JSON.parse(c[1]))
+      .map((c) => JSON.parse(String(c[1])))
       .filter((s: { status: string }) => s.status === "idle");
     expect(idleWrites.length).toBeGreaterThan(0);
     const finalState = idleWrites[idleWrites.length - 1];

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { initDispatcher, execute } from "../core/dispatcher.js";
+import { initDispatcher, execute } from "../core/engine/dispatcher.js";
 import type { ContextManager } from "../core/types.js";
 import { stubBackend, stubResolveActiveModel } from "./helpers/stub-backend.js";
 import { TalonError } from "../core/errors.js";

--- a/src/__tests__/integration/claude-live-discovery.test.ts
+++ b/src/__tests__/integration/claude-live-discovery.test.ts
@@ -13,7 +13,11 @@
 
 import { describe, expect, it } from "vitest";
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import { clearModels, getModels, resolveModelId } from "../../core/models/catalog.js";
+import {
+  clearModels,
+  getModels,
+  resolveModelId,
+} from "../../core/models/catalog.js";
 import { registerClaudeModels } from "../../backend/claude-sdk/models.js";
 import { cliAvailable, cliVersion } from "./live-backend-helpers.js";
 

--- a/src/__tests__/integration/claude-live-discovery.test.ts
+++ b/src/__tests__/integration/claude-live-discovery.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, expect, it } from "vitest";
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import { clearModels, getModels, resolveModelId } from "../../core/models.js";
+import { clearModels, getModels, resolveModelId } from "../../core/models/catalog.js";
 import { registerClaudeModels } from "../../backend/claude-sdk/models.js";
 import { cliAvailable, cliVersion } from "./live-backend-helpers.js";
 

--- a/src/__tests__/integration/kilo-real-bootstrap.test.ts
+++ b/src/__tests__/integration/kilo-real-bootstrap.test.ts
@@ -49,7 +49,7 @@ import {
   stopProcess,
   waitForHealthy,
 } from "./live-backend-helpers.js";
-import { Gateway } from "../../core/gateway.js";
+import { Gateway } from "../../core/engine/gateway.js";
 import { makeRecordingHandler } from "./recording-handler.js";
 import type { Frontend } from "../../bootstrap.js";
 import type { ContextManager } from "../../core/types.js";
@@ -362,7 +362,7 @@ kiloDescribe("Kilo backend — real bootstrap (integration)", () => {
     recording.reset();
     const textBlocks: string[] = [];
     const toolUses: { name: string; input: Record<string, unknown> }[] = [];
-    const { execute } = await import("../../core/dispatcher.js");
+    const { execute } = await import("../../core/engine/dispatcher.js");
 
     const result = await execute({
       chatId: "real-bootstrap-test-1",
@@ -433,7 +433,7 @@ kiloDescribe("Kilo backend — real bootstrap (integration)", () => {
 
   it("chat-switch disconnects the previous chat's MCP server", async () => {
     recording.reset();
-    const { execute } = await import("../../core/dispatcher.js");
+    const { execute } = await import("../../core/engine/dispatcher.js");
     const { getRegisteredMcpServerNames } =
       await import("../../backend/kilo/server.js");
 

--- a/src/__tests__/integration/openai-agents-live-discovery.test.ts
+++ b/src/__tests__/integration/openai-agents-live-discovery.test.ts
@@ -29,7 +29,7 @@
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 
-import { Gateway } from "../../core/gateway.js";
+import { Gateway } from "../../core/engine/gateway.js";
 import { resetSession } from "../../storage/sessions.js";
 import type { TalonConfig } from "../../util/config.js";
 

--- a/src/__tests__/integration/opencode-real-bootstrap.test.ts
+++ b/src/__tests__/integration/opencode-real-bootstrap.test.ts
@@ -32,7 +32,7 @@ import {
   stopProcess,
   waitForHealthy,
 } from "./live-backend-helpers.js";
-import { Gateway } from "../../core/gateway.js";
+import { Gateway } from "../../core/engine/gateway.js";
 import { makeRecordingHandler } from "./recording-handler.js";
 import type { Frontend } from "../../bootstrap.js";
 import type { ContextManager } from "../../core/types.js";
@@ -278,7 +278,7 @@ opencodeDescribe("OpenCode backend — real bootstrap (integration)", () => {
     recording.reset();
     const textBlocks: string[] = [];
     const toolUses: { name: string; input: Record<string, unknown> }[] = [];
-    const { execute } = await import("../../core/dispatcher.js");
+    const { execute } = await import("../../core/engine/dispatcher.js");
 
     const result = await execute({
       chatId: "opencode-real-bootstrap-1",
@@ -346,7 +346,7 @@ opencodeDescribe("OpenCode backend — real bootstrap (integration)", () => {
 
   it("chat-switch disconnects the previous chat's MCP server", async () => {
     recording.reset();
-    const { execute } = await import("../../core/dispatcher.js");
+    const { execute } = await import("../../core/engine/dispatcher.js");
     const { getRegisteredMcpServerNames } =
       await import("../../backend/opencode/server.js");
 

--- a/src/__tests__/integration/talon-bootstrap.ts
+++ b/src/__tests__/integration/talon-bootstrap.ts
@@ -34,9 +34,9 @@ import { tmpdir } from "node:os";
 
 import type { TalonConfig } from "../../util/config.js";
 import { initBackendAndDispatcher, type Frontend } from "../../bootstrap.js";
-import { execute as dispatcherExecute } from "../../core/dispatcher.js";
+import { execute as dispatcherExecute } from "../../core/engine/dispatcher.js";
 import { resetSession } from "../../storage/sessions.js";
-import { Gateway } from "../../core/gateway.js";
+import { Gateway } from "../../core/engine/gateway.js";
 import type { FrontendActionHandler } from "../../core/types.js";
 
 import type { StubScript } from "./stub-claude/protocol.js";

--- a/src/__tests__/integration/talon-functional.test.ts
+++ b/src/__tests__/integration/talon-functional.test.ts
@@ -55,7 +55,7 @@ describe.skipIf(!stubReady)("Talon functional — bootstrap", () => {
     // pulls them out of `q.supportedModels()`, tests run through unmodified
     // bootstrap.
     await import("./talon-bootstrap.js").then((m) => m.ensureBooted());
-    const { getModels } = await import("../../core/models.js");
+    const { getModels } = await import("../../core/models/catalog.js");
     const ids = getModels().map((m) => m.id);
     expect(ids).toContain("claude-sonnet-4-6");
     expect(ids).toContain("default");

--- a/src/__tests__/integration/telegram-live/test-bot.ts
+++ b/src/__tests__/integration/telegram-live/test-bot.ts
@@ -15,7 +15,7 @@
 
 import { Bot, InputFile } from "grammy";
 import { createTelegramActionHandler } from "../../../frontend/telegram/actions.js";
-import type { Gateway } from "../../../core/gateway.js";
+import type { Gateway } from "../../../core/engine/gateway.js";
 
 export interface TestBotEnv {
   bot: Bot;

--- a/src/__tests__/mcp-env.test.ts
+++ b/src/__tests__/mcp-env.test.ts
@@ -1,0 +1,76 @@
+/**
+ * MCP env contract — buildTalonMcpEnv (backend side) and parseEnvList
+ * (server side) are the two halves of the env-var protocol between
+ * backends and the spawned mcp-server subprocess.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildTalonMcpEnv,
+  parseEnvList,
+  ENV_DISABLED_TOOLS,
+  ENV_DISABLED_TOOL_TAGS,
+} from "../core/tools/mcp-env.js";
+import { composeTools } from "../core/tools/index.js";
+
+describe("buildTalonMcpEnv", () => {
+  it("builds the base trio without exclusions", () => {
+    const env = buildTalonMcpEnv({
+      bridgeUrl: "http://127.0.0.1:1",
+      chatId: "42",
+      frontend: "telegram",
+    });
+    expect(env).toEqual({
+      TALON_BRIDGE_URL: "http://127.0.0.1:1",
+      TALON_CHAT_ID: "42",
+      TALON_FRONTEND: "telegram",
+    });
+  });
+
+  it("carries config exclusions as comma-separated vars", () => {
+    const env = buildTalonMcpEnv({
+      bridgeUrl: "u",
+      chatId: "c",
+      frontend: "telegram",
+      config: {
+        disabledTools: ["send_dice"],
+        disabledToolTags: ["stickers", "web"],
+      },
+    });
+    expect(env[ENV_DISABLED_TOOLS]).toBe("send_dice");
+    expect(env[ENV_DISABLED_TOOL_TAGS]).toBe("stickers,web");
+  });
+
+  it("omits exclusion vars when lists are empty or config absent", () => {
+    const env = buildTalonMcpEnv({
+      bridgeUrl: "u",
+      chatId: "c",
+      frontend: "telegram",
+      config: { disabledTools: [], disabledToolTags: [] },
+    });
+    expect(env[ENV_DISABLED_TOOLS]).toBeUndefined();
+    expect(env[ENV_DISABLED_TOOL_TAGS]).toBeUndefined();
+  });
+});
+
+describe("parseEnvList", () => {
+  it("splits, trims, and drops blanks", () => {
+    expect(parseEnvList("a, b ,,c")).toEqual(["a", "b", "c"]);
+    expect(parseEnvList(undefined)).toEqual([]);
+    expect(parseEnvList("")).toEqual([]);
+  });
+});
+
+describe("composeTools with exclusions (the server-side effect)", () => {
+  it("excluding the stickers tag removes the sticker tools", () => {
+    const all = composeTools({ frontend: "telegram" });
+    const trimmed = composeTools({
+      frontend: "telegram",
+      excludeTags: ["stickers"],
+    });
+    expect(trimmed.length).toBeLessThan(all.length);
+    expect(trimmed.some((t) => t.tag === "stickers")).toBe(false);
+    // end_turn survives — it's tagged messaging, not stickers.
+    expect(trimmed.some((t) => t.name === "end_turn")).toBe(true);
+  });
+});

--- a/src/__tests__/openai-agents-backend.test.ts
+++ b/src/__tests__/openai-agents-backend.test.ts
@@ -35,7 +35,7 @@ describe("openai-agents / constants", () => {
     expect(OPENAI_AGENTS_SYSTEM_PROMPT_SUFFIX).toContain("end_turn");
     expect(OPENAI_AGENTS_SYSTEM_PROMPT_SUFFIX).toContain("send");
     expect(OPENAI_AGENTS_SYSTEM_PROMPT_SUFFIX).toContain("react");
-    expect(OPENAI_AGENTS_SYSTEM_PROMPT_SUFFIX).toContain("tool-only delivery");
+    expect(OPENAI_AGENTS_SYSTEM_PROMPT_SUFFIX).toContain("Response flow");
     expect(OPENAI_AGENTS_SYSTEM_PROMPT_SUFFIX).toContain("FLOW VIOLATION");
   });
 });

--- a/src/__tests__/reload-plugins.test.ts
+++ b/src/__tests__/reload-plugins.test.ts
@@ -147,7 +147,7 @@ const mockBackendNoMcp = stubBackend({
 
 // ── Import after mocks ────────────────────────────────────────────────────
 
-import { handleSharedAction } from "../core/gateway-actions.js";
+import { handleSharedAction } from "../core/engine/gateway-actions.js";
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 

--- a/src/__tests__/reload-plugins.test.ts
+++ b/src/__tests__/reload-plugins.test.ts
@@ -45,7 +45,7 @@ vi.mock("../storage/chat-settings.js", () => ({
 vi.mock("../core/errors.js", () => ({
   classify: vi.fn(),
 }));
-vi.mock("../core/models.js", () => ({
+vi.mock("../core/models/catalog.js", () => ({
   getFallbackModel: vi.fn(),
 }));
 vi.mock("../util/trace.js", () => ({

--- a/src/__tests__/shared-handle-retry.test.ts
+++ b/src/__tests__/shared-handle-retry.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { QueryParams } from "../backend/shared/handler-types.js";
 import { applyRetryDecision } from "../backend/shared/handle-retry.js";
 import { TalonError } from "../core/errors.js";
-import { registerModels, clearModels } from "../core/models.js";
+import { registerModels, clearModels } from "../core/models/catalog.js";
 import { setChatModel } from "../storage/chat-settings.js";
 import { resetSession, getSession } from "../storage/sessions.js";
 

--- a/src/__tests__/shared-model-retry.test.ts
+++ b/src/__tests__/shared-model-retry.test.ts
@@ -9,11 +9,11 @@ import { TalonError } from "../core/errors.js";
 
 // Mock getFallbackModel — we don't want to depend on the actual model
 // registry here; this lets us test all branches.
-vi.mock("../core/models.js", () => ({
+vi.mock("../core/models/catalog.js", () => ({
   getFallbackModel: vi.fn(),
 }));
 
-const { getFallbackModel } = await import("../core/models.js");
+const { getFallbackModel } = await import("../core/models/catalog.js");
 const getFallbackModelMock = vi.mocked(getFallbackModel);
 
 describe("classifyRetry", () => {

--- a/src/__tests__/status-context.test.ts
+++ b/src/__tests__/status-context.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCacheDisplay,
   buildContextDisplay,
-} from "../frontend/status-context.js";
+} from "../frontend/shared/status-context.js";
 
 describe("status context display", () => {
   it("uses authoritative contextTokens when present", () => {

--- a/src/__tests__/teams-frontend.test.ts
+++ b/src/__tests__/teams-frontend.test.ts
@@ -298,7 +298,7 @@ describe("teams actions", () => {
       proxyFetch: vi.fn(async () => ({ ok: true, text: async () => "" })),
     }));
 
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
 
@@ -320,7 +320,7 @@ describe("teams actions", () => {
   });
 
   it("send_message returns ok for empty text (no-op)", async () => {
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();
@@ -342,7 +342,7 @@ describe("teams actions", () => {
       })),
     }));
 
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();
@@ -357,7 +357,7 @@ describe("teams actions", () => {
   });
 
   it("get_chat_info returns channel info", async () => {
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();
@@ -373,7 +373,7 @@ describe("teams actions", () => {
   });
 
   it("unsupported actions return errors instead of pretending success", async () => {
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();
@@ -397,7 +397,7 @@ describe("teams actions", () => {
   });
 
   it("unknown actions return null", async () => {
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();
@@ -425,7 +425,7 @@ describe("teams actions", () => {
       handlePluginAction: vi.fn(async () => null),
     }));
 
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();
@@ -465,7 +465,7 @@ describe("teams actions", () => {
       handlePluginAction: vi.fn(async () => null),
     }));
 
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();
@@ -559,7 +559,7 @@ describe("teams actions — branch coverage", () => {
   });
 
   it("send_message with undefined text uses empty string fallback", async () => {
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();
@@ -587,7 +587,7 @@ describe("teams actions — branch coverage", () => {
       handlePluginAction: vi.fn(async () => null),
     }));
 
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();
@@ -691,7 +691,7 @@ describe("teams actions — non-Error throw coverage", () => {
       }), // eslint-disable-line @typescript-eslint/no-throw-literal
     }));
 
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();
@@ -713,7 +713,7 @@ describe("teams actions — non-Error throw coverage", () => {
       }), // eslint-disable-line @typescript-eslint/no-throw-literal
     }));
 
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();
@@ -746,7 +746,7 @@ describe("teams actions — non-Error throw coverage", () => {
       })),
     }));
 
-    const { Gateway } = await import("../core/gateway.js");
+    const { Gateway } = await import("../core/engine/gateway.js");
     const { createTeamsActionHandler } =
       await import("../frontend/teams/actions.js");
     const gateway = new Gateway();

--- a/src/__tests__/telegram-helpers.test.ts
+++ b/src/__tests__/telegram-helpers.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { clearModels, registerModels } from "../core/models.js";
+import { clearModels, registerModels } from "../core/models/catalog.js";
 import {
   formatCompactModelLabel,
   formatDuration,

--- a/src/__tests__/telegram-model-menu-controller.test.ts
+++ b/src/__tests__/telegram-model-menu-controller.test.ts
@@ -47,7 +47,7 @@ import {
   rebindChat,
   releaseChat,
   resetBackendPoolForTest,
-} from "../core/backend-controller.js";
+} from "../core/engine/backend-controller.js";
 import {
   registerBackend,
   clearBackends,

--- a/src/__tests__/telegram-model-menu-controller.test.ts
+++ b/src/__tests__/telegram-model-menu-controller.test.ts
@@ -90,7 +90,7 @@ function makeFakeBackend(
     getSettingsPresentation: vi.fn().mockResolvedValue(picker),
     getModelInfo: vi.fn().mockResolvedValue(fakeModel),
     // Mirror the model into resolveModel so per-chat override
-    // validation in `core/active-model.ts` accepts any stored id —
+    // validation in `core/models/active-model.ts` accepts any stored id —
     // these tests focus on the picker output, not the resolver.
     resolveModel: vi.fn().mockResolvedValue({
       kind: "exact" as const,

--- a/src/__tests__/tool-functional.test.ts
+++ b/src/__tests__/tool-functional.test.ts
@@ -350,7 +350,7 @@ import {
   // re-export for test side-only — handler depends on the InputFile constructor
 } from "../frontend/telegram/actions.js";
 import type { Bot } from "grammy";
-import type { Gateway } from "../core/gateway.js";
+import type { Gateway } from "../core/engine/gateway.js";
 
 interface BotApiSpy {
   setMessageReaction: ReturnType<typeof vi.fn>;

--- a/src/__tests__/triggers-extended.test.ts
+++ b/src/__tests__/triggers-extended.test.ts
@@ -1,5 +1,5 @@
 /**
- * Extended branch coverage for src/core/triggers.ts.
+ * Extended branch coverage for src/core/background/triggers.ts.
  *
  * Complements src/__tests__/triggers.test.ts.  Those tests cover the happy
  * paths (bash, cancel, timeout, shutdown, TALON_FIRE).  This file covers the
@@ -44,7 +44,7 @@ const {
   resumeAfterRestart,
   shutdownTriggers,
   _internals,
-} = await import("../core/triggers.js");
+} = await import("../core/background/triggers.js");
 
 import type { Trigger } from "../storage/trigger-store.js";
 const {

--- a/src/__tests__/triggers.test.ts
+++ b/src/__tests__/triggers.test.ts
@@ -29,7 +29,7 @@ const {
   shutdownTriggers,
   getRunningCount,
   resumeAfterRestart,
-} = await import("../core/triggers.js");
+} = await import("../core/background/triggers.js");
 
 import type { Trigger } from "../storage/trigger-store.js";
 

--- a/src/__tests__/workspace-migrate.test.ts
+++ b/src/__tests__/workspace-migrate.test.ts
@@ -201,56 +201,40 @@ describe("initWorkspace — identity and prompt seeding", () => {
     }
   });
 
-  it("seeds .md prompt files from prompts/ directory", async () => {
-    // prompts/ is resolved relative to process.cwd()
-    const promptsDir = join(TEST_ROOT, "prompts");
-    mkdirSync(promptsDir, { recursive: true });
-    writeFileSync(join(promptsDir, "system.md"), "# System Prompt");
-    writeFileSync(join(promptsDir, "dream.md"), "# Dream Prompt");
-    writeFileSync(join(promptsDir, "not-a-prompt.txt"), "ignored");
+  it("seeds .md prompt files from the package prompts/ directory", async () => {
+    // Seeding reads the PACKAGE prompts dir (resolved relative to the
+    // module, not process.cwd()) — a daemon launched from any other
+    // directory used to silently seed nothing.
+    const { initWorkspace } = await import("../util/workspace.js");
+    initWorkspace(join(TEST_ROOT, "ws"));
 
-    const originalCwd = process.cwd;
-    process.cwd = () => TEST_ROOT;
-
-    try {
-      const { initWorkspace } = await import("../util/workspace.js");
-      initWorkspace(join(TEST_ROOT, "ws"));
-
-      // prompts are seeded to ~/.talon/prompts/
-      const talonPromptsDir = join(NEW_ROOT, "prompts");
-      expect(existsSync(join(talonPromptsDir, "system.md"))).toBe(true);
-      expect(existsSync(join(talonPromptsDir, "dream.md"))).toBe(true);
-      // .txt file should NOT be copied
-      expect(existsSync(join(talonPromptsDir, "not-a-prompt.txt"))).toBe(false);
-    } finally {
-      process.cwd = originalCwd;
-    }
+    // prompts are seeded to ~/.talon/prompts/
+    const talonPromptsDir = join(NEW_ROOT, "prompts");
+    expect(existsSync(join(talonPromptsDir, "base.md"))).toBe(true);
+    expect(existsSync(join(talonPromptsDir, "dream.md"))).toBe(true);
+    // The architecture README is docs, not a prompt — never seeded.
+    expect(existsSync(join(talonPromptsDir, "README.md"))).toBe(false);
+    // system/ templates are package-owned and read in place — a seeded
+    // copy would go stale, so the directory is never copied.
+    expect(existsSync(join(talonPromptsDir, "system"))).toBe(false);
+    // Non-.md files (e.g. custom.md.example) are not copied.
+    expect(existsSync(join(talonPromptsDir, "custom.md.example"))).toBe(false);
   });
 
   it("does not overwrite existing prompt files", async () => {
-    const promptsDir = join(TEST_ROOT, "prompts");
-    mkdirSync(promptsDir, { recursive: true });
-    writeFileSync(join(promptsDir, "custom.md"), "# Package version");
-
     const talonPromptsDir = join(NEW_ROOT, "prompts");
     mkdirSync(talonPromptsDir, { recursive: true });
+    // Pre-existing user copy of a real package prompt must survive.
     writeFileSync(
-      join(talonPromptsDir, "custom.md"),
+      join(talonPromptsDir, "base.md"),
       "# User customized version",
     );
 
-    const originalCwd = process.cwd;
-    process.cwd = () => TEST_ROOT;
+    const { initWorkspace } = await import("../util/workspace.js");
+    initWorkspace(join(TEST_ROOT, "ws"));
 
-    try {
-      const { initWorkspace } = await import("../util/workspace.js");
-      initWorkspace(join(TEST_ROOT, "ws"));
-
-      // User version should be preserved
-      const content = readFileSync(join(talonPromptsDir, "custom.md"), "utf-8");
-      expect(content).toBe("# User customized version");
-    } finally {
-      process.cwd = originalCwd;
-    }
+    // User version should be preserved
+    const content = readFileSync(join(talonPromptsDir, "base.md"), "utf-8");
+    expect(content).toBe("# User customized version");
   });
 });

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -21,8 +21,8 @@ import {
 } from "../../storage/sessions.js";
 import { log, logError, logWarn } from "../../util/log.js";
 import { traceMessage } from "../../util/trace.js";
-import { incrementCounter, recordHistogram } from "../../util/metrics.js";
-import { isTurnTerminator, stripMcpPrefix } from "../../core/tools/index.js";
+import { incrementCounter } from "../../util/metrics.js";
+import { isTurnTerminator } from "../../core/tools/index.js";
 
 import type { Query } from "@anthropic-ai/claude-agent-sdk";
 import {
@@ -55,6 +55,9 @@ import {
   buildDeliveryContract,
   buildFlowViolationReminder,
   buildFirstTurnReminder,
+  recordToolCall,
+  recordTurnMetrics,
+  recordFlowViolation,
 } from "../shared/index.js";
 
 // ── Post-result watchdog ────────────────────────────────────────────────────
@@ -240,7 +243,7 @@ export async function* runChatTurn(
         }
 
         for (const tool of result.tools) {
-          incrementCounter(`tool_calls.${stripMcpPrefix(tool.name)}`);
+          recordToolCall(tool.name, "claude");
           captureIntoState(tool.name, tool.input);
           if (isTurnTerminator(tool.name, tool.input)) {
             state.turnTerminated = true;
@@ -318,8 +321,12 @@ export async function* runChatTurn(
   // ── Persist session and usage ─────────────────────────────────────────────
 
   const durationMs = Date.now() - t0;
-  recordHistogram("response_latency_ms", durationMs);
-  incrementCounter("queries_total");
+  recordTurnMetrics({
+    backend: "claude",
+    durationMs,
+    toolCalls: state.toolCalls,
+    apiCalls: state.numApiCalls,
+  });
   if (state.newSessionId) setSessionId(chatId, state.newSessionId);
   recordUsage(chatId, {
     inputTokens: state.sdkInputTokens,
@@ -355,7 +362,7 @@ export async function* runChatTurn(
   });
 
   if (violation.violated) {
-    incrementCounter("scratchpad.trailing_text_dropped");
+    recordFlowViolation(violation.shouldRetry ? "retried" : "cap_exhausted");
     log(
       "agent",
       `[${chatId}] flow violation: ${violation.reason}. ${
@@ -366,7 +373,6 @@ export async function* runChatTurn(
     );
 
     if (violation.shouldRetry) {
-      incrementCounter("scratchpad.flow_violation_retried");
       yield* runChatTurn(
         { ...params, text: violation.reminder },
         {
@@ -376,7 +382,6 @@ export async function* runChatTurn(
       );
       return;
     }
-    incrementCounter("scratchpad.flow_violation_cap_exhausted");
   }
 
   // Reached the non-retry path — this turn counts as one user-visible turn.

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -33,7 +33,7 @@ import type { ChatRunParams } from "../../core/agent-runtime/capabilities.js";
 import { makeBareModelRef } from "../../core/agent-runtime/model-ref.js";
 import { applyRetryDecisionStream } from "../shared/handle-retry.js";
 import { getConfig } from "./state.js";
-import { buildSdkOptions } from "./options.js";
+import { buildSdkOptions, getActiveFrontends } from "./options.js";
 import {
   createStreamState,
   isSystemInit,
@@ -52,6 +52,9 @@ import {
   FLOW_VIOLATION_MAX_RETRIES,
   captureDeliveredText,
   summarizeUsage,
+  buildDeliveryContract,
+  buildFlowViolationReminder,
+  buildFirstTurnReminder,
 } from "../shared/index.js";
 
 // ── Post-result watchdog ────────────────────────────────────────────────────
@@ -119,14 +122,27 @@ export async function* runChatTurn(
   const session = getSession(chatId);
   const t0 = Date.now();
 
+  // Primary messaging frontend, if any. Drives the delivery-contract
+  // suffix and the frontend-aware flow-violation text. Empty in
+  // terminal mode, where no delivery tools exist and the strict
+  // tool-only contract must not be asserted.
+  const frontend: string | undefined = getActiveFrontends()[0];
+
   // Frozen per-session prompt (keyed by session epoch) — stable across
   // turns so the provider's prompt-cache prefix survives other chats'
-  // session resets. See backend/shared/system-prompt.ts.
+  // session resets. See backend/shared/system-prompt.ts. The delivery
+  // contract joins as the backend suffix — the tail of the static
+  // prompt, the highest-salience spot — so models see the tool-only
+  // flow before their first turn instead of discovering it via a
+  // [FLOW VIOLATION] retry.
   const preparedPrompt = prepareSystemPrompt({
     config,
     previousTurns: session.turns,
     chatId,
     sessionEpoch: session.createdAt,
+    backendSuffix: frontend
+      ? buildDeliveryContract("tool-only", frontend)
+      : undefined,
   });
 
   const abortController = new AbortController();
@@ -137,12 +153,20 @@ export async function* runChatTurn(
     preparedPrompt,
   );
 
-  const prompt = formatUserPrompt({
+  let prompt = formatUserPrompt({
     text,
     senderName: senderName ?? "user",
     isGroup,
     messageId: params.messageId,
   });
+  // First turn of a session is where flow violations cluster — the
+  // model hasn't seen the contract in action yet. One line appended to
+  // the turn-0 user message (never the system prompt, so the cached
+  // prefix is untouched) pre-empts the 2x-token violation retry.
+  // Skipped on flow retries: those already carry the full reminder.
+  if (frontend && session.turns === 0 && !_internal.flowRetries) {
+    prompt += `\n\n${buildFirstTurnReminder(frontend)}`;
+  }
   log("agent", `[${chatId}] <- (${text.length} chars)`);
   traceMessage(chatId, "in", text, { senderName, isGroup });
 
@@ -327,6 +351,7 @@ export async function* runChatTurn(
     retried: (_internal.flowRetries ?? 0) > 0,
     retryCount: _internal.flowRetries ?? 0,
     maxRetries: FLOW_VIOLATION_MAX_RETRIES,
+    ...(frontend ? { reminder: buildFlowViolationReminder(frontend) } : {}),
   });
 
   if (violation.violated) {

--- a/src/backend/claude-sdk/model-provider.ts
+++ b/src/backend/claude-sdk/model-provider.ts
@@ -11,8 +11,8 @@ import {
   getModels,
   resolveModel as coreResolveModel,
   resolveModelId,
-} from "../../core/models.js";
-import type { ModelInfo } from "../../core/models.js";
+} from "../../core/models/catalog.js";
+import type { ModelInfo } from "../../core/models/catalog.js";
 import type {
   UnifiedModelInfo,
   UnifiedModelResolution,

--- a/src/backend/claude-sdk/models.ts
+++ b/src/backend/claude-sdk/models.ts
@@ -12,9 +12,9 @@ import {
   registerModels,
   clearModelsByProvider,
   registerProviderPrefix,
-} from "../../core/models.js";
-import type { ModelInfo } from "../../core/models.js";
-import { normalizeReasoningLevels } from "../../core/reasoning-levels.js";
+} from "../../core/models/catalog.js";
+import type { ModelInfo } from "../../core/models/catalog.js";
+import { normalizeReasoningLevels } from "../../core/models/reasoning-levels.js";
 import { log, logError } from "../../util/log.js";
 
 type SdkModelInfo = {

--- a/src/backend/claude-sdk/options.ts
+++ b/src/backend/claude-sdk/options.ts
@@ -6,7 +6,6 @@
  */
 
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
 import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "@anthropic-ai/claude-agent-sdk";
 import type {
   Options,
@@ -24,6 +23,11 @@ import { getPluginMcpServers } from "../../core/plugin.js";
 import { resolveModelId } from "../../core/models.js";
 import { wrapMcpServer } from "../../util/mcp-launcher.js";
 import { isTurnTerminator } from "../../core/tools/index.js";
+import {
+  buildTalonMcpEnv,
+  talonMcpServerCommand,
+} from "../../core/tools/mcp-env.js";
+import { nonTerminalFrontends } from "../shared/frontends.js";
 import { log, logError } from "../../util/log.js";
 import { getConfig, getBridgePort } from "./state.js";
 import { ALLOWED_TOOLS_CHAT, EFFORT_MAP } from "./constants.js";
@@ -51,11 +55,7 @@ export type BuildSdkOptionsResult = {
  * should wrap in try/catch and treat as "no frontends available").
  */
 export function getActiveFrontends(): readonly string[] {
-  const config = getConfig();
-  const allFrontends = Array.isArray(config.frontend)
-    ? config.frontend
-    : [config.frontend];
-  return allFrontends.filter((f) => f !== "terminal");
+  return nonTerminalFrontends(getConfig().frontend);
 }
 
 /**
@@ -71,21 +71,9 @@ export function buildMcpServers(
   const config = getConfig();
   const bridgeUrl = `http://127.0.0.1:${getBridgePort()}`;
 
-  // tsx as a Node loader is passed via `--import <url>`. Node accepts URLs
-  // or absolute paths, but on Windows a raw backslash path (`D:\…\tsx`) is
-  // ambiguous between path and URL — the loader hook fails to register and
-  // every subsequent `import` of a .ts file throws. `pathToFileURL` produces
-  // a cross-platform `file://` URL that Node always treats as a loader URL.
-  const tsxImport = pathToFileURL(
-    resolve(
-      import.meta.dirname ?? ".",
-      "../../../node_modules/tsx/dist/esm/index.mjs",
-    ),
-  ).href;
-  const mcpServerPath = resolve(
-    import.meta.dirname ?? ".",
-    "../../core/tools/mcp-server.ts",
-  );
+  // Shared spawn spec — see talonMcpServerCommand for the tsx-loader
+  // and Windows rationale.
+  const [mcpCommand, ...mcpArgs] = talonMcpServerCommand();
 
   // Frontend-specific MCP tool servers (one per non-terminal frontend)
   const frontends = getActiveFrontends();
@@ -97,20 +85,10 @@ export function buildMcpServers(
 
   for (const frontend of frontends) {
     const serverName = `${frontend}-tools`;
-    const mcpEnv = {
-      TALON_BRIDGE_URL: bridgeUrl,
-      TALON_CHAT_ID: chatId,
-      TALON_FRONTEND: frontend,
-    };
-    // `node --import <tsx-loader>` everywhere — tsx as a Node loader works
-    // identically on Windows and POSIX, and avoids spawning `npx.cmd` (which
-    // Node 20.19+ refuses to execute via child_process.spawn without
-    // shell:true; CVE-2024-27980 mitigation). The wrapping launcher would
-    // hit the same .cmd ban when calling its child.
     servers[serverName] = wrapMcpServer({
-      command: "node",
-      args: ["--import", tsxImport, mcpServerPath],
-      env: mcpEnv,
+      command: mcpCommand,
+      args: mcpArgs,
+      env: buildTalonMcpEnv({ bridgeUrl, chatId, frontend, config }),
     });
   }
 

--- a/src/backend/claude-sdk/options.ts
+++ b/src/backend/claude-sdk/options.ts
@@ -20,7 +20,7 @@ import type { PreparedSystemPrompt } from "../shared/system-prompt.js";
 import { getSession } from "../../storage/sessions.js";
 import { getChatSettings } from "../../storage/chat-settings.js";
 import { getPluginMcpServers } from "../../core/plugin.js";
-import { resolveModelId } from "../../core/models.js";
+import { resolveModelId } from "../../core/models/catalog.js";
 import { wrapMcpServer } from "../../util/mcp-launcher.js";
 import { isTurnTerminator } from "../../core/tools/index.js";
 import {

--- a/src/backend/codex/constants.ts
+++ b/src/backend/codex/constants.ts
@@ -2,6 +2,8 @@
  * Codex backend constants.
  */
 
+import { buildDeliveryContract } from "../shared/delivery-contract.js";
+
 /**
  * System-prompt suffix appended to the user-configured system prompt.
  *
@@ -11,26 +13,15 @@
  * Delivery tools (`end_turn` / `send` / `react`) work via MCP — the
  * agent's `mcp_tool_call` items route through Talon's MCP server.
  *
- * Both routes are valid; the suffix below documents the model's
- * choices.
+ * Both routes are valid — the shared text-or-tools contract
+ * (prompts/system/contract-text-or-tools.md) documents the choice.
+ * Telegram-shaped tool names: this constant is static and the prior
+ * hand-written text hardcoded the same names.
  */
-export const CODEX_SYSTEM_PROMPT_SUFFIX = `
-
-## Codex Delivery
-
-Two ways to deliver a reply — pick whichever fits:
-
-- **Plain text** — your agent_message text is the reply. Just answer
-  normally. (Reasoning content stays private.)
-- **Delivery tools** — call \`end_turn(text="...", reply_to=N)\` for
-  threaded replies, \`send(type="text"|"photo"|"poll"|...)\` for rich
-  content, or \`react(emoji="...")\` for emoji acknowledgements. Use
-  these when you need reply targeting, buttons, attachments, or
-  multiple bubbles.
-
-If you call a delivery tool, don't also repeat the same text in plain
-output — Talon dedupes but it's cleaner to commit to one route.
-`;
+export const CODEX_SYSTEM_PROMPT_SUFFIX = `\n\n${buildDeliveryContract(
+  "text-or-tools",
+  "telegram",
+)}\n`;
 
 /**
  * Default model used by the Codex backend when none is configured AND

--- a/src/backend/codex/discovery.ts
+++ b/src/backend/codex/discovery.ts
@@ -44,7 +44,7 @@ import { join } from "node:path";
 import { log, logDebug } from "../../util/log.js";
 import { getState } from "./state.js";
 import type { CodexAuthInfo } from "./auth.js";
-import { normalizeReasoningLevels } from "../../core/reasoning-levels.js";
+import { normalizeReasoningLevels } from "../../core/models/reasoning-levels.js";
 
 /** Shape of one entry returned by OpenAI's `/v1/models`. Sparse — only `id` is reliably present. */
 interface OpenAiModelEntry {

--- a/src/backend/codex/handler.ts
+++ b/src/backend/codex/handler.ts
@@ -52,7 +52,7 @@ import {
 import { getChatSettings } from "../../storage/chat-settings.js";
 import { log, logError, logWarn } from "../../util/log.js";
 import { traceMessage } from "../../util/trace.js";
-import { incrementCounter, recordHistogram } from "../../util/metrics.js";
+import { incrementCounter } from "../../util/metrics.js";
 import { isTurnTerminator, stripMcpPrefix } from "../../core/tools/index.js";
 
 import {
@@ -68,6 +68,8 @@ import {
   buildDeliveryFailureReminder,
   TextBlockDeliveryError,
   applyRetryDecision,
+  recordToolCall,
+  recordTurnMetrics,
   type StreamState,
 } from "../shared/index.js";
 
@@ -613,22 +615,17 @@ export async function handleMessage(
   // Surface a synthetic error if Codex failed the turn upstream.
   if (turnFailedError) {
     streamState.syntheticError = turnFailedError;
-    incrementCounter("codex.turn_failed");
   }
 
   const responseText = finalizeResponseText(streamState);
   const durationMs = Date.now() - t0;
-  recordHistogram("response_latency_ms", durationMs);
-  incrementCounter("queries_total");
-  incrementCounter("codex.turns_total");
-  recordHistogram("codex.tool_calls_per_turn", codexToolMetrics.count);
-  if (codexToolMetrics.count > 0) {
-    incrementCounter("codex.turns_with_tools_total");
-  }
-  if (streamState.numApiCalls > 0) {
-    incrementCounter("codex.api_calls_total", streamState.numApiCalls);
-    recordHistogram("codex.api_calls_per_turn", streamState.numApiCalls);
-  }
+  recordTurnMetrics({
+    backend: "codex",
+    durationMs,
+    toolCalls: codexToolMetrics.count,
+    apiCalls: streamState.numApiCalls,
+    failed: Boolean(turnFailedError),
+  });
 
   recordUsage(chatId, {
     inputTokens: streamState.sdkInputTokens,
@@ -864,9 +861,10 @@ function recordCodexToolMetric(
   ctx: HandleEventContext,
   toolName: string,
 ): void {
-  incrementCounter(`tool_calls.${toolName}`);
-  incrementCounter("codex.tool_calls_total");
-  incrementCounter(`codex.tool_calls.${toolName}`);
+  // Shared vocabulary: `tool_calls.<bare>` (prefix-stripped, so codex
+  // MCP calls land on the same keys as every other backend) plus the
+  // `backend.codex.tool_calls` dimension.
+  recordToolCall(toolName, "codex");
   ctx.codexToolMetrics.count += 1;
 }
 

--- a/src/backend/codex/handler.ts
+++ b/src/backend/codex/handler.ts
@@ -87,7 +87,7 @@ import {
   getModelInfo,
   isCodexOAuthIncompat,
 } from "./models.js";
-import { supportsReasoningLevel } from "../../core/reasoning-levels.js";
+import { supportsReasoningLevel } from "../../core/models/reasoning-levels.js";
 import { markOAuthIncompat } from "./oauth-incompat.js";
 import { classifyRateLimits, readLastRolloutSnapshot } from "./token-usage.js";
 

--- a/src/backend/codex/init.ts
+++ b/src/backend/codex/init.ts
@@ -25,6 +25,7 @@ import { Codex } from "@openai/codex-sdk";
 import type { TalonConfig } from "../../util/config.js";
 import type { FrontendName } from "../registry.js";
 import { log, logWarn } from "../../util/log.js";
+import { nonTerminalFrontends } from "../shared/frontends.js";
 import { getState } from "./state.js";
 import { asCodexConfig, buildCodexMcpServers } from "./mcp-config.js";
 import { detectCodexAuth, type CodexAuthInfo } from "./auth.js";
@@ -170,6 +171,7 @@ export function ensureCodex(chatId: string): Codex {
     bridgeUrl,
     frontends,
     braveApiKey: state.config.braveApiKey,
+    toolExclusions: state.config,
   });
 
   // The Codex CLI's `--config` flag flattens dotted JSON paths into
@@ -234,6 +236,5 @@ export function codexSubprocessEnv(
 function getActiveFrontends(
   frontend: TalonConfig["frontend"],
 ): readonly string[] {
-  const all = Array.isArray(frontend) ? frontend : [frontend];
-  return all.filter((f) => f !== "terminal");
+  return nonTerminalFrontends(frontend);
 }

--- a/src/backend/codex/mcp-config.ts
+++ b/src/backend/codex/mcp-config.ts
@@ -24,10 +24,14 @@
  */
 
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
 import type { CodexOptions } from "@openai/codex-sdk";
 import { wrapMcpCommand } from "../../util/mcp-launcher.js";
 import { getPluginMcpServers } from "../../core/plugin.js";
+import {
+  buildTalonMcpEnv,
+  talonMcpServerCommand,
+  type ToolExclusionConfig,
+} from "../../core/tools/mcp-env.js";
 
 /**
  * AppToolApproval values accepted by Codex's `mcp_servers.<name>` table.
@@ -123,43 +127,28 @@ export function buildCodexMcpServers(args: {
   bridgeUrl: string;
   frontends: readonly string[];
   braveApiKey?: string;
+  /** Tool-surface trimming slice of the Talon config. */
+  toolExclusions?: ToolExclusionConfig | null;
 }): Record<string, CodexMcpServer> {
   const { chatId, bridgeUrl, frontends, braveApiKey } = args;
 
-  // tsx as a Node loader is passed via `--import <url>`. Node accepts URLs
-  // or absolute paths, but on Windows a raw backslash path is ambiguous
-  // between path and URL; `pathToFileURL` produces a cross-platform
-  // `file://` URL that Node always treats as a loader URL.
-  const tsxImport = pathToFileURL(
-    resolve(
-      import.meta.dirname ?? ".",
-      "../../../node_modules/tsx/dist/esm/index.mjs",
-    ),
-  ).href;
-  const mcpServerPath = resolve(
-    import.meta.dirname ?? ".",
-    "../../core/tools/mcp-server.ts",
-  );
-
   const servers: Record<string, CodexMcpServer> = {};
 
-  // Frontend MCP tool servers (one per non-terminal frontend).
+  // Frontend MCP tool servers (one per non-terminal frontend). Spawn
+  // spec is shared — see talonMcpServerCommand for the tsx-loader and
+  // Windows rationale.
   for (const frontend of frontends) {
     const serverName = `${frontend}-tools`;
-    const wrapped = wrapMcpCommand([
-      "node",
-      "--import",
-      tsxImport,
-      mcpServerPath,
-    ]);
+    const wrapped = wrapMcpCommand(talonMcpServerCommand());
     servers[serverName] = {
       command: wrapped[0],
       args: wrapped.slice(1),
-      env: {
-        TALON_BRIDGE_URL: bridgeUrl,
-        TALON_CHAT_ID: chatId,
-        TALON_FRONTEND: frontend,
-      },
+      env: buildTalonMcpEnv({
+        bridgeUrl,
+        chatId,
+        frontend,
+        config: args.toolExclusions,
+      }),
       default_tools_approval_mode: TALON_MCP_DEFAULT_APPROVAL,
     };
   }

--- a/src/backend/kilo/handler.ts
+++ b/src/backend/kilo/handler.ts
@@ -34,7 +34,6 @@ import {
 import { getChatSettings } from "../../storage/chat-settings.js";
 import { log, logError, logWarn } from "../../util/log.js";
 import { traceMessage } from "../../util/trace.js";
-import { incrementCounter, recordHistogram } from "../../util/metrics.js";
 
 import {
   ensureServer,
@@ -64,6 +63,7 @@ import {
   routeDelivery,
   sleep,
   applyRetryDecision,
+  recordTurnMetrics,
 } from "../shared/index.js";
 import { processStreamEvent, finalizePartsIntoState } from "./events.js";
 import { subscribeSseStream } from "../remote-server/sse-stream.js";
@@ -241,8 +241,12 @@ export async function handleMessage(
 
   const responseText = finalizeResponseText(state);
   const durationMs = Date.now() - t0;
-  recordHistogram("response_latency_ms", durationMs);
-  incrementCounter("queries_total");
+  recordTurnMetrics({
+    backend: "kilo",
+    durationMs,
+    toolCalls: state.toolCalls,
+    apiCalls: state.numApiCalls,
+  });
 
   if (state.newSessionId) {
     // setSessionId tolerates "same id" calls — keep it simple.

--- a/src/backend/kilo/models.ts
+++ b/src/backend/kilo/models.ts
@@ -10,7 +10,7 @@
  */
 
 import { ensureServer } from "./server.js";
-import { normalizeReasoningLevels } from "../../core/reasoning-levels.js";
+import { normalizeReasoningLevels } from "../../core/models/reasoning-levels.js";
 import type { ReasoningEffortLevel } from "../../core/types.js";
 
 // ---------------------------------------------------------------------------

--- a/src/backend/kilo/one-shot.ts
+++ b/src/backend/kilo/one-shot.ts
@@ -1,25 +1,14 @@
 /**
  * Kilo one-shot agent runner — used by heartbeat & dream.
  *
- * The heartbeat/dream modules own timing, locking, and the run log file.
- * This module owns everything Kilo-specific: ensuring the Kilo HTTP server
- * is up, registering an MCP server tagged with the contextLabel (so the
- * agent's outbound tool calls reach the right frontend), creating an
- * ephemeral session, running the prompt, and cleaning up.
- *
- * Kilo runs in a long-lived process (the local HTTP server), so there are
- * no orphan subprocesses to evict — the corresponding `evictOrphanSubprocesses`
- * is intentionally not implemented.
- *
- * Note on abort semantics: the Kilo SDK does expose `session.abort` but the
- * REST `prompt` endpoint blocks until the underlying provider returns. The
- * heartbeat module's outer abort grace is what actually unblocks the lock
- * — we call `session.abort` as a best-effort cleanup so the model stops
- * spending tokens once the timeout fires.
+ * Thin binding over the shared remote-server runner (see
+ * `backend/remote-server/one-shot.ts` for the design notes): Kilo
+ * supplies its server bootstrap, model-selection parser, and delivery
+ * suffix; everything else is the shared lifecycle.
  */
 
 import type { OneShotAgentParams } from "../../core/types.js";
-import { logWarn } from "../../util/log.js";
+import { runRemoteOneShotAgent } from "../remote-server/one-shot.js";
 import {
   ensureServer,
   ensureChatMcpServer,
@@ -31,132 +20,21 @@ import {
   KILO_SYSTEM_PROMPT_SUFFIX,
   errMsg,
 } from "./server.js";
-import { appendBackendSuffix } from "../shared/index.js";
 
-export async function runOneShotAgent(
-  params: OneShotAgentParams,
-): Promise<void> {
-  const {
-    prompt,
-    systemPrompt,
-    model,
-    contextLabel,
-    abortController,
-    appendLog,
-  } = params;
-
-  const oc = await ensureServer();
-  const { providerID: selectedProviderID, modelID } =
-    parseStoredKiloModelSelection(model);
-  const providerID =
-    selectedProviderID ?? (await resolveProviderID(oc, modelID));
-
-  const chatMcpServerName = await ensureChatMcpServer(oc, contextLabel);
-  await ensurePluginMcpServers(oc, contextLabel);
-  const toolOverrides = await buildToolOverrides(oc, chatMcpServerName);
-
-  const sessionResp = await oc.session.create({
-    title: `One-shot ${contextLabel} ${new Date().toISOString()}`,
-  });
-  const sessionData = sessionResp.data as Record<string, unknown> | undefined;
-  const sessionID =
-    typeof sessionData?.id === "string" ? sessionData.id : String(Date.now());
-
-  // Abort handler: when the heartbeat timeout fires, ask Kilo to stop
-  // generating. The await on `session.prompt` will reject; we propagate.
-  const onAbort = (): void => {
-    oc.session
-      .abort({ sessionID })
-      .catch((err) =>
-        logWarn(
-          "agent",
-          `One-shot session.abort failed for ${sessionID}: ${errMsg(err)}`,
-        ),
-      );
-  };
-  abortController.signal.addEventListener("abort", onAbort, { once: true });
-
-  try {
-    if (abortController.signal.aborted) {
-      throw new Error("Aborted before prompt was sent");
-    }
-
-    const finalSystemPrompt = appendBackendSuffix(
-      systemPrompt,
-      KILO_SYSTEM_PROMPT_SUFFIX,
-    );
-
-    const resp = await oc.session.prompt({
-      sessionID,
-      parts: [{ type: "text", text: prompt }],
-      model: { providerID, modelID },
-      system: finalSystemPrompt,
-      ...(toolOverrides ? { tools: toolOverrides } : {}),
-    });
-
-    const data = resp.data as Record<string, unknown> | undefined;
-    const parts = Array.isArray(data?.parts)
-      ? (data.parts as Array<Record<string, unknown>>)
-      : [];
-
-    for (const part of parts) {
-      await appendKiloPart(appendLog, part);
-    }
-  } finally {
-    abortController.signal.removeEventListener("abort", onAbort);
-    await disconnectChatMcpServer(oc, chatMcpServerName);
-    try {
-      await oc.session.delete({ sessionID });
-    } catch (err) {
-      logWarn(
-        "agent",
-        `Failed to delete one-shot Kilo session ${sessionID}: ${errMsg(err)}`,
-      );
-    }
-  }
-}
-
-async function appendKiloPart(
-  appendLog: (text: string) => Promise<void>,
-  part: Record<string, unknown>,
-): Promise<void> {
-  const ts = new Date().toISOString().slice(11, 19);
-  const type = typeof part.type === "string" ? part.type : "unknown";
-
-  if (type === "text") {
-    const text = typeof part.text === "string" ? part.text : "";
-    if (text) await appendLog(`\n## [${ts}] Assistant\n${text}\n`);
-    return;
-  }
-
-  if (type === "tool" || type === "tool_use") {
-    const name =
-      typeof part.tool === "string"
-        ? part.tool
-        : typeof part.name === "string"
-          ? part.name
-          : "tool";
-    const input =
-      "input" in part ? part.input : "state" in part ? part.state : null;
-    await appendLog(
-      `\n**Tool call:** \`${name}\`\n\`\`\`json\n${JSON.stringify(input, null, 2)}\n\`\`\`\n`,
-    );
-    return;
-  }
-
-  if (type === "step-start" || type === "step-finish") {
-    return;
-  }
-
-  if (type === "reasoning") {
-    const text = typeof part.text === "string" ? part.text : "";
-    if (text) await appendLog(`\n### [${ts}] Reasoning\n${text}\n`);
-    return;
-  }
-
-  // Fallback: dump unknown part types so we don't lose information.
-  const truncated = JSON.stringify(part, null, 2).slice(0, 2000);
-  await appendLog(
-    `\n### [${ts}] Part (${type})\n\`\`\`json\n${truncated}\n\`\`\`\n`,
+export function runOneShotAgent(params: OneShotAgentParams): Promise<void> {
+  return runRemoteOneShotAgent(
+    {
+      label: "Kilo",
+      systemPromptSuffix: KILO_SYSTEM_PROMPT_SUFFIX,
+      ensureServer,
+      parseModelSelection: parseStoredKiloModelSelection,
+      resolveProviderID,
+      ensureChatMcpServer,
+      ensurePluginMcpServers,
+      buildToolOverrides,
+      disconnectChatMcpServer,
+      errMsg,
+    },
+    params,
   );
 }

--- a/src/backend/kilo/server.ts
+++ b/src/backend/kilo/server.ts
@@ -24,6 +24,7 @@ import {
 import type { TalonConfig } from "../../util/config.js";
 import type { FrontendName } from "../registry.js";
 import { logWarn } from "../../util/log.js";
+import { buildDeliveryContract } from "../shared/delivery-contract.js";
 import { clearModelCatalogCache } from "./models.js";
 import {
   guessProviderID,
@@ -74,26 +75,16 @@ export const TALON_MCP_SERVER_NAME = SHARED_TALON_MCP_SERVER_NAME;
  *      bridges to Telegram, so it's the right path when you need
  *      reply-to targeting, buttons, photos, polls, etc.
  *
- * Both routes work; pick whichever fits the message. The suffix below
- * keeps it short — the tool descriptions themselves carry the detail.
+ * Both routes work; pick whichever fits the message. The shared
+ * text-or-tools contract (prompts/system/contract-text-or-tools.md)
+ * documents the choice — the tool descriptions carry the detail.
+ * Telegram-shaped tool names: this constant is static and the prior
+ * hand-written text hardcoded the same names.
  */
-export const KILO_SYSTEM_PROMPT_SUFFIX = `
-
-## Kilo Delivery
-
-Two ways to deliver a reply — pick whichever fits:
-
-- **Plain text** — your assistant text is the reply. Just answer
-  normally. (Reasoning content stays private.)
-- **Delivery tools** — call \`end_turn(text="...", reply_to=N)\` for
-  threaded replies, \`send(type="text"|"photo"|"poll"|...)\` for rich
-  content, or \`react(emoji="...")\` for emoji acknowledgements. Use
-  these when you need reply targeting, buttons, attachments, or
-  multiple bubbles.
-
-If you call a delivery tool, don't also repeat the same text in plain
-output — Talon dedupes but it's cleaner to commit to one route.
-`;
+export const KILO_SYSTEM_PROMPT_SUFFIX = `\n\n${buildDeliveryContract(
+  "text-or-tools",
+  "telegram",
+)}\n`;
 
 // ── State ───────────────────────────────────────────────────────────────────
 

--- a/src/backend/openai-agents/constants.ts
+++ b/src/backend/openai-agents/constants.ts
@@ -10,67 +10,53 @@
  * orchestration) with MCP servers wired from the plugin system.
  */
 
+import { buildDeliveryContract } from "../shared/delivery-contract.js";
+
 /**
- * System-prompt suffix appended to the user-configured system prompt.
- *
- * The openai-agents handler enforces a strict tool-only delivery
- * contract — same as claude-sdk. Trailing prose is private scratchpad
- * and is NEVER shipped to the user as a fallback. Replies must reach
- * the chat through a delivery tool call. A turn that produces only
- * prose triggers one [FLOW VIOLATION] reminder retry; a second
- * violation accepts a silent drop. This suffix tells the model that
- * up front so it doesn't have to discover it via the reminder.
+ * Agents-specific addendum to the shared tool-only delivery contract:
+ * this backend namespaces every MCP tool, so the contract's bare tool
+ * names need a mapping note.
  */
-export const OPENAI_AGENTS_SYSTEM_PROMPT_SUFFIX = `
+const OPENAI_AGENTS_NAMESPACING_NOTE = `
+### Tool namespacing on this backend
 
-## Reply contract — tool-only delivery
-
-Your output stream (the prose you produce alongside tool calls) is
-PRIVATE scratchpad. The user never sees it. The ONLY way text reaches
-the user is through a delivery tool call:
-
-- **Delivery tools** — call the namespaced delivery tool for the active
-  frontend. Substitute \`<frontend>\` with the active frontend ID —
-  e.g. \`mcp_telegram-tools__end_turn\` on Telegram,
-  \`mcp_discord-tools__end_turn\` on Discord.
-  - \`mcp_<frontend>-tools__end_turn(text="...", reply_to=N)\` —
-    canonical final reply. Optional \`reply_to\` for threaded replies,
-    optional \`buttons\` for inline keyboards.
-  - \`mcp_<frontend>-tools__end_turn()\` (no args) — explicit silent
-    close after you've done something (e.g. just reacted with an
-    emoji) and have nothing else to say. Use this rather than
-    producing prose-with-no-tool.
-  - \`mcp_<frontend>-tools__send(type="text"|"photo"|"poll"|"voice"|...)\`
-    — mid-turn rich content. Does NOT close the turn — typically
-    followed by another \`send(...)\` and finally an
-    \`end_turn(...)\` / \`end_turn()\`.
-  - \`mcp_<frontend>-tools__react(message_id, emoji)\` — emoji
-    reaction. Often the right response to acknowledge without
-    replying. Pair with \`end_turn()\` to close cleanly.
-
-### Why tools are namespaced
-
-This backend prefixes every MCP tool with \`mcp_<serverName>__\` so
-collisions across plugins are impossible — Telegram's
-\`cancel_scheduled\` (scheduled message) and the email plugin's
-\`cancel_scheduled\` (scheduled email) coexist as
-\`mcp_telegram-tools__cancel_scheduled\` and
-\`mcp_email-tools__cancel_scheduled\`. The available-tools list you
-receive at turn start has the authoritative names; use them verbatim.
-Built-in tools (Read, Write, Edit, Bash, Glob, Grep) are NOT
-prefixed — they stay short.
-
-**There is no plain-text fallback.** If you write a thoughtful reply
-in your output stream and forget to wrap it in a tool call, the
-handler will re-prompt you ONCE with a \`[FLOW VIOLATION]\` reminder.
-A second miss in the same turn drops the prose silently. To save
-the user a round-trip of latency, ALWAYS call a delivery tool —
-don't talk first and ask "did you get that?" second.
+Every MCP tool is prefixed with \`mcp_<serverName>__\` so collisions
+across plugins are impossible — e.g. the delivery tools above appear
+as \`mcp_<frontend>-tools__end_turn\`, \`mcp_<frontend>-tools__send\`,
+\`mcp_<frontend>-tools__react\` (\`mcp_telegram-tools__end_turn\` on
+Telegram, \`mcp_discord-tools__end_turn\` on Discord). The
+available-tools list you receive at turn start has the authoritative
+names; use them verbatim. Built-in tools (Read, Write, Edit, Bash,
+Glob, Grep) are NOT prefixed — they stay short.
 
 If you produce trailing prose AND call \`end_turn(text=...)\` with
 the same text, the handler dedupes; you're not punished for being
 careful, but the tool call is the source of truth.
 `;
+
+/**
+ * Build the system-prompt suffix for a frontend: the shared tool-only
+ * delivery contract (single source of truth, same text claude-sdk
+ * appends) plus the namespacing addendum above.
+ *
+ * The openai-agents handler enforces strict tool-only delivery —
+ * trailing prose is private scratchpad and is NEVER shipped to the
+ * user as a fallback. A prose-only turn triggers one [FLOW VIOLATION]
+ * reminder retry; a second violation accepts a silent drop. The
+ * suffix tells the model that up front so it doesn't have to discover
+ * it via the reminder.
+ */
+export function buildOpenAiAgentsSuffix(frontend: string): string {
+  return `\n\n${buildDeliveryContract("tool-only", frontend)}\n${OPENAI_AGENTS_NAMESPACING_NOTE}`;
+}
+
+/**
+ * Telegram-shaped default suffix. Prefer `buildOpenAiAgentsSuffix`
+ * with the active frontend; this constant exists for the public
+ * barrel export and tests.
+ */
+export const OPENAI_AGENTS_SYSTEM_PROMPT_SUFFIX =
+  buildOpenAiAgentsSuffix("telegram");
 
 /**
  * Default model used by the OpenAI Agents backend when none is

--- a/src/backend/openai-agents/discovery.ts
+++ b/src/backend/openai-agents/discovery.ts
@@ -33,7 +33,7 @@
 
 import { log, logDebug } from "../../util/log.js";
 import { getState, type EndpointModelCapabilities } from "./state.js";
-import { normalizeReasoningLevels } from "../../core/reasoning-levels.js";
+import { normalizeReasoningLevels } from "../../core/models/reasoning-levels.js";
 
 /**
  * Shape of one entry returned by an OpenAI-compatible `/models`

--- a/src/backend/openai-agents/handler.ts
+++ b/src/backend/openai-agents/handler.ts
@@ -62,11 +62,13 @@ import {
   classifyRetry,
   summarizeUsage,
   routeDelivery,
+  buildFirstTurnReminder,
+  buildFlowViolationReminder,
 } from "../shared/index.js";
 import { detectFlowViolation } from "../shared/flow-violation.js";
 
 import {
-  OPENAI_AGENTS_SYSTEM_PROMPT_SUFFIX,
+  buildOpenAiAgentsSuffix,
   OPENAI_AGENTS_DEFAULT_MODEL,
   OPENAI_AGENTS_MAX_TURNS,
   OPENAI_AGENTS_AGENT_NAME,
@@ -127,21 +129,34 @@ export async function handleMessage(
     OPENAI_AGENTS_DEFAULT_MODEL;
   log("agent", `[${chatId}] OpenAI Agents model resolved: ${activeModel}`);
 
+  // Primary messaging frontend drives the delivery-contract suffix and
+  // the frontend-aware flow-violation/first-turn text. Empty in
+  // terminal mode (no delivery tools — contract enforcement is skipped
+  // below anyway).
+  const frontends = getActiveFrontends();
+  const frontend: string | undefined = frontends[0];
+
   // Per-session frozen prompt + Agents-specific delivery suffix.
   const { text: systemPrompt } = prepareSystemPrompt({
     config,
     previousTurns,
-    backendSuffix: OPENAI_AGENTS_SYSTEM_PROMPT_SUFFIX,
+    backendSuffix: buildOpenAiAgentsSuffix(frontend ?? "telegram"),
     chatId,
     sessionEpoch: session.createdAt,
   });
 
-  const prompt = formatUserPrompt({
+  let prompt = formatUserPrompt({
     text,
     senderName: senderName ?? "user",
     isGroup,
     messageId,
   });
+  // First-turn nudge — see the claude-sdk handler for rationale: turn 0
+  // is where flow violations cluster, and one line in the user message
+  // costs nothing on later turns and never touches the cached prefix.
+  if (frontend && previousTurns === 0 && !_retried) {
+    prompt += `\n\n${buildFirstTurnReminder(frontend)}`;
+  }
 
   log("agent", `[${chatId}] <- (${text.length} chars)`);
   traceMessage(chatId, "in", text, { senderName, isGroup });
@@ -153,7 +168,6 @@ export async function handleMessage(
   // every turn by ~5s and intermittently raced into
   // `MCP error -32001: Request timed out`. See `mcp-pool.ts`.
   const bridgeUrl = `http://127.0.0.1:${state.gatewayPortFn()}`;
-  const frontends = getActiveFrontends();
   let mcpBundle: Awaited<ReturnType<typeof getOrCreateBundle>>;
   try {
     mcpBundle = await getOrCreateBundle({
@@ -426,6 +440,9 @@ export async function handleMessage(
           turnTerminated: streamState.turnTerminated,
           deliveredTextNorms: streamState.deliveredTextNorms,
           retried: _retried,
+          ...(frontend
+            ? { reminder: buildFlowViolationReminder(frontend) }
+            : {}),
         })
       : ({ violated: false } as const);
 

--- a/src/backend/openai-agents/handler.ts
+++ b/src/backend/openai-agents/handler.ts
@@ -64,6 +64,9 @@ import {
   routeDelivery,
   buildFirstTurnReminder,
   buildFlowViolationReminder,
+  recordToolCall,
+  recordTurnMetrics,
+  recordFlowViolation,
 } from "../shared/index.js";
 import { detectFlowViolation } from "../shared/flow-violation.js";
 
@@ -175,6 +178,7 @@ export async function handleMessage(
       bridgeUrl,
       frontends,
       braveApiKey: config.braveApiKey,
+      toolExclusions: config,
     });
   } catch (err) {
     logError(
@@ -402,8 +406,12 @@ export async function handleMessage(
 
   const responseText = finalizeResponseText(streamState);
   const durationMs = Date.now() - t0;
-  recordHistogram("response_latency_ms", durationMs);
-  incrementCounter("queries_total");
+  recordTurnMetrics({
+    backend: "openai-agents",
+    durationMs,
+    toolCalls: streamState.toolCalls,
+    apiCalls: streamState.numApiCalls,
+  });
 
   recordUsage(chatId, {
     inputTokens: streamState.sdkInputTokens,
@@ -447,7 +455,7 @@ export async function handleMessage(
       : ({ violated: false } as const);
 
   if (violation.violated) {
-    incrementCounter("scratchpad.trailing_text_dropped");
+    recordFlowViolation(violation.shouldRetry ? "retried" : "cap_exhausted");
     log(
       "agent",
       `[${chatId}] flow violation: trailing prose (${violation.trailing.length} chars) without end_turn/send. ${
@@ -458,7 +466,6 @@ export async function handleMessage(
     );
 
     if (violation.shouldRetry) {
-      incrementCounter("scratchpad.flow_violation_retried");
       // Recursive call owns the `incrementTurns` for this user message.
       return handleMessage({ ...params, text: violation.reminder }, true);
     }
@@ -634,7 +641,7 @@ function handleToolCalled(item: unknown, ctx: HandleRunItemContext): void {
     }
   }
 
-  incrementCounter(`tool_calls.${stripMcpPrefix(toolName)}`);
+  recordToolCall(toolName, "openai-agents");
   recordToolUse(ctx.state, toolName, input);
 
   if (ctx.onToolUse) {

--- a/src/backend/openai-agents/init.ts
+++ b/src/backend/openai-agents/init.ts
@@ -46,6 +46,7 @@ import { setDefaultOpenAIClient, setOpenAIAPI } from "@openai/agents";
 import type { TalonConfig } from "../../util/config.js";
 import type { FrontendName } from "../registry.js";
 import { log, logWarn } from "../../util/log.js";
+import { nonTerminalFrontends } from "../shared/frontends.js";
 import { getState } from "./state.js";
 import { startDiscovery, refreshDiscovery } from "./discovery.js";
 
@@ -231,9 +232,5 @@ export function getOpenAIBaseUrl(): string | undefined {
  * the terminal frontend.
  */
 export function getActiveFrontends(): readonly string[] {
-  const state = getState();
-  const fe = state.config?.frontend;
-  if (!fe) return [];
-  const all = Array.isArray(fe) ? fe : [fe];
-  return all.filter((f) => f !== "terminal");
+  return nonTerminalFrontends(getState().config?.frontend);
 }

--- a/src/backend/openai-agents/mcp-pool.ts
+++ b/src/backend/openai-agents/mcp-pool.ts
@@ -44,9 +44,13 @@
 import { connectMcpServers, MCPServerStdio } from "@openai/agents";
 import type { MCPServer } from "@openai/agents";
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
 import { wrapMcpCommand } from "../../util/mcp-launcher.js";
 import { getPluginMcpServers } from "../../core/plugin.js";
+import {
+  buildTalonMcpEnv,
+  talonMcpServerCommand,
+  type ToolExclusionConfig,
+} from "../../core/tools/mcp-env.js";
 import { log, logWarn } from "../../util/log.js";
 
 /**
@@ -77,6 +81,8 @@ export interface BundleInputs {
   bridgeUrl: string;
   frontends: readonly string[];
   braveApiKey?: string;
+  /** Tool-surface trimming slice of the Talon config. */
+  toolExclusions?: ToolExclusionConfig | null;
 }
 
 /** Live bundles keyed by chatId. */
@@ -181,42 +187,25 @@ export function getActiveBundleIds(): readonly string[] {
 async function buildBundle(args: BundleInputs): Promise<OpenAIAgentsMcpBundle> {
   const { chatId, bridgeUrl, frontends, braveApiKey } = args;
 
-  // tsx as a Node loader is passed via `--import <url>`. Same
-  // cross-platform `file://` URL handling as the other backends —
-  // `pathToFileURL` produces a URL Node always treats as a loader URL.
-  const tsxImport = pathToFileURL(
-    resolve(
-      import.meta.dirname ?? ".",
-      "../../../node_modules/tsx/dist/esm/index.mjs",
-    ),
-  ).href;
-  const mcpServerPath = resolve(
-    import.meta.dirname ?? ".",
-    "../../core/tools/mcp-server.ts",
-  );
-
   const built: MCPServerStdio[] = [];
 
   // Frontend MCP tool servers (one per non-terminal frontend). Each
   // exposes the Talon-native delivery surface (send, react, end_turn,
-  // …) for that frontend, scoped to `chatId`.
+  // …) for that frontend, scoped to `chatId`. Spawn spec is shared —
+  // see talonMcpServerCommand for the tsx-loader / Windows rationale.
   for (const frontend of frontends) {
-    const wrapped = wrapMcpCommand([
-      "node",
-      "--import",
-      tsxImport,
-      mcpServerPath,
-    ]);
+    const wrapped = wrapMcpCommand(talonMcpServerCommand());
     built.push(
       new MCPServerStdio({
         name: `${frontend}-tools`,
         command: wrapped[0],
         args: wrapped.slice(1),
-        env: {
-          TALON_BRIDGE_URL: bridgeUrl,
-          TALON_CHAT_ID: chatId,
-          TALON_FRONTEND: frontend,
-        },
+        env: buildTalonMcpEnv({
+          bridgeUrl,
+          chatId,
+          frontend,
+          config: args.toolExclusions,
+        }),
         cacheToolsList: true,
       }),
     );

--- a/src/backend/opencode/handler.ts
+++ b/src/backend/opencode/handler.ts
@@ -36,7 +36,6 @@ import {
 import { getChatSettings } from "../../storage/chat-settings.js";
 import { log, logError, logWarn } from "../../util/log.js";
 import { traceMessage } from "../../util/trace.js";
-import { incrementCounter, recordHistogram } from "../../util/metrics.js";
 
 import {
   ensureServer,
@@ -66,6 +65,7 @@ import {
   routeDelivery,
   sleep,
   applyRetryDecision,
+  recordTurnMetrics,
 } from "../shared/index.js";
 import {
   processStreamEvent,
@@ -252,8 +252,12 @@ export async function handleMessage(
 
   const responseText = finalizeResponseText(state);
   const durationMs = Date.now() - t0;
-  recordHistogram("response_latency_ms", durationMs);
-  incrementCounter("queries_total");
+  recordTurnMetrics({
+    backend: "opencode",
+    durationMs,
+    toolCalls: state.toolCalls,
+    apiCalls: state.numApiCalls,
+  });
 
   if (state.newSessionId) {
     const stored = getSession(chatId).sessionId;

--- a/src/backend/opencode/models.ts
+++ b/src/backend/opencode/models.ts
@@ -5,7 +5,7 @@
  */
 
 import { ensureServer } from "./server.js";
-import { normalizeReasoningLevels } from "../../core/reasoning-levels.js";
+import { normalizeReasoningLevels } from "../../core/models/reasoning-levels.js";
 import type { ReasoningEffortLevel } from "../../core/types.js";
 
 // ---------------------------------------------------------------------------

--- a/src/backend/opencode/one-shot.ts
+++ b/src/backend/opencode/one-shot.ts
@@ -1,18 +1,14 @@
 /**
  * OpenCode one-shot agent runner — used by heartbeat & dream.
  *
- * Mirrors src/backend/kilo/one-shot.ts (Kilo is a fork of OpenCode and the
- * SDK shape is the same). See that file's header for the design notes.
- *
- * Note on abort semantics: the OpenCode SDK exposes `session.abort` but the
- * REST `prompt` endpoint blocks until the underlying provider returns. The
- * heartbeat module's outer abort grace is what actually unblocks the lock
- * — we call `session.abort` as a best-effort cleanup so the model stops
- * spending tokens once the timeout fires.
+ * Thin binding over the shared remote-server runner (see
+ * `backend/remote-server/one-shot.ts` for the design notes): OpenCode
+ * supplies its server bootstrap, model-selection parser, and delivery
+ * suffix; everything else is the shared lifecycle.
  */
 
 import type { OneShotAgentParams } from "../../core/types.js";
-import { logWarn } from "../../util/log.js";
+import { runRemoteOneShotAgent } from "../remote-server/one-shot.js";
 import {
   ensureServer,
   ensureChatMcpServer,
@@ -24,134 +20,21 @@ import {
   OPENCODE_SYSTEM_PROMPT_SUFFIX,
   errMsg,
 } from "./server.js";
-import { appendBackendSuffix } from "../shared/index.js";
 
-export async function runOneShotAgent(
-  params: OneShotAgentParams,
-): Promise<void> {
-  const {
-    prompt,
-    systemPrompt,
-    model,
-    contextLabel,
-    abortController,
-    appendLog,
-  } = params;
-
-  const oc = await ensureServer();
-  const { providerID: selectedProviderID, modelID } =
-    parseStoredOpenCodeModelSelection(model);
-  const providerID =
-    selectedProviderID ?? (await resolveProviderID(oc, modelID));
-
-  const chatMcpServerName = await ensureChatMcpServer(oc, contextLabel);
-  await ensurePluginMcpServers(oc, contextLabel);
-  const toolOverrides = await buildToolOverrides(oc, chatMcpServerName);
-
-  const sessionResp = await oc.session.create({
-    title: `One-shot ${contextLabel} ${new Date().toISOString()}`,
-  });
-  const sessionData = sessionResp.data as Record<string, unknown> | undefined;
-  const sessionID =
-    typeof sessionData?.id === "string" ? sessionData.id : String(Date.now());
-
-  // Abort handler: when the heartbeat timeout fires, ask OpenCode to stop
-  // generating. The await on `session.prompt` will reject; we propagate.
-  // Without this, runaway generation on a hung heartbeat keeps spending
-  // tokens until the provider returns naturally — kilo/one-shot.ts has the
-  // same handler and this file got out of sync with it.
-  const onAbort = (): void => {
-    oc.session
-      .abort({ sessionID })
-      .catch((err) =>
-        logWarn(
-          "agent",
-          `One-shot session.abort failed for ${sessionID}: ${errMsg(err)}`,
-        ),
-      );
-  };
-  abortController.signal.addEventListener("abort", onAbort, { once: true });
-
-  try {
-    if (abortController.signal.aborted) {
-      throw new Error("Aborted before prompt was sent");
-    }
-
-    const finalSystemPrompt = appendBackendSuffix(
-      systemPrompt,
-      OPENCODE_SYSTEM_PROMPT_SUFFIX,
-    );
-
-    const resp = await oc.session.prompt({
-      sessionID,
-      parts: [{ type: "text", text: prompt }],
-      model: { providerID, modelID },
-      system: finalSystemPrompt,
-      ...(toolOverrides ? { tools: toolOverrides } : {}),
-    });
-
-    const data = resp.data as Record<string, unknown> | undefined;
-    const parts = Array.isArray(data?.parts)
-      ? (data.parts as Array<Record<string, unknown>>)
-      : [];
-
-    for (const part of parts) {
-      await appendOpenCodePart(appendLog, part);
-    }
-  } finally {
-    abortController.signal.removeEventListener("abort", onAbort);
-    await disconnectChatMcpServer(oc, chatMcpServerName);
-    try {
-      await oc.session.delete({ sessionID });
-    } catch (err) {
-      logWarn(
-        "agent",
-        `Failed to delete one-shot OpenCode session ${sessionID}: ${errMsg(err)}`,
-      );
-    }
-  }
-}
-
-async function appendOpenCodePart(
-  appendLog: (text: string) => Promise<void>,
-  part: Record<string, unknown>,
-): Promise<void> {
-  const ts = new Date().toISOString().slice(11, 19);
-  const type = typeof part.type === "string" ? part.type : "unknown";
-
-  if (type === "text") {
-    const text = typeof part.text === "string" ? part.text : "";
-    if (text) await appendLog(`\n## [${ts}] Assistant\n${text}\n`);
-    return;
-  }
-
-  if (type === "tool" || type === "tool_use") {
-    const name =
-      typeof part.tool === "string"
-        ? part.tool
-        : typeof part.name === "string"
-          ? part.name
-          : "tool";
-    const input =
-      "input" in part ? part.input : "state" in part ? part.state : null;
-    await appendLog(
-      `\n**Tool call:** \`${name}\`\n\`\`\`json\n${JSON.stringify(input, null, 2)}\n\`\`\`\n`,
-    );
-    return;
-  }
-
-  if (type === "step-start" || type === "step-finish") {
-    return;
-  }
-
-  if (type === "reasoning") {
-    const text = typeof part.text === "string" ? part.text : "";
-    if (text) await appendLog(`\n### [${ts}] Reasoning\n${text}\n`);
-    return;
-  }
-
-  const truncated = JSON.stringify(part, null, 2).slice(0, 2000);
-  await appendLog(
-    `\n### [${ts}] Part (${type})\n\`\`\`json\n${truncated}\n\`\`\`\n`,
+export function runOneShotAgent(params: OneShotAgentParams): Promise<void> {
+  return runRemoteOneShotAgent(
+    {
+      label: "OpenCode",
+      systemPromptSuffix: OPENCODE_SYSTEM_PROMPT_SUFFIX,
+      ensureServer,
+      parseModelSelection: parseStoredOpenCodeModelSelection,
+      resolveProviderID,
+      ensureChatMcpServer,
+      ensurePluginMcpServers,
+      buildToolOverrides,
+      disconnectChatMcpServer,
+      errMsg,
+    },
+    params,
   );
 }

--- a/src/backend/opencode/server.ts
+++ b/src/backend/opencode/server.ts
@@ -24,6 +24,7 @@ import {
 import type { TalonConfig } from "../../util/config.js";
 import type { FrontendName } from "../registry.js";
 import { logWarn } from "../../util/log.js";
+import { buildDeliveryContract } from "../shared/delivery-contract.js";
 import { clearModelCatalogCache } from "./models.js";
 import {
   guessProviderID,
@@ -55,15 +56,13 @@ const OPENCODE_HOSTNAME = "127.0.0.1";
 const OPENCODE_PORT = Number(process.env.OPENCODE_PORT ?? 4096);
 const OPENCODE_BASE_URL = `http://${OPENCODE_HOSTNAME}:${OPENCODE_PORT}`;
 const TALON_MCP_SERVER_NAME = SHARED_TALON_MCP_SERVER_NAME;
-const OPENCODE_SYSTEM_PROMPT_SUFFIX = `
-
-## OpenCode Delivery Override
-
-- You are running through Talon's OpenCode backend.
-- Return your normal user-facing reply as plain assistant text.
-- Do not rely on the Telegram send tool for ordinary replies.
-- Use tools only when they are genuinely needed for side effects or extra capabilities.
-`;
+// Text-preferred delivery: plain assistant text is the reply; tools
+// only for genuine side effects. Single-sourced from the shared
+// contract templates (prompts/system/contract-text-preferred.md).
+const OPENCODE_SYSTEM_PROMPT_SUFFIX = `\n\n${buildDeliveryContract(
+  "text-preferred",
+  "telegram",
+)}\n`;
 
 // ── State ───────────────────────────────────────────────────────────────────
 

--- a/src/backend/remote-server/events.ts
+++ b/src/backend/remote-server/events.ts
@@ -29,6 +29,7 @@ import {
   appendText,
   closeCurrentSegment,
   recordToolUse,
+  recordToolCall,
   type StreamState,
 } from "../shared/index.js";
 import { log, logDebug } from "../../util/log.js";
@@ -37,8 +38,6 @@ import { log, logDebug } from "../../util/log.js";
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
-import { incrementCounter } from "../../util/metrics.js";
-import { stripMcpPrefix } from "../../core/tools/index.js";
 
 // ── Streaming timing ───────────────────────────────────────────────────────
 
@@ -224,9 +223,9 @@ async function processPartUpdate(
       );
     }
   }
-  // Count every tool the model calls — parity with claude-sdk which
-  // increments per tool.
-  incrementCounter(`tool_calls.${stripMcpPrefix(toolName)}`);
+  // Count every tool the model calls — shared vocabulary across
+  // backends (prefix-stripped name + backend dimension).
+  recordToolCall(toolName, ctx.backendLabel.toLowerCase());
   recordToolUse(ctx.state, toolName, input);
   if (ctx.onToolUse) {
     try {

--- a/src/backend/remote-server/mcp.ts
+++ b/src/backend/remote-server/mcp.ts
@@ -37,6 +37,10 @@
 import { log, logWarn } from "../../util/log.js";
 import { wrapMcpCommand } from "../../util/mcp-launcher.js";
 import { getPluginMcpServers } from "../../core/plugin.js";
+import {
+  buildTalonMcpEnv,
+  talonMcpServerCommand,
+} from "../../core/tools/mcp-env.js";
 import type { RemoteAgentClient } from "./client.js";
 import type { RemoteServerState } from "./state.js";
 import { errMsg } from "./state.js";
@@ -135,8 +139,6 @@ export async function ensureChatMcpServer<TClient extends RemoteAgentClient>(
 
   const startedAt = Date.now();
   try {
-    const toolsPath = new URL("../../core/tools/mcp-server.ts", import.meta.url)
-      .pathname;
     await client.mcp.add({
       name: serverName,
       config: {
@@ -144,12 +146,16 @@ export async function ensureChatMcpServer<TClient extends RemoteAgentClient>(
         // Wrap under Talon's launcher supervisor so the child dies cleanly
         // when the SDK pipe closes OR Talon's bridge URL stops responding
         // (catches the "agent-server-outlives-Talon" failure mode).
-        command: wrapMcpCommand(["node", "--import", "tsx", toolsPath]),
-        environment: {
-          TALON_BRIDGE_URL: `http://127.0.0.1:${state.gatewayPortFn()}`,
-          TALON_CHAT_ID: chatId,
-          TALON_FRONTEND: state.frontendName,
-        },
+        // Spawn spec shared with every other backend — see
+        // talonMcpServerCommand (and unlike the previous bare "tsx"
+        // specifier, it doesn't depend on the spawn cwd resolving tsx).
+        command: wrapMcpCommand(talonMcpServerCommand()),
+        environment: buildTalonMcpEnv({
+          bridgeUrl: `http://127.0.0.1:${state.gatewayPortFn()}`,
+          chatId,
+          frontend: state.frontendName,
+          config: state.config,
+        }),
       },
     });
     state.registeredMcpServers.add(serverName);

--- a/src/backend/remote-server/one-shot.ts
+++ b/src/backend/remote-server/one-shot.ts
@@ -1,0 +1,225 @@
+/**
+ * Shared one-shot agent runner for the remote-server backend family
+ * (Kilo, OpenCode) — used by heartbeat & dream.
+ *
+ * The heartbeat/dream modules own timing, locking, and the run log
+ * file. This module owns everything agent-server-specific: ensuring
+ * the HTTP server is up, registering an MCP server tagged with the
+ * contextLabel (so the agent's outbound tool calls reach the right
+ * frontend), creating an ephemeral session, running the prompt,
+ * rendering the response parts into the run log, and cleaning up.
+ *
+ * Both backends previously carried byte-for-byte copies of this file
+ * that drifted (the abort handler landed in one and not the other);
+ * the per-backend differences are exactly the `RemoteOneShotBindings`
+ * fields — server bootstrap, model-selection parsing, and the
+ * delivery-contract suffix.
+ *
+ * These servers run in a long-lived process, so there are no orphan
+ * subprocesses to evict — `evictOrphanSubprocesses` is intentionally
+ * not implemented for this family.
+ *
+ * Note on abort semantics: both SDKs expose `session.abort` but the
+ * REST `prompt` endpoint blocks until the underlying provider
+ * returns. The heartbeat module's outer abort grace is what actually
+ * unblocks the lock — `session.abort` is best-effort cleanup so the
+ * model stops spending tokens once the timeout fires.
+ */
+
+import type { OneShotAgentParams } from "../../core/types.js";
+import { logWarn } from "../../util/log.js";
+import { appendBackendSuffix } from "../shared/index.js";
+
+// ── Client surface ──────────────────────────────────────────────────────────
+
+/**
+ * The slice of the SDK client the one-shot path touches. Wider than
+ * `RemoteAgentClient` (which covers only the always-shared helpers):
+ * one-shot drives the session lifecycle directly. Method syntax keeps
+ * parameter checking bivariant so both concrete SDK clients satisfy
+ * it structurally.
+ */
+export interface RemoteOneShotClient {
+  session: {
+    create(args: { title: string }): Promise<{ data?: unknown }>;
+    prompt(args: {
+      sessionID: string;
+      parts: Array<{ type: "text"; text: string }>;
+      model: { providerID: string; modelID: string };
+      system: string;
+      tools?: Record<string, boolean>;
+    }): Promise<{ data?: unknown }>;
+    abort(args: { sessionID: string }): Promise<unknown>;
+    delete(args: { sessionID: string }): Promise<unknown>;
+  };
+}
+
+// ── Bindings ────────────────────────────────────────────────────────────────
+
+/** The per-backend seams: server bootstrap, model parsing, suffix. */
+export type RemoteOneShotBindings<TClient extends RemoteOneShotClient> = {
+  /** Display label for log lines ("Kilo", "OpenCode"). */
+  label: string;
+  /** Delivery-contract suffix appended to the system prompt. */
+  systemPromptSuffix: string;
+  ensureServer(): Promise<TClient>;
+  /** Split a stored model value into provider/model ids. */
+  parseModelSelection(value: string): {
+    providerID?: string;
+    modelID: string;
+  };
+  resolveProviderID(client: TClient, modelID: string): Promise<string>;
+  ensureChatMcpServer(client: TClient, chatId: string): Promise<string>;
+  ensurePluginMcpServers(client: TClient, chatId: string): Promise<string[]>;
+  buildToolOverrides(
+    client: TClient,
+    chatServerName: string,
+  ): Promise<Record<string, boolean> | undefined>;
+  disconnectChatMcpServer(client: TClient, serverName: string): Promise<void>;
+  errMsg(e: unknown): string;
+};
+
+// ── Runner ──────────────────────────────────────────────────────────────────
+
+export async function runRemoteOneShotAgent<
+  TClient extends RemoteOneShotClient,
+>(
+  bindings: RemoteOneShotBindings<TClient>,
+  params: OneShotAgentParams,
+): Promise<void> {
+  const {
+    prompt,
+    systemPrompt,
+    model,
+    contextLabel,
+    abortController,
+    appendLog,
+  } = params;
+  const { label, errMsg } = bindings;
+
+  const oc = await bindings.ensureServer();
+  const { providerID: selectedProviderID, modelID } =
+    bindings.parseModelSelection(model);
+  const providerID =
+    selectedProviderID ?? (await bindings.resolveProviderID(oc, modelID));
+
+  const chatMcpServerName = await bindings.ensureChatMcpServer(
+    oc,
+    contextLabel,
+  );
+  await bindings.ensurePluginMcpServers(oc, contextLabel);
+  const toolOverrides = await bindings.buildToolOverrides(
+    oc,
+    chatMcpServerName,
+  );
+
+  const sessionResp = await oc.session.create({
+    title: `One-shot ${contextLabel} ${new Date().toISOString()}`,
+  });
+  const sessionData = sessionResp.data as Record<string, unknown> | undefined;
+  const sessionID =
+    typeof sessionData?.id === "string" ? sessionData.id : String(Date.now());
+
+  // Abort handler: when the heartbeat timeout fires, ask the server to
+  // stop generating. The await on `session.prompt` will reject; we
+  // propagate. Without this, runaway generation on a hung heartbeat
+  // keeps spending tokens until the provider returns naturally.
+  const onAbort = (): void => {
+    oc.session
+      .abort({ sessionID })
+      .catch((err) =>
+        logWarn(
+          "agent",
+          `One-shot session.abort failed for ${sessionID}: ${errMsg(err)}`,
+        ),
+      );
+  };
+  abortController.signal.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    if (abortController.signal.aborted) {
+      throw new Error("Aborted before prompt was sent");
+    }
+
+    const finalSystemPrompt = appendBackendSuffix(
+      systemPrompt,
+      bindings.systemPromptSuffix,
+    );
+
+    const resp = await oc.session.prompt({
+      sessionID,
+      parts: [{ type: "text", text: prompt }],
+      model: { providerID, modelID },
+      system: finalSystemPrompt,
+      ...(toolOverrides ? { tools: toolOverrides } : {}),
+    });
+
+    const data = resp.data as Record<string, unknown> | undefined;
+    const parts = Array.isArray(data?.parts)
+      ? (data.parts as Array<Record<string, unknown>>)
+      : [];
+
+    for (const part of parts) {
+      await appendResponsePart(appendLog, part);
+    }
+  } finally {
+    abortController.signal.removeEventListener("abort", onAbort);
+    await bindings.disconnectChatMcpServer(oc, chatMcpServerName);
+    try {
+      await oc.session.delete({ sessionID });
+    } catch (err) {
+      logWarn(
+        "agent",
+        `Failed to delete one-shot ${label} session ${sessionID}: ${errMsg(err)}`,
+      );
+    }
+  }
+}
+
+// ── Run-log rendering ───────────────────────────────────────────────────────
+
+/** Render one response part into the Markdown run log. */
+async function appendResponsePart(
+  appendLog: (text: string) => Promise<void>,
+  part: Record<string, unknown>,
+): Promise<void> {
+  const ts = new Date().toISOString().slice(11, 19);
+  const type = typeof part.type === "string" ? part.type : "unknown";
+
+  if (type === "text") {
+    const text = typeof part.text === "string" ? part.text : "";
+    if (text) await appendLog(`\n## [${ts}] Assistant\n${text}\n`);
+    return;
+  }
+
+  if (type === "tool" || type === "tool_use") {
+    const name =
+      typeof part.tool === "string"
+        ? part.tool
+        : typeof part.name === "string"
+          ? part.name
+          : "tool";
+    const input =
+      "input" in part ? part.input : "state" in part ? part.state : null;
+    await appendLog(
+      `\n**Tool call:** \`${name}\`\n\`\`\`json\n${JSON.stringify(input, null, 2)}\n\`\`\`\n`,
+    );
+    return;
+  }
+
+  if (type === "step-start" || type === "step-finish") {
+    return;
+  }
+
+  if (type === "reasoning") {
+    const text = typeof part.text === "string" ? part.text : "";
+    if (text) await appendLog(`\n### [${ts}] Reasoning\n${text}\n`);
+    return;
+  }
+
+  // Fallback: dump unknown part types so we don't lose information.
+  const truncated = JSON.stringify(part, null, 2).slice(0, 2000);
+  await appendLog(
+    `\n### [${ts}] Part (${type})\n\`\`\`json\n${truncated}\n\`\`\`\n`,
+  );
+}

--- a/src/backend/shared/delivery-contract.ts
+++ b/src/backend/shared/delivery-contract.ts
@@ -1,0 +1,158 @@
+/**
+ * Delivery-contract text — single source of truth for "how a reply
+ * reaches the user" documentation.
+ *
+ * The response-flow contract is a property of the BACKEND (claude-sdk
+ * and openai-agents enforce strict tool-only delivery; codex / kilo /
+ * opencode accept plain assistant text), while the delivery TOOL NAMES
+ * are a property of the FRONTEND (telegram/discord ship `end_turn` /
+ * `send` / `react`; teams ships `end_turn` / `send_message`). Before
+ * this module, the strict contract was hardcoded into the frontend
+ * prompt files (prompts/telegram.md etc.) — buried mid-prompt where
+ * models routinely missed it on the first turn of a session, and
+ * contradicted by the text-mode backends' own suffixes.
+ *
+ * Backends now build their suffix from here and append it via
+ * `prepareSystemPrompt({ backendSuffix })`, which places the contract
+ * at the END of the static prompt — the highest-salience position —
+ * without touching the prompt-cache-friendly static/dynamic split.
+ *
+ * Also here:
+ *   - `buildFlowViolationReminder` — frontend-aware [FLOW VIOLATION]
+ *     re-prompt text (the shared constant used to hardcode telegram's
+ *     tool names, which made the reminder wrong on Teams).
+ *   - `buildFirstTurnReminder` — a one-line nudge appended to the
+ *     formatted user prompt on the FIRST turn of a session. First
+ *     turns are where flow violations cluster: the model hasn't seen
+ *     the contract in action yet. One short line on turn 0 is far
+ *     cheaper than the 2x-token violation retry it prevents.
+ *
+ * The contract bodies live in `prompts/system/contract-*.md`
+ * (package-owned templates, see core/prompt/templates.ts). The
+ * one-line runtime reminders below stay in code: they are
+ * logic-adjacent strings, like log messages.
+ */
+
+import { loadSystemTemplate } from "../../core/prompt/templates.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * How a backend delivers replies to the user.
+ *
+ *   - `tool-only` — output stream is private scratchpad; replies MUST
+ *     go through a delivery tool (claude-sdk, openai-agents).
+ *   - `text-or-tools` — plain assistant text is delivered as the
+ *     reply; delivery tools add rich content / targeting (codex, kilo,
+ *     opencode).
+ */
+export type DeliveryMode = "tool-only" | "text-or-tools";
+
+/** Frontend-specific delivery tool names. */
+export type DeliveryToolNames = {
+  /** Turn-closing final-reply tool. */
+  endTurn: string;
+  /** Mid-turn / rich-content send tool. */
+  send: string;
+  /** Emoji-reaction tool, when the frontend supports reactions. */
+  react?: string;
+};
+
+// ── Frontend tool-name registry ─────────────────────────────────────────────
+
+const FRONTEND_TOOLS: Record<string, DeliveryToolNames> = {
+  telegram: { endTurn: "end_turn", send: "send", react: "react" },
+  discord: { endTurn: "end_turn", send: "send", react: "react" },
+  teams: { endTurn: "end_turn", send: "send_message" },
+};
+
+const DEFAULT_TOOLS: DeliveryToolNames = {
+  endTurn: "end_turn",
+  send: "send",
+  react: "react",
+};
+
+/**
+ * Delivery tool names for a frontend. Unknown frontends (and
+ * `terminal`, which has no outbound messaging surface) fall back to
+ * the telegram-shaped defaults — harmless, since backends only enforce
+ * the contract when a frontend MCP server is actually wired.
+ */
+export function deliveryToolsForFrontend(frontend: string): DeliveryToolNames {
+  return FRONTEND_TOOLS[frontend] ?? DEFAULT_TOOLS;
+}
+
+/**
+ * Register (or override) the delivery tool names for a frontend.
+ * Extension seam: a new frontend declares its tool names here at
+ * registration time and every backend's contract, flow-violation
+ * reminder, and first-turn nudge pick them up — no edits to this
+ * module or to any backend.
+ */
+export function registerFrontendDeliveryTools(
+  frontend: string,
+  tools: DeliveryToolNames,
+): void {
+  FRONTEND_TOOLS[frontend] = tools;
+}
+
+// ── Contract suffix ─────────────────────────────────────────────────────────
+
+/**
+ * Build the response-flow contract section a backend appends to the
+ * static system prompt. The prose lives in package-owned templates
+ * (`prompts/system/contract-*.md`) — kept deliberately tight: this is
+ * read on every session, so every sentence must earn its tokens. The
+ * per-tool details (parameter shapes, examples) live in the MCP tool
+ * descriptions, which the model also has in context.
+ */
+export function buildDeliveryContract(
+  mode: DeliveryMode,
+  frontend: string,
+): string {
+  const t = deliveryToolsForFrontend(frontend);
+  return loadSystemTemplate(`contract-${mode}`, {
+    end_turn: t.endTurn,
+    send: t.send,
+    react: t.react,
+  });
+}
+
+// ── Flow-violation reminder ─────────────────────────────────────────────────
+
+/**
+ * Frontend-aware [FLOW VIOLATION] reminder. Same shape as the legacy
+ * shared `FLOW_VIOLATION_REMINDER`, but with the frontend's actual
+ * tool names (the constant hardcoded \`send\`/\`react\`, which don't
+ * exist on Teams).
+ */
+export function buildFlowViolationReminder(frontend: string): string {
+  const t = deliveryToolsForFrontend(frontend);
+  const reactPart = t.react
+    ? `, or \`${t.react}(emoji=...)\` for an emoji acknowledgement`
+    : "";
+  return (
+    "[FLOW VIOLATION] Your previous turn ended without a delivery tool, so the " +
+    "user saw nothing. Replies must go through a tool call: " +
+    `\`${t.endTurn}(text=...)\` for a final reply, ` +
+    `\`${t.endTurn}()\` (no args) to close silently, ` +
+    `\`${t.send}(...)\` for mid-turn rich content${reactPart}. ` +
+    "Tool calls alone do not close the turn. Retry now using the correct tool call."
+  );
+}
+
+// ── First-turn nudge ────────────────────────────────────────────────────────
+
+/**
+ * One-line reminder appended to the formatted user prompt on the first
+ * turn of a session (strict backends only). Lives in the user message,
+ * not the system prompt, so it costs nothing on later turns and never
+ * perturbs the cached static prefix.
+ */
+export function buildFirstTurnReminder(frontend: string): string {
+  const t = deliveryToolsForFrontend(frontend);
+  return (
+    `[New session — reminder: your prose output is never shown to the user. ` +
+    `Deliver your reply via ${t.endTurn}(text=...), or ${t.endTurn}() to stay silent.]`
+  );
+}

--- a/src/backend/shared/delivery-contract.ts
+++ b/src/backend/shared/delivery-contract.ts
@@ -43,10 +43,11 @@ import { loadSystemTemplate } from "../../core/prompt/templates.js";
  *   - `tool-only` — output stream is private scratchpad; replies MUST
  *     go through a delivery tool (claude-sdk, openai-agents).
  *   - `text-or-tools` — plain assistant text is delivered as the
- *     reply; delivery tools add rich content / targeting (codex, kilo,
- *     opencode).
+ *     reply; delivery tools add rich content / targeting (codex, kilo).
+ *   - `text-preferred` — plain text is the normal route; tools only
+ *     for genuine side effects (opencode).
  */
-export type DeliveryMode = "tool-only" | "text-or-tools";
+export type DeliveryMode = "tool-only" | "text-or-tools" | "text-preferred";
 
 /** Frontend-specific delivery tool names. */
 export type DeliveryToolNames = {

--- a/src/backend/shared/flow-violation.ts
+++ b/src/backend/shared/flow-violation.ts
@@ -51,6 +51,13 @@ export type FlowViolationInputs = {
   retryCount?: number;
   /** Maximum synthetic flow-violation retries before accepting the drop. */
   maxRetries?: number;
+  /**
+   * Reminder text to ship on retry. Defaults to the legacy
+   * telegram-shaped `FLOW_VIOLATION_REMINDER`; backends should pass
+   * `buildFlowViolationReminder(frontend)` so the tool names match
+   * what's actually registered (Teams has `send_message`, not `send`).
+   */
+  reminder?: string;
 };
 
 /** Outcome of the flow-violation check. */
@@ -111,6 +118,6 @@ export function detectFlowViolation(
     trailing,
     reason,
     shouldRetry: retryCount < maxRetries,
-    reminder: FLOW_VIOLATION_REMINDER,
+    reminder: inputs.reminder ?? FLOW_VIOLATION_REMINDER,
   };
 }

--- a/src/backend/shared/frontends.ts
+++ b/src/backend/shared/frontends.ts
@@ -1,0 +1,21 @@
+/**
+ * Frontend-list helpers shared across backends.
+ *
+ * Every backend needs "which frontends get an MCP tool server?" at
+ * spawn time; before this helper, claude-sdk, openai-agents, and codex
+ * each carried their own copy of the same normalise-and-filter logic.
+ */
+
+/**
+ * Normalise a config `frontend` value (string or array, possibly
+ * undefined) to the list of messaging frontends — i.e. those that
+ * need an MCP tool server spawned. `terminal` is excluded: it has no
+ * outbound messaging surface (the agent runs to stdout).
+ */
+export function nonTerminalFrontends(
+  frontend: string | readonly string[] | undefined,
+): readonly string[] {
+  if (!frontend) return [];
+  const all = Array.isArray(frontend) ? frontend : [frontend as string];
+  return all.filter((f) => f !== "terminal");
+}

--- a/src/backend/shared/index.ts
+++ b/src/backend/shared/index.ts
@@ -89,6 +89,15 @@ export {
 
 export { sleep } from "./sleep.js";
 
+export { nonTerminalFrontends } from "./frontends.js";
+
+export {
+  recordToolCall,
+  recordTurnMetrics,
+  recordFlowViolation,
+  type TurnMetricInputs,
+} from "./metrics.js";
+
 export {
   applyRetryDecision,
   type ApplyRetryDecisionInputs,

--- a/src/backend/shared/index.ts
+++ b/src/backend/shared/index.ts
@@ -1,23 +1,32 @@
 /**
  * Shared backend framework — barrel re-export.
  *
- * Helpers used by every concrete backend (`claude-sdk`, `kilo`, `opencode`)
- * to keep behaviour aligned and avoid copy-paste drift.
+ * Helpers used by every concrete backend (`claude-sdk`, `codex`,
+ * `kilo`, `opencode`, `openai-agents`) to keep behaviour aligned and
+ * avoid copy-paste drift.
  *
  * What's here:
  *   - `delivered-text` — scratchpad/dedup primitives.
+ *   - `delivery-contract` — per-backend response-flow contract
+ *     (rendered from prompts/system templates), frontend-aware
+ *     flow-violation reminder, first-turn nudge.
  *   - `flow-violation` — flow-violation detection + reminder text.
+ *   - `metrics` — the shared metric vocabulary (tool calls, per-turn
+ *     rollups, flow violations) with backend dimensions.
  *   - `prompt-format` — user-prompt formatter ([time] [Name] [msg_id:N]).
+ *   - `frontends` — config `frontend` → messaging-frontend list.
  *   - `session-name` — first-message → short session title.
  *   - `usage` — cache-hit % + log summarisers.
- *   - `system-prompt` — first-turn rebuild + backend suffix.
+ *   - `system-prompt` — per-session prompt snapshots + backend suffix
+ *     (assembly itself lives in `core/prompt/`).
  *   - `model-retry` — session-expiry / context-overflow / fallback decisions.
  *   - `stream-state` — backend-agnostic accumulator for stream loops.
  *
  * What's NOT here (intentionally):
  *   - SDK-specific event types — those live in each backend.
  *   - Session storage — that's `src/storage/sessions.ts`.
- *   - MCP server registration — backend-specific transport details.
+ *   - MCP server registration — backend-specific transport details
+ *     (the spawn/env contract they share is `core/tools/mcp-env.ts`).
  */
 
 export {

--- a/src/backend/shared/index.ts
+++ b/src/backend/shared/index.ts
@@ -36,6 +36,16 @@ export {
 
 export { formatUserPrompt, type PromptFormatInputs } from "./prompt-format.js";
 
+export {
+  buildDeliveryContract,
+  buildFlowViolationReminder,
+  buildFirstTurnReminder,
+  deliveryToolsForFrontend,
+  registerFrontendDeliveryTools,
+  type DeliveryMode,
+  type DeliveryToolNames,
+} from "./delivery-contract.js";
+
 export { extractSessionName } from "./session-name.js";
 
 export {

--- a/src/backend/shared/metrics.ts
+++ b/src/backend/shared/metrics.ts
@@ -1,0 +1,105 @@
+/**
+ * Backend metric piping — one vocabulary for every backend.
+ *
+ * Before this module each backend hand-rolled its own counters:
+ * claude-sdk and the remote-server family stripped MCP prefixes off
+ * tool names, codex didn't (so `tool_calls.mcp__…` and
+ * `tool_calls.send` counted the same tool twice under different
+ * keys); only codex recorded per-turn tool/API histograms; and
+ * openai-agents never counted flow-violation cap exhaustion. Cross-
+ * backend comparisons were impossible because the names didn't line
+ * up.
+ *
+ * ## Metric vocabulary
+ *
+ * Shared (no backend dimension — comparable across the fleet):
+ *   - `queries_total`                      counter, one per user-visible turn
+ *   - `response_latency_ms`                histogram
+ *   - `tool_calls.<bare-name>`             counter, MCP prefix stripped
+ *   - `tool_calls_per_turn`                histogram
+ *   - `turns_with_tools_total`             counter
+ *   - `api_calls_total` / `api_calls_per_turn`
+ *   - `scratchpad.trailing_text_dropped` / `.flow_violation_retried`
+ *     / `.flow_violation_cap_exhausted`
+ *
+ * Per-backend dimension (`backend.<id>.…`, id = BackendId):
+ *   - `backend.<id>.queries`
+ *   - `backend.<id>.response_latency_ms`   histogram
+ *   - `backend.<id>.tool_calls`
+ *   - `backend.<id>.turn_failed`
+ *
+ * Keep names LOW-CARDINALITY: the metrics store caps total keys at
+ * 500. Tool names are bounded by the tool catalog; backend ids by the
+ * registry. Never interpolate chat ids, model ids, or user input.
+ */
+
+import { incrementCounter, recordHistogram } from "../../util/metrics.js";
+import { stripMcpPrefix } from "../../core/tools/index.js";
+
+/**
+ * Count one tool call. `toolName` may be raw from any backend —
+ * MCP-prefixed (`mcp__telegram-tools__send`), server-prefixed
+ * (`talon-tools-123_send`), or bare — it is normalised so every
+ * backend lands on the same `tool_calls.<bare>` key.
+ */
+export function recordToolCall(toolName: string, backend?: string): void {
+  incrementCounter(`tool_calls.${stripMcpPrefix(toolName)}`);
+  if (backend) incrementCounter(`backend.${backend}.tool_calls`);
+}
+
+/** Per-turn rollup recorded once at the end of every chat turn. */
+export type TurnMetricInputs = {
+  /** Backend id, e.g. "claude", "codex", "kilo", "openai-agents", "opencode". */
+  backend: string;
+  durationMs: number;
+  /** Tool calls observed this turn (omit when the backend can't count them). */
+  toolCalls?: number;
+  /** Upstream API calls this turn (omit when unknown). */
+  apiCalls?: number;
+  /** True when the turn ended in a delivered failure. */
+  failed?: boolean;
+};
+
+/**
+ * Record the uniform per-turn metric set. Replaces the per-backend
+ * `recordHistogram("response_latency_ms")` + `incrementCounter
+ * ("queries_total")` pairs (and codex's private `codex.*` family).
+ */
+export function recordTurnMetrics(inputs: TurnMetricInputs): void {
+  recordHistogram("response_latency_ms", inputs.durationMs);
+  recordHistogram(
+    `backend.${inputs.backend}.response_latency_ms`,
+    inputs.durationMs,
+  );
+  incrementCounter("queries_total");
+  incrementCounter(`backend.${inputs.backend}.queries`);
+
+  if (inputs.failed) incrementCounter(`backend.${inputs.backend}.turn_failed`);
+
+  if (inputs.toolCalls !== undefined) {
+    recordHistogram("tool_calls_per_turn", inputs.toolCalls);
+    if (inputs.toolCalls > 0) incrementCounter("turns_with_tools_total");
+  }
+  if (inputs.apiCalls !== undefined && inputs.apiCalls > 0) {
+    incrementCounter("api_calls_total", inputs.apiCalls);
+    recordHistogram("api_calls_per_turn", inputs.apiCalls);
+  }
+}
+
+/**
+ * Record a flow violation (prose written without a delivery tool).
+ * Always counts the dropped text; the outcome picks the second
+ * counter. Centralised because openai-agents historically skipped the
+ * cap-exhausted counter, making "how often do models ignore the
+ * reminder" unanswerable for that backend.
+ */
+export function recordFlowViolation(
+  outcome: "retried" | "cap_exhausted",
+): void {
+  incrementCounter("scratchpad.trailing_text_dropped");
+  incrementCounter(
+    outcome === "retried"
+      ? "scratchpad.flow_violation_retried"
+      : "scratchpad.flow_violation_cap_exhausted",
+  );
+}

--- a/src/backend/shared/model-retry.ts
+++ b/src/backend/shared/model-retry.ts
@@ -22,7 +22,7 @@
  */
 
 import type { TalonError } from "../../core/errors.js";
-import { getFallbackModel } from "../../core/models.js";
+import { getFallbackModel } from "../../core/models/catalog.js";
 
 // ── Public API ──────────────────────────────────────────────────────────────
 

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -21,7 +21,7 @@ import { cleanupOldLogs } from "./storage/daily-log.js";
 import {
   initDispatcher,
   execute as dispatcherExecute,
-} from "./core/dispatcher.js";
+} from "./core/engine/dispatcher.js";
 import { initPulse, resetPulseTimer } from "./core/background/pulse.js";
 import { initCron } from "./core/background/cron.js";
 import {
@@ -114,7 +114,7 @@ export async function bootstrap(
  * Create the AI backend and wire the dispatcher.
  * Call this after creating the frontend.
  *
- * The backend controller (`core/backend-controller.ts`) is the single
+ * The backend controller (`core/engine/backend-controller.ts`) is the single
  * source of truth for the active backend. Dispatcher / dream /
  * heartbeat all read through `getActiveBackend()` so a runtime swap
  * via `switchBackend(id, config)` propagates without any re-init.
@@ -140,7 +140,7 @@ export async function initBackendAndDispatcher(
     releaseChat,
     isBackendAvailable,
     isModelValidForBackend,
-  } = await import("./core/backend-controller.js");
+  } = await import("./core/engine/backend-controller.js");
 
   // Boot the backend pool — binds the chat / heartbeat / dream roles
   // from `config.backend`, `config.heartbeatBackend`,
@@ -247,7 +247,7 @@ export async function initBackendAndDispatcher(
       const { resolveActiveModelForChat } =
         await import("./core/models/active-model.js");
       const { getBackendIdForChat, getBackendForChat: getBE } =
-        await import("./core/backend-controller.js");
+        await import("./core/engine/backend-controller.js");
       const beId = getBackendIdForChat(chatId);
       const be = getBE(chatId);
       const { model, ref } = await resolveActiveModelForChat(

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -22,14 +22,14 @@ import {
   initDispatcher,
   execute as dispatcherExecute,
 } from "./core/dispatcher.js";
-import { initPulse, resetPulseTimer } from "./core/pulse.js";
-import { initCron } from "./core/cron.js";
+import { initPulse, resetPulseTimer } from "./core/background/pulse.js";
+import { initCron } from "./core/background/cron.js";
 import {
   initTriggers,
   resumeAfterRestart as resumeTriggersAfterRestart,
-} from "./core/triggers.js";
-import { initDream } from "./core/dream.js";
-import { initHeartbeat } from "./core/heartbeat.js";
+} from "./core/background/triggers.js";
+import { initDream } from "./core/background/dream.js";
+import { initHeartbeat } from "./core/background/heartbeat.js";
 import { log } from "./util/log.js";
 import type { TalonConfig } from "./util/config.js";
 import type { ContextManager } from "./core/types.js";
@@ -245,7 +245,7 @@ export async function initBackendAndDispatcher(
     // of submitting an empty id to the backend.
     resolveActiveModel: async (chatId: string) => {
       const { resolveActiveModelForChat } =
-        await import("./core/active-model.js");
+        await import("./core/models/active-model.js");
       const { getBackendIdForChat, getBackendForChat: getBE } =
         await import("./core/backend-controller.js");
       const beId = getBackendIdForChat(chatId);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -370,7 +370,7 @@ async function runSetup(): Promise<void> {
     // Setup wizard may run before Claude Code is installed — use static list
     registerClaudeModelsStatic(CLAUDE_MODELS_STATIC);
   }
-  const { getModels } = await import("./core/models.js");
+  const { getModels } = await import("./core/models/catalog.js");
   const registeredModels = getModels();
 
   const model = await p.select({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -935,7 +935,7 @@ async function startChat(): Promise<void> {
   const { flushTriggers } = await import("./storage/trigger-store.js");
   const { createTerminalFrontend } =
     await import("./frontend/terminal/index.js");
-  const { Gateway } = await import("./core/gateway.js");
+  const { Gateway } = await import("./core/engine/gateway.js");
 
   const { config } = await bootstrap({ frontendNames: ["terminal"] });
 
@@ -957,7 +957,7 @@ async function startChat(): Promise<void> {
   // Mirror the index.ts wiring: keep the gateway's cached backend
   // reference in sync with chat-role rebinds.
   const { onBackendChange, roleHolder } =
-    await import("./core/backend-controller.js");
+    await import("./core/engine/backend-controller.js");
   const CHAT_ROLE_HOLDER = roleHolder("chat");
   onBackendChange((holder, newBackend) => {
     if (holder !== CHAT_ROLE_HOLDER) return;

--- a/src/core/agent-runtime/capabilities.ts
+++ b/src/core/agent-runtime/capabilities.ts
@@ -89,7 +89,7 @@ export interface BackgroundRunner {
 /**
  * Catalog operations, split into a small REQUIRED core (resolution:
  * `resolveModelInfo` / `getDefaultModelId` / `getRawModelInfo`, which
- * the dispatcher and `core/active-model.ts` depend on) and an OPTIONAL
+ * the dispatcher and `core/models/active-model.ts` depend on) and an OPTIONAL
  * picker / catalog-browse surface. A fixed-model backend (Claude SDK
  * on a model alias) can implement only the core and let the `/model`
  * picker degrade gracefully; catalog-driven backends (Kilo, OpenCode,
@@ -98,13 +98,13 @@ export interface BackgroundRunner {
  * The catalog speaks `UnifiedModelInfo` — the rich shape every
  * backend's `models.ts` produces internally. `ModelRef` is only
  * the resolver's output, an enriched routing identity.
- * `core/active-model.ts` wraps catalog calls into refs for
+ * `core/models/active-model.ts` wraps catalog calls into refs for
  * `/status` and `/model` display.
  */
 export interface ModelCatalog {
   // ── Required core: resolution ───────────────────────────────────
   /**
-   * Backend-native resolve. Used by `core/active-model.ts` for the
+   * Backend-native resolve. Used by `core/models/active-model.ts` for the
    * per-chat override validation and by the frontend's
    * resolution-error formatter.
    */

--- a/src/core/agent-runtime/model-ref.ts
+++ b/src/core/agent-runtime/model-ref.ts
@@ -59,7 +59,7 @@ export type CacheSupport = "none" | "read" | "readwrite";
 
 /**
  * Where the resolver picked this model from. Mirrors
- * `ActiveModelSource` in `core/active-model.ts` so the two systems
+ * `ActiveModelSource` in `core/models/active-model.ts` so the two systems
  * speak the same vocabulary. Values are stable for logging and
  * toast wording.
  */

--- a/src/core/background/cron.ts
+++ b/src/core/background/cron.ts
@@ -9,7 +9,7 @@
  */
 
 import { Cron } from "croner";
-import { execute, getActiveCount } from "../dispatcher.js";
+import { execute, getActiveCount } from "../engine/dispatcher.js";
 import {
   getAllCronJobs,
   recordCronRun,

--- a/src/core/background/cron.ts
+++ b/src/core/background/cron.ts
@@ -9,14 +9,14 @@
  */
 
 import { Cron } from "croner";
-import { execute, getActiveCount } from "./dispatcher.js";
+import { execute, getActiveCount } from "../dispatcher.js";
 import {
   getAllCronJobs,
   recordCronRun,
   type CronJob,
-} from "../storage/cron-store.js";
-import { appendDailyLog } from "../storage/daily-log.js";
-import { log, logError, logWarn } from "../util/log.js";
+} from "../../storage/cron-store.js";
+import { appendDailyLog } from "../../storage/daily-log.js";
+import { log, logError, logWarn } from "../../util/log.js";
 
 // ── Dependencies (injected at startup) ──────────────────────────────────────
 

--- a/src/core/background/dream.ts
+++ b/src/core/background/dream.ts
@@ -12,14 +12,14 @@
  */
 
 import { existsSync, readFileSync, mkdirSync, appendFileSync } from "node:fs";
-import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import writeFileAtomic from "write-file-atomic";
-import { files as pathFiles, dirs } from "../util/paths.js";
-import { log, logError, logWarn } from "../util/log.js";
-import { getDefaultModel } from "./models.js";
-import type { OneShotAgentParams } from "./types.js";
-import type { Backend } from "./agent-runtime/capabilities.js";
+import { files as pathFiles, dirs } from "../../util/paths.js";
+import { PACKAGE_PROMPTS_DIR } from "../prompt/templates.js";
+import { log, logError, logWarn } from "../../util/log.js";
+import { getDefaultModel } from "../models/catalog.js";
+import type { OneShotAgentParams } from "../types.js";
+import type { Backend } from "../agent-runtime/capabilities.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -154,9 +154,10 @@ async function runDreamAgent(lastRunTimestamp: number): Promise<string> {
   const memoryFile = pathFiles.memory;
   const dreamStateFile = DREAM_STATE_FILE;
 
-  // Load prompt template from prompts/dream.md and interpolate variables
-  const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-  const promptPath = resolve(projectRoot, "prompts/dream.md");
+  // Load prompt template from the package prompts/ dir and interpolate
+  // variables (PACKAGE_PROMPTS_DIR is the canonical resolver — no
+  // module-relative "../.." that breaks when this file moves).
+  const promptPath = resolve(PACKAGE_PROMPTS_DIR, "dream.md");
 
   let prompt: string;
   try {

--- a/src/core/background/dream.ts
+++ b/src/core/background/dream.ts
@@ -297,8 +297,20 @@ If commands fail, log the error and continue — this stage is optional.`
 // ── Dream logging helpers ─────────────────────────────────────────────────
 
 function createDreamLogFile(): string {
-  if (!existsSync(DREAM_LOGS_DIR)) {
-    mkdirSync(DREAM_LOGS_DIR, { recursive: true });
+  // Best-effort, like appendDreamLog: a failure to create the log
+  // directory must not abort the dream run itself — the per-append
+  // writes are already caught, so a missing dir just means dropped
+  // log entries.
+  try {
+    if (!existsSync(DREAM_LOGS_DIR)) {
+      mkdirSync(DREAM_LOGS_DIR, { recursive: true });
+    }
+  } catch (err) {
+    logError(
+      "dream",
+      "Failed to create dream log dir — run continues, log entries will be dropped",
+      err,
+    );
   }
   const now = new Date();
   const ts = now.toISOString().replace(/[:.]/g, "-").slice(0, 19); // 2026-04-01T21-30-00

--- a/src/core/background/heartbeat.ts
+++ b/src/core/background/heartbeat.ts
@@ -47,28 +47,33 @@ function envMs(name: string, fallback: number): number {
   return Number.isFinite(n) && n > 0 ? n : fallback;
 }
 
-/** Overridable via env (eg integration tests). Falls back to 10 min. */
-const HEARTBEAT_TIMEOUT_MS = envMs(
-  "TALON_HEARTBEAT_TIMEOUT_MS",
-  DEFAULT_HEARTBEAT_TIMEOUT_MS,
-);
+/**
+ * Overridable via env (eg integration tests). Falls back to 10 min.
+ * Read per RUN, not at module load, so tests (and operators) can
+ * adjust without re-importing the module.
+ */
+function heartbeatTimeoutMs(): number {
+  return envMs("TALON_HEARTBEAT_TIMEOUT_MS", DEFAULT_HEARTBEAT_TIMEOUT_MS);
+}
 /**
  * After we abort the agent on timeout, wait this long for the agent promise
  * to settle gracefully. If it still hasn't settled we release the lock anyway
  * (so the next heartbeat can fire) and ask the backend to evict any orphan
- * subprocesses it spawned.
+ * subprocesses it spawned. Read per run — see heartbeatTimeoutMs.
  */
-const HEARTBEAT_ABORT_GRACE_MS = envMs(
-  "TALON_HEARTBEAT_ABORT_GRACE_MS",
-  DEFAULT_HEARTBEAT_ABORT_GRACE_MS,
-);
+function heartbeatAbortGraceMs(): number {
+  return envMs(
+    "TALON_HEARTBEAT_ABORT_GRACE_MS",
+    DEFAULT_HEARTBEAT_ABORT_GRACE_MS,
+  );
+}
 const HEARTBEAT_LOGS_DIR = resolve(dirs.logs, "heartbeats");
 const STARTUP_DELAY_MS = 5 * 60 * 1000; // 5-minute delay before first run
 
 // ── Errors ───────────────────────────────────────────────────────────────────
 
 /**
- * Thrown when the heartbeat exceeds {@link HEARTBEAT_TIMEOUT_MS}. Distinguishes
+ * Thrown when the heartbeat exceeds the configured timeout. Distinguishes
  * timeouts from agent-internal failures so callers can advance state on the
  * former (the hour was spent) but preserve it on the latter (retry as-is).
  */
@@ -388,7 +393,7 @@ async function runHeartbeatAgent(
   // AbortController is the canonical way to signal a cancellation to a backend.
   // .abort() should tear down any spawned subprocess (Claude SDK) or stop
   // streaming further parts (Kilo/OpenCode). We defend against backends that
-  // ignore it — see HEARTBEAT_ABORT_GRACE_MS below.
+  // ignore it — see heartbeatAbortGraceMs below.
   const abortController = new AbortController();
 
   const oneShotParams: OneShotAgentParams = {
@@ -413,7 +418,7 @@ async function runHeartbeatAgent(
         /* ignore */
       }
       reject(new HeartbeatTimeoutError());
-    }, HEARTBEAT_TIMEOUT_MS);
+    }, heartbeatTimeoutMs());
     t.unref(); // Don't prevent Node.js from exiting cleanly during shutdown
     timeoutHandle = t;
   });
@@ -450,12 +455,12 @@ async function runHeartbeatAgent(
       // lock anyway and ask the backend to evict any orphan subprocesses.
       const settled = await raceWithTimeout(
         agentPromise.catch(() => "settled"),
-        HEARTBEAT_ABORT_GRACE_MS,
+        heartbeatAbortGraceMs(),
       );
       if (settled === "timed_out") {
         logWarn(
           "heartbeat",
-          `Heartbeat #${runCount} backend ignored abort after ${HEARTBEAT_ABORT_GRACE_MS}ms — releasing lock and evicting orphan subprocesses`,
+          `Heartbeat #${runCount} backend ignored abort after ${heartbeatAbortGraceMs()}ms — releasing lock and evicting orphan subprocesses`,
         );
         // Fire-and-forget — we don't block the next heartbeat on subprocess
         // cleanup. Backends that don't spawn per-run subprocesses (Kilo,
@@ -521,8 +526,20 @@ async function raceWithTimeout<T>(
 let heartbeatLogFileSequence = 0;
 
 async function createHeartbeatLogFile(): Promise<string> {
-  if (!existsSync(HEARTBEAT_LOGS_DIR)) {
-    await mkdir(HEARTBEAT_LOGS_DIR, { recursive: true });
+  // Best-effort, like every appendHeartbeatLog call: a failure to
+  // create the log directory must not abort the heartbeat run itself.
+  // The per-append writes are already caught, so a missing dir just
+  // means dropped log entries.
+  try {
+    if (!existsSync(HEARTBEAT_LOGS_DIR)) {
+      await mkdir(HEARTBEAT_LOGS_DIR, { recursive: true });
+    }
+  } catch (err) {
+    logError(
+      "heartbeat",
+      "Failed to create heartbeat log dir — run continues, log entries will be dropped",
+      err,
+    );
   }
   const now = new Date();
   const ts = now.toISOString().replace(/[:.]/g, "-");

--- a/src/core/background/heartbeat.ts
+++ b/src/core/background/heartbeat.ts
@@ -12,12 +12,12 @@ import { existsSync, readFileSync, mkdirSync } from "node:fs";
 import { appendFile, mkdir } from "node:fs/promises";
 import { resolve } from "node:path";
 import writeFileAtomic from "write-file-atomic";
-import { files as pathFiles, dirs } from "../util/paths.js";
-import { log, logError, logWarn } from "../util/log.js";
-import { toYMD } from "../util/time.js";
-import { getDefaultModel } from "./models.js";
-import type { OneShotAgentParams } from "./types.js";
-import type { Backend } from "./agent-runtime/capabilities.js";
+import { files as pathFiles, dirs } from "../../util/paths.js";
+import { log, logError, logWarn } from "../../util/log.js";
+import { toYMD } from "../../util/time.js";
+import { getDefaultModel } from "../models/catalog.js";
+import type { OneShotAgentParams } from "../types.js";
+import type { Backend } from "../agent-runtime/capabilities.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/core/background/index.ts
+++ b/src/core/background/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Background agents — everything that runs without a user message.
+ *
+ *   - `heartbeat` — periodic autonomous agent pass ("anything need
+ *     doing?"), prompted by prompts/heartbeat.md.
+ *   - `dream`    — memory-consolidation agent (daily notes → memory,
+ *     mempalace mining), prompted by prompts/dream.md.
+ *   - `pulse`    — lightweight liveness/typing-indicator ticker.
+ *   - `cron`     — persistent user-scheduled jobs (message / query).
+ *   - `triggers` — user-authored watcher scripts that fire wake-ups.
+ *
+ * All of these drive the backend through the same `BackgroundRunner`
+ * surface (core/agent-runtime/capabilities.ts) — they never talk to a
+ * concrete backend directly.
+ */
+
+export * from "./heartbeat.js";
+export * from "./dream.js";
+export * from "./pulse.js";
+export * from "./cron.js";
+export * from "./triggers.js";

--- a/src/core/background/pulse.ts
+++ b/src/core/background/pulse.ts
@@ -8,16 +8,16 @@
  * Knows nothing about the backend or frontend — uses the dispatcher.
  */
 
-import { execute, getActiveCount } from "./dispatcher.js";
+import { execute, getActiveCount } from "../dispatcher.js";
 import {
   setChatPulse,
   getRegisteredPulseChats,
   getChatSettings,
   setPulseLastCheckMsgId,
-} from "../storage/chat-settings.js";
-import { getRecentHistory, getLatestMessageId } from "../storage/history.js";
-import { log, logError } from "../util/log.js";
-import { formatSmartTimestamp } from "../util/time.js";
+} from "../../storage/chat-settings.js";
+import { getRecentHistory, getLatestMessageId } from "../../storage/history.js";
+import { log, logError } from "../../util/log.js";
+import { formatSmartTimestamp } from "../../util/time.js";
 
 // ── State ────────────────────────────────────────────────────────────────────
 

--- a/src/core/background/pulse.ts
+++ b/src/core/background/pulse.ts
@@ -8,7 +8,7 @@
  * Knows nothing about the backend or frontend — uses the dispatcher.
  */
 
-import { execute, getActiveCount } from "../dispatcher.js";
+import { execute, getActiveCount } from "../engine/dispatcher.js";
 import {
   setChatPulse,
   getRegisteredPulseChats,

--- a/src/core/background/triggers.ts
+++ b/src/core/background/triggers.ts
@@ -27,7 +27,7 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createWriteStream, readFileSync, type WriteStream } from "node:fs";
 import { createInterface } from "node:readline";
-import { execute as dispatcherExecute } from "../dispatcher.js";
+import { execute as dispatcherExecute } from "../engine/dispatcher.js";
 import {
   getAllTriggers,
   getTrigger,

--- a/src/core/background/triggers.ts
+++ b/src/core/background/triggers.ts
@@ -27,7 +27,7 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createWriteStream, readFileSync, type WriteStream } from "node:fs";
 import { createInterface } from "node:readline";
-import { execute as dispatcherExecute } from "./dispatcher.js";
+import { execute as dispatcherExecute } from "../dispatcher.js";
 import {
   getAllTriggers,
   getTrigger,
@@ -36,9 +36,9 @@ import {
   type Trigger,
   type TriggerStatus,
   FIRE_PAYLOAD_MAX_BYTES,
-} from "../storage/trigger-store.js";
-import { log, logError, logWarn } from "../util/log.js";
-import { appendDailyLog } from "../storage/daily-log.js";
+} from "../../storage/trigger-store.js";
+import { log, logError, logWarn } from "../../util/log.js";
+import { appendDailyLog } from "../../storage/daily-log.js";
 
 // ── Dependencies (injected at startup) ──────────────────────────────────────
 

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -14,7 +14,7 @@ import type { ContextManager, ExecuteParams, ExecuteResult } from "./types.js";
 import type { Backend } from "./agent-runtime/capabilities.js";
 import { pipeEventsToCallbacks } from "./agent-runtime/event-bridge.js";
 import { log, logDebug, logWarn } from "../util/log.js";
-import { maybeStartDream } from "./dream.js";
+import { maybeStartDream } from "./background/dream.js";
 
 // ── Dependencies (injected at startup) ──────────────────────────────────────
 

--- a/src/core/engine/backend-controller.ts
+++ b/src/core/engine/backend-controller.ts
@@ -41,14 +41,14 @@
  * haven't been ported.
  */
 
-import type { Backend } from "./agent-runtime/capabilities.js";
-import type { TalonConfig } from "../util/config.js";
+import type { Backend } from "../agent-runtime/capabilities.js";
+import type { TalonConfig } from "../../util/config.js";
 import {
   getBackend,
   listBackends,
   type BackendInitContext,
-} from "../backend/registry.js";
-import { log, logWarn } from "../util/log.js";
+} from "../../backend/registry.js";
+import { log, logWarn } from "../../util/log.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 

--- a/src/core/engine/dispatcher.ts
+++ b/src/core/engine/dispatcher.ts
@@ -10,11 +10,11 @@
  */
 
 import { randomBytes } from "node:crypto";
-import type { ContextManager, ExecuteParams, ExecuteResult } from "./types.js";
-import type { Backend } from "./agent-runtime/capabilities.js";
-import { pipeEventsToCallbacks } from "./agent-runtime/event-bridge.js";
-import { log, logDebug, logWarn } from "../util/log.js";
-import { maybeStartDream } from "./background/dream.js";
+import type { ContextManager, ExecuteParams, ExecuteResult } from "../types.js";
+import type { Backend } from "../agent-runtime/capabilities.js";
+import { pipeEventsToCallbacks } from "../agent-runtime/event-bridge.js";
+import { log, logDebug, logWarn } from "../../util/log.js";
+import { maybeStartDream } from "../background/dream.js";
 
 // ── Dependencies (injected at startup) ──────────────────────────────────────
 
@@ -35,7 +35,7 @@ type DispatcherDeps = {
   getBackend: (chatId?: string) => Backend;
   resolveActiveModel: (chatId: string) => Promise<{
     model: string | null;
-    ref: import("./agent-runtime/model-ref.js").ModelRef | null;
+    ref: import("../agent-runtime/model-ref.js").ModelRef | null;
     backendId: string;
   }>;
   context: ContextManager;

--- a/src/core/engine/gateway-actions.ts
+++ b/src/core/engine/gateway-actions.ts
@@ -8,14 +8,14 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import * as cheerio from "cheerio";
-import { dirs } from "../util/paths.js";
+import { dirs } from "../../util/paths.js";
 import {
   getRecentFormatted,
   searchHistory,
   getMessagesByUser,
   getKnownUsers,
-} from "../storage/history.js";
-import { formatMediaIndex } from "../storage/media-index.js";
+} from "../../storage/history.js";
+import { formatMediaIndex } from "../../storage/media-index.js";
 import {
   addCronJob,
   getCronJob,
@@ -25,7 +25,7 @@ import {
   validateCronExpression,
   generateCronId,
   type CronJobType,
-} from "../storage/cron-store.js";
+} from "../../storage/cron-store.js";
 import {
   addTrigger,
   deleteTrigger,
@@ -44,11 +44,11 @@ import {
   DEFAULT_TIMEOUT_SECONDS,
   MAX_ACTIVE_PER_CHAT,
   type TriggerLanguage,
-} from "../storage/trigger-store.js";
-import { cancelTrigger, spawnTrigger } from "./background/triggers.js";
-import { log, logWarn } from "../util/log.js";
-import type { ActionResult } from "./types.js";
-import type { Backend } from "./agent-runtime/capabilities.js";
+} from "../../storage/trigger-store.js";
+import { cancelTrigger, spawnTrigger } from "../background/triggers.js";
+import { log, logWarn } from "../../util/log.js";
+import type { ActionResult } from "../types.js";
+import type { Backend } from "../agent-runtime/capabilities.js";
 
 /** Extract readable text from HTML using cheerio (proper DOM parser). */
 function extractText(html: string, maxLength = 8000): string {
@@ -535,10 +535,10 @@ export async function handleSharedAction(
     case "reload_plugins": {
       try {
         const { reloadPlugins, getPluginPromptAdditions } =
-          await import("./plugin.js");
-        const { rebuildSystemPrompt } = await import("../util/config.js");
+          await import("../plugin.js");
+        const { rebuildSystemPrompt } = await import("../../util/config.js");
         const { clearSystemPromptSnapshots } =
-          await import("../backend/shared/system-prompt.js");
+          await import("../../backend/shared/system-prompt.js");
 
         // reloadPlugins reads + validates config internally — no double read.
         // Frontends are derived from config if not explicitly provided.

--- a/src/core/engine/gateway.ts
+++ b/src/core/engine/gateway.ts
@@ -14,15 +14,15 @@ import {
   type ServerResponse,
 } from "node:http";
 import pRetry, { AbortError } from "p-retry";
-import { classify } from "./errors.js";
+import { classify } from "../errors.js";
 import { getActiveCount } from "./dispatcher.js";
-import { getHealthStatus } from "../util/watchdog.js";
-import { getActiveSessionCount } from "../storage/sessions.js";
-import { log, logError, logDebug } from "../util/log.js";
+import { getHealthStatus } from "../../util/watchdog.js";
+import { getActiveSessionCount } from "../../storage/sessions.js";
+import { log, logError, logDebug } from "../../util/log.js";
 import { handleSharedAction } from "./gateway-actions.js";
-import { handlePluginAction } from "./plugin.js";
-import type { FrontendActionHandler } from "./types.js";
-import type { Backend } from "./agent-runtime/capabilities.js";
+import { handlePluginAction } from "../plugin.js";
+import type { FrontendActionHandler } from "../types.js";
+import type { Backend } from "../agent-runtime/capabilities.js";
 
 // ── Per-chat context state ───────────────────────────────────────────────────
 

--- a/src/core/engine/index.ts
+++ b/src/core/engine/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Engine — the message-flow core.
+ *
+ *   - `dispatcher`         — per-chat serial, cross-chat parallel turn
+ *     execution; the single entry point for "run this user message".
+ *   - `gateway`            — loopback HTTP bridge the MCP tool
+ *     subprocesses call back into.
+ *   - `gateway-actions`    — the action handlers the bridge dispatches
+ *     to (send/edit/react/cron/trigger/admin …).
+ *   - `backend-controller` — backend lifecycle: init, hot-swap,
+ *     cleanup, registry lookup.
+ *
+ * Everything here is frontend- and backend-agnostic: frontends feed
+ * the dispatcher, backends are reached through the agent-runtime
+ * capability slots.
+ */
+
+export * from "./dispatcher.js";
+export * from "./gateway.js";
+export * from "./backend-controller.js";

--- a/src/core/gateway-actions.ts
+++ b/src/core/gateway-actions.ts
@@ -45,7 +45,7 @@ import {
   MAX_ACTIVE_PER_CHAT,
   type TriggerLanguage,
 } from "../storage/trigger-store.js";
-import { cancelTrigger, spawnTrigger } from "./triggers.js";
+import { cancelTrigger, spawnTrigger } from "./background/triggers.js";
 import { log, logWarn } from "../util/log.js";
 import type { ActionResult } from "./types.js";
 import type { Backend } from "./agent-runtime/capabilities.js";

--- a/src/core/models/active-model.ts
+++ b/src/core/models/active-model.ts
@@ -63,18 +63,18 @@
 import {
   getChatModelForBackend,
   getChatSettings,
-} from "../storage/chat-settings.js";
-import type { Backend } from "./agent-runtime/capabilities.js";
+} from "../../storage/chat-settings.js";
+import type { Backend } from "../agent-runtime/capabilities.js";
 import {
   isBackendId,
   makeBareModelRef,
   type CacheSupport,
   type ModelRef,
   type ModelSource,
-} from "./agent-runtime/model-ref.js";
-import type { UnifiedModelInfo } from "./types.js";
-import type { TalonConfig } from "../util/config.js";
-import { logWarn } from "../util/log.js";
+} from "../agent-runtime/model-ref.js";
+import type { UnifiedModelInfo } from "../types.js";
+import type { TalonConfig } from "../../util/config.js";
+import { logWarn } from "../../util/log.js";
 
 /**
  * Reasons `resolveActiveModelForChat` chose its returned value.
@@ -358,7 +358,7 @@ async function materialiseRef(
 
 function unifiedToModelRef(
   info: UnifiedModelInfo,
-  backend: import("./agent-runtime/model-ref.js").BackendId,
+  backend: import("../agent-runtime/model-ref.js").BackendId,
   cache: CacheSupport,
 ): ModelRef {
   return {

--- a/src/core/models/catalog.ts
+++ b/src/core/models/catalog.ts
@@ -7,7 +7,7 @@
  * system and the backend-specific model definition files.
  */
 
-import type { ReasoningEffortLevel } from "./types.js";
+import type { ReasoningEffortLevel } from "../types.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/core/models/index.ts
+++ b/src/core/models/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Model layer — everything about "which model is the chat using".
+ *
+ *   - `catalog`          — model-id resolution, defaults, and the
+ *     curated cross-backend catalog.
+ *   - `active-model`     — per-chat active-model resolution
+ *     (chat-settings → config → backend default).
+ *   - `reasoning-levels` — the reasoning-effort vocabulary shared by
+ *     every backend (order, labels, normalisation).
+ *
+ * Presentation helpers (menus, status lines) live in `frontend/` —
+ * this layer is pure domain.
+ */
+
+export * from "./catalog.js";
+export * from "./active-model.js";
+export * from "./reasoning-levels.js";

--- a/src/core/models/reasoning-levels.ts
+++ b/src/core/models/reasoning-levels.ts
@@ -1,4 +1,4 @@
-import type { ReasoningEffortLevel } from "./types.js";
+import type { ReasoningEffortLevel } from "../types.js";
 
 export const REASONING_LEVEL_ORDER: ReasoningEffortLevel[] = [
   "off",

--- a/src/core/prompt/assemble.ts
+++ b/src/core/prompt/assemble.ts
@@ -1,0 +1,238 @@
+/**
+ * System-prompt assembly — the single place where Talon's system
+ * instructions are composed.
+ *
+ * ## Section pipeline
+ *
+ * The prompt is an ordered list of markdown sections joined by
+ * `\n\n---\n\n`. Static sections (stable for a session's lifetime)
+ * and dynamic sections (volatile between rebuilds) are kept apart so
+ * providers can prompt-cache the static prefix — see
+ * `SystemPromptParts`.
+ *
+ *   STATIC                                  source
+ *   1. Identity                             ~/.talon/prompts/identity.md
+ *                                           + ~/.talon/workspace/identity.md
+ *   2. Core behaviour                       ~/.talon/prompts/custom.md,
+ *                                           else base.md, else fallback
+ *   3. Frontend capabilities                ~/.talon/prompts/<frontend>.md
+ *   4. Persistent memory (size-capped)      prompts/system/persistent-memory.md
+ *                                           wrapping ~/.talon/workspace/memory/memory.md
+ *   5. Workspace / cron / triggers docs     prompts/system/{workspace,cron,triggers}.md
+ *   6. Plugin additions                     plugin.systemPrompt() contributions
+ *   (7. Delivery contract — appended by the backend as its suffix,
+ *       AFTER plugins, so it is the last thing the model reads.
+ *       See backend/shared/delivery-contract.ts.)
+ *
+ *   DYNAMIC
+ *   1. Daily-memory pointer                 prompts/system/daily-memory.md
+ *                                           (names today's file — changes at midnight)
+ *   2. Workspace file listing               workspace-listing.ts
+ *                                           (file sizes change as logs grow)
+ *
+ * ## Ownership
+ *
+ * Files under `~/.talon/prompts/` are seeded once and user-editable —
+ * edits win over package updates. Files under the package's
+ * `prompts/system/` are read directly from the package and are NOT
+ * seeded: they document runtime behaviour versioned with the code
+ * (tool names, flow enforcement, trigger limits), where a stale
+ * seeded copy would describe a contract the code no longer
+ * implements. See prompts/README.md.
+ *
+ * ## Deliberate omissions
+ *
+ * No "Current Date & Time" section: every user message already
+ * carries a `[YYYY-MM-DD HH:MM:SS]` tag (see shared/prompt-format),
+ * the daily-memory pointer names today's file, and the `check_time`
+ * tool covers timezone queries. A minute-precision timestamp here was
+ * the single biggest cache-buster — it guaranteed every rebuild
+ * produced a unique prompt.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { dirs, files as pathFiles } from "../../util/paths.js";
+import { todayAndYesterday } from "../../util/time.js";
+import { log } from "../../util/log.js";
+import { loadSystemTemplate } from "./templates.js";
+import { renderWorkspaceListing } from "./workspace-listing.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * System prompt split for prompt-cache friendliness.
+ *
+ * `staticText` holds everything stable for the lifetime of a session
+ * (identity, behaviour, frontend docs, memory snapshot, capability
+ * docs, plugin additions). `dynamicText` holds volatile context
+ * (workspace file listing, daily-memory pointer) that changes between
+ * rebuilds.
+ *
+ * The Claude SDK backend sends these as separate blocks divided by
+ * `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`, so the static prefix is eligible
+ * for cross-session prompt caching while volatile content lives after
+ * the cache boundary. Other backends join them into a single string —
+ * keeping volatile content last still maximises their providers'
+ * automatic prefix caching.
+ */
+export type SystemPromptParts = {
+  staticText: string;
+  dynamicText: string;
+};
+
+/** Join the two prompt parts into the single-string form. */
+export function joinSystemPromptParts(parts: SystemPromptParts): string {
+  if (!parts.dynamicText) return parts.staticText;
+  if (!parts.staticText) return parts.dynamicText;
+  return `${parts.staticText}\n\n---\n\n${parts.dynamicText}`;
+}
+
+// ── Tunables ────────────────────────────────────────────────────────────────
+
+/**
+ * Cap on how much of `memory.md` is injected into the static prompt.
+ * Memory files grow without bound over months of use; injecting all
+ * of it bloats EVERY session from its very first turn. 12k chars is
+ * roughly 3k tokens — past that, the model gets the head of the file
+ * plus a truncation pointer and can Read the rest on demand.
+ */
+export const MEMORY_INJECT_MAX_CHARS = 12_000;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function readOptionalFile(path: string): string {
+  try {
+    if (existsSync(path)) return readFileSync(path, "utf-8").trim();
+  } catch {
+    /* ignore */
+  }
+  return "";
+}
+
+/**
+ * Truncate memory content at the cap, snapping back to the previous
+ * newline so the cut never lands mid-sentence. Returns the (possibly
+ * shortened) content and whether truncation happened.
+ */
+function capMemory(content: string): { text: string; truncated: boolean } {
+  if (content.length <= MEMORY_INJECT_MAX_CHARS) {
+    return { text: content, truncated: false };
+  }
+  const head = content.slice(0, MEMORY_INJECT_MAX_CHARS);
+  const lastNewline = head.lastIndexOf("\n");
+  return {
+    text: (lastNewline > 0 ? head.slice(0, lastNewline) : head).trimEnd(),
+    truncated: true,
+  };
+}
+
+let lastLoggedPromptKey = "";
+
+// ── Assembly ────────────────────────────────────────────────────────────────
+
+/** Inputs for `assembleSystemPrompt`. */
+export type AssemblePromptInputs = {
+  /** Primary frontend whose prompt file to load (default: telegram). */
+  frontend?: string;
+  /** Plugin system-prompt contributions (static; change on plugin reload). */
+  pluginPromptAdditions?: string[];
+};
+
+/**
+ * Assemble the system prompt. See the module docstring for the
+ * section pipeline, ownership rules, and the static/dynamic split.
+ */
+export function assembleSystemPrompt(
+  inputs: AssemblePromptInputs,
+): SystemPromptParts {
+  const promptDir = dirs.prompts;
+  const staticParts: string[] = [];
+  const dynamicParts: string[] = [];
+  const loaded: string[] = [];
+
+  // 1. Identity — static personality from prompts/identity.md plus the
+  //    bot's own evolving identity file in the workspace.
+  const identityPrompt = readOptionalFile(resolve(promptDir, "identity.md"));
+  const identityUser = readOptionalFile(pathFiles.identity);
+  if (identityPrompt || identityUser) {
+    const identityParts = [identityPrompt, identityUser].filter(Boolean);
+    staticParts.push(`## Identity\n\n${identityParts.join("\n\n")}`);
+    loaded.push("identity");
+  }
+
+  // 2. Core behaviour — custom.md replaces base.md wholesale when present.
+  const custom = readOptionalFile(resolve(promptDir, "custom.md"));
+  const basePrompt = readOptionalFile(resolve(promptDir, "base.md"));
+  if (custom) {
+    staticParts.push(custom);
+    loaded.push("custom");
+  } else if (basePrompt) {
+    staticParts.push(basePrompt);
+    loaded.push("base");
+  } else staticParts.push("You are a sharp and helpful AI assistant.");
+
+  // 3. Frontend capabilities (telegram.md / discord.md / teams.md / …).
+  const frontendFile = `${inputs.frontend ?? "telegram"}.md`;
+  const frontendPrompt = readOptionalFile(resolve(promptDir, frontendFile));
+  if (frontendPrompt) {
+    staticParts.push(frontendPrompt);
+    loaded.push(frontendFile.replace(".md", ""));
+  }
+
+  // 4. Persistent memory — size-capped so a memory file that has grown
+  //    for months can't bloat every session from turn 0.
+  const memory = readOptionalFile(pathFiles.memory);
+  if (memory) {
+    const { text, truncated } = capMemory(memory);
+    staticParts.push(
+      loadSystemTemplate("persistent-memory", {
+        content: text,
+        truncated: truncated ? "yes" : undefined,
+      }),
+    );
+    loaded.push(truncated ? "memory(capped)" : "memory");
+  }
+
+  // 5. Capability docs — workspace layout, cron, triggers. Concise by
+  //    design: per-tool protocols and examples live in the MCP tool
+  //    descriptions, which the model also has in context.
+  staticParts.push(
+    loadSystemTemplate("workspace"),
+    loadSystemTemplate("cron"),
+    loadSystemTemplate("triggers"),
+  );
+
+  // 6. Plugin contributions. Static: they only change on plugin
+  //    reload, which triggers a full rebuild.
+  if (inputs.pluginPromptAdditions) {
+    for (const addition of inputs.pluginPromptAdditions) {
+      staticParts.push(addition);
+    }
+  }
+
+  // Dynamic 1: daily-memory pointer (names today's file — read on
+  // demand, not injected; changes at midnight).
+  const { today } = todayAndYesterday();
+  dynamicParts.push(
+    loadSystemTemplate("daily-memory", {
+      daily_dir: dirs.dailyMemory,
+      today,
+    }),
+  );
+
+  // Dynamic 2: workspace file listing (sizes change as logs grow).
+  const workspaceFiles = renderWorkspaceListing(dirs.workspace);
+  if (workspaceFiles) dynamicParts.push(workspaceFiles);
+
+  const loadedKey = loaded.join(" + ");
+  if (loadedKey && loadedKey !== lastLoggedPromptKey) {
+    log("config", `System prompt: ${loadedKey}`);
+    lastLoggedPromptKey = loadedKey;
+  }
+
+  return {
+    staticText: staticParts.join("\n\n---\n\n"),
+    dynamicText: dynamicParts.join("\n\n---\n\n"),
+  };
+}

--- a/src/core/prompt/index.ts
+++ b/src/core/prompt/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Prompt subsystem — barrel export.
+ *
+ * One stop for everything system-prompt:
+ *   - `assemble`          — section pipeline + static/dynamic split
+ *   - `templates`         — package-owned `prompts/system/*.md` loader
+ *   - `workspace-listing` — lazy workspace tree for the dynamic tail
+ *
+ * The per-session freezing/caching of assembled prompts lives in
+ * `backend/shared/system-prompt.ts` (it is a backend concern); the
+ * delivery-contract suffix builders live in
+ * `backend/shared/delivery-contract.ts`.
+ */
+
+export {
+  assembleSystemPrompt,
+  joinSystemPromptParts,
+  MEMORY_INJECT_MAX_CHARS,
+  type AssemblePromptInputs,
+  type SystemPromptParts,
+} from "./assemble.js";
+
+export {
+  loadSystemTemplate,
+  renderTemplate,
+  clearTemplateCache,
+  PACKAGE_PROMPTS_DIR,
+  type TemplateVars,
+} from "./templates.js";
+
+export { renderWorkspaceListing } from "./workspace-listing.js";

--- a/src/core/prompt/templates.ts
+++ b/src/core/prompt/templates.ts
@@ -1,0 +1,89 @@
+/**
+ * Package-owned prompt templates — loader + minimal renderer.
+ *
+ * Talon's prompt text lives in two places with different ownership:
+ *
+ *   - **User-editable prompts** (`identity.md`, `base.md`/`custom.md`,
+ *     frontend files like `telegram.md`) are seeded once into
+ *     `~/.talon/prompts/` and read from there — user edits win, and
+ *     package updates deliberately never overwrite them.
+ *
+ *   - **System templates** (`prompts/system/*.md` — delivery
+ *     contracts, capability docs, section wrappers) are read straight
+ *     from the PACKAGE directory and are NOT seeded. They describe
+ *     runtime behaviour that is versioned with the code (tool names,
+ *     flow enforcement, trigger limits); a stale seeded copy would
+ *     silently document a contract the code no longer implements.
+ *
+ * Template syntax — kept deliberately tiny:
+ *
+ *   - `{{name}}` — substitute the variable (missing → empty string).
+ *   - `{{#if name}}…{{/if}}` — keep the enclosed text only when the
+ *     variable is present and non-empty. No nesting, no else.
+ *
+ * Templates are cached per (file, no-vars) read: the file content is
+ * read once per process; rendering with vars is pure string work.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ── Package prompt directory ────────────────────────────────────────────────
+
+/** Absolute path to the package's `prompts/` directory. */
+export const PACKAGE_PROMPTS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../prompts",
+);
+
+const SYSTEM_DIR = resolve(PACKAGE_PROMPTS_DIR, "system");
+
+// ── Renderer ────────────────────────────────────────────────────────────────
+
+export type TemplateVars = Record<string, string | undefined>;
+
+/**
+ * Render `{{#if name}}…{{/if}}` blocks then `{{name}}` substitutions.
+ * Unknown variables render as empty strings — a template must degrade
+ * to readable prose when an optional var (e.g. a frontend without
+ * reactions) is absent.
+ */
+export function renderTemplate(template: string, vars: TemplateVars): string {
+  const withConditionals = template.replace(
+    /\{\{#if\s+(\w+)\}\}([\s\S]*?)\{\{\/if\}\}/g,
+    (_m, name: string, body: string) => (vars[name] ? body : ""),
+  );
+  return withConditionals.replace(
+    /\{\{(\w+)\}\}/g,
+    (_m, name: string) => vars[name] ?? "",
+  );
+}
+
+// ── Loader ──────────────────────────────────────────────────────────────────
+
+const fileCache = new Map<string, string>();
+
+/**
+ * Load a system template by name (e.g. `"contract-tool-only"`) and
+ * render it with `vars`. Throws if the file is missing — system
+ * templates ship with the package, so absence is a packaging bug, not
+ * a user-configuration state.
+ */
+export function loadSystemTemplate(
+  name: string,
+  vars: TemplateVars = {},
+): string {
+  const path = resolve(SYSTEM_DIR, `${name}.md`);
+  let raw = fileCache.get(path);
+  if (raw === undefined) {
+    raw = readFileSync(path, "utf-8").trim();
+    fileCache.set(path, raw);
+  }
+  return renderTemplate(raw, vars);
+}
+
+/** Test seam: drop the file cache (e.g. after writing fixture templates). */
+export function clearTemplateCache(): void {
+  fileCache.clear();
+}

--- a/src/core/prompt/workspace-listing.ts
+++ b/src/core/prompt/workspace-listing.ts
@@ -1,0 +1,91 @@
+/**
+ * Workspace file listing for the system prompt's dynamic tail.
+ *
+ * Renders a compact tree of `~/.talon/workspace/` so the model knows
+ * what artifacts exist. Volatile by nature (file sizes change as logs
+ * grow), so it always belongs to the DYNAMIC prompt part — never the
+ * cacheable static prefix.
+ *
+ * Any directory with more than `COLLAPSE_THRESHOLD` rendered entries
+ * collapses to a single `name/ (N files)` summary line, so per-file
+ * sizes inside such a directory are never needed. The tree is built
+ * lazily: `statSync` is deferred to render time and only ever called
+ * for files that actually appear in the output. The eager
+ * implementation stat'd every file during the walk — on a workspace
+ * with tens of thousands of files (logs, build artifacts, media) that
+ * meant one blocking syscall per file on every session start, just to
+ * print a handful of summary lines.
+ */
+
+import { readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+const COLLAPSE_THRESHOLD = 8;
+
+// A node contributes `count` rendered lines to its parent (used to
+// decide the collapse) and renders those lines lazily via `render()`.
+type Node = { count: number; render: () => string[] };
+
+function buildNode(dir: string, prefix: string): Node {
+  const children: Node[] = [];
+  try {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      if (
+        e.name.startsWith(".") ||
+        e.name === "node_modules" ||
+        e.name === "talon.log"
+      )
+        continue;
+      const full = resolve(dir, e.name);
+      if (e.isDirectory()) {
+        const sub = buildNode(full, `${prefix}${e.name}/`);
+        if (sub.count === 0) continue; // empty dir → omitted
+        if (sub.count <= COLLAPSE_THRESHOLD) {
+          children.push(sub); // expand inline
+        } else {
+          // Collapse to one summary line — never render (or stat) the
+          // files inside.
+          const line = `${prefix}${e.name}/ (${sub.count} files)`;
+          children.push({ count: 1, render: () => [line] });
+        }
+      } else {
+        children.push({
+          count: 1,
+          render: () => {
+            let sz = 0;
+            try {
+              sz = statSync(full).size;
+            } catch {
+              /* file vanished between readdir and stat — show 0B */
+            }
+            return [
+              `${prefix}${e.name} (${sz < 1024 ? sz + "B" : (sz / 1024).toFixed(0) + "KB"})`,
+            ];
+          },
+        });
+      }
+    }
+  } catch {
+    /* unreadable dir → treat as empty */
+  }
+  const count = children.reduce((n, c) => n + c.count, 0);
+  return { count, render: () => children.flatMap((c) => c.render()) };
+}
+
+/**
+ * Render the `## Current Workspace Contents` section, or an empty
+ * string when the workspace is missing or empty.
+ */
+export function renderWorkspaceListing(workspaceDir: string): string {
+  try {
+    const files = buildNode(workspaceDir, "").render();
+    if (files.length === 0) return "";
+    return (
+      "## Current Workspace Contents\n\n" +
+      files.map((f) => `  ${f}`).join("\n")
+    );
+  } catch {
+    /* no workspace yet */
+    return "";
+  }
+}

--- a/src/core/tools/mcp-env.ts
+++ b/src/core/tools/mcp-env.ts
@@ -1,0 +1,94 @@
+/**
+ * Talon MCP server environment — the single place that defines the
+ * env-var contract between backends (which spawn `mcp-server.ts` as a
+ * subprocess) and the server itself (which reads these vars at boot).
+ *
+ * Before this helper, four backends (claude-sdk, codex, openai-agents,
+ * kilo/opencode via remote-server) each hand-built the same
+ * `{TALON_BRIDGE_URL, TALON_CHAT_ID, TALON_FRONTEND}` literal —
+ * adding a variable meant editing all four. Now they call
+ * `buildTalonMcpEnv` and new vars propagate everywhere.
+ *
+ * Tool-surface trimming: every registered MCP tool costs context
+ * tokens in EVERY session (name + description + schema). Deployments
+ * that never use whole tool groups (stickers, polls, triggers, …) can
+ * reclaim that budget via `disabledToolTags` / `disabledTools` in
+ * talon.json — carried to the subprocess as comma-separated env vars.
+ */
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+// ── Env-var names (shared constants, not stringly-typed call sites) ────────
+
+export const ENV_BRIDGE_URL = "TALON_BRIDGE_URL";
+export const ENV_CHAT_ID = "TALON_CHAT_ID";
+export const ENV_FRONTEND = "TALON_FRONTEND";
+export const ENV_DISABLED_TOOLS = "TALON_DISABLED_TOOLS";
+export const ENV_DISABLED_TOOL_TAGS = "TALON_DISABLED_TOOL_TAGS";
+
+// ── Builder (backend side) ──────────────────────────────────────────────────
+
+/** The slice of TalonConfig the MCP env cares about. */
+export type ToolExclusionConfig = {
+  disabledTools?: readonly string[];
+  disabledToolTags?: readonly string[];
+};
+
+export type TalonMcpEnvInputs = {
+  bridgeUrl: string;
+  chatId: string;
+  frontend: string;
+  /** Pass the Talon config (or the exclusion slice of it) when available. */
+  config?: ToolExclusionConfig | null;
+};
+
+/** Build the env map for spawning Talon's unified MCP tool server. */
+export function buildTalonMcpEnv(
+  inputs: TalonMcpEnvInputs,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    [ENV_BRIDGE_URL]: inputs.bridgeUrl,
+    [ENV_CHAT_ID]: inputs.chatId,
+    [ENV_FRONTEND]: inputs.frontend,
+  };
+  const tools = inputs.config?.disabledTools;
+  if (tools?.length) env[ENV_DISABLED_TOOLS] = tools.join(",");
+  const tags = inputs.config?.disabledToolTags;
+  if (tags?.length) env[ENV_DISABLED_TOOL_TAGS] = tags.join(",");
+  return env;
+}
+
+// ── Spawn spec ──────────────────────────────────────────────────────────────
+
+/**
+ * The command line that launches Talon's unified MCP tool server.
+ *
+ * tsx as a Node loader is passed via `--import <file-url>`: Node
+ * accepts URLs or absolute paths, but on Windows a raw backslash path
+ * is ambiguous between path and URL — `pathToFileURL` always parses
+ * as a loader URL. `node --import` (vs spawning `npx`/`tsx` directly)
+ * also sidesteps the Node 20.19+ refusal to spawn `.cmd` shims
+ * without `shell: true` (CVE-2024-27980 mitigation).
+ *
+ * Returns a fresh array: callers wrap it in their own supervisor
+ * (`wrapMcpServer` / `wrapMcpCommand`) and may mutate it.
+ */
+export function talonMcpServerCommand(): string[] {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const tsxImport = pathToFileURL(
+    resolve(here, "../../../node_modules/tsx/dist/esm/index.mjs"),
+  ).href;
+  return ["node", "--import", tsxImport, resolve(here, "mcp-server.ts")];
+}
+
+// ── Parser (server side) ────────────────────────────────────────────────────
+
+/** Parse a comma-separated env var into a trimmed, de-blanked list. */
+export function parseEnvList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}

--- a/src/core/tools/mcp-server.ts
+++ b/src/core/tools/mcp-server.ts
@@ -15,7 +15,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { composeTools } from "./index.js";
 import { createBridge, textResult } from "./bridge.js";
-import type { ToolFrontend } from "./types.js";
+import {
+  ENV_DISABLED_TOOLS,
+  ENV_DISABLED_TOOL_TAGS,
+  parseEnvList,
+} from "./mcp-env.js";
+import type { ToolFrontend, ToolTag } from "./types.js";
 
 process.on("unhandledRejection", (err) => {
   const detail =
@@ -60,8 +65,25 @@ const bridge = createBridge(BRIDGE_URL, CHAT_ID);
 const serverName = `${FRONTEND}-tools`;
 const server = new McpServer({ name: serverName, version: "3.0.0" });
 
-// Compose and register all tools for the active frontend
-const tools = composeTools({ frontend: FRONTEND });
+// Compose and register the tool set for the active frontend, minus
+// any config-disabled tools/tags (see `disabledTools` /
+// `disabledToolTags` in talon.json — every registered tool costs
+// context tokens in every session, so unused groups are trimmable).
+// `end_turn` is exempt: tool-only backends need it to close every turn.
+const excludeNames = parseEnvList(process.env[ENV_DISABLED_TOOLS]).filter(
+  (name) => name !== "end_turn",
+);
+const excludeTags = parseEnvList(
+  process.env[ENV_DISABLED_TOOL_TAGS],
+) as ToolTag[];
+
+const tools = composeTools({ frontend: FRONTEND, excludeTags, excludeNames });
+if (excludeTags.length > 0 && !tools.some((t) => t.name === "end_turn")) {
+  const endTurn = composeTools({ frontend: FRONTEND }).find(
+    (t) => t.name === "end_turn",
+  );
+  if (endTurn) tools.push(endTurn);
+}
 
 for (const tool of tools) {
   server.tool(tool.name, tool.description, tool.schema, async (params) =>

--- a/src/frontend/discord/actions.ts
+++ b/src/frontend/discord/actions.ts
@@ -2,7 +2,7 @@
  * Discord-specific action handlers.
  *
  * Handles MCP tool actions that require the Discord API. Platform-agnostic
- * actions (cron, fetch_url, history) are handled by core/gateway-actions.ts
+ * actions (cron, fetch_url, history) are handled by core/engine/gateway-actions.ts
  * before this is called. The gateway maps a request to this handler by
  * numeric chatId; we resolve it back to a Discord channel via the registry
  * maintained in handlers.ts.
@@ -35,8 +35,8 @@ import {
   ButtonStyle,
   ChannelType,
 } from "discord.js";
-import { withRetry } from "../../core/gateway.js";
-import type { Gateway } from "../../core/gateway.js";
+import { withRetry } from "../../core/engine/gateway.js";
+import type { Gateway } from "../../core/engine/gateway.js";
 import type { ActionResult } from "../../core/types.js";
 import { lookupDiscordChat, sendChunked } from "./handlers.js";
 import { suppressMentions, safeSlice, DISCORD_MAX_TEXT } from "./formatting.js";

--- a/src/frontend/discord/admin.ts
+++ b/src/frontend/discord/admin.ts
@@ -18,7 +18,7 @@ import {
   validateCronExpression,
 } from "../../storage/cron-store.js";
 import { getActiveCount } from "../../core/dispatcher.js";
-import { getPulseStatus } from "../../core/pulse.js";
+import { getPulseStatus } from "../../core/background/pulse.js";
 import { getHealthStatus, getRecentErrors } from "../../util/watchdog.js";
 import { formatDuration, formatModelLabel } from "./helpers.js";
 import {

--- a/src/frontend/discord/admin.ts
+++ b/src/frontend/discord/admin.ts
@@ -9,7 +9,7 @@
 import { readFileSync } from "node:fs";
 import { files, dirs } from "../../util/paths.js";
 import type { TalonConfig } from "../../util/config.js";
-import type { Gateway } from "../../core/gateway.js";
+import type { Gateway } from "../../core/engine/gateway.js";
 import { resetSession, getAllSessions } from "../../storage/sessions.js";
 import { clearHistory } from "../../storage/history.js";
 import { getChatSettings } from "../../storage/chat-settings.js";
@@ -17,7 +17,7 @@ import {
   getAllCronJobs,
   validateCronExpression,
 } from "../../storage/cron-store.js";
-import { getActiveCount } from "../../core/dispatcher.js";
+import { getActiveCount } from "../../core/engine/dispatcher.js";
 import { getPulseStatus } from "../../core/background/pulse.js";
 import { getHealthStatus, getRecentErrors } from "../../util/watchdog.js";
 import { formatDuration, formatModelLabel } from "./helpers.js";

--- a/src/frontend/discord/callbacks.ts
+++ b/src/frontend/discord/callbacks.ts
@@ -48,7 +48,7 @@ import {
   disablePulse,
   enablePulse,
   isPulseEnabled,
-} from "../../core/pulse.js";
+} from "../../core/background/pulse.js";
 import { isInteractionAllowed, registerDiscordChat } from "./handlers.js";
 import {
   renderSettingsText,
@@ -62,7 +62,7 @@ import {
   getBackendIdForChat,
   resolveChatBackend,
 } from "../../core/backend-controller.js";
-import { resolveActiveModelForChat } from "../../core/active-model.js";
+import { resolveActiveModelForChat } from "../../core/models/active-model.js";
 import {
   displayReasoningEffort,
   getActiveReasoningLevels,

--- a/src/frontend/discord/callbacks.ts
+++ b/src/frontend/discord/callbacks.ts
@@ -33,7 +33,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import type { TalonConfig } from "../../util/config.js";
-import type { Gateway } from "../../core/gateway.js";
+import type { Gateway } from "../../core/engine/gateway.js";
 import {
   getChatSettings,
   setChatModelForBackend,
@@ -56,18 +56,18 @@ import {
   formatDuration,
   EFFORT_DESCRIPTIONS,
 } from "./helpers.js";
-import { execute } from "../../core/dispatcher.js";
+import { execute } from "../../core/engine/dispatcher.js";
 import { deriveNumericChatId } from "../../util/chat-id.js";
 import {
   getBackendIdForChat,
   resolveChatBackend,
-} from "../../core/backend-controller.js";
+} from "../../core/engine/backend-controller.js";
 import { resolveActiveModelForChat } from "../../core/models/active-model.js";
 import {
   displayReasoningEffort,
   getActiveReasoningLevels,
   supportsReasoningLevel,
-} from "../reasoning-levels.js";
+} from "../shared/reasoning-levels.js";
 import { appendDailyLog } from "../../storage/daily-log.js";
 import { logError } from "../../util/log.js";
 import {

--- a/src/frontend/discord/commands.ts
+++ b/src/frontend/discord/commands.ts
@@ -34,7 +34,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import type { TalonConfig } from "../../util/config.js";
-import type { Gateway } from "../../core/gateway.js";
+import type { Gateway } from "../../core/engine/gateway.js";
 import { files } from "../../util/paths.js";
 import {
   resetSession,
@@ -74,12 +74,15 @@ import {
 import { getLoadedPlugins } from "../../core/plugin.js";
 import { getMetrics } from "../../util/metrics.js";
 import { handleAdminSubcommand } from "./admin.js";
-import { buildCacheDisplay, buildContextDisplay } from "../status-context.js";
+import {
+  buildCacheDisplay,
+  buildContextDisplay,
+} from "../shared/status-context.js";
 import {
   displayReasoningEffort,
   getActiveReasoningLevels,
   supportsReasoningLevel,
-} from "../reasoning-levels.js";
+} from "../shared/reasoning-levels.js";
 import {
   isAdmin,
   isInteractionAllowed,
@@ -89,7 +92,7 @@ import { deriveNumericChatId } from "../../util/chat-id.js";
 import {
   getBackendIdForChat,
   resolveChatBackend,
-} from "../../core/backend-controller.js";
+} from "../../core/engine/backend-controller.js";
 import { resolveActiveModelForChat } from "../../core/models/active-model.js";
 
 import { log, logError, logWarn } from "../../util/log.js";

--- a/src/frontend/discord/commands.ts
+++ b/src/frontend/discord/commands.ts
@@ -57,8 +57,8 @@ import {
   enablePulse,
   isPulseEnabled,
   resetPulseCheckpoint,
-} from "../../core/pulse.js";
-import { forceDream } from "../../core/dream.js";
+} from "../../core/background/pulse.js";
+import { forceDream } from "../../core/background/dream.js";
 import { getWorkspaceDiskUsage } from "../../util/workspace.js";
 import { appendDailyLog } from "../../storage/daily-log.js";
 import {
@@ -90,7 +90,7 @@ import {
   getBackendIdForChat,
   resolveChatBackend,
 } from "../../core/backend-controller.js";
-import { resolveActiveModelForChat } from "../../core/active-model.js";
+import { resolveActiveModelForChat } from "../../core/models/active-model.js";
 
 import { log, logError, logWarn } from "../../util/log.js";
 import {

--- a/src/frontend/discord/handlers.ts
+++ b/src/frontend/discord/handlers.ts
@@ -17,7 +17,7 @@ import { resolve } from "node:path";
 import type { Client, Message, Attachment, TextBasedChannel } from "discord.js";
 import { ChannelType } from "discord.js";
 import type { TalonConfig } from "../../util/config.js";
-import { execute } from "../../core/dispatcher.js";
+import { execute } from "../../core/engine/dispatcher.js";
 import { classify, friendlyMessage } from "../../core/errors.js";
 import {
   appendDailyLog,

--- a/src/frontend/discord/helpers.ts
+++ b/src/frontend/discord/helpers.ts
@@ -7,8 +7,8 @@
  *  - chat IDs are Discord snowflakes (strings), not numbers.
  */
 
-import { resolveModel } from "../../core/models.js";
-import { REASONING_LEVEL_DESCRIPTIONS } from "../../core/reasoning-levels.js";
+import { resolveModel } from "../../core/models/catalog.js";
+import { REASONING_LEVEL_DESCRIPTIONS } from "../../core/models/reasoning-levels.js";
 import { DISCORD_MAX_TEXT, DISCORD_SAFE_RESERVE } from "./formatting.js";
 
 const DEFAULT_PULSE_INTERVAL_MS = 5 * 60 * 1000;

--- a/src/frontend/discord/index.ts
+++ b/src/frontend/discord/index.ts
@@ -23,7 +23,7 @@ import {
 import { once } from "node:events";
 import type { TalonConfig } from "../../util/config.js";
 import type { ContextManager } from "../../core/types.js";
-import type { Gateway } from "../../core/gateway.js";
+import type { Gateway } from "../../core/engine/gateway.js";
 import { log, logError, logWarn } from "../../util/log.js";
 import { createDiscordActionHandler } from "./actions.js";
 import {

--- a/src/frontend/discord/middleware.ts
+++ b/src/frontend/discord/middleware.ts
@@ -18,7 +18,7 @@ import type { Client, Message } from "discord.js";
 import { ChannelType } from "discord.js";
 import type { TalonConfig } from "../../util/config.js";
 import { pushMessage } from "../../storage/history.js";
-import { registerChat } from "../../core/pulse.js";
+import { registerChat } from "../../core/background/pulse.js";
 import { deriveNumericChatId } from "../../util/chat-id.js";
 import { handleMessage, getSenderName } from "./handlers.js";
 

--- a/src/frontend/reasoning-levels.ts
+++ b/src/frontend/reasoning-levels.ts
@@ -1,11 +1,11 @@
 import type { ReasoningEffortLevel, UnifiedModelInfo } from "../core/types.js";
 import type { Backend } from "../core/agent-runtime/capabilities.js";
-import { resolveActiveModelForChat } from "../core/active-model.js";
+import { resolveActiveModelForChat } from "../core/models/active-model.js";
 import type { TalonConfig } from "../util/config.js";
 import {
   normalizeReasoningLevels,
   supportsReasoningLevel,
-} from "../core/reasoning-levels.js";
+} from "../core/models/reasoning-levels.js";
 export { supportsReasoningLevel };
 
 export type ActiveReasoningLevels = {

--- a/src/frontend/shared/reasoning-levels.ts
+++ b/src/frontend/shared/reasoning-levels.ts
@@ -1,11 +1,14 @@
-import type { ReasoningEffortLevel, UnifiedModelInfo } from "../core/types.js";
-import type { Backend } from "../core/agent-runtime/capabilities.js";
-import { resolveActiveModelForChat } from "../core/models/active-model.js";
-import type { TalonConfig } from "../util/config.js";
+import type {
+  ReasoningEffortLevel,
+  UnifiedModelInfo,
+} from "../../core/types.js";
+import type { Backend } from "../../core/agent-runtime/capabilities.js";
+import { resolveActiveModelForChat } from "../../core/models/active-model.js";
+import type { TalonConfig } from "../../util/config.js";
 import {
   normalizeReasoningLevels,
   supportsReasoningLevel,
-} from "../core/models/reasoning-levels.js";
+} from "../../core/models/reasoning-levels.js";
 export { supportsReasoningLevel };
 
 export type ActiveReasoningLevels = {

--- a/src/frontend/shared/status-context.ts
+++ b/src/frontend/shared/status-context.ts
@@ -1,4 +1,4 @@
-import type { CacheMetricsSupport } from "../core/types.js";
+import type { CacheMetricsSupport } from "../../core/types.js";
 
 export interface ContextDisplay {
   known: boolean;

--- a/src/frontend/teams/actions.ts
+++ b/src/frontend/teams/actions.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ActionResult, FrontendActionHandler } from "../../core/types.js";
-import type { Gateway } from "../../core/gateway.js";
+import type { Gateway } from "../../core/engine/gateway.js";
 import { buildAdaptiveCard, splitTeamsMessage } from "./formatting.js";
 import { log, logError } from "../../util/log.js";
 import { proxyFetch } from "./proxy-fetch.js";

--- a/src/frontend/teams/index.ts
+++ b/src/frontend/teams/index.ts
@@ -10,13 +10,13 @@
 
 import type { TalonConfig } from "../../util/config.js";
 import type { ContextManager } from "../../core/types.js";
-import type { Gateway } from "../../core/gateway.js";
+import type { Gateway } from "../../core/engine/gateway.js";
 import { log, logError } from "../../util/log.js";
 import { deriveNumericChatId } from "../../util/chat-id.js";
 import { resolveModel } from "../../core/models/catalog.js";
 import { createTeamsActionHandler, postToTeams } from "./actions.js";
 import { splitTeamsMessage, buildAdaptiveCard } from "./formatting.js";
-import { buildCacheDisplay } from "../status-context.js";
+import { buildCacheDisplay } from "../shared/status-context.js";
 import {
   initGraphClient,
   type GraphClient,
@@ -164,7 +164,7 @@ export function createTeamsFrontend(
       if (!graphClient) throw new Error("Graph client not initialized");
 
       const chatId = graphClient.getStoredChatId()!;
-      const { execute } = await import("../../core/dispatcher.js");
+      const { execute } = await import("../../core/engine/dispatcher.js");
 
       log("teams", "Teams frontend running");
       log("teams", `Send: Power Automate webhook`);

--- a/src/frontend/teams/index.ts
+++ b/src/frontend/teams/index.ts
@@ -13,7 +13,7 @@ import type { ContextManager } from "../../core/types.js";
 import type { Gateway } from "../../core/gateway.js";
 import { log, logError } from "../../util/log.js";
 import { deriveNumericChatId } from "../../util/chat-id.js";
-import { resolveModel } from "../../core/models.js";
+import { resolveModel } from "../../core/models/catalog.js";
 import { createTeamsActionHandler, postToTeams } from "./actions.js";
 import { splitTeamsMessage, buildAdaptiveCard } from "./formatting.js";
 import { buildCacheDisplay } from "../status-context.js";

--- a/src/frontend/telegram/actions.ts
+++ b/src/frontend/telegram/actions.ts
@@ -3,7 +3,7 @@
  *
  * Handles MCP tool actions that require the Telegram Bot API.
  * Platform-agnostic actions (cron, fetch_url, history) are handled
- * by core/gateway-actions.ts before this is called.
+ * by core/engine/gateway-actions.ts before this is called.
  */
 
 import {
@@ -29,8 +29,8 @@ import {
   getOnlineCount as userbotOnlineCount,
   saveStickerPack as userbotSaveStickerPack,
 } from "./userbot.js";
-import { withRetry } from "../../core/gateway.js";
-import type { Gateway } from "../../core/gateway.js";
+import { withRetry } from "../../core/engine/gateway.js";
+import type { Gateway } from "../../core/engine/gateway.js";
 import type { ActionResult } from "../../core/types.js";
 import { logWarn, logError } from "../../util/log.js";
 

--- a/src/frontend/telegram/admin.ts
+++ b/src/frontend/telegram/admin.ts
@@ -15,7 +15,7 @@ import {
   validateCronExpression,
 } from "../../storage/cron-store.js";
 import { getActiveCount } from "../../core/dispatcher.js";
-import { getPulseStatus } from "../../core/pulse.js";
+import { getPulseStatus } from "../../core/background/pulse.js";
 import { getHealthStatus, getRecentErrors } from "../../util/watchdog.js";
 import { formatDuration, formatModelLabel } from "./helpers.js";
 

--- a/src/frontend/telegram/admin.ts
+++ b/src/frontend/telegram/admin.ts
@@ -14,7 +14,7 @@ import {
   getAllCronJobs,
   validateCronExpression,
 } from "../../storage/cron-store.js";
-import { getActiveCount } from "../../core/dispatcher.js";
+import { getActiveCount } from "../../core/engine/dispatcher.js";
 import { getPulseStatus } from "../../core/background/pulse.js";
 import { getHealthStatus, getRecentErrors } from "../../util/watchdog.js";
 import { formatDuration, formatModelLabel } from "./helpers.js";

--- a/src/frontend/telegram/callbacks.ts
+++ b/src/frontend/telegram/callbacks.ts
@@ -20,7 +20,7 @@ import {
   listAvailableBackends,
   rebindChat,
   releaseChat,
-} from "../../core/backend-controller.js";
+} from "../../core/engine/backend-controller.js";
 import {
   registerChat,
   disablePulse,
@@ -54,7 +54,7 @@ import {
   displayReasoningEffort,
   getActiveReasoningLevels,
   supportsReasoningLevel,
-} from "../reasoning-levels.js";
+} from "../shared/reasoning-levels.js";
 
 /**
  * Wrapper around `editMessageText` that swallows Telegram's

--- a/src/frontend/telegram/callbacks.ts
+++ b/src/frontend/telegram/callbacks.ts
@@ -27,7 +27,7 @@ import {
   enablePulse,
   isPulseEnabled,
   resetPulseCheckpoint,
-} from "../../core/pulse.js";
+} from "../../core/background/pulse.js";
 import { handleCallbackQuery } from "./handlers.js";
 import { escapeHtml } from "./formatting.js";
 import {
@@ -49,7 +49,7 @@ import {
   resolveBackendForChat,
   toggleChatFreeOnly,
 } from "./model-menu.js";
-import { resolveActiveModelForChat } from "../../core/active-model.js";
+import { resolveActiveModelForChat } from "../../core/models/active-model.js";
 import {
   displayReasoningEffort,
   getActiveReasoningLevels,

--- a/src/frontend/telegram/commands.ts
+++ b/src/frontend/telegram/commands.ts
@@ -28,8 +28,8 @@ import {
   enablePulse,
   isPulseEnabled,
   resetPulseCheckpoint,
-} from "../../core/pulse.js";
-import { forceDream } from "../../core/dream.js";
+} from "../../core/background/pulse.js";
+import { forceDream } from "../../core/background/dream.js";
 import { isUserClientReady } from "./userbot.js";
 import { getWorkspaceDiskUsage } from "../../util/workspace.js";
 import { appendDailyLog } from "../../storage/daily-log.js";
@@ -53,7 +53,7 @@ import {
   resolveBackendForChat,
 } from "./model-menu.js";
 import { getBackendIdForChat } from "../../core/backend-controller.js";
-import { resolveActiveModelForChat } from "../../core/active-model.js";
+import { resolveActiveModelForChat } from "../../core/models/active-model.js";
 
 import {
   displayReasoningEffort,

--- a/src/frontend/telegram/commands.ts
+++ b/src/frontend/telegram/commands.ts
@@ -52,18 +52,21 @@ import {
   buildModelMenuViewForChat,
   resolveBackendForChat,
 } from "./model-menu.js";
-import { getBackendIdForChat } from "../../core/backend-controller.js";
+import { getBackendIdForChat } from "../../core/engine/backend-controller.js";
 import { resolveActiveModelForChat } from "../../core/models/active-model.js";
 
 import {
   displayReasoningEffort,
   getActiveReasoningLevels,
   supportsReasoningLevel,
-} from "../reasoning-levels.js";
+} from "../shared/reasoning-levels.js";
 import { handleAdminCommand } from "./admin.js";
 import { getLoadedPlugins } from "../../core/plugin.js";
 import { getMetrics } from "../../util/metrics.js";
-import { buildCacheDisplay, buildContextDisplay } from "../status-context.js";
+import {
+  buildCacheDisplay,
+  buildContextDisplay,
+} from "../shared/status-context.js";
 
 // Admin user ID is set via talon.json or TALON_ADMIN_USER_ID env var
 let ADMIN_USER_ID = 0;

--- a/src/frontend/telegram/handlers.ts
+++ b/src/frontend/telegram/handlers.ts
@@ -6,7 +6,7 @@
 import type { Bot, Context } from "grammy";
 import type { TalonConfig } from "../../util/config.js";
 import { markdownToTelegramHtml, escapeHtml } from "./formatting.js";
-import { execute } from "../../core/dispatcher.js";
+import { execute } from "../../core/engine/dispatcher.js";
 import { classify, friendlyMessage } from "../../core/errors.js";
 import { writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";

--- a/src/frontend/telegram/helpers.ts
+++ b/src/frontend/telegram/helpers.ts
@@ -3,10 +3,10 @@
  */
 
 import { escapeHtml } from "./formatting.js";
-import type { ModelInfo } from "../../core/models.js";
+import type { ModelInfo } from "../../core/models/catalog.js";
 import type { ReasoningEffortLevel } from "../../core/types.js";
-import { REASONING_LEVEL_LABELS } from "../../core/reasoning-levels.js";
-import { getModels, resolveModel, resolveModelId } from "../../core/models.js";
+import { REASONING_LEVEL_LABELS } from "../../core/models/reasoning-levels.js";
+import { getModels, resolveModel, resolveModelId } from "../../core/models/catalog.js";
 const DEFAULT_PULSE_INTERVAL_MS = 5 * 60 * 1000;
 const DEFAULT_METRICS_MESSAGE_MAX = 3800;
 

--- a/src/frontend/telegram/helpers.ts
+++ b/src/frontend/telegram/helpers.ts
@@ -6,7 +6,11 @@ import { escapeHtml } from "./formatting.js";
 import type { ModelInfo } from "../../core/models/catalog.js";
 import type { ReasoningEffortLevel } from "../../core/types.js";
 import { REASONING_LEVEL_LABELS } from "../../core/models/reasoning-levels.js";
-import { getModels, resolveModel, resolveModelId } from "../../core/models/catalog.js";
+import {
+  getModels,
+  resolveModel,
+  resolveModelId,
+} from "../../core/models/catalog.js";
 const DEFAULT_PULSE_INTERVAL_MS = 5 * 60 * 1000;
 const DEFAULT_METRICS_MESSAGE_MAX = 3800;
 

--- a/src/frontend/telegram/index.ts
+++ b/src/frontend/telegram/index.ts
@@ -11,7 +11,7 @@ import { autoRetry } from "@grammyjs/auto-retry";
 import { apiThrottler } from "@grammyjs/transformer-throttler";
 import type { TalonConfig } from "../../util/config.js";
 import type { ContextManager } from "../../core/types.js";
-import type { Gateway } from "../../core/gateway.js";
+import type { Gateway } from "../../core/engine/gateway.js";
 import { createTelegramActionHandler, sendText } from "./actions.js";
 import { initUserClient, disconnectUserClient } from "./userbot.js";
 import { registerCommands, setAdminUserId } from "./commands.js";

--- a/src/frontend/telegram/middleware.ts
+++ b/src/frontend/telegram/middleware.ts
@@ -7,7 +7,7 @@ import type { Bot } from "grammy";
 import type { TalonConfig } from "../../util/config.js";
 import { pushMessage } from "../../storage/history.js";
 import { allowChat, revokeChat } from "./userbot.js";
-import { registerChat } from "../../core/pulse.js";
+import { registerChat } from "../../core/background/pulse.js";
 import { log } from "../../util/log.js";
 import { getSenderName } from "./handlers.js";
 import {

--- a/src/frontend/telegram/model-menu.ts
+++ b/src/frontend/telegram/model-menu.ts
@@ -44,7 +44,7 @@ import {
   getChatSettings,
   setChatFreeOnly,
 } from "../../storage/chat-settings.js";
-import { resolveActiveModelForChat } from "../../core/active-model.js";
+import { resolveActiveModelForChat } from "../../core/models/active-model.js";
 
 /**
  * Resolve the backend serving a given chat right now.

--- a/src/frontend/telegram/model-menu.ts
+++ b/src/frontend/telegram/model-menu.ts
@@ -39,7 +39,7 @@ import {
   hasChatBackendOverride,
   listAvailableBackends,
   resolveChatBackend,
-} from "../../core/backend-controller.js";
+} from "../../core/engine/backend-controller.js";
 import {
   getChatSettings,
   setChatFreeOnly,

--- a/src/frontend/terminal/commands.ts
+++ b/src/frontend/terminal/commands.ts
@@ -12,7 +12,7 @@ import type { Renderer } from "./renderer.js";
 import { formatTimeAgo } from "./renderer.js";
 import { isTerminalChatId } from "../../util/chat-id.js";
 import { resolveModel as coreResolveModel } from "../../core/models/catalog.js";
-import { buildCacheDisplay } from "../status-context.js";
+import { buildCacheDisplay } from "../shared/status-context.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/frontend/terminal/commands.ts
+++ b/src/frontend/terminal/commands.ts
@@ -11,7 +11,7 @@ import type { Backend } from "../../core/agent-runtime/capabilities.js";
 import type { Renderer } from "./renderer.js";
 import { formatTimeAgo } from "./renderer.js";
 import { isTerminalChatId } from "../../util/chat-id.js";
-import { resolveModel as coreResolveModel } from "../../core/models.js";
+import { resolveModel as coreResolveModel } from "../../core/models/catalog.js";
 import { buildCacheDisplay } from "../status-context.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -166,7 +166,7 @@ export function registerBuiltinCommands(): void {
             ctx.renderer.writeln(`  …and ${total - list.length} more`);
           }
         } else {
-          const { getModels } = await import("../../core/models.js");
+          const { getModels } = await import("../../core/models/catalog.js");
           const names = getModels()
             .map((m) => m.aliases[0] ?? m.id)
             .join(", ");

--- a/src/frontend/terminal/index.ts
+++ b/src/frontend/terminal/index.ts
@@ -11,7 +11,7 @@
 import pc from "picocolors";
 import type { TalonConfig } from "../../util/config.js";
 import type { ContextManager, ActionResult } from "../../core/types.js";
-import type { Gateway } from "../../core/gateway.js";
+import type { Gateway } from "../../core/engine/gateway.js";
 import { log } from "../../util/log.js";
 import {
   deriveNumericChatId,
@@ -26,7 +26,7 @@ import {
   clearCommands,
   type CommandContext,
 } from "./commands.js";
-import { buildCacheDisplay } from "../status-context.js";
+import { buildCacheDisplay } from "../shared/status-context.js";
 
 // ── State ────────────────────────────────────────────────────────────────────
 
@@ -156,7 +156,7 @@ export function createTerminalFrontend(
       );
       renderer.writeln(`  ${pc.dim("─".repeat(renderer.cols - 2))}`);
 
-      const { execute } = await import("../../core/dispatcher.js");
+      const { execute } = await import("../../core/engine/dispatcher.js");
       const { getSessionInfo } = await import("../../storage/sessions.js");
       const input = createInput(`  ${pc.green("❯")} `);
 

--- a/src/frontend/terminal/index.ts
+++ b/src/frontend/terminal/index.ts
@@ -17,7 +17,7 @@ import {
   deriveNumericChatId,
   generateTerminalChatId,
 } from "../../util/chat-id.js";
-import { resolveModel } from "../../core/models.js";
+import { resolveModel } from "../../core/models/catalog.js";
 import { createRenderer } from "./renderer.js";
 import { createInput } from "./input.js";
 import {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,14 +15,14 @@ import { flushTriggers } from "./storage/trigger-store.js";
 import { flushHistory } from "./storage/history.js";
 import { flushMediaIndex } from "./storage/media-index.js";
 import { getActiveCount } from "./core/dispatcher.js";
-import { startPulseTimer, stopPulseTimer } from "./core/pulse.js";
+import { startPulseTimer, stopPulseTimer } from "./core/background/pulse.js";
 import {
   startHeartbeatTimer,
   stopHeartbeatTimer,
   awaitCurrentRun as awaitHeartbeat,
-} from "./core/heartbeat.js";
-import { startCronTimer, stopCronTimer } from "./core/cron.js";
-import { shutdownTriggers } from "./core/triggers.js";
+} from "./core/background/heartbeat.js";
+import { startCronTimer, stopCronTimer } from "./core/background/cron.js";
+import { shutdownTriggers } from "./core/background/triggers.js";
 import { startWatchdog, stopWatchdog } from "./util/watchdog.js";
 import { log, logError, logWarn } from "./util/log.js";
 import { bootstrap, initBackendAndDispatcher } from "./bootstrap.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { flushCronJobs } from "./storage/cron-store.js";
 import { flushTriggers } from "./storage/trigger-store.js";
 import { flushHistory } from "./storage/history.js";
 import { flushMediaIndex } from "./storage/media-index.js";
-import { getActiveCount } from "./core/dispatcher.js";
+import { getActiveCount } from "./core/engine/dispatcher.js";
 import { startPulseTimer, stopPulseTimer } from "./core/background/pulse.js";
 import {
   startHeartbeatTimer,
@@ -26,7 +26,7 @@ import { shutdownTriggers } from "./core/background/triggers.js";
 import { startWatchdog, stopWatchdog } from "./util/watchdog.js";
 import { log, logError, logWarn } from "./util/log.js";
 import { bootstrap, initBackendAndDispatcher } from "./bootstrap.js";
-import { Gateway } from "./core/gateway.js";
+import { Gateway } from "./core/engine/gateway.js";
 import type { Frontend } from "./bootstrap.js";
 
 // ── Bootstrap ────────────────────────────────────────────────────────────────
@@ -81,7 +81,7 @@ gateway.backend = backend;
 // touch the gateway field — those roles run from their own getBackend
 // providers (dispatcher routes per chat).
 const { onBackendChange, roleHolder } =
-  await import("./core/backend-controller.js");
+  await import("./core/engine/backend-controller.js");
 const CHAT_ROLE_HOLDER = roleHolder("chat");
 onBackendChange((holder, newBackend, info) => {
   if (holder !== CHAT_ROLE_HOLDER) return;

--- a/src/storage/chat-settings.ts
+++ b/src/storage/chat-settings.ts
@@ -34,7 +34,7 @@ export type ChatSettings = {
    * orphan-bug class (model from backend X persisting when switching
    * to backend Y).
    *
-   * Resolution order (see `core/active-model.ts`):
+   * Resolution order (see `core/models/active-model.ts`):
    *   1. `modelByBackend[activeBackend]` if it validates on the catalog
    *   2. `backend.getDefaultModel()` (canonical for backends that have one)
    *   3. `config.backendDefaults[activeBackend]` (operator override)
@@ -490,4 +490,4 @@ export const EFFORT_LEVELS: EffortLevel[] = [
  * Resolve a user-provided model name (alias or full ID) to the canonical model ID.
  * Delegates to the model registry; falls through unknown names unchanged.
  */
-export { resolveModelId as resolveModelName } from "../core/models.js";
+export { resolveModelId as resolveModelName } from "../core/models/catalog.js";

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -1,17 +1,14 @@
-import {
-  existsSync,
-  readFileSync,
-  mkdirSync,
-  readdirSync,
-  statSync,
-} from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, mkdirSync } from "node:fs";
 import writeFileAtomic from "write-file-atomic";
 import { z } from "zod";
 import { dirs, files as pathFiles } from "./paths.js";
-import { setTimezone, todayAndYesterday } from "./time.js";
-import { log } from "./log.js";
+import { setTimezone } from "./time.js";
 import { BACKEND_IDS } from "../core/agent-runtime/model-ref.js";
+import {
+  assembleSystemPrompt,
+  joinSystemPromptParts,
+  type SystemPromptParts,
+} from "../core/prompt/assemble.js";
 
 /**
  * Backend-id literal source.
@@ -319,32 +316,13 @@ const configSchema = z.object({
   teamsGraphPollMs: z.number().int().min(5000).default(10000),
 });
 
-/**
- * System prompt split for prompt-cache friendliness.
- *
- * `staticText` holds everything that is stable for the lifetime of a
- * session (identity, base/frontend prompts, memory file, tool docs,
- * plugin additions). `dynamicText` holds volatile context (workspace
- * file listing, daily-memory pointer) that changes between rebuilds.
- *
- * The Claude SDK backend sends these as separate blocks divided by
- * `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`, so the static prefix is eligible
- * for cross-session prompt caching while volatile content lives after
- * the cache boundary. Other backends join them into a single string —
- * keeping volatile content last still maximises their providers'
- * automatic prefix caching.
- */
-export type SystemPromptParts = {
-  staticText: string;
-  dynamicText: string;
-};
-
-/** Join the two prompt parts into the single-string form. */
-export function joinSystemPromptParts(parts: SystemPromptParts): string {
-  if (!parts.dynamicText) return parts.staticText;
-  if (!parts.staticText) return parts.dynamicText;
-  return `${parts.staticText}\n\n---\n\n${parts.dynamicText}`;
-}
+// System-prompt assembly lives in core/prompt/ (section pipeline,
+// templates, workspace listing). Re-exported here so existing
+// consumers keep importing from util/config.
+export {
+  joinSystemPromptParts,
+  type SystemPromptParts,
+} from "../core/prompt/assemble.js";
 
 export type TalonConfig = z.infer<typeof configSchema> & {
   systemPrompt: string;
@@ -405,233 +383,9 @@ function ensureConfigFile(): boolean {
 }
 
 // ── System prompt assembly ──────────────────────────────────────────────────
+// Delegated to core/prompt/assemble.ts — see that module for the
+// section pipeline, file ownership rules, and the static/dynamic split.
 
-function readOptionalFile(path: string): string {
-  try {
-    if (existsSync(path)) return readFileSync(path, "utf-8").trim();
-  } catch {
-    /* ignore */
-  }
-  return "";
-}
-
-let lastLoggedPromptKey = "";
-
-/**
- * Assemble the system prompt from prompt files, memory, and plugin
- * additions.
- *
- * Returns a static/dynamic split (see `SystemPromptParts`). Everything
- * volatile — the workspace file listing (file sizes change as logs
- * grow) and the daily-memory pointer (contains today's date) — goes in
- * `dynamicText` so the static prefix stays byte-identical between
- * rebuilds as long as the prompt files, memory, and plugins are
- * unchanged. A byte-identical static prefix is what makes provider
- * prompt caching hit across sessions.
- *
- * Deliberately omitted: a "Current Date & Time" section. Every user
- * message already carries a `[YYYY-MM-DD HH:MM:SS]` tag (see
- * `formatUserPrompt`), the daily-memory pointer names today's file,
- * and the `check_time` tool covers timezone queries. A minute-precision
- * timestamp in the system prompt was the single biggest cache-buster:
- * it guaranteed every rebuild produced a unique prompt.
- */
-function loadSystemPrompt(
-  frontend?: string,
-  pluginPromptAdditions?: string[],
-): SystemPromptParts {
-  const promptDir = dirs.prompts;
-  const parts: string[] = [];
-  const dynamicParts: string[] = [];
-
-  const loaded: string[] = [];
-
-  // Identity — static personality from prompts/identity.md + dynamic config from ~/.talon/workspace/identity.md
-  const identityPrompt = readOptionalFile(resolve(promptDir, "identity.md"));
-  const identityUser = readOptionalFile(pathFiles.identity);
-  if (identityPrompt || identityUser) {
-    const identityParts = [identityPrompt, identityUser].filter(Boolean);
-    parts.push(`## Identity\n\n${identityParts.join("\n\n")}`);
-    loaded.push("identity");
-  }
-
-  // Load base prompt (shared across all frontends)
-  const custom = readOptionalFile(resolve(promptDir, "custom.md"));
-  const basePrompt = readOptionalFile(resolve(promptDir, "base.md"));
-  if (custom) {
-    parts.push(custom);
-    loaded.push("custom");
-  } else if (basePrompt) {
-    parts.push(basePrompt);
-    loaded.push("base");
-  } else parts.push("You are a sharp and helpful AI assistant.");
-
-  // Load frontend-specific prompt
-  const frontendFile = `${frontend ?? "telegram"}.md`;
-  const frontendPrompt = readOptionalFile(resolve(promptDir, frontendFile));
-  if (frontendPrompt) {
-    parts.push(frontendPrompt);
-    loaded.push(frontendFile.replace(".md", ""));
-  }
-
-  const memory = readOptionalFile(pathFiles.memory);
-  if (memory) {
-    parts.push(
-      `## Persistent Memory\n\nThe following is your memory file. Reference it naturally. Update it via the Write tool when you learn important new information.\nFile: ~/.talon/workspace/memory/memory.md\n\n${memory}`,
-    );
-    loaded.push("memory");
-  }
-
-  // Point the bot at daily memory files (read on demand, not injected).
-  // Dynamic: names today's file, so it changes at midnight.
-  const { today } = todayAndYesterday();
-  dynamicParts.push(
-    `## Daily Memory\n\nYour daily notes are stored in \`${dirs.dailyMemory}/\`. Today's file is \`${today}.md\`. Use the Read tool to check recent daily notes when you need context from previous days.`,
-  );
-
-  const loadedKey = loaded.join(" + ");
-  if (loadedKey && loadedKey !== lastLoggedPromptKey) {
-    log("config", `System prompt: ${loadedKey}`);
-    lastLoggedPromptKey = loadedKey;
-  }
-
-  // Workspace file listing for context. Dynamic: file sizes change as
-  // logs grow, so even back-to-back rebuilds differ.
-  //
-  // Any directory with more than 8 rendered entries collapses to a single
-  // `name/ (N files)` summary line, so the per-file sizes inside such a
-  // directory are computed and then thrown away. The tree is therefore built
-  // lazily: `statSync` is deferred to render time and is only ever called for
-  // files that actually appear in the output. The earlier implementation
-  // stat'd every file eagerly during the walk — on a workspace with tens of
-  // thousands of files (logs, build artifacts, media) that meant one blocking
-  // `statSync` syscall per file on every session start, walking the whole
-  // tree just to print a handful of summary lines.
-  const workspaceDir = dirs.workspace;
-  let workspaceFiles = "";
-  try {
-    // A node contributes `count` rendered lines to its parent (used to decide
-    // the >8 collapse) and renders those lines lazily via `render()`.
-    type Node = { count: number; render: () => string[] };
-
-    const buildNode = (dir: string, prefix: string): Node => {
-      const children: Node[] = [];
-      try {
-        for (const e of readdirSync(dir, { withFileTypes: true })) {
-          if (
-            e.name.startsWith(".") ||
-            e.name === "node_modules" ||
-            e.name === "talon.log"
-          )
-            continue;
-          const full = resolve(dir, e.name);
-          if (e.isDirectory()) {
-            const sub = buildNode(full, `${prefix}${e.name}/`);
-            if (sub.count === 0) continue; // empty dir → omitted
-            if (sub.count <= 8) {
-              children.push(sub); // expand inline
-            } else {
-              // Collapse to one summary line — never render (or stat) the
-              // files inside.
-              const line = `${prefix}${e.name}/ (${sub.count} files)`;
-              children.push({ count: 1, render: () => [line] });
-            }
-          } else {
-            children.push({
-              count: 1,
-              render: () => {
-                let sz = 0;
-                try {
-                  sz = statSync(full).size;
-                } catch {
-                  /* file vanished between readdir and stat — show 0B */
-                }
-                return [
-                  `${prefix}${e.name} (${sz < 1024 ? sz + "B" : (sz / 1024).toFixed(0) + "KB"})`,
-                ];
-              },
-            });
-          }
-        }
-      } catch {
-        /* unreadable dir → treat as empty */
-      }
-      const count = children.reduce((n, c) => n + c.count, 0);
-      return { count, render: () => children.flatMap((c) => c.render()) };
-    };
-
-    const files = buildNode(workspaceDir, "").render();
-    if (files.length > 0)
-      workspaceFiles =
-        "## Current Workspace Contents\n\n" +
-        files.map((f) => `  ${f}`).join("\n");
-  } catch {
-    /* no workspace yet */
-  }
-  if (workspaceFiles) dynamicParts.push(workspaceFiles);
-
-  parts.push(`## Workspace
-
-You have a workspace directory at \`~/.talon/workspace/\`. This is your home — organize it however you want.
-- \`~/.talon/workspace/memory/memory.md\` is your persistent memory file. Update it when you learn important things.
-- \`~/.talon/workspace/memory/daily/YYYY-MM-DD.md\` is your daily notes file. Write observations, learnings, corrections, and follow-ups here throughout the day. Keep entries concise.
-- Daily interaction logs are saved to \`~/.talon/workspace/logs/\` automatically.
-- Files users send you (photos, docs, voice) are saved to \`~/.talon/workspace/uploads/\`.
-- Persistent cron jobs are managed via the cron tools.
-- Everything else is yours to create and organize as you see fit.
-
-## Cron Jobs
-
-You can create persistent recurring scheduled tasks using cron tools. Jobs survive restarts.
-- \`create_cron_job\` — create a new recurring job with a cron schedule
-- \`list_cron_jobs\` — list all jobs in the current chat
-- \`edit_cron_job\` — modify an existing job (schedule, content, enable/disable)
-- \`delete_cron_job\` — remove a job permanently
-Two job types: "message" sends text directly, "query" runs a Claude prompt with full tool access.
-
----
-
-## Triggers (long-running watcher scripts)
-
-You can author **arbitrary scripts** that run as supervised subprocesses and signal back to wake you up — for polling, watching, or waiting on conditions where a fixed cron schedule doesn't fit. Use these when "check periodically until X" or "fire when Y changes" is a better fit than a calendar.
-
-Tools:
-- \`trigger_create(name, language, script, timeout_seconds?, description?)\` — write and spawn the script
-- \`trigger_list\` — list all triggers in this chat with status, fire count, last error
-- \`trigger_cancel(trigger_id)\` — SIGTERM (then SIGKILL after 5s)
-- \`trigger_logs(trigger_id, lines?)\` — tail of stdout + stderr from the run
-- \`trigger_delete(trigger_id)\` — remove from disk (cancels first if alive)
-
-Languages: \`bash\`, \`python\`, \`node\`.
-
-**Stdout protocol:**
-- A line starting with \`TALON_FIRE: <text>\` fires a wake-up immediately and the script keeps running. Use this for watchers that emit multiple events.
-- Exit 0 → final wake-up with the tail of the log as payload.
-- Exit non-zero → error wake-up with the exit code and log tail.
-- Hard timeout (default 24h, max 7d) → "timed_out" wake-up.
-
-When a trigger fires, you receive a system-prefixed wake-up message containing the trigger name, status, and payload. You decide whether to message the user, take an action, or do nothing.
-
-**Limits:** 5 active triggers per chat. Triggers are killed on Talon shutdown — they do **not** survive a restart. If you need persistence across restarts, recreate them when you see status "terminated" in \`trigger_list\`.
-
-**When to use cron vs triggers:**
-- "Every Monday at 9 AM" → cron (calendar-driven, recurring)
-- "Wake me when this PR merges" → trigger (one-shot, condition-driven)
-- "Tell me if BTC moves >5%" → trigger with mid-run \`TALON_FIRE:\` (long-running, multi-event)`);
-
-  // Plugin system prompt contributions (injected by caller). Static:
-  // they only change on plugin reload, which triggers a full rebuild.
-  if (pluginPromptAdditions) {
-    for (const addition of pluginPromptAdditions) {
-      parts.push(addition);
-    }
-  }
-
-  return {
-    staticText: parts.join("\n\n---\n\n"),
-    dynamicText: dynamicParts.join("\n\n---\n\n"),
-  };
-}
 
 // ── Main loader ─────────────────────────────────────────────────────────────
 
@@ -663,7 +417,7 @@ export function loadConfig(): TalonConfig {
 
   const activeFrontend = frontends[0];
 
-  const promptParts = loadSystemPrompt(activeFrontend);
+  const promptParts = assembleSystemPrompt({ frontend: activeFrontend });
   return {
     ...parsed,
     workspace: dirs.workspace,
@@ -683,10 +437,11 @@ export function rebuildSystemPrompt(
   const frontends = Array.isArray(config.frontend)
     ? config.frontend
     : [config.frontend];
-  const promptParts = loadSystemPrompt(
-    frontends[0],
-    pluginAdditions.length > 0 ? pluginAdditions : undefined,
-  );
+  const promptParts = assembleSystemPrompt({
+    frontend: frontends[0],
+    pluginPromptAdditions:
+      pluginAdditions.length > 0 ? pluginAdditions : undefined,
+  });
   config.systemPromptParts = promptParts;
   config.systemPrompt = joinSystemPromptParts(promptParts);
 }

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -401,7 +401,6 @@ function ensureConfigFile(): boolean {
 // Delegated to core/prompt/assemble.ts — see that module for the
 // section pipeline, file ownership rules, and the static/dynamic split.
 
-
 // ── Main loader ─────────────────────────────────────────────────────────────
 
 export function loadConfig(): TalonConfig {

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -268,6 +268,21 @@ const configSchema = z.object({
   timezone: z.string().optional(),
   plugins: z.array(pluginEntrySchema).default([]),
 
+  /**
+   * Tool-surface trimming. Every registered MCP tool costs context
+   * tokens in every session (name + description + schema), so
+   * deployments that never use a tool group can reclaim that budget:
+   *
+   *   - `disabledToolTags` — hide whole groups by tag, e.g.
+   *     ["stickers", "web", "triggers"]. See ToolTag in core/tools.
+   *   - `disabledTools` — hide individual tools by name.
+   *
+   * `end_turn` can never be disabled: tool-only backends need it to
+   * close every turn.
+   */
+  disabledTools: z.array(z.string()).optional(),
+  disabledToolTags: z.array(z.string()).optional(),
+
   // GitHub — GitHub API access via official MCP server
   github: z
     .object({

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -20,6 +20,7 @@ import {
 import { join, resolve } from "node:path";
 import { log } from "./log.js";
 import { dirs, files as pathFiles } from "./paths.js";
+import { PACKAGE_PROMPTS_DIR } from "../core/prompt/templates.js";
 
 const IDENTITY_SEED = `# Identity
 
@@ -149,12 +150,18 @@ export function initWorkspace(root: string): void {
     writeFileSync(pathFiles.identity, IDENTITY_SEED);
   }
 
-  // Seed prompt files from the package into ~/.talon/prompts/
-  // Only copies files that don't already exist — user edits are preserved.
-  const packagePrompts = resolve(process.cwd(), "prompts");
+  // Seed user-editable prompt files from the package into
+  // ~/.talon/prompts/. Only copies files that don't already exist —
+  // user edits are preserved. Resolved relative to the package (NOT
+  // process.cwd(): a daemon launched from any other directory used to
+  // silently seed nothing). Skipped: the architecture README (docs,
+  // not a prompt) and the system/ subdirectory (package-owned
+  // templates read in place — a seeded copy would go stale; see
+  // prompts/README.md).
+  const packagePrompts = PACKAGE_PROMPTS_DIR;
   if (existsSync(packagePrompts)) {
     for (const file of readdirSync(packagePrompts)) {
-      if (!file.endsWith(".md")) continue;
+      if (!file.endsWith(".md") || file === "README.md") continue;
       const dst = join(dirs.prompts, file);
       if (!existsSync(dst)) {
         copyFileSync(join(packagePrompts, file), dst);


### PR DESCRIPTION
## Summary

Three-commit pass over context efficiency, the prompting system, backend piping, and repo structure.

### Prompt architecture (`e5d1002`)

- **Prompt prose moved out of TS template literals** into `prompts/system/*.md` templates with a minimal `{{var}}` / `{{#if}}` renderer (`core/prompt/templates.ts`). System templates are package-owned and read in place — *not* seeded to `~/.talon/prompts/` — so they can never go stale the way seeded prompt files do.
- **System-prompt assembly extracted** from `util/config.ts` into `core/prompt/assemble.ts` with an explicit, documented section pipeline; the prompt-cache static/dynamic split is preserved end-to-end. `prompts/README.md` is the architecture map.
- **The response-flow contract is now a backend concern, single-sourced** in `backend/shared/delivery-contract.ts` and rendered from the shared templates, parameterized by delivery mode (`tool-only` / `text-or-tools` / `text-preferred`) and per-frontend tool names (Teams uses `send_message`; the registry is extensible via `registerFrontendDeliveryTools`).
- **First-turn flow violations addressed at the root**: claude-sdk previously appended *no* delivery contract — it sat buried mid-prompt in `telegram.md` and contradicted the text-mode backends' suffixes. The contract now lands at the tail of the static prompt (highest salience), a one-line nudge is appended to the turn-0 user message (free on later turns, never perturbs the cached prefix), and the `[FLOW VIOLATION]` reminder is frontend-aware (it used to tell Teams models to call tools that don't exist there).
- **Leaner session start**: `memory.md` injection capped (`MEMORY_INJECT_MAX_CHARS`) with a read-the-rest pointer; frontend prompts stop duplicating MCP tool docs (schemas are in context anyway) — `telegram.md` 109→44 lines; cron/trigger docs condensed to pointers at the tool descriptions.

### Backend piping + metrics (`bdaebac`)

- **One metric vocabulary across all five backends** (`backend/shared/metrics.ts`): `recordToolCall` strips MCP prefixes uniformly (codex was double-counting tools under unstripped keys), `recordTurnMetrics` gives every backend the per-turn histograms only codex had, plus `backend.<id>.*` dimensions, and `recordFlowViolation` centralizes the scratchpad counters (openai-agents never counted cap exhaustion).
- **Tool-surface trimming**: new `disabledTools` / `disabledToolTags` config — each registered MCP tool costs schema tokens in every session (~60 registered by default). `end_turn` cannot be disabled.
- **Dedup**: the MCP env literal (4 copies) and tsx spawn spec (3 copies) collapsed into `core/tools/mcp-env.ts`; three `getActiveFrontends` implementations → `nonTerminalFrontends`.
- **Bug fix**: prompt seeding resolved `prompts/` against `process.cwd()` — a daemon launched from any other directory silently seeded nothing. Now uses the package dir.

### Core restructure + docs (`fa5e46a`)

- `src/core/background/` — heartbeat, dream, pulse, cron, triggers (everything that runs without a user message). `dream.ts` no longer resolves its prompt via a move-fragile module-relative `"../.."`.
- `src/core/models/` — catalog, active-model, reasoning-levels behind a barrel.
- Docs caught up with reality: README and `docs/backends.md` still documented the deleted `QueryBackend` interface and **never mentioned the openai-agents backend** — both now describe the `Backend` capability-slot interface, list all five backends, and document the new config fields.

## Test plan

- Full unit suite: 2,552 passed / 0 failed (the suites failing at import lack optional SDKs locally — identical on `main`).
- `tsc --noEmit` at the exact same 95-error baseline as `main`.
- New unit tests: delivery contracts (all modes + frontend variants), template renderer, MCP env contract, exclusion filtering, memory cap.
- Codex metric assertions migrated to the normalized names; claude-sdk watchdog and workspace-seeding tests updated for the new mocks/behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)