### PR TITLE
fix: four correctness bugs — infinite retry loop, FTS corruption, LIKE injection, nested transaction crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "vitest": "^4.1.3"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {

--- a/src/backend/openai-agents/handler.ts
+++ b/src/backend/openai-agents/handler.ts
@@ -68,7 +68,10 @@ import {
   recordTurnMetrics,
   recordFlowViolation,
 } from "../shared/index.js";
-import { detectFlowViolation } from "../shared/flow-violation.js";
+import {
+  detectFlowViolation,
+  FLOW_VIOLATION_MAX_RETRIES,
+} from "../shared/flow-violation.js";
 
 import {
   buildOpenAiAgentsSuffix,
@@ -103,6 +106,7 @@ export function getActiveAbort(chatId: string): AbortController | undefined {
 export async function handleMessage(
   params: QueryParams,
   _retried = false,
+  _flowRetries = 0,
 ): Promise<QueryResult> {
   const state = getState();
   const config = state.config;
@@ -157,7 +161,7 @@ export async function handleMessage(
   // First-turn nudge — see the claude-sdk handler for rationale: turn 0
   // is where flow violations cluster, and one line in the user message
   // costs nothing on later turns and never touches the cached prefix.
-  if (frontend && previousTurns === 0 && !_retried) {
+  if (frontend && previousTurns === 0 && !_retried && _flowRetries === 0) {
     prompt += `\n\n${buildFirstTurnReminder(frontend)}`;
   }
 
@@ -453,7 +457,10 @@ export async function handleMessage(
           trailingText: streamState.lastTrailingText,
           turnTerminated: streamState.turnTerminated,
           deliveredTextNorms: streamState.deliveredTextNorms,
-          retried: _retried,
+          toolCalls: streamState.toolCalls,
+          retried: _flowRetries > 0,
+          retryCount: _flowRetries,
+          maxRetries: FLOW_VIOLATION_MAX_RETRIES,
           ...(frontend
             ? { reminder: buildFlowViolationReminder(frontend) }
             : {}),
@@ -473,7 +480,11 @@ export async function handleMessage(
 
     if (violation.shouldRetry) {
       // Recursive call owns the `incrementTurns` for this user message.
-      return handleMessage({ ...params, text: violation.reminder }, true);
+      return handleMessage(
+        { ...params, text: violation.reminder },
+        _retried,
+        _flowRetries + 1,
+      );
     }
   }
 
@@ -484,7 +495,7 @@ export async function handleMessage(
   // Guarded by `!_retried` so the FLOW_VIOLATION_REMINDER doesn't get
   // captured as the session name when the retry recurses through this
   // path with `params.text = reminder`.
-  if (previousTurns === 0 && !_retried) {
+  if (previousTurns === 0 && !_retried && _flowRetries === 0) {
     const name = extractSessionName(text);
     if (name) setSessionName(chatId, name);
   }

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -104,16 +104,37 @@ export function getDatabase(path: string = defaultPath()): SqlDatabase {
   return database;
 }
 
-/** Run `fn` inside a transaction; rolls back on throw. */
+let transactionDepth = 0;
+
+/** Run `fn` inside a transaction; rolls back on throw. Nested calls use SAVEPOINTs. */
 export function inTransaction<T>(fn: () => T): T {
   const database = getDatabase();
+  if (transactionDepth > 0) {
+    const sp = `sp${transactionDepth}`;
+    database.exec(`SAVEPOINT "${sp}"`);
+    transactionDepth++;
+    try {
+      const result = fn();
+      database.exec(`RELEASE "${sp}"`);
+      transactionDepth--;
+      return result;
+    } catch (err) {
+      database.exec(`ROLLBACK TO "${sp}"`);
+      database.exec(`RELEASE "${sp}"`);
+      transactionDepth--;
+      throw err;
+    }
+  }
   database.exec("BEGIN");
+  transactionDepth++;
   try {
     const result = fn();
     database.exec("COMMIT");
+    transactionDepth--;
     return result;
   } catch (err) {
     database.exec("ROLLBACK");
+    transactionDepth--;
     throw err;
   }
 }

--- a/src/storage/repositories/history-repo.ts
+++ b/src/storage/repositories/history-repo.ts
@@ -40,7 +40,7 @@ function rowToMessage(row: Row): HistoryMessage {
 export function insert(chatId: string, msg: HistoryMessage): void {
   getDatabase()
     .prepare(
-      `INSERT INTO history_messages (chat_id, ${ROW_COLUMNS})
+      `INSERT OR IGNORE INTO history_messages (chat_id, ${ROW_COLUMNS})
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
@@ -122,13 +122,18 @@ export function bySenderName(
   nameFragment: string,
   limit: number,
 ): HistoryMessage[] {
+  const escaped = nameFragment
+    .toLowerCase()
+    .replace(/\\/g, "\\\\")
+    .replace(/%/g, "\\%")
+    .replace(/_/g, "\\_");
   const rows = getDatabase()
     .prepare(
       `SELECT ${ROW_COLUMNS} FROM history_messages
-       WHERE chat_id = ? AND lower(sender_name) LIKE ?
+       WHERE chat_id = ? AND lower(sender_name) LIKE ? ESCAPE '\\'
        ORDER BY id DESC LIMIT ?`,
     )
-    .all(chatId, `%${nameFragment.toLowerCase()}%`, limit) as Row[];
+    .all(chatId, `%${escaped}%`, limit) as Row[];
   return rows.reverse().map(rowToMessage);
 }
 

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -27,7 +27,7 @@ export const MIGRATIONS: readonly string[] = [
     file_path       TEXT
   );
   CREATE INDEX idx_history_chat ON history_messages(chat_id, id);
-  CREATE INDEX idx_history_chat_msg ON history_messages(chat_id, msg_id);
+  CREATE UNIQUE INDEX idx_history_chat_msg ON history_messages(chat_id, msg_id);
   CREATE INDEX idx_history_chat_sender ON history_messages(chat_id, sender_id, id);
 
   CREATE VIRTUAL TABLE history_fts USING fts5(


### PR DESCRIPTION
## Summary

Deep review of the recent large refactor (SQLite storage layer, daemon control, backend unification, agent-runtime overhaul). Four confirmed correctness bugs found and fixed.

---

### Bug 1 — `openai-agents`: infinite flow-violation retry loop (CRITICAL)

**File:** `src/backend/openai-agents/handler.ts`

The flow-violation retry used a boolean `_retried` flag instead of a counter. Inside `detectFlowViolation`, `retryCount` was derived as `retried ? 1 : 0` — so once the first retry fired and `_retried` became `true`, `retryCount` was permanently stuck at `1` while `maxRetries` is `3`. `shouldRetry` was always `true`, causing **infinite recursive API calls** whenever the model kept violating the delivery contract.

The same call was also missing `toolCalls: streamState.toolCalls`, meaning tool-call-only violations (model calls tools, no trailing text, never calls `end_turn`) were silently missed because the early-exit `if (trailing.length === 0 && toolCalls === 0)` always fired.

**Fix:** Add a `_flowRetries: number` counter (mirroring `_internal.flowRetries` in the claude-sdk handler) that increments on each flow-violation recursion. Pass `retryCount: _flowRetries`, `maxRetries: FLOW_VIOLATION_MAX_RETRIES`, and `toolCalls: streamState.toolCalls` to `detectFlowViolation`. This aligns the openai-agents backend with the claude-sdk behavior.

---

### Bug 2 — `schema.ts`: plain INDEX instead of UNIQUE on `(chat_id, msg_id)` (HIGH)

**File:** `src/storage/schema.ts`, `src/storage/repositories/history-repo.ts`

`idx_history_chat_msg` was created as a plain `INDEX`, not `UNIQUE`. Telegram can redeliver the same update on reconnect; each redelivery inserts a second row with the same `(chat_id, msg_id)`. The FTS5 `history_ai` trigger fires for each duplicate row, corrupting the full-text index. Queries like `recent`, `searchFts`, and `bySenderId` return duplicate messages. `setFilePath` updates all duplicate rows simultaneously. The author was aware of this risk — `byMsgId` has an `ORDER BY id DESC LIMIT 1` workaround — but the other queries have no such guard.

**Fix:** `CREATE UNIQUE INDEX` in migration 1. The `INSERT` in `history-repo.ts` becomes `INSERT OR IGNORE` so idempotent re-delivery is silently deduplicated rather than failing with a constraint error.

---

### Bug 3 — `history-repo.ts`: LIKE wildcard injection in `bySenderName` (MEDIUM)

**File:** `src/storage/repositories/history-repo.ts`

`nameFragment` was embedded directly into a SQL LIKE pattern (`%fragment%`) without escaping `%`, `_`, or `\`. A name fragment containing `%` matches every sender in the chat, leaking all message history regardless of sender. `_` matches any single character. This flows from the `get_user_messages` tool, which exposes `user_name` as a plain `z.string()` with no sanitization — so any user (or the LLM itself) can trigger the unintended matches.

**Fix:** Escape `\`, `%`, and `_` in `nameFragment` before building the pattern, and add `ESCAPE '\\'` to the SQL query.

---

### Bug 4 — `db.ts`: `inTransaction` crashes on nested calls (MEDIUM / latent)

**File:** `src/storage/db.ts`

`inTransaction` issued `database.exec("BEGIN")` unconditionally. SQLite throws `"cannot start a transaction within a transaction"` when `BEGIN` is issued inside an already-active transaction. No current code path triggers this, but the lack of a reentrancy guard means any future composition of two transactional helpers (migration step calling `insertMany`, a batch operation wrapping individual inserts) will crash at runtime with no compile-time warning.

**Fix:** Track a depth counter; use `SAVEPOINT`/`RELEASE`/`ROLLBACK TO` for nested calls — the standard SQLite nested-transaction pattern supported by both `node:sqlite` and `bun:sqlite`.

---

## Test plan

- [ ] All 24 `openai-agents-backend`, `history-persistence`, and `shared-flow-violation` tests pass
- [ ] All 108 `history.*` and `storage-save-errors` tests pass
- [ ] Verify: repeated message delivery from Telegram no longer inserts duplicate rows
- [ ] Verify: `bySenderName("%")` no longer returns all senders
- [ ] Verify: flow violation on openai-agents backend caps at `FLOW_VIOLATION_MAX_RETRIES` (3) retries, not infinite

https://claude.ai/code/session_01NktP7Y4EyokDSvU8P7HyJn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NktP7Y4EyokDSvU8P7HyJn)_