### PR TITLE
chore: doctor verifies native plane; docker context trim; coverage ratchet to 65%

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,17 @@ coverage/
 *.log
 .env
 .git/
+.github/
+docs/
+
+# Test tree — `COPY src/ src/` would otherwise bake ~2300 tests into the
+# production image; the runtime never imports them.
+src/__tests__/
+
+# Native build state — the embedded artifacts in src/native/ are the
+# artifact of record; local cargo/zig/gleam caches are huge and would
+# bloat the docker build context upload.
+native/**/target/
+native/**/.zig-cache/
+native/**/build/
+native/**/*.wasm

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -831,6 +831,40 @@ async function runDoctor(): Promise<void> {
       ? `  ${pc.green("\u2713")} Workspace: ${pc.dim(dirs.root)}`
       : `  ${pc.yellow("!")} Workspace missing`,
   );
+  // Native plane: instantiate the embedded modules (Rust blake3, Zig
+  // textops, Gleam scheduler-core) and verify a known answer from each.
+  // Catches a corrupted install \u2014 truncated artifact, engine without
+  // wasm support \u2014 here instead of mid-message in a frontend.
+  try {
+    const { blake3Hex } = await import("./native/blake3.js");
+    const { splitMessage } = await import("./native/textops.js");
+    const { backoffDelayMs } = await import("./native/scheduler-core.js");
+    const emptyDigest = await blake3Hex("");
+    const chunks = splitMessage("doctor check ".repeat(4), 16);
+    const delayMs = backoffDelayMs(1, { baseMs: 1000, capMs: 2000, seed: 1 });
+    const healthy =
+      emptyDigest ===
+        "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262" &&
+      chunks.length > 1 &&
+      chunks.every((c) => c.length <= 16) &&
+      delayMs >= 750 &&
+      delayMs <= 1250;
+    if (healthy) {
+      console.log(
+        `  ${pc.green("\u2713")} Native modules: blake3 (Rust), textops (Zig), scheduler-core (Gleam)`,
+      );
+    } else {
+      console.log(
+        `  ${pc.red("\u2717")} Native modules loaded but returned unexpected results`,
+      );
+      issues++;
+    }
+  } catch (err) {
+    console.log(
+      `  ${pc.red("\u2717")} Native modules failed to load: ${pc.dim(err instanceof Error ? err.message : String(err))}`,
+    );
+    issues++;
+  }
   // Backend-specific binary check (only required for the active backend).
   const doctorConfig = existsSync(CONFIG_FILE) ? loadConfig() : undefined;
   const activeBackend = doctorConfig?.backend ?? "claude";

--- a/src/frontend/telegram/handlers.ts
+++ b/src/frontend/telegram/handlers.ts
@@ -881,7 +881,6 @@ function createStreamCallbacks(
 async function processAndReply(params: ProcessAndReplyParams): Promise<void> {
   const {
     bot,
-    config,
     chatId,
     numericChatId,
     replyToId,
@@ -920,7 +919,7 @@ async function processAndReply(params: ProcessAndReplyParams): Promise<void> {
       trackDmUser(senderId, senderName, senderUsername);
     }
 
-    const result = await execute({
+    await execute({
       chatId: String(chatId),
       numericChatId,
       prompt,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,11 +47,13 @@ export default defineConfig({
       // Catches "tests dropped on critical code" without being so tight
       // that minor refactors break CI. Tightened over time as the suite
       // grows. Each ratchet should bump in increments of ~5%.
+      // Ratcheted 60 → 65 at actuals of 70.5/69.4/70.5 (2026-06);
+      // branches stays 60 (actual 63.2 — too tight for a 5pt bump).
       thresholds: {
-        lines: 60,
-        functions: 60,
+        lines: 65,
+        functions: 65,
         branches: 60,
-        statements: 60,
+        statements: 65,
       },
     },
   },


### PR DESCRIPTION
## What

Hardening/polish pass continuing #312/#313.

- **`talon doctor` verifies the native plane**: instantiates the embedded Rust (blake3), Zig (textops), and Gleam (scheduler-core) modules and checks a known answer from each — a corrupted install fails the environment check instead of a frontend mid-message.
  ```
  ✓ Native modules: blake3 (Rust), textops (Zig), scheduler-core (Gleam)
  ```
- **Docker context trim**: `.dockerignore` now excludes `src/__tests__/` (the production image was baking in ~2300 tests via `COPY src/ src/`) plus native build caches (cargo `target/` + `.zig-cache` ≈ 48MB of context upload on dev machines).
- **Coverage ratchet 60 → 65** for lines/functions/statements per the config's own ratchet policy (actuals 70.5/70.5/69.4); branches stays 60 (actual 63.2 — a 5pt bump would be too tight).
- Fixes the two unused-variable lint warnings in `telegram/handlers.ts`.

## Tests

Full suite green with coverage thresholds enforced (vitest exit 0), tsc clean, prettier clean, doctor output verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)