### PR TITLE
feat(telegram): /doctor command — shared doctor core with native-module report

### DIFF
--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  checkNativeModules,
+  collectDoctorReport,
+  type DoctorReport,
+} from "../core/doctor.js";
+import { renderDoctorMessage } from "../frontend/telegram/helpers.js";
+
+describe("checkNativeModules", () => {
+  it("verifies all three embedded modules with provenance", async () => {
+    const native = await checkNativeModules();
+    expect(native.map((m) => m.name)).toEqual([
+      "blake3",
+      "textops",
+      "scheduler-core",
+    ]);
+    for (const mod of native) {
+      expect(mod.ok, `${mod.name}: ${mod.note}`).toBe(true);
+    }
+    const byName = Object.fromEntries(native.map((m) => [m.name, m]));
+    expect(byName.blake3.language).toBe("Rust");
+    expect(byName.blake3.sizeBytes).toBeGreaterThan(0);
+    expect(byName.textops.language).toBe("Zig");
+    expect(byName.textops.sizeBytes).toBeGreaterThan(0);
+    expect(byName["scheduler-core"].language).toBe("Gleam");
+    // Gleam compiles to plain JS — there is no embedded wasm artifact.
+    expect(byName["scheduler-core"].sizeBytes).toBeUndefined();
+  });
+});
+
+describe("collectDoctorReport", () => {
+  it("fails the config check when no config file exists", async () => {
+    const report = await collectDoctorReport({ hasConfigFile: false });
+    const labels = report.checks.map((c) => c.label);
+    expect(labels).toContain("No config file");
+    expect(report.issues).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reports a configured bundled backend with zero backend issues", async () => {
+    const report = await collectDoctorReport({
+      hasConfigFile: true,
+      config: { frontend: "terminal", backend: "kilo" },
+    });
+    const labels = report.checks.map((c) => c.label);
+    expect(labels).toContain("Frontend: terminal");
+    expect(labels).toContain("Kilo SDK bundled");
+    expect(report.native).toHaveLength(3);
+    // Node version and workspace presence vary by machine — assert
+    // that nothing *else* (frontend, backend, native) raises an issue.
+    const envCheck = (label: string) =>
+      label.startsWith("Node.js ") || label.startsWith("Workspace");
+    const nonEnvIssues = report.checks.filter(
+      (c) => (c.status === "fail" || c.issue) && !envCheck(c.label),
+    );
+    expect(nonEnvIssues).toEqual([]);
+    expect(report.native.every((m) => m.ok)).toBe(true);
+  });
+
+  it("flags an unconfigured telegram frontend", async () => {
+    const report = await collectDoctorReport({
+      hasConfigFile: true,
+      config: { frontend: "telegram", backend: "opencode" },
+    });
+    const labels = report.checks.map((c) => c.label);
+    expect(labels).toContain("Frontend not fully configured");
+    expect(report.issues).toBeGreaterThanOrEqual(1);
+  });
+
+  it("counts warn checks marked as issues (missing openai-agents auth)", async () => {
+    const prev = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      const report = await collectDoctorReport({
+        hasConfigFile: true,
+        config: { frontend: "terminal", backend: "openai-agents" },
+      });
+      const auth = report.checks.find(
+        (c) => c.label === "OpenAI Agents auth missing",
+      );
+      expect(auth?.status).toBe("warn");
+      expect(auth?.issue).toBe(true);
+      expect(report.issues).toBeGreaterThanOrEqual(1);
+    } finally {
+      if (prev !== undefined) process.env.OPENAI_API_KEY = prev;
+    }
+  });
+});
+
+describe("renderDoctorMessage", () => {
+  const healthyReport: DoctorReport = {
+    checks: [
+      { label: "Node.js 24.0.0", status: "ok" },
+      { label: "Frontend: telegram", status: "ok", detail: "configured" },
+    ],
+    native: [
+      {
+        name: "blake3",
+        language: "Rust",
+        target: "wasm32-unknown-unknown",
+        sizeBytes: 60_000,
+        ok: true,
+      },
+      {
+        name: "scheduler-core",
+        language: "Gleam",
+        target: "JavaScript",
+        ok: true,
+      },
+    ],
+    issues: 0,
+  };
+
+  it("renders sections, modules, process info, and the all-clear", () => {
+    const html = renderDoctorMessage(healthyReport);
+    expect(html).toContain("<b>🩺 Talon Doctor</b>");
+    expect(html).toContain("<b>Environment</b>");
+    expect(html).toContain("<b>Native modules</b>");
+    expect(html).toContain("<code>blake3</code>");
+    expect(html).toContain("Rust → wasm32-unknown-unknown · 58.6 KB");
+    // No size segment for modules without an embedded artifact.
+    expect(html).toContain("Gleam → JavaScript\n");
+    expect(html).toContain("Uptime ");
+    expect(html).toContain(`PID ${process.pid}`);
+    expect(html).toContain("✅ All checks passed.");
+  });
+
+  it("renders failures with counts and escapes HTML in details", () => {
+    const html = renderDoctorMessage({
+      checks: [
+        {
+          label: "Claude Code <binary> not found",
+          status: "fail",
+          detail: "/usr/local/bin/<claude>",
+        },
+      ],
+      native: [
+        {
+          name: "textops",
+          language: "Zig",
+          target: "wasm32-freestanding",
+          ok: false,
+          note: "magic <header> mismatch",
+        },
+      ],
+      issues: 2,
+    });
+    expect(html).toContain("❌ Claude Code &lt;binary&gt; not found");
+    expect(html).toContain("(/usr/local/bin/&lt;claude&gt;)");
+    expect(html).toContain("(magic &lt;header&gt; mismatch)");
+    expect(html).toContain("⚠️ 2 issue(s) found.");
+    expect(html).not.toContain("<claude>");
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -800,164 +800,35 @@ async function tailLogs(): Promise<void> {
 
 // ── Doctor ──────────────────────────────────────────────────────────────────
 
+const DOCTOR_ICONS: Record<string, string> = {
+  ok: pc.green("\u2713"),
+  warn: pc.yellow("!"),
+  fail: pc.red("\u2717"),
+  info: pc.dim("-"),
+};
+
 async function runDoctor(): Promise<void> {
   printBanner();
   console.log(`  ${pc.bold("Environment check")}\n`);
-  let issues = 0;
-  const major = parseInt(process.versions.node.split(".")[0], 10);
-  console.log(
-    major >= 24
-      ? `  ${pc.green("\u2713")} Node.js ${process.versions.node}`
-      : `  ${pc.red("\u2717")} Node.js ${process.versions.node} ${pc.dim("(need >=24)")}`,
-  );
-  if (major < 24) issues++;
-  if (existsSync(CONFIG_FILE)) {
-    const config = loadConfig();
-    const fes = Array.isArray(config.frontend)
-      ? config.frontend
-      : [config.frontend];
-    console.log(
-      isConfigured(config)
-        ? `  ${pc.green("\u2713")} Frontend: ${fes.join(", ")} (configured)`
-        : `  ${pc.red("\u2717")} Frontend not fully configured`,
-    );
-    if (!isConfigured(config)) issues++;
-  } else {
-    console.log(`  ${pc.red("\u2717")} No config file`);
-    issues++;
+  const { collectDoctorReport } = await import("./core/doctor.js");
+  const hasConfigFile = existsSync(CONFIG_FILE);
+  const report = await collectDoctorReport({
+    config: hasConfigFile ? loadConfig() : undefined,
+    hasConfigFile,
+  });
+  for (const check of report.checks) {
+    const detail = check.detail ? ` ${pc.dim(`(${check.detail})`)}` : "";
+    console.log(`  ${DOCTOR_ICONS[check.status]} ${check.label}${detail}`);
   }
-  console.log(
-    existsSync(dirs.root)
-      ? `  ${pc.green("\u2713")} Workspace: ${pc.dim(dirs.root)}`
-      : `  ${pc.yellow("!")} Workspace missing`,
-  );
-  // Native plane: instantiate the embedded modules (Rust blake3, Zig
-  // textops, Gleam scheduler-core) and verify a known answer from each.
-  // Catches a corrupted install \u2014 truncated artifact, engine without
-  // wasm support \u2014 here instead of mid-message in a frontend.
-  try {
-    const { blake3Hex } = await import("./native/blake3.js");
-    const { splitMessage } = await import("./native/textops.js");
-    const { backoffDelayMs } = await import("./native/scheduler-core.js");
-    const emptyDigest = await blake3Hex("");
-    const chunks = splitMessage("doctor check ".repeat(4), 16);
-    const delayMs = backoffDelayMs(1, { baseMs: 1000, capMs: 2000, seed: 1 });
-    const healthy =
-      emptyDigest ===
-        "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262" &&
-      chunks.length > 1 &&
-      chunks.every((c) => c.length <= 16) &&
-      delayMs >= 750 &&
-      delayMs <= 1250;
-    if (healthy) {
-      console.log(
-        `  ${pc.green("\u2713")} Native modules: blake3 (Rust), textops (Zig), scheduler-core (Gleam)`,
-      );
-    } else {
-      console.log(
-        `  ${pc.red("\u2717")} Native modules loaded but returned unexpected results`,
-      );
-      issues++;
-    }
-  } catch (err) {
+  // Native plane, one line per embedded module with provenance.
+  for (const mod of report.native) {
+    const size = mod.sizeBytes
+      ? ` \u00b7 ${(mod.sizeBytes / 1024).toFixed(1)} KB`
+      : "";
+    const note = mod.note ? ` ${pc.dim(`(${mod.note})`)}` : "";
     console.log(
-      `  ${pc.red("\u2717")} Native modules failed to load: ${pc.dim(err instanceof Error ? err.message : String(err))}`,
+      `  ${mod.ok ? pc.green("\u2713") : pc.red("\u2717")} Native: ${mod.name} ${pc.dim(`${mod.language} \u2192 ${mod.target}${size}`)}${note}`,
     );
-    issues++;
-  }
-  // Backend-specific binary check (only required for the active backend).
-  const doctorConfig = existsSync(CONFIG_FILE) ? loadConfig() : undefined;
-  const activeBackend = doctorConfig?.backend ?? "claude";
-  if (activeBackend === "claude") {
-    try {
-      const { execFileSync } = await import("node:child_process");
-      if (doctorConfig?.claudeBinary) {
-        const cmd = process.platform === "win32" ? "where" : "which";
-        try {
-          execFileSync(cmd, [doctorConfig.claudeBinary], { stdio: "pipe" });
-          console.log(
-            `  ${pc.green("\u2713")} Claude Code binary: ${pc.dim(doctorConfig.claudeBinary)}`,
-          );
-        } catch {
-          console.log(
-            `  ${pc.red("\u2717")} Claude Code binary not found: ${pc.dim(doctorConfig.claudeBinary)}`,
-          );
-          issues++;
-        }
-      } else {
-        const lookupCmd = process.platform === "win32" ? "where" : "which";
-        execFileSync(lookupCmd, ["claude"], { stdio: "pipe" });
-        console.log(`  ${pc.green("\u2713")} Claude Code installed`);
-      }
-    } catch {
-      console.log(`  ${pc.red("\u2717")} Claude Code not found`);
-      issues++;
-    }
-  } else if (activeBackend === "codex") {
-    try {
-      const { execFileSync } = await import("node:child_process");
-      const lookupCmd = process.platform === "win32" ? "where" : "which";
-      execFileSync(lookupCmd, ["codex"], { stdio: "pipe" });
-      console.log(`  ${pc.green("\u2713")} Codex CLI installed`);
-      const { detectCodexAuth } = await import("./backend/codex/auth.js");
-      const auth = detectCodexAuth({
-        codexApiKey: doctorConfig?.codexApiKey,
-        openaiApiKey: doctorConfig?.openaiApiKey,
-        openaiBaseUrl: doctorConfig?.openaiBaseUrl,
-      });
-      for (const diagnostic of auth.diagnostics) {
-        console.log(`  ${pc.yellow("!")} ${diagnostic}`);
-      }
-      if (auth.mode !== "none") {
-        console.log(
-          `  ${pc.green("\u2713")} Codex auth: ${pc.dim(
-            auth.baseUrl ? `${auth.source} (${auth.baseUrl})` : auth.source,
-          )}`,
-        );
-      } else {
-        console.log(
-          `  ${pc.yellow("!")} Codex auth missing (set CODEX_API_KEY, TALON_CODEX_KEY, codexApiKey, or run \`codex login\`)`,
-        );
-        issues++;
-      }
-    } catch {
-      console.log(
-        `  ${pc.red("\u2717")} Codex CLI not found (npm i -g @openai/codex)`,
-      );
-      issues++;
-    }
-  } else if (activeBackend === "kilo" || activeBackend === "opencode") {
-    // Kilo / OpenCode are bundled as npm deps \u2014 no external binary to check.
-    console.log(
-      `  ${pc.green("\u2713")} ${activeBackend === "kilo" ? "Kilo" : "OpenCode"} SDK bundled`,
-    );
-  } else if (activeBackend === "openai-agents") {
-    console.log(`  ${pc.green("\u2713")} OpenAI Agents SDK bundled`);
-    const hasEnvKey = Boolean(process.env.OPENAI_API_KEY);
-    const hasCfgKey = Boolean(doctorConfig?.openaiApiKey);
-    const envBase = process.env.OPENAI_BASE_URL;
-    const cfgBase = doctorConfig?.openaiBaseUrl;
-    if (hasEnvKey || hasCfgKey) {
-      const sources: string[] = [];
-      if (hasEnvKey) sources.push("OPENAI_API_KEY env");
-      if (hasCfgKey) sources.push("openaiApiKey in talon.json");
-      console.log(
-        `  ${pc.green("\u2713")} OpenAI Agents auth: ${pc.dim(sources.join(", "))}`,
-      );
-    } else {
-      console.log(
-        `  ${pc.yellow("!")} OpenAI Agents auth missing (set OPENAI_API_KEY or openaiApiKey in talon.json)`,
-      );
-      issues++;
-    }
-    if (envBase || cfgBase) {
-      const baseSrc = envBase ? `env (${envBase})` : `config (${cfgBase})`;
-      console.log(
-        `  ${pc.green("\u2713")} OpenAI-compatible endpoint: ${pc.dim(baseSrc)}`,
-      );
-    } else {
-      console.log(`  ${pc.dim("-")} Endpoint: api.openai.com (default)`);
-    }
   }
   const instance = await findRunningInstance();
   if (instance) {
@@ -966,9 +837,9 @@ async function runDoctor(): Promise<void> {
     console.log(`  ${pc.dim("-")} Bot is not running`);
   }
   console.log(
-    issues === 0
+    report.issues === 0
       ? `\n  ${pc.green("All checks passed.")}\n`
-      : `\n  ${pc.yellow(`${issues} issue(s) found.`)}\n`,
+      : `\n  ${pc.yellow(`${report.issues} issue(s) found.`)}\n`,
   );
 }
 

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -1,0 +1,335 @@
+/**
+ * Doctor — structured environment and native-plane diagnostics.
+ *
+ * One collection pass shared by every surface that reports health:
+ * `talon doctor` renders the report with terminal colors (src/cli.ts),
+ * the Telegram /doctor command renders it as HTML (frontend/telegram).
+ * Keeping the checks here means a new check shows up everywhere at
+ * once instead of drifting per-frontend.
+ *
+ * Checks are pure data (label / status / detail) — no console output,
+ * no process.exit. Renderers decide presentation.
+ */
+
+import { existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { dirs } from "../util/paths.js";
+
+export type DoctorStatus = "ok" | "warn" | "fail" | "info";
+
+export interface DoctorCheck {
+  label: string;
+  status: DoctorStatus;
+  detail?: string;
+  /**
+   * Counts toward the issue total even when status is "warn" — used
+   * for soft failures like missing backend auth where the bot still
+   * starts but a backend won't work.
+   */
+  issue?: boolean;
+}
+
+/** One embedded native module: provenance plus a live self-test result. */
+export interface NativeModuleCheck {
+  name: string;
+  /** Source language ("Rust", "Zig", "Gleam"). */
+  language: string;
+  /** Compile target ("wasm32-unknown-unknown", "wasm32-freestanding", "JavaScript"). */
+  target: string;
+  /** Embedded artifact size, when the module ships as wasm bytes. */
+  sizeBytes?: number;
+  ok: boolean;
+  /** Failure detail when !ok. */
+  note?: string;
+}
+
+export interface DoctorReport {
+  checks: DoctorCheck[];
+  native: NativeModuleCheck[];
+  /** Failed checks + warn-with-issue checks + failed native modules. */
+  issues: number;
+}
+
+/**
+ * The slice of config doctor reads. Both the CLI's local Config and
+ * TalonConfig satisfy this structurally.
+ */
+export interface DoctorConfigSlice {
+  frontend: string | string[];
+  backend?: string;
+  botToken?: string;
+  teamsWebhookUrl?: string;
+  discord?: { botToken?: string };
+  claudeBinary?: string;
+  codexApiKey?: string;
+  openaiApiKey?: string;
+  openaiBaseUrl?: string;
+}
+
+const BLAKE3_EMPTY_DIGEST =
+  "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262";
+
+/** Decoded byte length of a base64 string without materializing it. */
+function base64ByteLength(b64: string): number {
+  let padding = 0;
+  if (b64.endsWith("==")) padding = 2;
+  else if (b64.endsWith("=")) padding = 1;
+  return Math.floor((b64.length * 3) / 4) - padding;
+}
+
+function errorNote(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Instantiate each embedded module and verify a known answer from it.
+ * Catches a corrupted install — truncated artifact, engine without
+ * wasm support — at check time instead of mid-message in a frontend.
+ */
+export async function checkNativeModules(): Promise<NativeModuleCheck[]> {
+  const results: NativeModuleCheck[] = [];
+
+  // Rust → wasm32: BLAKE3 hashing (media dedupe, workspace digests).
+  const blake3: NativeModuleCheck = {
+    name: "blake3",
+    language: "Rust",
+    target: "wasm32-unknown-unknown",
+    ok: false,
+  };
+  try {
+    const { BLAKE3_WASM_BASE64 } =
+      await import("../native/blake3-wasm-bytes.js");
+    blake3.sizeBytes = base64ByteLength(BLAKE3_WASM_BASE64);
+    const { blake3Hex } = await import("../native/blake3.js");
+    const digest = await blake3Hex("");
+    blake3.ok = digest === BLAKE3_EMPTY_DIGEST;
+    if (!blake3.ok) blake3.note = "self-test digest mismatch";
+  } catch (err) {
+    blake3.note = errorNote(err);
+  }
+  results.push(blake3);
+
+  // Zig → wasm32: message splitting (every frontend's chunker).
+  const textops: NativeModuleCheck = {
+    name: "textops",
+    language: "Zig",
+    target: "wasm32-freestanding",
+    ok: false,
+  };
+  try {
+    const { TEXTOPS_WASM_BASE64 } =
+      await import("../native/textops-wasm-bytes.js");
+    textops.sizeBytes = base64ByteLength(TEXTOPS_WASM_BASE64);
+    const { splitMessage } = await import("../native/textops.js");
+    const chunks = splitMessage("doctor check ".repeat(4), 16);
+    textops.ok = chunks.length > 1 && chunks.every((c) => c.length <= 16);
+    if (!textops.ok) textops.note = "self-test split out of bounds";
+  } catch (err) {
+    textops.note = errorNote(err);
+  }
+  results.push(textops);
+
+  // Gleam → JS: scheduler decision core (backoff, breaker, catch-up).
+  const scheduler: NativeModuleCheck = {
+    name: "scheduler-core",
+    language: "Gleam",
+    target: "JavaScript",
+    ok: false,
+  };
+  try {
+    const { backoffDelayMs } = await import("../native/scheduler-core.js");
+    const delayMs = backoffDelayMs(1, { baseMs: 1000, capMs: 2000, seed: 1 });
+    // Attempt 1 at base 1000ms with ±25% jitter must land in [750, 1250].
+    scheduler.ok = delayMs >= 750 && delayMs <= 1250;
+    if (!scheduler.ok)
+      scheduler.note = `self-test delay ${delayMs}ms outside jitter window`;
+  } catch (err) {
+    scheduler.note = errorNote(err);
+  }
+  results.push(scheduler);
+
+  return results;
+}
+
+/** Whether every configured frontend has its required credentials. */
+function frontendConfigured(config: DoctorConfigSlice): boolean {
+  const fes = Array.isArray(config.frontend)
+    ? config.frontend
+    : [config.frontend];
+  return fes.every((fe) => {
+    if (fe === "telegram") return Boolean(config.botToken);
+    if (fe === "terminal") return true;
+    if (fe === "teams") return Boolean(config.teamsWebhookUrl);
+    if (fe === "discord") return Boolean(config.discord?.botToken);
+    return false;
+  });
+}
+
+function binaryOnPath(name: string): boolean {
+  try {
+    const lookupCmd = process.platform === "win32" ? "where" : "which";
+    execFileSync(lookupCmd, [name], { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Binary / auth checks for the active backend only. */
+async function checkBackend(
+  config: DoctorConfigSlice | undefined,
+): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+  const backend = config?.backend ?? "claude";
+
+  if (backend === "claude") {
+    if (config?.claudeBinary) {
+      checks.push(
+        binaryOnPath(config.claudeBinary)
+          ? {
+              label: "Claude Code binary",
+              status: "ok",
+              detail: config.claudeBinary,
+            }
+          : {
+              label: "Claude Code binary not found",
+              status: "fail",
+              detail: config.claudeBinary,
+            },
+      );
+    } else {
+      checks.push(
+        binaryOnPath("claude")
+          ? { label: "Claude Code installed", status: "ok" }
+          : { label: "Claude Code not found", status: "fail" },
+      );
+    }
+  } else if (backend === "codex") {
+    if (!binaryOnPath("codex")) {
+      checks.push({
+        label: "Codex CLI not found",
+        status: "fail",
+        detail: "npm i -g @openai/codex",
+      });
+      return checks;
+    }
+    checks.push({ label: "Codex CLI installed", status: "ok" });
+    const { detectCodexAuth } = await import("../backend/codex/auth.js");
+    const auth = detectCodexAuth({
+      codexApiKey: config?.codexApiKey,
+      openaiApiKey: config?.openaiApiKey,
+      openaiBaseUrl: config?.openaiBaseUrl,
+    });
+    for (const diagnostic of auth.diagnostics) {
+      checks.push({ label: diagnostic, status: "warn" });
+    }
+    if (auth.mode !== "none") {
+      checks.push({
+        label: "Codex auth",
+        status: "ok",
+        detail: auth.baseUrl ? `${auth.source} (${auth.baseUrl})` : auth.source,
+      });
+    } else {
+      checks.push({
+        label: "Codex auth missing",
+        status: "warn",
+        detail:
+          "set CODEX_API_KEY, TALON_CODEX_KEY, codexApiKey, or run `codex login`",
+        issue: true,
+      });
+    }
+  } else if (backend === "kilo" || backend === "opencode") {
+    // Bundled as npm deps — no external binary to check.
+    checks.push({
+      label: `${backend === "kilo" ? "Kilo" : "OpenCode"} SDK bundled`,
+      status: "ok",
+    });
+  } else if (backend === "openai-agents") {
+    checks.push({ label: "OpenAI Agents SDK bundled", status: "ok" });
+    const hasEnvKey = Boolean(process.env.OPENAI_API_KEY);
+    const hasCfgKey = Boolean(config?.openaiApiKey);
+    if (hasEnvKey || hasCfgKey) {
+      const sources: string[] = [];
+      if (hasEnvKey) sources.push("OPENAI_API_KEY env");
+      if (hasCfgKey) sources.push("openaiApiKey in talon.json");
+      checks.push({
+        label: "OpenAI Agents auth",
+        status: "ok",
+        detail: sources.join(", "),
+      });
+    } else {
+      checks.push({
+        label: "OpenAI Agents auth missing",
+        status: "warn",
+        detail: "set OPENAI_API_KEY or openaiApiKey in talon.json",
+        issue: true,
+      });
+    }
+    const envBase = process.env.OPENAI_BASE_URL;
+    const cfgBase = config?.openaiBaseUrl;
+    if (envBase || cfgBase) {
+      checks.push({
+        label: "OpenAI-compatible endpoint",
+        status: "ok",
+        detail: envBase ? `env (${envBase})` : `config (${cfgBase})`,
+      });
+    } else {
+      checks.push({
+        label: "Endpoint: api.openai.com (default)",
+        status: "info",
+      });
+    }
+  }
+
+  return checks;
+}
+
+/**
+ * Run every check and return the structured report. `config` is
+ * undefined when no config file exists yet (first run).
+ */
+export async function collectDoctorReport(opts: {
+  config?: DoctorConfigSlice;
+  hasConfigFile: boolean;
+}): Promise<DoctorReport> {
+  const checks: DoctorCheck[] = [];
+
+  const nodeMajor = parseInt(process.versions.node.split(".")[0], 10);
+  checks.push({
+    label: `Node.js ${process.versions.node}`,
+    status: nodeMajor >= 24 ? "ok" : "fail",
+    detail: nodeMajor >= 24 ? undefined : "need >=24",
+  });
+
+  if (opts.hasConfigFile && opts.config) {
+    const fes = Array.isArray(opts.config.frontend)
+      ? opts.config.frontend
+      : [opts.config.frontend];
+    checks.push(
+      frontendConfigured(opts.config)
+        ? {
+            label: `Frontend: ${fes.join(", ")}`,
+            status: "ok",
+            detail: "configured",
+          }
+        : { label: "Frontend not fully configured", status: "fail" },
+    );
+  } else {
+    checks.push({ label: "No config file", status: "fail" });
+  }
+
+  checks.push(
+    existsSync(dirs.root)
+      ? { label: "Workspace", status: "ok", detail: dirs.root }
+      : { label: "Workspace missing", status: "warn" },
+  );
+
+  const native = await checkNativeModules();
+  checks.push(...(await checkBackend(opts.config)));
+
+  const issues =
+    checks.filter((c) => c.status === "fail" || c.issue).length +
+    native.filter((m) => !m.ok).length;
+
+  return { checks, native, issues };
+}

--- a/src/frontend/telegram/commands.ts
+++ b/src/frontend/telegram/commands.ts
@@ -40,6 +40,7 @@ import {
   formatTokenCount,
   formatBytes,
   parseInterval,
+  renderDoctorMessage,
   renderMetricsMessages,
   renderSettingsText,
   renderSettingsKeyboard,
@@ -53,6 +54,7 @@ import {
   resolveBackendForChat,
 } from "./model-menu.js";
 import { getBackendIdForChat } from "../../core/engine/backend-controller.js";
+import { collectDoctorReport } from "../../core/doctor.js";
 import { resolveActiveModelForChat } from "../../core/models/active-model.js";
 
 import {
@@ -113,6 +115,7 @@ export function registerCommands(
         "<b>Session</b>",
         "  /status -- session info, usage, and stats",
         "  /metrics -- aggregate performance metrics (admin)",
+        "  /doctor -- environment and native-module health (admin)",
         "  /memory -- view what Talon remembers",
         "  /dream -- force memory consolidation now",
         "  /ping -- health check with latency",
@@ -664,6 +667,33 @@ export function registerCommands(
     }
     for (const message of renderMetricsMessages(getMetrics())) {
       await ctx.reply(message, { parse_mode: "HTML" });
+    }
+  });
+
+  bot.command("doctor", async (ctx) => {
+    if (ADMIN_USER_ID && ctx.from?.id !== ADMIN_USER_ID) {
+      await ctx.reply("Not authorized.");
+      return;
+    }
+    const sent = await ctx.reply("🩺 Running checks...");
+    try {
+      // Same checks as `talon doctor` — config exists by definition
+      // when the bot is processing this command.
+      const report = await collectDoctorReport({ config, hasConfigFile: true });
+      await bot.api.editMessageText(
+        ctx.chat.id,
+        sent.message_id,
+        renderDoctorMessage(report),
+        { parse_mode: "HTML" },
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await bot.api.editMessageText(
+        ctx.chat.id,
+        sent.message_id,
+        `🩺 Doctor failed: ${escapeHtml(msg)}`,
+        { parse_mode: "HTML" },
+      );
     }
   });
 

--- a/src/frontend/telegram/helpers.ts
+++ b/src/frontend/telegram/helpers.ts
@@ -3,6 +3,7 @@
  */
 
 import { escapeHtml } from "./formatting.js";
+import type { DoctorReport } from "../../core/doctor.js";
 import type { ModelInfo } from "../../core/models/catalog.js";
 import type { ReasoningEffortLevel } from "../../core/types.js";
 import { REASONING_LEVEL_LABELS } from "../../core/models/reasoning-levels.js";
@@ -208,6 +209,52 @@ export function renderMetricsMessages(
   }
 
   return chunks;
+}
+
+const DOCTOR_ICONS: Record<string, string> = {
+  ok: "✅",
+  warn: "⚠️",
+  fail: "❌",
+  info: "▫️",
+};
+
+/**
+ * Render a DoctorReport as one Telegram HTML message. Same data as
+ * `talon doctor` (src/core/doctor.ts) plus in-process runtime info —
+ * when this renders, the bot is by definition running, so the CLI's
+ * "is the bot up" probe becomes an uptime line instead.
+ */
+export function renderDoctorMessage(report: DoctorReport): string {
+  const lines = ["<b>🩺 Talon Doctor</b>", "", "<b>Environment</b>"];
+
+  for (const check of report.checks) {
+    const detail = check.detail ? ` (${escapeHtml(check.detail)})` : "";
+    lines.push(
+      `${DOCTOR_ICONS[check.status]} ${escapeHtml(check.label)}${detail}`,
+    );
+  }
+
+  lines.push("", "<b>Native modules</b>");
+  for (const mod of report.native) {
+    const size =
+      mod.sizeBytes !== undefined ? ` · ${formatBytes(mod.sizeBytes)}` : "";
+    const note = mod.note ? ` (${escapeHtml(mod.note)})` : "";
+    lines.push(
+      `${mod.ok ? DOCTOR_ICONS.ok : DOCTOR_ICONS.fail} <code>${escapeHtml(mod.name)}</code> — ${escapeHtml(mod.language)} → ${escapeHtml(mod.target)}${size}${note}`,
+    );
+  }
+
+  lines.push(
+    "",
+    "<b>Process</b>",
+    `Uptime ${formatDuration(process.uptime() * 1000)} · PID ${process.pid} · Node ${escapeHtml(process.versions.node)}`,
+    "",
+    report.issues === 0
+      ? `${DOCTOR_ICONS.ok} All checks passed.`
+      : `${DOCTOR_ICONS.warn} ${report.issues} issue(s) found.`,
+  );
+
+  return lines.join("\n");
 }
 
 export function renderSettingsText(

--- a/src/frontend/telegram/index.ts
+++ b/src/frontend/telegram/index.ts
@@ -97,6 +97,10 @@ export function createTelegramFrontend(
         { command: "reset", description: "Clear session and start fresh" },
         { command: "restart", description: "Restart the bot (admin)" },
         { command: "metrics", description: "Aggregate performance metrics" },
+        {
+          command: "doctor",
+          description: "Environment and native-module health",
+        },
         { command: "dream", description: "Force memory consolidation" },
         { command: "plugins", description: "List loaded plugins" },
         { command: "help", description: "All commands and features" },


### PR DESCRIPTION
## What

Adds an admin-gated **`/doctor`** command to the Telegram frontend that runs the same health checks as `talon doctor` and reports them as a formatted HTML message — including a per-module breakdown of the embedded native plane.

## How

- **`src/core/doctor.ts`** (new): the checks move out of `cli.ts` into a shared module returning structured data (`DoctorCheck[]` + `NativeModuleCheck[]` + issue count). Environment (Node, config/frontend, workspace), native-plane self-tests, and active-backend binary/auth checks all live here once, so a new check shows up in every surface.
- **Native module report**: each embedded module is instantiated and verified against a known answer, and reported with provenance — `blake3` (Rust → wasm32-unknown-unknown, 26.3 KB), `textops` (Zig → wasm32-freestanding, 3.4 KB), `scheduler-core` (Gleam → JavaScript) — including embedded artifact sizes.
- **CLI**: `runDoctor` now just renders the shared report with picocolors (~150 lines of inline checks deleted), gaining the per-module native lines.
- **Telegram**: `/doctor` (admin-only, like `/metrics`) edits a "Running checks..." placeholder into the report; renderer lives in `helpers.ts` for unit testing. Registered in `setMyCommands` and `/help`.

Example Telegram output:

```
🩺 Talon Doctor

Environment
✅ Node.js 24.1.0
✅ Frontend: telegram (configured)
✅ Workspace (/home/x/.talon)
✅ Claude Code installed

Native modules
✅ blake3 — Rust → wasm32-unknown-unknown · 26.3 KB
✅ textops — Zig → wasm32-freestanding · 3.4 KB
✅ scheduler-core — Gleam → JavaScript

Process
Uptime 2h 3m · PID 1234 · Node 24.1.0

✅ All checks passed.
```

## Tests

7 new tests in `src/__tests__/doctor.test.ts`: native-module provenance + self-tests, config-file / frontend / bundled-backend / auth-issue report shapes, HTML rendering with escaping. Full suite: 3043 passed, coverage gate (65%) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)