### PR TITLE
feat(native): talon-driver — native launcher binary for apt/brew/source

### DIFF
--- a/.github/scripts/tarball-check.mjs
+++ b/.github/scripts/tarball-check.mjs
@@ -33,6 +33,9 @@ const FORBIDDEN_PATTERNS = [
   /\bid_(rsa|ed25519|ecdsa)$/,
 
   // Build / dev artifacts that should never ship
+  // bin/ must contain only the portable talon.js shim — never the
+  // per-arch talon-driver binary (it would ship one arch to everyone).
+  /^bin\/(?!talon\.js$)/,
   /__tests__\//,
   /\.test\.[mc]?[jt]sx?$/,
   /\.spec\.[mc]?[jt]sx?$/,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
       - name: Cache zig toolchain
         id: zig-cache
         uses: actions/cache@v4
@@ -310,6 +315,22 @@ jobs:
             src/native/textops-wasm-bytes.ts \
             src/native/strsim-wasm-bytes.ts \
             src/native/htmlents-wasm-bytes.ts
+
+      # The talon-driver launcher is a native per-arch binary (not an
+      # embedded artifact), so there is nothing to drift-check — instead
+      # cross-compile the whole distribution matrix as a build guard, so
+      # a source change that breaks any target arch fails here.
+      - name: Cross-compile the launcher (all targets)
+        run: npm run build:driver:all
+
+      # Run the launcher's behavior suite here — this is the only job with
+      # the pinned zig toolchain, so it's where the build-and-drive tests
+      # in src/__tests__/talon-driver.test.ts actually execute (elsewhere
+      # they self-skip when zig is absent).
+      - name: Driver behavior tests
+        run: |
+          npm ci
+          npx vitest run src/__tests__/talon-driver.test.ts
 
   # ── WASM artifact reproducibility ──────────────────────────────
   # The Rust blake3-wasm crate (native/blake3-wasm) is committed alongside

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ native/scheduler-core/build/
 # native module build outputs (artifact of record is the embedded TS module)
 native/*/.zig-cache/
 native/*/*.wasm
+
+# talon-driver launcher — per-arch native binary, built by packaging/CI,
+# never committed (npm keeps shipping the portable bin/talon.js shim).
+bin/talon
+native/talon-driver/dist/

--- a/native/README.md
+++ b/native/README.md
@@ -1,8 +1,9 @@
 # Talon native plane
 
 Talon's hot paths and policy cores are written in systems languages and
-embedded into the TypeScript runtime. Five modules, five languages, one
-contract.
+embedded into the TypeScript runtime. Five embedded modules, five
+languages, one contract — plus a native launcher binary that fronts the
+CLI for the distribution channels.
 
 | Module | Language | Target | Used by |
 | --- | --- | --- | --- |
@@ -11,6 +12,13 @@ contract.
 | [strsim-c](strsim-c/) | C | wasm32-freestanding | "did you mean ...?" for Telegram + CLI (`src/native/strsim.ts`) |
 | [htmlents-cpp](htmlents-cpp/) | C++ | wasm32-freestanding | HTML escaping on every Telegram render (`src/native/htmlents.ts`) |
 | [scheduler-core](scheduler-core/) | Gleam | JavaScript | cron/heartbeat backoff, breaker, catch-up policy (`src/native/scheduler-core.ts`) |
+
+The launcher is a different kind of native component — a real
+executable, not an embedded artifact:
+
+| Component | Language | Target | Role |
+| --- | --- | --- | --- |
+| [talon-driver](talon-driver/) | C | native per-arch ELF / Mach-O | the `talon` front-door: finds Node >= 24, execs `bin/talon.js` (apt / brew / source installs) |
 
 ## The contract
 
@@ -43,12 +51,15 @@ contract.
 Each module only needs its own toolchain:
 
 ```sh
-npm run build:wasm    # Rust  → blake3
-npm run build:zig     # Zig   → textops
-npm run build:c       # C     → strsim
-npm run build:cpp     # C++   → htmlents
-npm run build:gleam   # Gleam → scheduler-core
-npm run build:native  # all five
+npm run build:wasm        # Rust  → blake3
+npm run build:zig         # Zig   → textops
+npm run build:c           # C     → strsim
+npm run build:cpp         # C++   → htmlents
+npm run build:gleam       # Gleam → scheduler-core
+npm run build:native      # all five embedded modules
+
+npm run build:driver      # C launcher → bin/talon (host)
+npm run build:driver:all  # launcher cross-compile matrix → dist/
 ```
 
 ## Adding a module

--- a/native/talon-driver/README.md
+++ b/native/talon-driver/README.md
@@ -1,0 +1,66 @@
+# talon-driver
+
+The native launcher that fronts the Talon CLI for the binary
+distribution channels — apt `.deb`, Homebrew bottle, source install.
+Packaging ships this per-arch executable as `talon`; it finds a usable
+Node, then hands off to the existing JS entry so there is exactly one
+startup code path.
+
+Written in C and compiled with the pinned Zig toolchain (`zig cc`,
+`native/.zig-version`) so it cross-compiles per arch with the same
+driver as the rest of the native plane. (Zig was the first choice, but
+Zig 0.16's process API is mid-refactor into the new `Io` interface with
+no stable `execv`; a launcher this load-bearing wants the boring,
+decades-stable POSIX calls.)
+
+POSIX-only by design: the native-binary channels are apt (Linux) and
+Homebrew (macOS). Windows keeps using the portable `bin/talon.js` npm
+shim, so there is no `execv`/`fork` to emulate there.
+
+## What it does
+
+1. **Resolve the JS entry** next to itself — `talon.js` beside the
+   launcher, then `../bin/talon.js`, then `../lib/talon/bin/talon.js`.
+   `TALON_JS` overrides.
+2. **Resolve Node >= 24.** If `TALON_NODE` is set it is authoritative
+   (used exactly, never overridden by a search). Otherwise, in priority
+   order:
+
+   ```
+   <self>/vendor/node → <self>/node → $PATH
+     → /usr/local/bin, /usr/bin, /opt/homebrew/bin, /opt/local/bin, /snap/bin
+     → $NVM_BIN/node, $VOLTA_HOME/bin/node
+   ```
+
+   The first candidate that exists and reports major >= 24 wins. The
+   `vendor/node` step is what lets a `.deb`/bottle bundle its own Node.
+3. **Hand off** via `execv(node, ["node", talon.js, ...args])` — the
+   launcher *becomes* node, so signals, exit codes, and `ps` all pass
+   straight through.
+4. **Diagnose** misses on stderr with a non-zero exit: no Node found
+   (install hints), only an old Node (reports the version it saw), or a
+   missing JS entry.
+
+The Node version probe runs `node --version` via `fork` + `execl` (no
+shell), so a node path with spaces or shell metacharacters is never
+reinterpreted.
+
+## Build
+
+```sh
+npm run build:driver          # host build → bin/talon
+npm run build:driver:all      # x86_64/aarch64 × linux-musl/macos → dist/
+node build.mjs --target=x86_64-linux-musl   # one cross target
+```
+
+Linux targets use musl, so `zig cc` emits a static binary with no libc
+dependency — one file that runs across distros. The binary is not
+committed (it is per-arch); `bin/talon.js` remains the npm entry point.
+
+## Tests
+
+`src/__tests__/talon-driver.test.ts` builds the launcher and drives the
+real binary against fake `node`/`talon.js` (exit + argv pass-through,
+the `TALON_NODE` override, version-floor rejection, PATH discovery,
+entry resolution). The suite skips when zig is absent; the CI Driver job
+builds and runs it with the pinned toolchain.

--- a/native/talon-driver/build.mjs
+++ b/native/talon-driver/build.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Build manifest for talon-driver — the C launcher compiled to a native
+// per-arch binary via `zig cc` (pinned toolchain, native/.zig-version),
+// the same driver the rest of the native plane builds through.
+//
+// Unlike the wasm modules there is no embedded artifact of record: the
+// launcher is a real executable shipped by the native-binary channels
+// (apt `.deb`, Homebrew bottle, source install), built per arch and not
+// committed. So this script just compiles — there is nothing to embed
+// or drift-check.
+//
+//   node build.mjs                       host build  -> bin/talon
+//   node build.mjs --target=<zig-target> cross build -> native/talon-driver/dist/
+//   node build.mjs --all                 the full distribution matrix
+//
+// Uses only node builtins so it runs on the bare runner node in CI
+// without an `npm ci`.
+import { execFileSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { requirePinnedZig } from "../shared/build-lib.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+const zig = requirePinnedZig();
+
+// The distribution matrix. Linux uses musl so `zig cc` emits a static
+// binary with no libc dependency — one file that runs across distros in
+// a `.deb`. macOS links the system libSystem as usual.
+const TARGETS = [
+  "x86_64-linux-musl",
+  "aarch64-linux-musl",
+  "x86_64-macos",
+  "aarch64-macos",
+];
+
+// -g0: no debug info in the shipped launcher (smaller, cleaner artifact).
+const COMMON_FLAGS = ["-O2", "-g0", "-std=c11", "-Wall", "-Wextra", "-Werror"];
+
+/** Compile for `target` (null = host) and return the output path. */
+function build(target) {
+  const args = ["cc", ...COMMON_FLAGS];
+  if (target) args.push("-target", target);
+
+  let outPath;
+  if (target) {
+    const distDir = join(here, "dist");
+    mkdirSync(distDir, { recursive: true });
+    outPath = join(distDir, `talon-${target}`);
+  } else {
+    outPath = join(repoRoot, "bin", "talon");
+  }
+
+  args.push("src/main.c", "-o", outPath);
+  execFileSync(zig, args, {
+    cwd: here,
+    stdio: "inherit",
+    // Keep the zig cc cache inside the module dir (gitignored) so builds
+    // never depend on or pollute machine-global state.
+    env: {
+      ...process.env,
+      ZIG_LOCAL_CACHE_DIR: join(here, ".zig-cache"),
+      ZIG_GLOBAL_CACHE_DIR: join(here, ".zig-cache", "global"),
+    },
+  });
+  console.log(`built ${outPath}${target ? ` (${target})` : " (host)"}`);
+  return outPath;
+}
+
+const argv = process.argv.slice(2);
+if (argv.includes("--all")) {
+  for (const target of TARGETS) build(target);
+} else {
+  const targetArg = argv.find((a) => a.startsWith("--target="));
+  build(targetArg ? targetArg.slice("--target=".length) : null);
+}

--- a/native/talon-driver/src/main.c
+++ b/native/talon-driver/src/main.c
@@ -1,0 +1,444 @@
+/*
+ * talon — native launcher driver.
+ *
+ * A compiled front-door for the Talon CLI. Packaging layers (apt
+ * `.deb`, Homebrew bottle, source install) ship this per-arch binary
+ * as `talon`; it locates a suitable Node, then hands off to the
+ * existing JS entry (`bin/talon.js`) so there is exactly one startup
+ * code path. The npm install keeps invoking `bin/talon.js` directly —
+ * this driver is for the native-binary distribution channels.
+ *
+ * Responsibilities, in order:
+ *   1. Resolve the JS entry next to ourselves (TALON_JS overrides).
+ *   2. Resolve a Node >= MIN_NODE_MAJOR. If TALON_NODE is set it is
+ *      authoritative — used exactly, never overridden by a search.
+ *      Otherwise the candidates, in priority order, are:
+ *        <self>/vendor/node -> <self>/node -> PATH
+ *          -> common install dirs -> version-manager hints
+ *      The first candidate that exists AND reports major >= the floor
+ *      wins; existing-but-too-old Nodes are remembered for diagnostics.
+ *   3. Replace ourselves with `node <talon.js> <args...>` via execv, so
+ *      signals, exit codes, and `ps` all pass straight through.
+ *   4. On any miss — no Node, only an old Node, missing JS entry —
+ *      print an actionable diagnostic to stderr and exit non-zero.
+ *
+ * POSIX-only by design: the native-binary channels are apt (Linux) and
+ * Homebrew (macOS). Windows keeps using the portable `bin/talon.js`
+ * npm shim, so there is no execv/fork dependency to emulate there.
+ *
+ * Written in C and compiled with the pinned Zig toolchain
+ * (`zig cc`, native/.zig-version) so it cross-compiles per arch with
+ * the same driver as the rest of the native plane. Zig was the first
+ * choice, but Zig 0.16's process API is mid-refactor into the new `Io`
+ * interface (no stable `execv`); a launcher this load-bearing wants the
+ * boring, decades-stable POSIX calls instead.
+ */
+
+#if defined(_WIN32)
+#error "talon-driver is POSIX-only; Windows uses the bin/talon.js npm shim."
+#endif
+
+/* Expose POSIX.2008 (readlink, strdup, strtok_r) before any include. */
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE
+#else
+#define _POSIX_C_SOURCE 200809L
+#define _DEFAULT_SOURCE
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+/* Minimum Node major version — matches package.json `engines.node`. */
+#define MIN_NODE_MAJOR 24
+
+/* Exit codes, borrowing sysexits.h conventions. (stderr distinguishes
+ * the cases; the code is intentionally coarse.) */
+#define EX_UNAVAILABLE 69 /* no usable node, or JS entry missing */
+#define EX_SOFTWARE 70    /* launcher internal error */
+#define EX_NOEXEC 126     /* node located but execv() itself failed */
+
+/* The most we ever track for the "found old node" diagnostic. */
+#define MAX_REJECTED 16
+
+struct rejected {
+  char path[PATH_MAX];
+  int major; /* -1 = version unknown */
+};
+
+static struct rejected g_rejected[MAX_REJECTED];
+static size_t g_rejected_len = 0;
+
+static void remember_rejected(const char *path, int major) {
+  if (g_rejected_len >= MAX_REJECTED) return;
+  snprintf(g_rejected[g_rejected_len].path, PATH_MAX, "%s", path);
+  g_rejected[g_rejected_len].major = major;
+  g_rejected_len++;
+}
+
+/* Join dir + "/" + leaf into out; returns false on truncation. */
+static bool join_path(char *out, size_t cap, const char *dir,
+                      const char *leaf) {
+  int n = snprintf(out, cap, "%s/%s", dir, leaf);
+  return n > 0 && (size_t)n < cap;
+}
+
+static bool file_exists(const char *path) { return access(path, F_OK) == 0; }
+
+static bool is_executable(const char *path) { return access(path, X_OK) == 0; }
+
+/* Directory containing this executable, resolved through symlinks. */
+static bool self_exe_dir(char *out, size_t cap) {
+  char buf[PATH_MAX];
+#if defined(__APPLE__)
+  char raw[PATH_MAX];
+  uint32_t size = sizeof(raw);
+  if (_NSGetExecutablePath(raw, &size) != 0) return false;
+  if (realpath(raw, buf) == NULL) return false;
+#else
+  ssize_t n = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+  if (n < 0) return false;
+  buf[n] = '\0';
+#endif
+  char *slash = strrchr(buf, '/');
+  if (slash == NULL) return false;
+  *slash = '\0';
+  int w = snprintf(out, cap, "%s", buf);
+  return w > 0 && (size_t)w < cap;
+}
+
+/*
+ * Run `<node> --version` and parse the major from `vMAJOR.MINOR.PATCH`.
+ * Returns the major, or -1 when the probe fails or output isn't a
+ * version. fork + execl (no shell) so a node path with spaces or shell
+ * metacharacters can never be reinterpreted.
+ */
+static int node_major(const char *node) {
+  int fds[2];
+  if (pipe(fds) != 0) return -1;
+
+  pid_t pid = fork();
+  if (pid < 0) {
+    close(fds[0]);
+    close(fds[1]);
+    return -1;
+  }
+  if (pid == 0) {
+    /* child: stdout -> pipe, stderr -> /dev/null, then exec node */
+    dup2(fds[1], STDOUT_FILENO);
+    int devnull = open("/dev/null", O_WRONLY);
+    if (devnull >= 0) {
+      dup2(devnull, STDERR_FILENO);
+      close(devnull);
+    }
+    close(fds[0]);
+    close(fds[1]);
+    execl(node, node, "--version", (char *)NULL);
+    _exit(127);
+  }
+
+  /*
+   * Parent: capture the first line into buf, then keep draining to EOF.
+   * Draining matters: a version-manager shim (asdf/mise/nvm/corepack)
+   * may print a banner to stdout after the version. If we closed the
+   * read end while the child was still writing, the child would take
+   * SIGPIPE and die on a signal — and a perfectly usable Node would be
+   * rejected as "version unreadable". Reading to EOF lets it exit 0.
+   */
+  close(fds[1]);
+  char buf[64];
+  char sink[256];
+  size_t off = 0;
+  ssize_t n;
+  for (;;) {
+    if (off < sizeof(buf) - 1) {
+      n = read(fds[0], buf + off, sizeof(buf) - 1 - off);
+      if (n > 0) {
+        off += (size_t)n;
+        continue;
+      }
+    } else {
+      n = read(fds[0], sink, sizeof(sink)); /* discard past the first line */
+      if (n > 0) continue;
+    }
+    break; /* EOF (0) or error (<0) */
+  }
+  buf[off] = '\0';
+  close(fds[0]);
+
+  int status;
+  if (waitpid(pid, &status, 0) < 0) return -1;
+  if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) return -1;
+
+  const char *p = buf;
+  if (*p == 'v') p++;
+  if (*p < '0' || *p > '9') return -1;
+  int major = 0;
+  while (*p >= '0' && *p <= '9') {
+    // Guard the accumulation: an absurd (bogus) version with a 10+ digit
+    // major would overflow signed int — undefined behavior — and could
+    // wrap to a value that slips past the >= MIN_NODE_MAJOR floor. Treat
+    // an out-of-range version as unreadable.
+    if (major > (INT_MAX - 9) / 10) return -1;
+    major = major * 10 + (*p - '0');
+    p++;
+  }
+  return major;
+}
+
+/* ── JS entry resolution ──────────────────────────────────────────── */
+
+static bool resolve_talon_js(const char *exe_dir, char *out, size_t cap) {
+  const char *override = getenv("TALON_JS");
+  if (override != NULL && override[0] != '\0') {
+    if (file_exists(override)) {
+      snprintf(out, cap, "%s", override);
+      return true;
+    }
+    fprintf(stderr, "talon: TALON_JS=%s does not exist; falling back.\n",
+            override);
+  }
+  /*
+   * The launcher normally sits in bin/ right next to talon.js. The
+   * ../bin and ../lib forms cover a /usr/bin/talon shim installed beside
+   * a /usr/lib/talon tree.
+   */
+  char candidate[PATH_MAX];
+  const char *relatives[] = {
+      "talon.js",
+      "../bin/talon.js",
+      "../lib/talon/bin/talon.js",
+  };
+  for (size_t i = 0; i < sizeof(relatives) / sizeof(relatives[0]); i++) {
+    if (!join_path(candidate, sizeof(candidate), exe_dir, relatives[i]))
+      continue;
+    if (file_exists(candidate)) {
+      snprintf(out, cap, "%s", candidate);
+      return true;
+    }
+  }
+  return false;
+}
+
+/* ── Node resolution ──────────────────────────────────────────────── */
+
+/*
+ * Probe one candidate node path. Returns true (and leaves `path` as the
+ * winner) when it exists and is new enough; otherwise records it for
+ * diagnostics and returns false. `seen`/`seen_len` dedupe so a node on
+ * both PATH and a common dir isn't version-spawned twice.
+ */
+static bool try_node(const char *path, char seen[][PATH_MAX], size_t *seen_len,
+                     size_t seen_cap) {
+  for (size_t i = 0; i < *seen_len; i++) {
+    if (strcmp(seen[i], path) == 0) return false;
+  }
+  if (*seen_len < seen_cap) {
+    snprintf(seen[*seen_len], PATH_MAX, "%s", path);
+    (*seen_len)++;
+  }
+  if (!is_executable(path)) return false;
+
+  int major = node_major(path);
+  if (major >= MIN_NODE_MAJOR) return true;
+  remember_rejected(path, major);
+  return false;
+}
+
+/*
+ * Find a usable node, writing its path into `out`. Walks the candidate
+ * list in priority order; returns false when nothing qualifies.
+ */
+static bool resolve_node(const char *exe_dir, char *out, size_t cap) {
+  static char seen[64][PATH_MAX];
+  size_t seen_len = 0;
+  const size_t seen_cap = sizeof(seen) / sizeof(seen[0]);
+  char cand[PATH_MAX];
+
+#define TRY(p)                                                  \
+  do {                                                          \
+    if (try_node((p), seen, &seen_len, seen_cap)) {             \
+      snprintf(out, cap, "%s", (p));                            \
+      return true;                                              \
+    }                                                           \
+  } while (0)
+
+  /*
+   * (a) Explicit override is authoritative: used exactly, never
+   * overridden by the implicit search. A set-but-unusable TALON_NODE is
+   * a hard miss with a clear message rather than a silent fall-through
+   * to some other node the user didn't ask for.
+   */
+  const char *talon_node = getenv("TALON_NODE");
+  if (talon_node != NULL && talon_node[0] != '\0') {
+    if (!is_executable(talon_node)) {
+      fprintf(stderr, "talon: TALON_NODE=%s is not an executable file.\n",
+              talon_node);
+      return false;
+    }
+    int major = node_major(talon_node);
+    if (major >= MIN_NODE_MAJOR) {
+      snprintf(out, cap, "%s", talon_node);
+      return true;
+    }
+    if (major < 0) {
+      // Executable but `node --version` gave nothing usable — name the
+      // path the user set instead of the generic "no node" advice.
+      fprintf(stderr,
+              "talon: TALON_NODE=%s did not report a usable version "
+              "(`node --version` failed).\n",
+              talon_node);
+      return false;
+    }
+    remember_rejected(talon_node, major); /* too old — caller reports the version */
+    return false;
+  }
+
+  /* (b) Vendored alongside the launcher (the bundled .deb / bottle). */
+  if (join_path(cand, sizeof(cand), exe_dir, "vendor/node")) TRY(cand);
+  if (join_path(cand, sizeof(cand), exe_dir, "node")) TRY(cand);
+
+  /* (c) Everything on PATH. */
+  const char *path_env = getenv("PATH");
+  if (path_env != NULL) {
+    char *dup = strdup(path_env);
+    if (dup != NULL) {
+      char *save = NULL;
+      for (char *dir = strtok_r(dup, ":", &save); dir != NULL;
+           dir = strtok_r(NULL, ":", &save)) {
+        // Absolute dirs only. A relative PATH element (".", "bin", an
+        // empty field — which also means CWD) must never cause us to
+        // run a CWD-relative ./node: this binary is the front door, and
+        // the cwd may be attacker-controlled.
+        if (dir[0] != '/') continue;
+        if (join_path(cand, sizeof(cand), dir, "node")) {
+          if (try_node(cand, seen, &seen_len, seen_cap)) {
+            snprintf(out, cap, "%s", cand);
+            free(dup);
+            return true;
+          }
+        }
+      }
+      free(dup);
+    }
+  }
+
+  /*
+   * (d) Common absolute install dirs + version-manager hints. PATH
+   * usually covers these, but a stripped systemd/cron environment often
+   * has a minimal PATH while Node lives in one of them.
+   */
+  const char *fixed[] = {
+      "/usr/local/bin", "/usr/bin", "/opt/homebrew/bin", "/opt/local/bin",
+      "/snap/bin",
+  };
+  for (size_t i = 0; i < sizeof(fixed) / sizeof(fixed[0]); i++) {
+    if (join_path(cand, sizeof(cand), fixed[i], "node")) TRY(cand);
+  }
+  // Version-manager hints — absolute only, same CWD-relative guard.
+  const char *nvm_bin = getenv("NVM_BIN");
+  if (nvm_bin != NULL && nvm_bin[0] == '/' &&
+      join_path(cand, sizeof(cand), nvm_bin, "node"))
+    TRY(cand);
+  const char *volta = getenv("VOLTA_HOME");
+  if (volta != NULL && volta[0] == '/' &&
+      join_path(cand, sizeof(cand), volta, "bin/node"))
+    TRY(cand);
+
+#undef TRY
+  return false;
+}
+
+/* ── Diagnostics ──────────────────────────────────────────────────── */
+
+static void report_no_node(void) {
+  if (g_rejected_len == 0) {
+    fprintf(stderr,
+            "talon: no Node.js runtime found.\n"
+            "  Talon needs Node.js >= %d. Install it, then re-run.\n"
+            "    Debian/Ubuntu : https://github.com/nodesource/distributions\n"
+            "    macOS (brew)  : brew install node\n"
+            "    any platform  : https://nodejs.org/\n"
+            "  Or point the launcher at one: TALON_NODE=/path/to/node talon\n",
+            MIN_NODE_MAJOR);
+    return;
+  }
+  /* Found node(s) but none new enough — report the newest seen. */
+  struct rejected *best = NULL;
+  for (size_t i = 0; i < g_rejected_len; i++) {
+    if (g_rejected[i].major < 0) continue;
+    if (best == NULL || g_rejected[i].major > best->major)
+      best = &g_rejected[i];
+  }
+  if (best != NULL) {
+    fprintf(stderr,
+            "talon: found Node v%d at %s, but Talon needs >= %d.\n"
+            "  Upgrade Node, or point the launcher at a newer one:\n"
+            "    TALON_NODE=/path/to/node talon\n",
+            best->major, best->path, MIN_NODE_MAJOR);
+  } else {
+    fprintf(stderr,
+            "talon: found a `node` but couldn't read its version\n"
+            "  (`node --version` failed). Check the install, or set\n"
+            "  TALON_NODE=/path/to/node.\n");
+  }
+}
+
+/* ── Entry point ──────────────────────────────────────────────────── */
+
+int main(int argc, char **argv) {
+  char exe_dir[PATH_MAX];
+  if (!self_exe_dir(exe_dir, sizeof(exe_dir))) {
+    fprintf(stderr, "talon: cannot locate own executable.\n");
+    return EX_SOFTWARE;
+  }
+
+  char talon_js[PATH_MAX];
+  if (!resolve_talon_js(exe_dir, talon_js, sizeof(talon_js))) {
+    fprintf(stderr,
+            "talon: cannot find the Talon JS entry next to this binary.\n"
+            "  Looked for talon.js beside the launcher (and ../bin/talon.js).\n"
+            "  Set TALON_JS=/path/to/bin/talon.js to override.\n");
+    return EX_UNAVAILABLE;
+  }
+
+  char node[PATH_MAX];
+  if (!resolve_node(exe_dir, node, sizeof(node))) {
+    report_no_node();
+    return EX_UNAVAILABLE;
+  }
+
+  /* Hand off: argv = [node, talon.js, <forwarded args...>, NULL]. */
+  char **child = calloc((size_t)argc + 2, sizeof(char *));
+  if (child == NULL) {
+    fprintf(stderr, "talon: out of memory.\n");
+    return EX_SOFTWARE;
+  }
+  child[0] = node;
+  child[1] = talon_js;
+  for (int i = 1; i < argc; i++) child[i + 1] = argv[i];
+  child[argc + 1] = NULL;
+
+  execv(node, child);
+
+  /* execv only returns on failure. */
+  fprintf(stderr, "talon: failed to exec node (%s): %s\n", node,
+          strerror(errno));
+  free(child);
+  return EX_NOEXEC;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.154",
-        "@anthropic-ai/sdk": "^0.95.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.175",
+        "@anthropic-ai/sdk": "^0.104.1",
         "@brave/brave-search-mcp-server": "^2.0.75",
         "@clack/prompts": "^1.2.0",
         "@grammyjs/auto-retry": "^2.0.2",
@@ -19,7 +19,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@openai/agents": "^0.11.4",
         "@openai/codex-sdk": "^0.139.0",
-        "@opencode-ai/sdk": "^1.4.0",
+        "@opencode-ai/sdk": "^1.17.4",
         "@playwright/mcp": "^0.0.76",
         "big-integer": "^1.6.52",
         "cheerio": "^1.2.0",
@@ -58,22 +58,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.173",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.173.tgz",
-      "integrity": "sha512-BsdL223y7vCUJA9uBW9osSrhufvwIT+J94IBkh83v+wjyjoBIwLXREdacFabair70bGNdtkw6cWCaYNThSQg7A==",
+      "version": "0.3.175",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.175.tgz",
+      "integrity": "sha512-RAuqHadT+JJqkUC0DsOHIivxTbe1+5Zu02SfIeJoxF1fNS/wazDCVGCmIMPQIRZ+d6HedV047tH7oYhRc2D1bQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.173",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.173",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.173",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.173",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.173",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.173",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.173",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.173"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.175",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.175",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.175",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.175",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.175",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.175",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.175",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.175"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.173",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.173.tgz",
-      "integrity": "sha512-McW1toJ4Qdo/i7bHnsiFMm2AtyCiK/5V90WgL7M9ZO9llrJr3riGRdBlRGHvWnS7rKuv5ttj4/SuBkLoL9o75A==",
+      "version": "0.3.175",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.175.tgz",
+      "integrity": "sha512-ud/25HB7esWldzXwGaa+gK8/+A1dZf6yJ5HCKCJN7BMFFJdbCe28pwCwoh9zE+5imNSuXtlqSRDMuxa2fPsYGw==",
       "cpu": [
         "arm64"
       ],
@@ -95,9 +95,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.173",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.173.tgz",
-      "integrity": "sha512-m2Oh1pQ69IUg6DSH6n1nAAAtRq+G7J2B/CKTbTfDAEmg5t0lzakZV9l28GZrlP21xl+PIg71dkiJ5u94KYgpRw==",
+      "version": "0.3.175",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.175.tgz",
+      "integrity": "sha512-QLd1FCTtLb0peWqIIf/FTNQI/pSn/kFdy+SuxFbodPaHB0gehDhoFZ6ADm2HLS83tWxqGQAa0G5cHstkiuDzNQ==",
       "cpu": [
         "x64"
       ],
@@ -108,11 +108,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.173",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.173.tgz",
-      "integrity": "sha512-Vb64WJOD2D9tKn/i0ErmLbO6I1187xTwL/kxEANjg4L1FGQnvdYBnZ6J6jU6+x8UgcuIi82imHROQp80gbPW2w==",
+      "version": "0.3.175",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.175.tgz",
+      "integrity": "sha512-mvCJ37aecg2dfzS8XZbwOfcmA45RFXUZwN84nXiKMnZFazZ6hn7daMmHlCXSp9zV0NpxbizLIb6SmmHgjefHzg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -121,11 +124,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.173",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.173.tgz",
-      "integrity": "sha512-uu8MnPwFBc9ayFg5c94aHaqJVLS51oHNVxHwud4nK27GliP5WoME3F7pmm1N/Jyy2ry2E2CLNnsAm5l3zemfYA==",
+      "version": "0.3.175",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.175.tgz",
+      "integrity": "sha512-2FKNFy6JxIgYXitZ7ARO5wxQWHdDhmw3O+RkuohshPQ+10n5Zf0CpX7Lx2Vq2vz0DFRCiY9cYiPHf8hAI7ZWWg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -134,11 +140,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.173",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.173.tgz",
-      "integrity": "sha512-0l9L5O+Uiw8gq9mu2NqGSYcSmX8RJMAh9GkGacTJqJbkfHCiFxqZmWBWODOt6HP7PTFCV+yMzQK/xJQjnag/jw==",
+      "version": "0.3.175",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.175.tgz",
+      "integrity": "sha512-vymQcmn39+BQ8JYwUrafPqgxbpMFBGLfV7PPIxQSsi3z4iBwciW4csb7KwpRaehODa3sD69HruAFpOUkJfMkzA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -147,11 +156,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.173",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.173.tgz",
-      "integrity": "sha512-ofKxyp/N8+LLSrClt+dJo0laCHDzmBgmN8+Q+zabJ54Jqc1KXee68UsziE7kLCqGbOSY7rsIK9d22T1uQyZkUw==",
+      "version": "0.3.175",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.175.tgz",
+      "integrity": "sha512-4YUpjcLbDqTYIuvb7gLWVRM3J9CiTisuiEMnckv8lrBWhj5AN0ULLG5pWTOxw4Pzsbja5pAdf9UMqzsKFiukUw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -160,9 +172,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.173",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.173.tgz",
-      "integrity": "sha512-aulIrBYjFDm+S5kl4CxC8A3KUiTDKLHoKV46Mat64E+skGEyBkC7WzZAGbpGKB2y8KZo1WbrwJTGefgyHMpDhw==",
+      "version": "0.3.175",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.175.tgz",
+      "integrity": "sha512-PwiduMKtisfEQRH8KP6bQ7T+XTC1yNFutrN3v1wQS7BuNTm2bPdXFkW97++OcjW5H4RgdVibIzQZ1V12Hcy4EA==",
       "cpu": [
         "arm64"
       ],
@@ -173,9 +185,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.173",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.173.tgz",
-      "integrity": "sha512-HjGkfDlNLI3Kh9NIUfevJ3SZY8Xv3td4zx5Cz3YE0VPrrjIkRvdEv9K6WTjT94tlS0TUXQS/kFT+NCmoGXuvZQ==",
+      "version": "0.3.175",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.175.tgz",
+      "integrity": "sha512-II4yfIrKCrscig918R6hEOvqEejX56nH8+NI9KvGY47g0rZnPgGgXZCQrRC5ZgRihqNiwF1i6faJxvmmOEx5Rw==",
       "cpu": [
         "x64"
       ],
@@ -186,12 +198,13 @@
       ]
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.95.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.95.0.tgz",
-      "integrity": "sha512-7It2B76OFJH9jC/a0TicXFMq0ZZM25ei+i/mK7JnsE1Ibmo0Yfkqm+DXOHeU/ZxxKwLLGPP6qaAvKmQmgV6XhA==",
+      "version": "0.104.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.1.tgz",
+      "integrity": "sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -1277,9 +1290,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.3.tgz",
-      "integrity": "sha512-oXrEjOuP3+J9pPNw3cmOnRma/xiVQ4WIIvGd6YkhPQgqqi2PnD/b1qfNY0AMead3QfNhKwKdDM4QFJdN2LpByg==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.4.tgz",
+      "integrity": "sha512-OdHkBoNIQOjQsPnFtkcxAp9HsLAKn/MQiq7wIQURkRARmw8yhFqGiMPYbNm+UfLn6bMkx97rdPkWQARejMyiXQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -2550,6 +2563,12 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3786,6 +3805,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -5880,6 +5905,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "talon": "./bin/talon.js"
   },
   "files": [
-    "bin/",
+    "bin/talon.js",
     "src/backend/",
     "src/core/",
     "src/frontend/",
@@ -77,11 +77,13 @@
     "build:zig": "node native/textops-wasm/build.mjs",
     "build:c": "node native/strsim-c/build.mjs",
     "build:cpp": "node native/htmlents-cpp/build.mjs",
-    "build:native": "npm run build:wasm && npm run build:zig && npm run build:c && npm run build:cpp && npm run build:gleam"
+    "build:native": "npm run build:wasm && npm run build:zig && npm run build:c && npm run build:cpp && npm run build:gleam",
+    "build:driver": "node native/talon-driver/build.mjs",
+    "build:driver:all": "node native/talon-driver/build.mjs --all"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.154",
-    "@anthropic-ai/sdk": "^0.95.0",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.175",
+    "@anthropic-ai/sdk": "^0.104.1",
     "@brave/brave-search-mcp-server": "^2.0.75",
     "@clack/prompts": "^1.2.0",
     "@grammyjs/auto-retry": "^2.0.2",
@@ -90,7 +92,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/agents": "^0.11.4",
     "@openai/codex-sdk": "^0.139.0",
-    "@opencode-ai/sdk": "^1.4.0",
+    "@opencode-ai/sdk": "^1.17.4",
     "@playwright/mcp": "^0.0.76",
     "big-integer": "^1.6.52",
     "cheerio": "^1.2.0",
@@ -122,7 +124,7 @@
     "vitest": "^4.1.3"
   },
   "overrides": {
-    "@anthropic-ai/sdk": "^0.95.0",
+    "@anthropic-ai/sdk": "^0.104.1",
     "ip-address": "^10.1.1",
     "fast-uri": "^3.1.2"
   }

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -13,3 +13,24 @@ The Dockerfile / Docker Compose configuration lives at the repository
 root for convention (`docker compose up -d` from the checkout). The
 `docker/` directory holds auxiliary harnesses (e.g. `docker/kilo-test/`
 for backend-specific test bots), not the primary production image.
+
+## Native launcher (`talon-driver`)
+
+The binary distribution channels — an apt `.deb`, a Homebrew bottle, a
+source install — ship the compiled launcher
+([`native/talon-driver`](../native/talon-driver/)) as the `talon` entry
+point instead of the npm `bin/talon.js` shim. It is a small native
+per-arch executable that locates a Node >= 24 and execs `bin/talon.js`,
+so packages don't depend on a particular Node being first on `PATH`.
+
+Build the per-arch artefacts for packaging:
+
+```sh
+npm run build:driver:all   # x86_64/aarch64 × linux-musl/macos → native/talon-driver/dist/
+```
+
+A `.deb` or bottle that vendors its own Node can drop it at
+`<prefix>/vendor/node` next to the launcher and it is picked up before
+any system Node (full resolution order is in the driver's README). The
+npm package is unchanged — it keeps shipping the portable
+`bin/talon.js`, which works on every platform including Windows.

--- a/src/__tests__/talon-driver.test.ts
+++ b/src/__tests__/talon-driver.test.ts
@@ -1,0 +1,260 @@
+/**
+ * talon-driver — the native C launcher (native/talon-driver) that
+ * fronts the CLI for the apt/brew/source distribution channels. It
+ * resolves a Node >= 24 and execs `node bin/talon.js <args>`.
+ *
+ * These tests build the launcher with the pinned Zig toolchain (zig cc)
+ * and drive the real binary against fake `node` scripts and a fake
+ * `talon.js`, asserting the behaviours that matter for a process that
+ * sits in front of everything: exit-code and argv pass-through, the
+ * authoritative TALON_NODE override, version-floor rejection with a
+ * useful message, PATH discovery, and entry-point resolution.
+ *
+ * If zig is not installed the suite skips — the CI Driver job builds
+ * with the pinned toolchain, and the wasm drift job covers the rest of
+ * the native plane.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const driverSrc = fileURLToPath(
+  new URL("../../native/talon-driver/src/main.c", import.meta.url),
+);
+
+function findZig(): string | null {
+  const fromEnv = process.env.ZIG;
+  if (fromEnv && existsSync(fromEnv)) return fromEnv;
+  const pinned = join(homedir(), ".zig-bin", "zig");
+  if (existsSync(pinned)) return pinned;
+  try {
+    execFileSync("zig", ["version"], { stdio: "ignore" });
+    return "zig";
+  } catch {
+    return null;
+  }
+}
+
+const zig = findZig();
+const suite = zig ? describe : describe.skip;
+if (!zig) {
+  console.warn("talon-driver tests skipped: zig toolchain not found");
+}
+
+suite("talon-driver launcher", () => {
+  let root: string;
+  let driverBin: string;
+
+  /** A fake `node`: prints its version, else echoes argv and exits `code`. */
+  function fakeNode(path: string, version: string, code = 0): void {
+    writeFileSync(
+      path,
+      `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "${version}"; exit 0; fi
+echo "NODE_ARGV: $*"
+exit ${code}
+`,
+    );
+    chmodSync(path, 0o755);
+  }
+
+  /** A fresh app dir holding a copy of the launcher beside a talon.js. */
+  function appWithJs(): { dir: string; bin: string } {
+    const dir = mkdtempSync(join(root, "app-"));
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir);
+    const bin = join(binDir, "talon");
+    copyFileSync(driverBin, bin);
+    chmodSync(bin, 0o755);
+    writeFileSync(join(binDir, "talon.js"), "process.exit(0);\n");
+    return { dir, bin };
+  }
+
+  function runDriver(
+    bin: string,
+    args: string[],
+    env: NodeJS.ProcessEnv,
+  ): { status: number | null; stderr: string; stdout: string } {
+    // Minimal base env so the launcher's PATH/common-dir scan can't
+    // reach a real system node unless the test puts one there.
+    const res = spawnSync(bin, args, {
+      env: { PATH: "/nonexistent", ...env },
+      encoding: "utf-8",
+    });
+    return { status: res.status, stderr: res.stderr, stdout: res.stdout };
+  }
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "talon-driver-"));
+    driverBin = join(root, "talon");
+    execFileSync(
+      zig as string,
+      [
+        "cc",
+        "-O2",
+        "-g0",
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        driverSrc,
+        "-o",
+        driverBin,
+      ],
+      { stdio: "pipe" },
+    );
+  });
+
+  afterAll(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("execs node with talon.js + forwarded args and passes the exit code", () => {
+    const { bin } = appWithJs();
+    const node = join(root, "node-ok");
+    fakeNode(node, "v24.3.1", 9);
+
+    const { status, stdout } = runDriver(bin, ["run", "--flag", "x"], {
+      TALON_NODE: node,
+    });
+    expect(status).toBe(9); // the launcher *becomes* node — node's code wins
+    // argv[0]=node is consumed; talon.js then the forwarded args follow.
+    expect(stdout).toContain("/talon.js run --flag x");
+  });
+
+  it("treats TALON_NODE as authoritative and rejects an old one with its version", () => {
+    const { bin } = appWithJs();
+    const old = join(root, "node-old");
+    fakeNode(old, "v18.20.4");
+
+    const { status, stderr } = runDriver(bin, ["run"], { TALON_NODE: old });
+    expect(status).toBe(69);
+    expect(stderr).toContain("Node v18");
+    expect(stderr).toContain(">= 24");
+  });
+
+  it("hard-fails when TALON_NODE points at a non-executable path", () => {
+    const { bin } = appWithJs();
+    const { status, stderr } = runDriver(bin, ["run"], {
+      TALON_NODE: join(root, "does-not-exist"),
+    });
+    expect(status).toBe(69);
+    expect(stderr).toContain("is not an executable file");
+  });
+
+  it("runs a node path containing spaces without shell reinterpretation", () => {
+    const { bin } = appWithJs();
+    const spaced = join(root, "node dir with spaces");
+    mkdirSync(spaced);
+    const node = join(spaced, "node");
+    fakeNode(node, "v24.0.0", 0);
+
+    const { status, stdout } = runDriver(bin, ["ok"], { TALON_NODE: node });
+    expect(status).toBe(0);
+    expect(stdout).toContain("/talon.js ok");
+  });
+
+  it("discovers node on PATH when TALON_NODE is unset", () => {
+    const { bin } = appWithJs();
+    const dir = mkdtempSync(join(root, "pathdir-"));
+    fakeNode(join(dir, "node"), "v25.1.0", 0);
+
+    const { status, stdout } = runDriver(bin, ["hi"], { PATH: dir });
+    expect(status).toBe(0);
+    expect(stdout).toContain("/talon.js hi");
+  });
+
+  it("ignores a relative PATH entry rather than running a CWD-relative ./node", () => {
+    // A relative PATH element (".") must never cause the launcher to run
+    // an attacker-planted ./node from the current working directory.
+    const { dir, bin } = appWithJs();
+    const evil = mkdtempSync(join(root, "cwd-"));
+    // ./node in the attacker-controlled cwd that would "succeed" if run.
+    fakeNode(join(evil, "node"), "v99.0.0", 0);
+
+    const res = spawnSync(bin, ["x"], {
+      cwd: evil,
+      env: { PATH: ".:/nonexistent" },
+      encoding: "utf-8",
+    });
+    void dir;
+    // No usable node found → exit 69, and the planted ./node never ran
+    // (it would have printed the NODE_ARGV line on success).
+    expect(res.status).toBe(69);
+    expect(res.stdout).not.toContain("NODE_ARGV");
+  });
+
+  it("accepts a chatty node that prints a banner after the version line", () => {
+    // Version-manager shims (asdf/mise/nvm) may print a banner to stdout
+    // after the version. The probe must drain the pipe to EOF, not close
+    // it early and SIGPIPE an otherwise-usable node.
+    const { bin } = appWithJs();
+    const node = join(root, "node-chatty");
+    writeFileSync(
+      node,
+      `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "v24.9.0"
+  # >63 bytes of banner after the version line — would SIGPIPE the child
+  # if the launcher stopped reading at the version.
+  i=0; while [ $i -lt 40 ]; do echo "notice: corepack banner line padding"; i=$((i+1)); done
+  exit 0
+fi
+echo "NODE_ARGV: $*"
+exit 0
+`,
+    );
+    chmodSync(node, 0o755);
+
+    const { status, stdout } = runDriver(bin, ["go"], { TALON_NODE: node });
+    expect(status).toBe(0);
+    expect(stdout).toContain("/talon.js go");
+  });
+
+  it("reports a missing JS entry instead of launching node", () => {
+    // Launcher in an isolated dir with no talon.js anywhere near it.
+    const lone = mkdtempSync(join(root, "lone-"));
+    const bin = join(lone, "talon");
+    copyFileSync(driverBin, bin);
+    chmodSync(bin, 0o755);
+    const node = join(root, "node-ok2");
+    fakeNode(node, "v24.3.1", 0);
+
+    const { status, stderr } = runDriver(bin, [], {
+      TALON_NODE: node,
+      TALON_JS: "",
+    });
+    expect(status).toBe(69);
+    expect(stderr).toContain("cannot find the Talon JS entry");
+  });
+
+  it("honors a TALON_JS override", () => {
+    const lone = mkdtempSync(join(root, "lone2-"));
+    const bin = join(lone, "talon");
+    copyFileSync(driverBin, bin);
+    chmodSync(bin, 0o755);
+    const js = join(root, "custom-entry.js");
+    writeFileSync(js, "process.exit(0);\n");
+    const node = join(root, "node-ok3");
+    fakeNode(node, "v24.3.1", 3);
+
+    const { status, stdout } = runDriver(bin, ["z"], {
+      TALON_NODE: node,
+      TALON_JS: js,
+    });
+    expect(status).toBe(3);
+    expect(stdout).toContain("custom-entry.js z");
+  });
+});


### PR DESCRIPTION
## Summary

Adds **`talon-driver`** — a native, per-arch launcher binary that fronts the Talon CLI for the binary distribution channels (apt `.deb`, Homebrew bottle, source install). It resolves a Node ≥ 24, then `execv`s `node bin/talon.js <args>`, so there is exactly one startup path and packages don't depend on a particular Node being first on `PATH`. The npm package is unchanged — it keeps shipping the portable `bin/talon.js` shim (Windows included).

This is the distribution front-door the apt/brew packaging thread needed.

### The launcher (`native/talon-driver/`)

- **C, compiled with the pinned Zig toolchain** (`zig cc`, `native/.zig-version`) — same driver as the rest of the native plane, cross-compiles per arch. (Zig itself was the first choice, but 0.16's process API is mid-refactor into the new `Io` interface with no stable `execv`; a launcher this load-bearing wants the decades-stable POSIX calls.)
- **Bundle-aware Node resolution.** `TALON_NODE` is authoritative; otherwise `<self>/vendor/node → <self>/node → $PATH → common install dirs → $NVM_BIN/$VOLTA_HOME`. The `vendor/node` step lets a `.deb`/bottle ship its own Node.
- **Clean hand-off:** `execv` so signals, exit codes, and `ps` pass straight through. Version probe via `fork`+`execl` (no shell).
- **Actionable diagnostics + non-zero exit** for no-Node / too-old-Node / missing-JS-entry.
- POSIX-only by design (apt = Linux, brew = macOS); Windows keeps the npm shim.
- `build.mjs`: host build → `bin/talon`; `--all` cross-compiles the matrix (x86_64/aarch64 × linux-musl/macos) → `dist/`. Linux targets are static musl ELFs.

### Wiring

- `npm run build:driver` / `build:driver:all`; README in `native/talon-driver/` + rows in `native/README.md`; packaging note in `packaging/README.md`.
- CI `zig-artifact` job cross-compiles all targets (build guard) **and runs the launcher's behavior suite** with the pinned toolchain.
- `bin/talon` and `dist/` gitignored — the binary is built by packaging/CI, never committed.

### Hardening (from an adversarial review of the launcher)

A multi-dimension review (memory-safety / security / behavior / build-CI), each finding independently reproduced, surfaced real issues — all fixed and regression-tested:

- **npm-publish leak (high):** `files: ["bin/"]` would have packed the host-arch `bin/talon` to every npm consumer (npm ignores `.gitignore`). Narrowed to `bin/talon.js`, and `tarball-check.mjs` now forbids anything under `bin/` except the shim (`/^bin\/(?!talon\.js$)/`).
- **CWD-relative `./node` execution (security):** a relative `PATH` entry (`.`) could run an attacker-planted `./node`. Now rejects non-absolute `PATH`/`NVM_BIN`/`VOLTA_HOME` entries.
- **Chatty-node false reject:** the version probe closed the pipe early and `SIGPIPE`d shims (asdf/mise/corepack) that print a banner after the version — a usable Node was rejected. Now drains to EOF.
- **Signed-overflow (UB)** parsing an absurd major version → clamped.
- **Diagnostics:** an unreadable `TALON_NODE` now names the path instead of generic advice.

### Dependency catch-up (folded in)

- `@anthropic-ai/claude-agent-sdk` → `^0.3.175`, `@opencode-ai/sdk` → `^1.17.4`.
- `@anthropic-ai/sdk` → `^0.104.1` (dependency **and** the `overrides` pin together — the override is why Dependabot couldn't bump it past `0.95`).

## Test plan

- New `src/__tests__/talon-driver.test.ts`: builds the real binary with `zig cc` and drives it against fake `node`/`talon.js` — exit-code & argv pass-through, authoritative `TALON_NODE`, version-floor rejection, PATH discovery, `TALON_JS` override, **relative-PATH rejection**, **chatty-node accept**. (9 tests; self-skips where zig is absent, runs in the CI zig job.)
- `npm pack --dry-run` confirms only `bin/talon.js` ships; `tarball:check` green.
- tsc / lint / prettier clean; full suite + coverage gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
