### PR TITLE
fix: stderr readline crash risk and cron non-null assertion

### DIFF
--- a/src/core/background/cron.ts
+++ b/src/core/background/cron.ts
@@ -157,8 +157,10 @@ function isDue(job: CronJob, now: Date): boolean {
     return true;
   } catch (err) {
     if (!warnedBadSchedule.has(job.id)) {
-      if (warnedBadSchedule.size >= MAX_WARNED_SCHEDULES)
-        warnedBadSchedule.delete(warnedBadSchedule.values().next().value!);
+      if (warnedBadSchedule.size >= MAX_WARNED_SCHEDULES) {
+        const oldest = warnedBadSchedule.values().next().value;
+        if (oldest !== undefined) warnedBadSchedule.delete(oldest);
+      }
       warnedBadSchedule.add(job.id);
       logWarn(
         "cron",

--- a/src/core/background/triggers.ts
+++ b/src/core/background/triggers.ts
@@ -361,6 +361,9 @@ function spawnDirect(
   if (child.stderr) {
     const rlErr = createInterface({ input: child.stderr, crlfDelay: Infinity });
     rlErr.on("line", (line) => handleStderrLine(trigger.id, line));
+    rlErr.on("error", (err) =>
+      logWarn("triggers", `stderr reader error [${trigger.id}]: ${err}`),
+    );
   }
 
   child.on("exit", (code, signal) => {


### PR DESCRIPTION
## Summary

Code review of the full codebase found two confirmed bugs, fixed here.

---

### Bug 1 — Crash risk: missing `error` handler on stderr readline in `spawnDirect` (`triggers.ts`)

**File:** `src/core/background/triggers.ts`  
**Severity:** High

In `spawnDirect`, the stdout `readline` interface correctly registers an `error` handler:

```ts
rl.on("error", (err) =>
  logWarn("triggers", `stdout reader error [${trigger.id}]: ${err}`),
);
```

The stderr `readline` interface (`rlErr`) did **not**:

```ts
// Before — no error handler
const rlErr = createInterface({ input: child.stderr, crlfDelay: Infinity });
rlErr.on("line", (line) => handleStderrLine(trigger.id, line));
```

In Node.js, an `EventEmitter` with no `error` listener that emits an `error` event throws an **uncaught exception**, which crashes the entire process. If a child process's stderr stream encounters a broken pipe, a buffer overflow, or any other stream-level error (e.g. the child closes stderr early, a write fails due to backpressure, etc.), this would take down Talon.

**Fix:** Added the same `error` handler pattern already used for stdout.

---

### Bug 2 — Non-null assertion on Set iterator in `warnedBadSchedule` eviction (`cron.ts`)

**File:** `src/core/background/cron.ts`  
**Severity:** Low

The LRU eviction for the `warnedBadSchedule` set used a non-null assertion (`!`) on the value returned by the iterator:

```ts
// Before
if (warnedBadSchedule.size >= MAX_WARNED_SCHEDULES)
  warnedBadSchedule.delete(warnedBadSchedule.values().next().value!);
```

`Iterator.next().value` is typed as `string | undefined` — `undefined` when `done: true` (i.e. the set is empty). The preceding size guard (`>= 200`) makes the assertion safe *today*, but the `!` bypasses TypeScript's type system and would silently pass `undefined` to `Set.delete()` if the guard condition were ever changed.

**Fix:** Extracted the value with an explicit `undefined` check:

```ts
// After
if (warnedBadSchedule.size >= MAX_WARNED_SCHEDULES) {
  const oldest = warnedBadSchedule.values().next().value;
  if (oldest !== undefined) warnedBadSchedule.delete(oldest);
}
```

---

## Other findings from the full review (not fixed here)

A broad review of all 223 source files was conducted. The two fixes above are the only changes with high confidence and clear correctness. Additional observations noted for awareness:

- **`job-health.ts` `recordJobFailure`:** `h.opens` is incremented after `stepBreaker("failure")`, so the opening event's `cooldownMs` parameter uses the pre-increment value while subsequent `jobAllowsRun` ticks use the post-increment value. Because `Breaker` stores no `cooldownMs` field and the Gleam state machine re-evaluates the cooldown on every tick, the actual open→half-open transition uses the post-increment (correct, escalated) value — so visible behavior is correct. The inconsistency is only in the parameter passed to the "failure" event call, which appears to be unused for the transition check. Worth a future audit of the Gleam scheduler core to confirm.
- **`cron-store.ts` `recordCronRun`:** Intentionally does not call `save()` after updating `lastRunAt`/`runCount` (relying on the 10-second autosave interval). A crash in the window between a run completing and the next autosave tick could cause a cron job to run again on restart if `lastRunAt` is lost. The comment acknowledges this trade-off. Worth documenting the blast radius explicitly.
- **`daily-log.ts` cleanup:** The YYYY-MM-DD.md filename format is compared lexicographically against a YYYY-MM-DD cutoff string (no extension). This is safe because dates always differ before the `.md` suffix, so the comparison is always resolved correctly before reaching the extension characters.

## Test plan

- [ ] Trigger a child process whose stderr stream raises a stream error (e.g. close stderr early) — confirm Talon does not crash and the error is logged at warn level
- [ ] Verify cron scheduler logs a warning for a job with an invalid schedule without panicking when `warnedBadSchedule` reaches capacity
- [ ] Run full unit + functional test suite (`npm test`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GoyGTMCpUct59vupJSgcdD)_