### PR TITLE
docs(agentevent): fix dispatcher-owned deliveryAck contract in migration doc

### DIFF
--- a/docs/agentevent-migration.md
+++ b/docs/agentevent-migration.md
@@ -39,17 +39,40 @@ export type StreamEventSink = {
 };
 ```
 
-The dispatcher consumes the backend stream and forwards every event in order:
+The dispatcher consumes the backend stream and forwards every event in order.
+`assistant_message` events get special handling so the dispatcher — not the
+frontend — owns `deliveryAck` settlement:
 
 ```ts
 for await (const event of stream) {
   if (event.type === "completed") agentResult = event.result;
+
+  // The dispatcher owns assistant_message.deliveryAck settlement, so the ack
+  // is ALWAYS settled — even with no onEvent sink, or a sink that ignores the
+  // event. The frontend's job is just to deliver and throw on failure; the
+  // dispatcher maps return → resolve (block delivered) and throw → reject
+  // (backend retries, e.g. the Codex oversized-message path). Without this the
+  // callback-shaped backend blocks forever awaiting delivery confirmation.
+  if (event.type === "assistant_message" && event.deliveryAck) {
+    try {
+      await params.onEvent?.(event);
+      event.deliveryAck.resolve();
+    } catch (err) {
+      event.deliveryAck.reject(err);
+    }
+    continue;
+  }
+
   await params.onEvent?.(event);          // serial: awaited in stream order
   if (event.type === "error") throw new AgentRunError(event.error);
 }
 ```
 
 - `completed` is captured for the dispatcher's `ExecuteResult` return value.
+- `assistant_message` with a `deliveryAck` is delivered, then the **dispatcher**
+  settles the ack: resolve when `onEvent` returns, reject when it throws. The
+  ack is always settled — even with no sink — so the callback-shaped backend
+  (`handler-to-events`) never blocks awaiting delivery confirmation.
 - `error` is forwarded to the sink, then rethrown as `AgentRunError`
   (`core/agent-runtime/events.ts`) so callers' `try/catch` paths — which
   classify via `core/errors.ts` — keep working unchanged.
@@ -66,10 +89,12 @@ frontend owns them (and each is independently revertible):
   that wants fire-and-forget throttling (Telegram draft edits on `text_delta`)
   simply doesn't await its own work — Telegram fires draft sends with `void`
   to preserve the old non-blocking behaviour.
-- **`assistant_message.deliveryAck`.** The consumer MUST `resolve()` on
-  successful delivery and `reject(err)` on failure. That's how callback-shaped
-  backends learn a block landed (notably Codex oversized-message retries). When
-  there is no ack and delivery throws, the consumer rethrows so the turn fails.
+- **`assistant_message` delivery.** The consumer does **not** settle
+  `deliveryAck` — the dispatcher owns it. The consumer signals success by
+  returning from `onEvent` and failure by **throwing**; the dispatcher resolves
+  the ack on return and rejects it on throw. That reject is how callback-shaped
+  backends learn a block failed to land and retry (notably the Codex
+  oversized-message path).
 - **`tool_call.input` shape.** It's typed `unknown` (backends may emit arrays).
   Frontends that render tool echoes via a `Record<string, unknown>` use the
   shared `toolInputToRecord(name, input)` helper (coerces non-plain-objects to
@@ -81,8 +106,9 @@ frontend owns them (and each is independently revertible):
 ## What's locked down
 
 - `dispatcher.test.ts` pins the event-forwarding contract: events reach
-  `onEvent`, a `deliveryAck` reject drives the backend retry path, and an
-  `error` terminator is rethrown as `AgentRunError`.
+  `onEvent`, the ack is settled even with no sink, a `deliveryAck` reject drives
+  the backend retry path, and an `error` terminator is rethrown as
+  `AgentRunError`.
 - `integration.test.ts` pins the dispatcher → backend → `onEvent` path and the
   `AgentRunError` classification.
 - `handler-to-events.test.ts` still pins the *producing* side (callbacks →


### PR DESCRIPTION
## What this does

Follow-up to #338. The migration doc (`docs/agentevent-migration.md`) merged with two unresolved Copilot review comments, both flagging that the doc **contradicts the contract the code actually implements** in `src/core/engine/dispatcher.ts`. This corrects the doc to match the code. **Docs-only — no code change.**

## The two fixes

**1. Dispatcher snippet ([#338 r3413478998](https://github.com/dylanneve1/talon/pull/338#discussion_r3413478998))**
The doc showed a plain `await onEvent` loop for *every* event, omitting the `assistant_message.deliveryAck` branch. The snippet now mirrors `dispatcher.ts` verbatim: the dispatcher settles the ack itself (resolve on `onEvent` return, reject on throw, `continue`), so it's always settled — even with no sink. Without that, the callback-shaped backend blocks forever awaiting delivery confirmation.

**2. Frontend-guarantees bullet ([#338 r3413479080](https://github.com/dylanneve1/talon/pull/338#discussion_r3413479080))**
The "What each frontend's `onEvent` must honour" list said the consumer MUST call `resolve()`/`reject()` on the ack. That's backwards and would push frontends to settle the ack themselves. Rewritten: the consumer does **not** touch `deliveryAck` — it signals success by returning and failure by **throwing**; the dispatcher maps that onto the ack.

Also added an `ack is settled even with no sink` line to the "What's locked down" list, which `dispatcher.test.ts` already pins.

## Verification

Prose-only change to one Markdown file; the described contract is copied directly from the merged `src/core/engine/dispatcher.ts`. No build/test impact.

---
_Doc fix by Talon (Claude Opus 4.8)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)