### PR TITLE
feat(commands): add /update self-update command for dev git checkouts

### DIFF
--- a/src/__tests__/integration/talon-bootstrap.ts
+++ b/src/__tests__/integration/talon-bootstrap.ts
@@ -169,6 +169,7 @@ export async function ensureBooted(args: EnsureBootedArgs = {}): Promise<void> {
   const config: TalonConfig = {
     frontend,
     backend: "claude",
+    devBuild: false,
     claudeBinary: STUB_BINARY,
     model: "claude-sonnet-4-6",
     maxMessageLength: 4000,

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -39,6 +39,7 @@ describe("plugin system", () => {
     return {
       frontend: "terminal",
       backend: "claude",
+      devBuild: false,
       model: "default",
       maxMessageLength: 4000,
       concurrency: 1,

--- a/src/__tests__/self-update.test.ts
+++ b/src/__tests__/self-update.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  runSelfUpdate,
+  getRepoRoot,
+  type CommandRunner,
+} from "../core/update/self-update.js";
+
+/**
+ * Build a runner that replies based on the command + args. `headSeq`
+ * supplies successive `git rev-parse HEAD` results (before, after).
+ */
+function makeRunner(opts: {
+  headSeq?: string[];
+  fail?: (cmd: string, args: readonly string[]) => string | null;
+  calls?: string[][];
+}): CommandRunner {
+  const heads = [...(opts.headSeq ?? ["aaaaaaaaaaaa", "aaaaaaaaaaaa"])];
+  return async (cmd, args) => {
+    opts.calls?.push([cmd, ...args]);
+    const failOut = opts.fail?.(cmd, args);
+    if (failOut) return { ok: false, output: failOut };
+    if (cmd === "git" && args[0] === "rev-parse") {
+      return { ok: true, output: heads.shift() ?? "aaaaaaaaaaaa" };
+    }
+    return { ok: true, output: "ok" };
+  };
+}
+
+const ROOT = "/repo";
+
+describe("runSelfUpdate", () => {
+  it("reports no change and skips install when HEAD does not move", async () => {
+    const calls: string[][] = [];
+    const res = await runSelfUpdate({
+      repoRoot: ROOT,
+      runner: makeRunner({ headSeq: ["abc123abc123", "abc123abc123"], calls }),
+    });
+    expect(res.ok).toBe(true);
+    expect(res.changed).toBe(false);
+    expect(res.before).toBe("abc123abc123");
+    // npm install must NOT have run.
+    expect(calls.some((c) => c[0] === "npm")).toBe(false);
+  });
+
+  it("pulls, installs, runs setup, and reports change on fast-forward", async () => {
+    const calls: string[][] = [];
+    const res = await runSelfUpdate({
+      repoRoot: ROOT,
+      remote: "upstream",
+      branch: "dev",
+      setup: ["npm run build"],
+      runner: makeRunner({ headSeq: ["aaa111aaa111", "bbb222bbb222"], calls }),
+    });
+    expect(res.ok).toBe(true);
+    expect(res.changed).toBe(true);
+    expect(res.before).toBe("aaa111aaa111");
+    expect(res.after).toBe("bbb222bbb222");
+    // Custom remote/branch threaded into fetch + pull.
+    expect(calls).toContainEqual(["git", "fetch", "upstream", "dev"]);
+    expect(calls).toContainEqual([
+      "git",
+      "pull",
+      "--ff-only",
+      "upstream",
+      "dev",
+    ]);
+    expect(calls).toContainEqual(["npm", "install"]);
+    expect(calls).toContainEqual(["sh", "-c", "npm run build"]);
+  });
+
+  it("defaults remote/branch to origin/main", async () => {
+    const calls: string[][] = [];
+    await runSelfUpdate({
+      repoRoot: ROOT,
+      runner: makeRunner({ headSeq: ["a1", "b2"], calls }),
+    });
+    expect(calls).toContainEqual(["git", "fetch", "origin", "main"]);
+    expect(calls).toContainEqual([
+      "git",
+      "pull",
+      "--ff-only",
+      "origin",
+      "main",
+    ]);
+  });
+
+  it("stops before install when the pull fails", async () => {
+    const calls: string[][] = [];
+    const res = await runSelfUpdate({
+      repoRoot: ROOT,
+      runner: makeRunner({
+        headSeq: ["a1", "b2"],
+        calls,
+        fail: (cmd, args) =>
+          cmd === "git" && args[0] === "pull" ? "not a fast-forward" : null,
+      }),
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/ff-only/i);
+    expect(calls.some((c) => c[0] === "npm")).toBe(false);
+  });
+
+  it("fails when npm install fails (after a real change)", async () => {
+    const res = await runSelfUpdate({
+      repoRoot: ROOT,
+      runner: makeRunner({
+        headSeq: ["a1", "b2"],
+        fail: (cmd) => (cmd === "npm" ? "ENOSPC" : null),
+      }),
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/npm install failed/i);
+    expect(res.changed).toBe(true);
+  });
+});
+
+describe("getRepoRoot", () => {
+  it("finds a dir containing both .git and package.json", () => {
+    const base = mkdtempSync(join(tmpdir(), "talon-repo-"));
+    try {
+      mkdirSync(join(base, ".git"));
+      writeFileSync(join(base, "package.json"), "{}");
+      const nested = join(base, "src", "core", "update");
+      mkdirSync(nested, { recursive: true });
+      expect(getRepoRoot(nested)).toBe(base);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when there is no git checkout above", () => {
+    const base = mkdtempSync(join(tmpdir(), "talon-nogit-"));
+    try {
+      const nested = join(base, "a", "b");
+      mkdirSync(nested, { recursive: true });
+      // No .git anywhere up to filesystem root from this temp dir.
+      const found = getRepoRoot(nested);
+      // Either null, or (paranoia) not inside our temp tree.
+      expect(found === null || !found.startsWith(base)).toBe(true);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/update/self-update.ts
+++ b/src/core/update/self-update.ts
@@ -1,0 +1,254 @@
+/**
+ * Self-update for git-checkout deployments (the `/update` command).
+ *
+ * Only meaningful when Talon runs from a git clone in a developer
+ * build: it pulls the latest code from a configurable remote/branch,
+ * reinstalls dependencies, runs any extra setup commands, and lets
+ * the caller respawn the process. Packaged/binary builds have no
+ * source tree on disk, so {@link getRepoRoot} returns `null` and the
+ * `/update` command is never registered.
+ *
+ * The pull is `--ff-only` on purpose: a fast-forward can never create
+ * a merge commit or leave the tree in a conflicted half-merged state.
+ * If the local checkout has diverged or is dirty, the pull fails
+ * loudly and nothing is installed or restarted — far safer than
+ * silently merging on a production host.
+ */
+
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Tuning knobs for {@link runSelfUpdate}. */
+export interface UpdateOptions {
+  /** Git remote to pull from (default `origin`). */
+  remote?: string;
+  /** Branch to pull (default `main`). */
+  branch?: string;
+  /**
+   * Extra shell commands run in the repo root after `npm install`
+   * and before restart (e.g. a build step). Each runs via `sh -c`.
+   */
+  setup?: readonly string[];
+  /** Override the repo root (tests). Defaults to {@link getRepoRoot}. */
+  repoRoot?: string;
+  /** Injectable command runner (tests). */
+  runner?: CommandRunner;
+}
+
+/** One executed step in an update run. */
+export interface UpdateStep {
+  label: string;
+  ok: boolean;
+  output: string;
+}
+
+/** Outcome of an update run. */
+export interface UpdateResult {
+  ok: boolean;
+  repoRoot: string | null;
+  steps: UpdateStep[];
+  /** Commit before the pull (short SHA), if known. */
+  before?: string;
+  /** Commit after the pull (short SHA), if known. */
+  after?: string;
+  /** True when the pull moved HEAD — i.e. a restart is warranted. */
+  changed: boolean;
+  /** Human-readable failure reason when `ok` is false. */
+  error?: string;
+}
+
+export type CommandRunner = (
+  cmd: string,
+  args: readonly string[],
+  cwd: string,
+  timeoutMs: number,
+) => Promise<{ ok: boolean; output: string }>;
+
+const GIT_TIMEOUT_MS = 60_000;
+const INSTALL_TIMEOUT_MS = 300_000;
+const SETUP_TIMEOUT_MS = 300_000;
+const MAX_OUTPUT_BUFFER = 16 * 1024 * 1024;
+
+const defaultRunner: CommandRunner = (cmd, args, cwd, timeoutMs) =>
+  new Promise((resolve) => {
+    execFile(
+      cmd,
+      [...args],
+      { cwd, timeout: timeoutMs, maxBuffer: MAX_OUTPUT_BUFFER },
+      (err, stdout, stderr) => {
+        const output = `${stdout ?? ""}${stderr ?? ""}`.trim();
+        resolve({
+          ok: !err,
+          output: err && !output ? err.message : output,
+        });
+      },
+    );
+  });
+
+/**
+ * Walk up from this module's location looking for a directory that
+ * is both a git checkout (`.git` present) and an npm package
+ * (`package.json` present). Returns that directory, or `null` when
+ * the process is not running from a source checkout (packaged binary,
+ * global install, etc.).
+ */
+export function getRepoRoot(startDir?: string): string | null {
+  let dir: string;
+  try {
+    dir = startDir ?? dirname(fileURLToPath(import.meta.url));
+  } catch {
+    return null;
+  }
+  for (let i = 0; i < 12; i++) {
+    if (
+      existsSync(join(dir, ".git")) &&
+      existsSync(join(dir, "package.json"))
+    ) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function shortSha(sha: string): string {
+  return sha.trim().slice(0, 12);
+}
+
+/**
+ * Pull latest code, reinstall deps, run setup commands. Stops at the
+ * first failing step and never restarts on its own — the caller
+ * decides (typically: respawn only when `changed` is true).
+ */
+export async function runSelfUpdate(
+  opts: UpdateOptions = {},
+): Promise<UpdateResult> {
+  const repoRoot = opts.repoRoot ?? getRepoRoot();
+  const steps: UpdateStep[] = [];
+  if (!repoRoot) {
+    return {
+      ok: false,
+      repoRoot: null,
+      steps,
+      changed: false,
+      error: "Not running from a git checkout — nothing to update.",
+    };
+  }
+
+  const remote = opts.remote?.trim() || "origin";
+  const branch = opts.branch?.trim() || "main";
+  const run = opts.runner ?? defaultRunner;
+
+  const record = async (
+    label: string,
+    cmd: string,
+    args: readonly string[],
+    timeoutMs: number,
+  ): Promise<UpdateStep> => {
+    const { ok, output } = await run(cmd, args, repoRoot, timeoutMs);
+    const step: UpdateStep = { label, ok, output };
+    steps.push(step);
+    return step;
+  };
+
+  const fail = (error: string, before?: string): UpdateResult => ({
+    ok: false,
+    repoRoot,
+    steps,
+    before,
+    changed: false,
+    error,
+  });
+
+  // Snapshot current HEAD so we can tell whether the pull moved it.
+  const head = await record(
+    "rev-parse HEAD",
+    "git",
+    ["rev-parse", "HEAD"],
+    GIT_TIMEOUT_MS,
+  );
+  if (!head.ok) return fail(`Failed to read current commit: ${head.output}`);
+  const before = shortSha(head.output);
+
+  const fetch = await record(
+    `fetch ${remote} ${branch}`,
+    "git",
+    ["fetch", remote, branch],
+    GIT_TIMEOUT_MS,
+  );
+  if (!fetch.ok) return fail(`git fetch failed: ${fetch.output}`, before);
+
+  const pull = await record(
+    `pull --ff-only ${remote} ${branch}`,
+    "git",
+    ["pull", "--ff-only", remote, branch],
+    GIT_TIMEOUT_MS,
+  );
+  if (!pull.ok) {
+    return fail(
+      `git pull --ff-only failed (local checkout diverged or dirty?): ${pull.output}`,
+      before,
+    );
+  }
+
+  const headAfter = await record(
+    "rev-parse HEAD (post-pull)",
+    "git",
+    ["rev-parse", "HEAD"],
+    GIT_TIMEOUT_MS,
+  );
+  const after = headAfter.ok ? shortSha(headAfter.output) : before;
+  const changed = after !== before;
+
+  // Nothing moved — skip the expensive install/setup and tell the
+  // caller no restart is needed.
+  if (!changed) {
+    return { ok: true, repoRoot, steps, before, after, changed: false };
+  }
+
+  const install = await record(
+    "npm install",
+    "npm",
+    ["install"],
+    INSTALL_TIMEOUT_MS,
+  );
+  if (!install.ok) {
+    return {
+      ok: false,
+      repoRoot,
+      steps,
+      before,
+      after,
+      changed,
+      error: `npm install failed: ${install.output}`,
+    };
+  }
+
+  for (const cmd of opts.setup ?? []) {
+    const trimmed = cmd.trim();
+    if (!trimmed) continue;
+    const setup = await record(
+      `setup: ${trimmed}`,
+      "sh",
+      ["-c", trimmed],
+      SETUP_TIMEOUT_MS,
+    );
+    if (!setup.ok) {
+      return {
+        ok: false,
+        repoRoot,
+        steps,
+        before,
+        after,
+        changed,
+        error: `setup command failed (${trimmed}): ${setup.output}`,
+      };
+    }
+  }
+
+  return { ok: true, repoRoot, steps, before, after, changed: true };
+}

--- a/src/frontend/telegram/commands.ts
+++ b/src/frontend/telegram/commands.ts
@@ -5,6 +5,7 @@
 import type { Bot } from "grammy";
 import { readFileSync, existsSync } from "node:fs";
 import { respawnSelf } from "../../util/respawn.js";
+import { getRepoRoot, runSelfUpdate } from "../../core/update/self-update.js";
 import type { TalonConfig } from "../../util/config.js";
 import { files } from "../../util/paths.js";
 import {
@@ -767,6 +768,64 @@ export function registerCommands(
     await ctx.reply("♻️ Restarting...");
     respawnSelf("telegram /restart");
   });
+
+  // /update — pull latest, reinstall, run setup, restart. Only wired
+  // up for developer builds running from a git checkout; packaged
+  // binaries have no source tree (getRepoRoot() === null) so the
+  // command stays absent entirely.
+  const updateRepoRoot = config.devBuild ? getRepoRoot() : null;
+  if (updateRepoRoot) {
+    bot.command("update", async (ctx) => {
+      if (ADMIN_USER_ID && ctx.from?.id !== ADMIN_USER_ID) {
+        await ctx.reply("Not authorized.");
+        return;
+      }
+      const remote = config.update?.remote ?? "origin";
+      const branch = config.update?.branch ?? "main";
+      const sent = await ctx.reply(
+        `⏳ Updating from <code>${escapeHtml(remote)}/${escapeHtml(branch)}</code>…`,
+        { parse_mode: "HTML" },
+      );
+      const edit = (text: string) =>
+        bot.api
+          .editMessageText(ctx.chat.id, sent.message_id, text, {
+            parse_mode: "HTML",
+          })
+          .catch(() => {});
+
+      // Fire-and-forget so grammY keeps processing other updates.
+      runSelfUpdate({
+        remote,
+        branch,
+        setup: config.update?.setup,
+        repoRoot: updateRepoRoot,
+      })
+        .then(async (res) => {
+          if (!res.ok) {
+            const tail = res.steps[res.steps.length - 1]?.output ?? "";
+            await edit(
+              `⚠️ Update failed: ${escapeHtml(res.error ?? "unknown error")}` +
+                (tail ? `\n\n<pre>${escapeHtml(tail.slice(-1500))}</pre>` : ""),
+            );
+            return;
+          }
+          if (!res.changed) {
+            await edit(
+              `✅ Already up to date at <code>${escapeHtml(res.before ?? "?")}</code> — no restart needed.`,
+            );
+            return;
+          }
+          await edit(
+            `✅ Updated <code>${escapeHtml(res.before ?? "?")}</code> → <code>${escapeHtml(res.after ?? "?")}</code>. ♻️ Restarting…`,
+          );
+          respawnSelf("telegram /update");
+        })
+        .catch(async (err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          await edit(`⚠️ Update crashed: ${escapeHtml(msg)}`);
+        });
+    });
+  }
 
   bot.command("plugins", async (ctx) => {
     const plugins = getLoadedPlugins();

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -298,6 +298,28 @@ const configSchema = z.object({
   disabledTools: z.array(z.string()).optional(),
   disabledToolTags: z.array(z.string()).optional(),
 
+  /**
+   * Developer build flag. Gates dev-only affordances such as the
+   * `/update` self-update command. Off by default so packaged /
+   * end-user deployments never expose them.
+   */
+  devBuild: z.boolean().default(false),
+
+  /**
+   * Self-update settings for the `/update` command. Only takes effect
+   * when `devBuild` is true AND the process runs from a git checkout.
+   * Pulls `remote/branch` (fast-forward only), reinstalls deps, runs
+   * any `setup` commands, then restarts.
+   */
+  update: z
+    .object({
+      remote: z.string().min(1).default("origin"),
+      branch: z.string().min(1).default("main"),
+      /** Extra shell commands run in the repo root after `npm install`. */
+      setup: z.array(z.string()).optional(),
+    })
+    .optional(),
+
   // GitHub — GitHub API access via official MCP server
   github: z
     .object({


### PR DESCRIPTION
## What

Adds an admin-only **`/update`** Telegram command for developers running Talon from a git clone: it pulls the latest code, reinstalls deps, runs optional setup commands, and restarts.

Requested by Dylan: *"an /update command if dev build is enabled and running from a git clone… in json you can specify a custom remote and/or branch but by default uses origin and main, will pull, run npm install, restart, and do any other setup stuff."*

## Gating

The command is registered **only when both** are true:
1. `devBuild: true` in config, and
2. the process is running from a git checkout — `getRepoRoot()` walks up from the module for a dir containing both `.git` and `package.json`. Packaged/bun-compiled binaries have no source tree → returns `null` → the command never appears.

## Behaviour

`runSelfUpdate()` (`src/core/update/self-update.ts`):
1. snapshot `HEAD`
2. `git fetch <remote> <branch>`
3. `git pull --ff-only <remote> <branch>`
4. if HEAD didn't move → report "already up to date", **no restart**
5. `npm install`
6. run each optional `update.setup[]` command (`sh -c`, in repo root)
7. return `changed: true`

The caller (`/update` handler) only calls the existing `respawnSelf()` when `changed` is true. Stops at the first failing step and **never restarts on failure**.

**`--ff-only` is deliberate:** a fast-forward can't create a merge commit or a conflicted half-merge on a prod host. A diverged/dirty checkout fails loudly with nothing installed or restarted.

## Config

```jsonc
{
  "devBuild": true,
  "update": {
    "remote": "origin",   // default
    "branch": "main",     // default
    "setup": ["npm run build"]  // optional, run after npm install
  }
}
```
Both `update` and its fields are optional; defaults are `origin`/`main`.

## Restart

Reuses the existing `respawnSelf()` handoff that `/restart` uses (detached successor + graceful SIGTERM) — works regardless of launch method, no supervisor required.

## Tests

- `runSelfUpdate`: no-op (HEAD unchanged, skips install), fast-forward (install + setup + custom remote/branch threaded through), default origin/main, pull-failure stops before install, install-failure.
- `getRepoRoot`: finds `.git`+`package.json` ancestor; returns null with no checkout.

Typecheck clean, oxlint clean, prettier clean, config + plugin suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)