### PR TITLE
ci: stop "Worker exited unexpectedly" flake in Blake3 Napi job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,9 +454,17 @@ jobs:
         run: npm run build:napi
 
       - name: Addon behavior + wasm parity + media-index consumer
+        # Pin to a single persistent fork. These three files load the
+        # native blake3 .node addon and a real better-sqlite3 handle;
+        # under vitest's default multi-fork pool the per-file worker
+        # churn intermittently dies with "Worker exited unexpectedly"
+        # (the tests themselves pass first). One fork, run sequentially,
+        # removes the concurrent native-addon load/teardown that causes
+        # the flake without changing any test logic.
         run: |
           npm ci
-          npx vitest run src/__tests__/blake3-napi.test.ts \
+          npx vitest run --pool=forks --no-file-parallelism --maxWorkers=1 \
+            src/__tests__/blake3-napi.test.ts \
             src/__tests__/blake3-wasm.test.ts \
             src/__tests__/media-index.test.ts
 


### PR DESCRIPTION
## Problem

The **Blake3 Napi** job intermittently fails with:

```
Error: [vitest-pool]: Worker forks emitted error.
Caused by: Error: Worker exited unexpectedly
##[error]Process completed with exit code 1.
```

…**after** the tests themselves pass (`✓ blake3-napi`, `✓ blake3-wasm`). It's a worker-fork lifecycle crash, not a test failure. Seen on multiple branches including `main` (e.g. the 06-14 main run, and PR #345's first run).

## Cause

The step runs three files that each load native resources — the blake3 `.node` addon and a real `better-sqlite3` handle — together under vitest's **default multi-fork parallel pool**. The concurrent per-file worker spawn/teardown around native modules occasionally segfaults/kills a worker, which vitest surfaces as "Worker exited unexpectedly".

The tests clean up correctly (media-index closes its DB in `afterEach`); the flake is pool churn, not a leak.

## Fix

Pin just this CI step to a single worker running the files sequentially:

```
npx vitest run --pool=forks --no-file-parallelism --maxWorkers=1 …
```

One fork, no concurrent native-addon load/teardown → no churn-induced crash. Scoped to this job only, so the main test matrix keeps its parallelism. No test logic changes — all 48 tests still pass locally under these flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)