### PR TITLE
feat(jobs): per-trigger/per-cron custom model (same backend) + model discovery tools

### DIFF
--- a/src/__tests__/active-model.test.ts
+++ b/src/__tests__/active-model.test.ts
@@ -57,6 +57,7 @@ const {
   getActiveModelForChat,
   describeActiveModelSource,
   getModelByBackendSnapshot,
+  resolveExplicitModelRef,
 } = await import("../core/models/active-model.js");
 const {
   setChatModelForBackend,
@@ -503,5 +504,45 @@ describe("per-backend storage semantics", () => {
     );
     expect(result.model).toBe("legacy-store-value");
     expect(result.source).toBe("override-valid");
+  });
+});
+
+describe("resolveExplicitModelRef — per-job model override", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("materialises a ref for a selectable model on the backend", async () => {
+    const be = fakeBackend({
+      resolveModel: async () => exactResolution("claude-haiku-4-5"),
+    });
+    const ref = await resolveExplicitModelRef("claude-haiku-4-5", be, "claude");
+    expect(ref).not.toBeNull();
+    expect(ref?.id).toBe("claude-haiku-4-5");
+    expect(ref?.backend).toBe("claude");
+  });
+
+  it("returns null for a model that is missing on the backend", async () => {
+    const be = fakeBackend({ resolveModel: async () => missingResolution() });
+    expect(await resolveExplicitModelRef("nope-1", be, "claude")).toBeNull();
+  });
+
+  it("returns null for a non-selectable model", async () => {
+    const be = fakeBackend({
+      resolveModel: async () => exactResolution("legacy-x", false),
+    });
+    expect(await resolveExplicitModelRef("legacy-x", be, "claude")).toBeNull();
+  });
+
+  it("returns null for an empty model id", async () => {
+    const be = fakeBackend({
+      resolveModel: async () => exactResolution("x"),
+    });
+    expect(await resolveExplicitModelRef("", be, "claude")).toBeNull();
+  });
+
+  it("trusts the id when the backend has no catalog to validate against", async () => {
+    const be = fakeBackend({}); // no models catalog
+    const ref = await resolveExplicitModelRef("some-model", be, "claude");
+    expect(ref).not.toBeNull();
+    expect(ref?.id).toBe("some-model");
   });
 });

--- a/src/__tests__/dispatcher.test.ts
+++ b/src/__tests__/dispatcher.test.ts
@@ -10,6 +10,7 @@ import {
   stubChatBackend,
   stubResolveActiveModel,
 } from "./helpers/stub-backend.js";
+import { makeBareModelRef } from "../core/agent-runtime/model-ref.js";
 
 function createMockDeps() {
   const acquired: number[] = [];
@@ -94,6 +95,74 @@ describe("dispatcher", () => {
         text: "hello",
       }),
     );
+  });
+
+  it("uses the per-run model override when it resolves", async () => {
+    const deps = createMockDeps();
+    const resolveModelOverride = vi.fn(async () =>
+      makeBareModelRef("claude", "claude-haiku-4-5", "discovered"),
+    );
+    initDispatcher({ ...deps, resolveModelOverride });
+
+    await execute({
+      chatId: "123",
+      numericChatId: 123,
+      prompt: "hello",
+      senderName: "Trigger",
+      isGroup: false,
+      source: "trigger",
+      modelOverride: "claude-haiku-4-5",
+    });
+
+    expect(resolveModelOverride).toHaveBeenCalledWith(
+      "123",
+      "claude-haiku-4-5",
+    );
+    expect(deps.query).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "claude-haiku-4-5" }),
+    );
+  });
+
+  it("falls back to the chat model when the override does not resolve", async () => {
+    const deps = createMockDeps();
+    const resolveModelOverride = vi.fn(async () => null);
+    initDispatcher({
+      ...deps,
+      resolveActiveModel: stubResolveActiveModel("claude", "stub-model"),
+      resolveModelOverride,
+    });
+
+    await execute({
+      chatId: "123",
+      numericChatId: 123,
+      prompt: "hello",
+      senderName: "Trigger",
+      isGroup: false,
+      source: "trigger",
+      modelOverride: "delisted-model",
+    });
+
+    expect(resolveModelOverride).toHaveBeenCalled();
+    expect(deps.query).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "stub-model" }),
+    );
+  });
+
+  it("ignores the override resolver when no modelOverride is set", async () => {
+    const deps = createMockDeps();
+    const resolveModelOverride = vi.fn(async () => null);
+    initDispatcher({ ...deps, resolveModelOverride });
+
+    await execute({
+      chatId: "123",
+      numericChatId: 123,
+      prompt: "hello",
+      senderName: "User",
+      isGroup: false,
+      source: "message",
+    });
+
+    expect(resolveModelOverride).not.toHaveBeenCalled();
   });
 
   it("acquires and releases context", async () => {

--- a/src/__tests__/gateway-actions.test.ts
+++ b/src/__tests__/gateway-actions.test.ts
@@ -53,6 +53,26 @@ vi.mock("../storage/cron-store.js", () => ({
   loadCronJobs: vi.fn(),
 }));
 
+// Backend controller + model resolver — exercised by the per-job model
+// override validation and the list_models / list_backends discovery actions.
+const mockGetBackendForChat = vi.fn((): unknown => ({ models: undefined }));
+const mockGetBackendIdForChat = vi.fn(() => "claude");
+const mockGetAvailableBackends = vi.fn((): { id: string; label: string }[] => [
+  { id: "claude", label: "Claude" },
+]);
+const mockGetPooledBackend = vi.fn((): unknown => null);
+vi.mock("../core/engine/backend-controller.js", () => ({
+  getBackendForChat: mockGetBackendForChat,
+  getBackendIdForChat: mockGetBackendIdForChat,
+  getAvailableBackends: mockGetAvailableBackends,
+  getPooledBackend: mockGetPooledBackend,
+}));
+
+const mockResolveExplicitModelRef = vi.fn(async (): Promise<unknown> => null);
+vi.mock("../core/models/active-model.js", () => ({
+  resolveExplicitModelRef: mockResolveExplicitModelRef,
+}));
+
 // Mock node:fs for fetch_url binary download path
 const mockExistsSync = vi.fn(() => true);
 const mockMkdirSync = vi.fn();
@@ -1769,5 +1789,151 @@ describe("gateway-actions — additional branch coverage", () => {
     );
     // Should succeed (downloaded as bin), covering ct ?? "" right side and ct.split("/")[1] ?? "file" right side
     expect(result?.ok).toBe(true);
+  });
+});
+
+// ── Per-job model override + model/backend discovery ────────────────────────
+
+describe("per-job model override + discovery actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetBackendIdForChat.mockReturnValue("claude");
+    mockGetBackendForChat.mockReturnValue({ models: undefined });
+    mockGetPooledBackend.mockReturnValue(null);
+    mockGetAvailableBackends.mockReturnValue([
+      { id: "claude", label: "Claude" },
+    ]);
+    mockResolveExplicitModelRef.mockResolvedValue(null);
+    mockValidateCronExpression.mockReturnValue({
+      valid: true,
+      next: "2026-04-01T09:00:00.000Z",
+    });
+  });
+
+  describe("create_cron_job model override", () => {
+    it("rejects a query model that isn't selectable on the chat's backend", async () => {
+      mockResolveExplicitModelRef.mockResolvedValue(null);
+      const result = await handleSharedAction(
+        {
+          action: "create_cron_job",
+          name: "Cheap job",
+          schedule: "0 9 * * *",
+          type: "query",
+          content: "do a thing",
+          model: "bogus-model",
+        },
+        42,
+      );
+      expect(result?.ok).toBe(false);
+      expect(result?.error).toMatch(/not a selectable model/i);
+      expect(mockAddCronJob).not.toHaveBeenCalled();
+    });
+
+    it("persists a valid query model", async () => {
+      mockResolveExplicitModelRef.mockResolvedValue({
+        id: "claude-haiku-4-5",
+        backend: "claude",
+      });
+      const result = await handleSharedAction(
+        {
+          action: "create_cron_job",
+          name: "Cheap job",
+          schedule: "0 9 * * *",
+          type: "query",
+          content: "do a thing",
+          model: "claude-haiku-4-5",
+        },
+        42,
+      );
+      expect(result?.ok).toBe(true);
+      expect(mockAddCronJob).toHaveBeenCalledWith(
+        expect.objectContaining({ model: "claude-haiku-4-5", type: "query" }),
+      );
+    });
+
+    it("rejects a model override on a non-query job before validating it", async () => {
+      const result = await handleSharedAction(
+        {
+          action: "create_cron_job",
+          name: "Msg job",
+          schedule: "0 9 * * *",
+          type: "message",
+          content: "hello",
+          model: "claude-haiku-4-5",
+        },
+        42,
+      );
+      expect(result?.ok).toBe(false);
+      expect(result?.error).toMatch(/only applies to 'query'/i);
+      expect(mockResolveExplicitModelRef).not.toHaveBeenCalled();
+      expect(mockAddCronJob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("list_models", () => {
+    it("lists selectable models on the chat's current backend", async () => {
+      mockGetBackendForChat.mockReturnValue({
+        models: {
+          listModels: async () => ({
+            models: [
+              {
+                id: "claude-opus-4-8",
+                displayName: "Opus 4.8",
+                selectable: true,
+                reasoning: true,
+                contextWindow: 1_000_000,
+              },
+              {
+                id: "claude-haiku-4-5",
+                displayName: "Haiku 4.5",
+                selectable: true,
+              },
+              { id: "legacy", displayName: "Legacy", selectable: false },
+            ],
+            total: 3,
+          }),
+        },
+      });
+      const result = await handleSharedAction({ action: "list_models" }, 42);
+      expect(result?.ok).toBe(true);
+      expect(result?.backend).toBe("claude");
+      const ids = (result?.models as { id: string }[]).map((m) => m.id);
+      expect(ids).toEqual(["claude-opus-4-8", "claude-haiku-4-5"]); // non-selectable dropped
+      expect(result?.text).toContain("claude-haiku-4-5");
+    });
+
+    it("reports a fixed-model backend with no catalog", async () => {
+      mockGetBackendForChat.mockReturnValue({ models: undefined });
+      const result = await handleSharedAction({ action: "list_models" }, 42);
+      expect(result?.ok).toBe(true);
+      expect(result?.text).toMatch(/fixed model/i);
+      expect(result?.models).toEqual([]);
+    });
+
+    it("errors on an unknown named backend", async () => {
+      const result = await handleSharedAction(
+        { action: "list_models", backend: "ghost" },
+        42,
+      );
+      expect(result?.ok).toBe(false);
+      expect(result?.error).toMatch(/unknown backend/i);
+    });
+  });
+
+  describe("list_backends", () => {
+    it("lists available backends and flags the current one", async () => {
+      mockGetAvailableBackends.mockReturnValue([
+        { id: "claude", label: "Claude" },
+        { id: "codex", label: "Codex" },
+      ]);
+      mockGetBackendIdForChat.mockReturnValue("codex");
+      const result = await handleSharedAction({ action: "list_backends" }, 42);
+      expect(result?.ok).toBe(true);
+      expect(result?.backends).toEqual([
+        { id: "claude", label: "Claude", current: false },
+        { id: "codex", label: "Codex", current: true },
+      ]);
+      expect(result?.text).toContain("current");
+    });
   });
 });

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -258,6 +258,21 @@ export async function initBackendAndDispatcher(
       );
       return { model, ref, backendId: beId };
     },
+    // Per-run model override (triggers/cron): validate + materialise an
+    // explicit model id against the chat's backend. Returns null when the id
+    // isn't selectable, so the dispatcher falls back to the chat model.
+    // Restricted to the chat's own backend so the session still resumes.
+    resolveModelOverride: async (chatId: string, modelId: string) => {
+      const { resolveExplicitModelRef } =
+        await import("./core/models/active-model.js");
+      const { getBackendIdForChat, getBackendForChat: getBE } =
+        await import("./core/engine/backend-controller.js");
+      return resolveExplicitModelRef(
+        modelId,
+        getBE(chatId),
+        getBackendIdForChat(chatId),
+      );
+    },
     context: frontend.context,
     sendTyping: frontend.sendTyping,
     onActivity: () => resetPulseTimer(),

--- a/src/core/background/cron.ts
+++ b/src/core/background/cron.ts
@@ -218,6 +218,11 @@ async function executeJob(job: CronJob): Promise<void> {
       senderName: "Cron",
       isGroup: false,
       source: "cron",
+      // Per-job model override (same backend) — runs this query on a cheaper
+      // model while still resuming the chat session. Only "query" jobs reach
+      // here, so a stored model always applies. Falls back to the chat model
+      // if the id no longer resolves.
+      ...(job.model ? { modelOverride: job.model } : {}),
     }),
     CRON_JOB_TIMEOUT_MS,
     `Cron job "${job.name}"`,

--- a/src/core/background/triggers.ts
+++ b/src/core/background/triggers.ts
@@ -732,6 +732,10 @@ async function fireWake(
       senderName: "Trigger",
       isGroup: false,
       source: "trigger",
+      // Per-trigger model override (same backend) — runs the wake-up turn on a
+      // cheaper model while still resuming the chat session. Falls back to the
+      // chat model if the id no longer resolves.
+      ...(t.model ? { modelOverride: t.model } : {}),
     });
   } catch (err) {
     logError("triggers", `wake dispatch failed [${triggerId}]`, err);

--- a/src/core/engine/backend-controller.ts
+++ b/src/core/engine/backend-controller.ts
@@ -124,6 +124,8 @@ const pool = new Map<string, PoolEntry>();
 const bindings = new Map<BackendHolder, string>();
 /** Captured at first init so subsequent calls don't need ctx plumbed through. */
 let initCtx: BackendInitContext | null = null;
+/** Captured at init so config-aware reads (available backends) need no plumbing. */
+let poolConfig: TalonConfig | null = null;
 
 const listeners = new Set<BackendChangeListener>();
 
@@ -241,6 +243,7 @@ export async function initBackendPool(
   ctx: BackendInitContext,
 ): Promise<void> {
   initCtx = ctx;
+  poolConfig = config;
   const initialisedHolders: BackendHolder[] = [];
   try {
     for (const role of ALL_ROLES) {
@@ -335,6 +338,26 @@ export function listAvailableBackends(
 /** Whether a backend id is registered and currently exposed by config. */
 export function isBackendAvailable(id: string, config?: TalonConfig): boolean {
   return listAvailableBackends(config).some((b) => b.id === id);
+}
+
+/**
+ * Available backends using the config captured at init — convenience for
+ * runtime readers (e.g. the `list_backends` tool) that don't have config
+ * plumbed through. Falls back to all registered backends pre-init.
+ */
+export function getAvailableBackends(): { id: string; label: string }[] {
+  return listAvailableBackends(poolConfig ?? undefined);
+}
+
+/**
+ * The live pooled `Backend` instance for an id, or `null` if it isn't currently
+ * pooled. Unlike `getBackendForRole`/`getBackendForChat` this never initialises
+ * on demand — it only returns backends already spun up (role backends + chat
+ * overrides), so a read-only caller (e.g. `list_models` for a non-current
+ * backend) can degrade gracefully instead of forcing a backend to boot.
+ */
+export function getPooledBackend(id: string): Backend | null {
+  return pool.get(id)?.backend ?? null;
 }
 
 /**
@@ -607,6 +630,7 @@ export function resetBackendPoolForTest(): void {
   pool.clear();
   bindings.clear();
   initCtx = null;
+  poolConfig = null;
 }
 
 /** Test-only: drop all listeners. */
@@ -629,6 +653,7 @@ export async function initBackendController(
   ctx: BackendInitContext,
 ): Promise<Backend> {
   initCtx = ctx;
+  poolConfig = config;
   const entry = await ensurePoolEntry(id, config);
   const holder = roleHolder("chat");
   entry.holders.add(holder);

--- a/src/core/engine/dispatcher.ts
+++ b/src/core/engine/dispatcher.ts
@@ -38,6 +38,15 @@ type DispatcherDeps = {
     ref: import("../agent-runtime/model-ref.js").ModelRef | null;
     backendId: string;
   }>;
+  /**
+   * Resolve an explicit per-run model override against the chat's backend.
+   * Returns the materialised ref, or `null` when the id isn't a selectable
+   * model on that backend. Optional: when unset, overrides are ignored.
+   */
+  resolveModelOverride?: (
+    chatId: string,
+    modelId: string,
+  ) => Promise<import("../agent-runtime/model-ref.js").ModelRef | null>;
   context: ContextManager;
   sendTyping: (chatId: number) => Promise<void>;
   onActivity: () => void;
@@ -101,8 +110,14 @@ async function run(params: ExecuteParams): Promise<ExecuteResult> {
 }
 
 async function executeInner(params: ExecuteParams): Promise<ExecuteResult> {
-  const { getBackend, resolveActiveModel, context, sendTyping, onActivity } =
-    deps!;
+  const {
+    getBackend,
+    resolveActiveModel,
+    resolveModelOverride,
+    context,
+    sendTyping,
+    onActivity,
+  } = deps!;
   // Read the backend fresh per call so backend swaps (chat-role
   // rebinds or per-chat overrides via the controller) take effect on
   // the next query without a dispatcher re-init.
@@ -150,6 +165,38 @@ async function executeInner(params: ExecuteParams): Promise<ExecuteResult> {
     };
   }
 
+  // Per-run model override (triggers/cron). Resolve against the chat's
+  // backend; on success swap the ref for this turn only, on failure fall
+  // back to the chat model so a stale override never kills the run. The
+  // override is restricted to the chat's own backend, so the session still
+  // resumes — only the model changes.
+  let runRef = resolvedRef;
+  if (params.modelOverride && resolveModelOverride) {
+    try {
+      const overrideRef = await resolveModelOverride(
+        params.chatId,
+        params.modelOverride,
+      );
+      if (overrideRef) {
+        runRef = overrideRef;
+        logDebug(
+          "dispatcher",
+          `[${reqId}] model override → ${params.modelOverride} (${params.source})`,
+        );
+      } else {
+        logWarn(
+          "dispatcher",
+          `[${reqId}] model override "${params.modelOverride}" not resolvable on backend ${backendId}; using chat model`,
+        );
+      }
+    } catch (err) {
+      logWarn(
+        "dispatcher",
+        `[${reqId}] model override resolution threw: ${err instanceof Error ? err.message : String(err)}; using chat model`,
+      );
+    }
+  }
+
   // Dream check — fire-and-forget background memory consolidation if due
   maybeStartDream();
 
@@ -190,7 +237,7 @@ async function executeInner(params: ExecuteParams): Promise<ExecuteResult> {
     }
     const stream = backend.chat.runChatTurn({
       chatId: params.chatId,
-      model: resolvedRef,
+      model: runRef,
       text: params.prompt,
       senderName: params.senderName,
       isGroup: params.isGroup,

--- a/src/core/engine/gateway-actions.ts
+++ b/src/core/engine/gateway-actions.ts
@@ -46,6 +46,13 @@ import {
   type TriggerLanguage,
 } from "../../storage/trigger-store.js";
 import { cancelTrigger, spawnTrigger } from "../background/triggers.js";
+import { resolveExplicitModelRef } from "../models/active-model.js";
+import {
+  getBackendForChat,
+  getBackendIdForChat,
+  getAvailableBackends,
+  getPooledBackend,
+} from "./backend-controller.js";
 import {
   deleteScript,
   formatScript,
@@ -117,6 +124,41 @@ function extractText(html: string, maxLength = 8000): string {
   // Get text content, normalize whitespace
   const text = $("body").text().replace(/\s+/g, " ").trim();
   return text.slice(0, maxLength);
+}
+
+/**
+ * Validate a per-job model override so create_cron_job / trigger_create can
+ * reject a bad override up front — the agent retries or tells the user —
+ * instead of storing one that fails at fire time.
+ *
+ * The override is restricted to the chat's own backend so the wake-up can
+ * resume the existing session (a session id is backend-specific). The model
+ * must therefore be selectable on the chat's backend; returns an error string
+ * when it isn't, or `null` when it's valid.
+ */
+async function validateJobModelOverride(
+  chatId: number,
+  model: string,
+): Promise<string | null> {
+  try {
+    const chatIdStr = String(chatId);
+    const ref = await resolveExplicitModelRef(
+      model,
+      getBackendForChat(chatIdStr),
+      getBackendIdForChat(chatIdStr),
+    );
+    if (!ref) {
+      return (
+        `Model "${model}" is not a selectable model on this chat's backend. ` +
+        `Leave model unset to use the chat's model, or pick a valid model id ` +
+        `on the same backend (cross-backend models aren't allowed — they'd ` +
+        `break session continuity).`
+      );
+    }
+    return null;
+  } catch (err) {
+    return `Could not validate model override: ${err instanceof Error ? err.message : String(err)}`;
+  }
 }
 
 export async function handleSharedAction(
@@ -287,11 +329,19 @@ export async function handleSharedAction(
       const jobType = (body.type as CronJobType) ?? "message";
       const content = String(body.content ?? "");
       const timezone = body.timezone ? String(body.timezone) : undefined;
+      const model = body.model ? String(body.model) : undefined;
 
       if (!schedule) return { ok: false, error: "Missing schedule expression" };
       if (!content) return { ok: false, error: "Missing content" };
       if (content.length > 10_000)
         return { ok: false, error: "Content too long (max 10,000 chars)" };
+      // A model override only makes sense for "query" jobs (a "message" job
+      // just sends text — no model runs).
+      if (model && jobType !== "query")
+        return {
+          ok: false,
+          error: "A model override only applies to 'query' jobs.",
+        };
 
       const validation = validateCronExpression(schedule, timezone);
       if (!validation.valid)
@@ -299,6 +349,13 @@ export async function handleSharedAction(
           ok: false,
           error: `Invalid cron expression: ${validation.error}`,
         };
+
+      // Validate the model up front so a bad id is rejected here instead of
+      // silently failing at fire time.
+      if (model) {
+        const modelErr = await validateJobModelOverride(chatId, model);
+        if (modelErr) return { ok: false, error: modelErr };
+      }
 
       const id = generateCronId();
       addCronJob({
@@ -312,6 +369,7 @@ export async function handleSharedAction(
         createdAt: Date.now(),
         runCount: 0,
         timezone,
+        ...(model ? { model } : {}),
       });
       log("gateway", `create_cron_job: "${name}" [${schedule}]`);
       return {
@@ -405,6 +463,7 @@ export async function handleSharedAction(
         ? String(body.description)
         : undefined;
       const persistent = body.persistent === true;
+      const model = body.model ? String(body.model) : undefined;
 
       const nameErr = validateName(name);
       if (nameErr) return { ok: false, error: nameErr };
@@ -441,6 +500,13 @@ export async function handleSharedAction(
         };
       }
 
+      // Validate the model up front so a bad id is rejected here instead of
+      // silently failing at fire time.
+      if (model) {
+        const modelErr = await validateJobModelOverride(chatId, model);
+        if (modelErr) return { ok: false, error: modelErr };
+      }
+
       const id = generateTriggerId();
       const lang = language as TriggerLanguage;
       let scriptPath: string;
@@ -468,6 +534,7 @@ export async function handleSharedAction(
         timeoutSeconds,
         fireCount: 0,
         persistent,
+        ...(model ? { model } : {}),
       };
       addTrigger(trigger);
 
@@ -1017,6 +1084,98 @@ export async function handleSharedAction(
           error: `Plugin reload failed: ${err instanceof Error ? err.message : err}`,
         };
       }
+    }
+
+    // ── Model / backend discovery ────────────────────────────────────────
+
+    case "list_models": {
+      const chatIdStr = String(chatId);
+      const currentId = getBackendIdForChat(chatIdStr);
+      const requested = body.backend ? String(body.backend).trim() : "";
+      const targetId = requested || currentId;
+
+      // Only return a backend we already have a live instance for — never
+      // boot one just to read its catalog. The chat's own backend is always
+      // live; another backend is only listable while it's pooled.
+      const instance =
+        targetId === currentId
+          ? getBackendForChat(chatIdStr)
+          : getPooledBackend(targetId);
+
+      if (!instance) {
+        const avail = getAvailableBackends().map((b) => b.id);
+        if (!avail.includes(targetId))
+          return {
+            ok: false,
+            error: `Unknown backend "${targetId}". Available backends: ${avail.join(", ") || "(none)"}.`,
+          };
+        return {
+          ok: false,
+          error: `Backend "${targetId}" isn't currently active, so its model catalog isn't loaded. Switch this chat to it first, or call list_models with no argument to see this chat's backend ("${currentId}") models.`,
+        };
+      }
+
+      const catalog = instance.models;
+      if (!catalog?.listModels)
+        return {
+          ok: true,
+          backend: targetId,
+          models: [],
+          text: `Backend "${targetId}" runs a fixed model (no selectable model catalog).`,
+        };
+
+      const { models } = await catalog.listModels("all");
+      const selectable = models.filter((m) => m.selectable);
+      const slim = selectable.map((m) => ({
+        id: m.id,
+        displayName: m.displayName,
+        reasoning: m.reasoning ?? false,
+        contextWindow: m.contextWindow,
+        free: m.free ?? false,
+      }));
+      if (slim.length === 0)
+        return {
+          ok: true,
+          backend: targetId,
+          models: [],
+          text: `Backend "${targetId}" exposes no selectable models.`,
+        };
+      const lines = slim.map((m) => {
+        const bits = [
+          m.reasoning ? "reasoning" : null,
+          m.contextWindow ? `${Math.round(m.contextWindow / 1000)}k ctx` : null,
+          m.free ? "free" : null,
+        ].filter(Boolean);
+        const name =
+          m.displayName && m.displayName !== m.id ? ` (${m.displayName})` : "";
+        return `- ${m.id}${name}${bits.length ? ` — ${bits.join(", ")}` : ""}`;
+      });
+      return {
+        ok: true,
+        backend: targetId,
+        models: slim,
+        text: `Selectable models on "${targetId}" (${slim.length}):\n${lines.join("\n")}`,
+      };
+    }
+
+    case "list_backends": {
+      const currentId = getBackendIdForChat(String(chatId));
+      const backends = getAvailableBackends().map((b) => ({
+        id: b.id,
+        label: b.label,
+        current: b.id === currentId,
+      }));
+      if (backends.length === 0)
+        return { ok: true, backends: [], text: "No backends are available." };
+      const lines = backends.map(
+        (b) =>
+          `- ${b.id}${b.label && b.label !== b.id ? ` (${b.label})` : ""}${b.current ? " — current" : ""}`,
+      );
+      return {
+        ok: true,
+        backends,
+        text: `Available backends (${backends.length}):\n${lines.join("\n")}`,
+      };
     }
 
     default:

--- a/src/core/models/active-model.ts
+++ b/src/core/models/active-model.ts
@@ -251,6 +251,26 @@ async function validateModelOnBackend(
   }
 }
 
+/**
+ * Validate + materialise an *explicit* model id against a backend, bypassing the
+ * per-chat resolution chain. Returns the `ModelRef` when the id is a selectable
+ * model on the backend, or `null` when it isn't (unknown / not selectable).
+ *
+ * Used for per-job (trigger/cron) model overrides, which are restricted to the
+ * chat's own backend so the wake-up can resume the existing session: at
+ * create-time to reject a bad id with a clear error, and at fire-time to fall
+ * back gracefully if the catalog changed after the job was created.
+ */
+export async function resolveExplicitModelRef(
+  modelId: string,
+  backend: Backend | null,
+  backendId: string | null,
+): Promise<ModelRef | null> {
+  if (!modelId) return null;
+  if (!(await validateModelOnBackend(backend, modelId))) return null;
+  return materialiseRef(modelId, backend, backendId);
+}
+
 async function safeBackendDefault(backend: Backend): Promise<string | null> {
   if (!backend.models?.getDefaultModelId) return null;
   try {

--- a/src/core/tools/index.ts
+++ b/src/core/tools/index.ts
@@ -20,6 +20,7 @@ import { scriptTools } from "./scripts.js";
 import { skillTools } from "./skills.js";
 import { webTools } from "./web.js";
 import { adminTools } from "./admin.js";
+import { modelTools } from "./models.js";
 
 /** All built-in tool definitions. */
 export const ALL_TOOLS: readonly ToolDefinition[] = [
@@ -36,6 +37,7 @@ export const ALL_TOOLS: readonly ToolDefinition[] = [
   ...skillTools,
   ...webTools,
   ...adminTools,
+  ...modelTools,
 ];
 
 /**

--- a/src/core/tools/models.ts
+++ b/src/core/tools/models.ts
@@ -1,0 +1,39 @@
+/**
+ * Model / backend discovery tools.
+ *
+ * These let the model see what it's running on: the selectable models on a
+ * backend and the list of available backends. The main use is picking a valid
+ * `model` id for a per-trigger / per-cron model override — those overrides are
+ * restricted to THIS chat's current backend (so the wake-up can resume the
+ * session), which is exactly what `list_models` (no argument) returns.
+ */
+
+import { z } from "zod";
+import type { ToolDefinition } from "./types.js";
+
+export const modelTools: ToolDefinition[] = [
+  {
+    name: "list_models",
+    description:
+      "List the selectable models on a backend. With no argument, lists the models on THIS chat's current backend — the only backend whose models a per-trigger/per-cron `model` override can use (overrides stay on the chat's backend so the session resumes with continuity). Use this to pick a valid model id before setting `model` on trigger_create or create_cron_job. Optionally pass `backend` to inspect another backend's models for awareness (only currently-active backends can be listed).",
+    schema: {
+      backend: z
+        .string()
+        .optional()
+        .describe(
+          "Backend id to list models for (e.g. 'claude'). Defaults to this chat's current backend. Call list_backends to see valid ids.",
+        ),
+    },
+    execute: (params, bridge) => bridge("list_models", params),
+    tag: "models",
+  },
+
+  {
+    name: "list_backends",
+    description:
+      "List the available backends (providers) and which one this chat is currently using. Useful for understanding the model/provider landscape. Note: a per-job `model` override must stay on this chat's current backend, so use list_models (no argument) to pick a model for a trigger or cron job.",
+    schema: {},
+    execute: (_params, bridge) => bridge("list_backends", {}),
+    tag: "models",
+  },
+];

--- a/src/core/tools/scheduling.ts
+++ b/src/core/tools/scheduling.ts
@@ -28,7 +28,9 @@ Examples:
   "0 8 * * 1"     = every Monday at 8:00 AM
 
 Type "message" sends the content as a text message.
-Type "query" runs the content as a Claude prompt with full tool access (can search, create files, send messages, etc).`,
+Type "query" runs the content as a Claude prompt with full tool access (can search, create files, send messages, etc).
+
+Model: leave "model" unset to run on this chat's model (preferred). Only set it for a "query" job that should run on a cheaper model from the SAME backend as this chat — e.g. a routine daily task that doesn't need the flagship model. The job still resumes this chat's session (same backend = session continuity preserved). The model must be a valid, selectable model id on this chat's backend; an invalid or cross-backend id is rejected — pick from the available models.`,
     schema: {
       name: z.string().describe("Human-readable name for the job"),
       schedule: z
@@ -45,6 +47,12 @@ Type "query" runs the content as a Claude prompt with full tool access (can sear
         .optional()
         .describe(
           "IANA timezone (e.g. 'America/New_York'). Defaults to system timezone.",
+        ),
+      model: z
+        .string()
+        .optional()
+        .describe(
+          "Optional model override for 'query' jobs. Unset = this chat's model (preferred). Set only to run on a cheaper model from the SAME backend as this chat (session continuity is preserved). Must be a valid, selectable model id on this chat's backend — call list_models to see valid ids; an invalid or cross-backend id is rejected.",
         ),
     },
     execute: (params, bridge) => bridge("create_cron_job", params),

--- a/src/core/tools/triggers.ts
+++ b/src/core/tools/triggers.ts
@@ -101,6 +101,12 @@ export const triggerTools: ToolDefinition[] = [
         .describe(
           "If true, respawn this trigger automatically when Talon restarts. Default false.",
         ),
+      model: z
+        .string()
+        .optional()
+        .describe(
+          "Optional model override for the wake-up turn. Unset = this chat's model (preferred). Set only when the wake-up handling is mechanical (e.g. 'check what broke and act') and a cheaper model from the SAME backend suffices; the wake-up still resumes this chat's session (same backend = session continuity preserved). Must be a valid, selectable model id on this chat's backend — call list_models to see valid ids; cross-backend ids are rejected.",
+        ),
     },
     execute: (params, bridge) => bridge("trigger_create", params),
     tag: "triggers",

--- a/src/core/tools/types.ts
+++ b/src/core/tools/types.ts
@@ -29,7 +29,8 @@ export type ToolTag =
   | "scripts"
   | "skills"
   | "web"
-  | "admin";
+  | "admin"
+  | "models";
 
 /** The bridge caller signature — injected into execute(). */
 export type BridgeFunction = (

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -202,6 +202,16 @@ export type ExecuteParams = {
   /** Provider message ID. Numeric for Telegram, string snowflake for Discord. */
   messageId?: number | string;
   source: "message" | "pulse" | "cron" | "trigger";
+  /**
+   * Optional per-run model override (a model id valid on the chat's backend).
+   * When set and resolvable, the turn runs on this model instead of the chat's
+   * resolved model — used by triggers/cron to run a cheaper model while still
+   * resuming the chat session. Restricted to the chat's own backend so session
+   * continuity is preserved. If it can't be resolved at fire time (e.g. the
+   * catalog changed), the dispatcher falls back to the chat model rather than
+   * failing the run.
+   */
+  modelOverride?: string;
 } & StreamEventSink;
 
 /** What the dispatcher returns after execution. */

--- a/src/storage/cron-store.ts
+++ b/src/storage/cron-store.ts
@@ -40,6 +40,13 @@ export type CronJob = {
   runCount: number;
   /** IANA timezone (e.g. "America/New_York"). Defaults to system timezone. */
   timezone?: string;
+  /**
+   * Optional model override for `query` jobs — a model id valid on the chat's
+   * own backend. Unset = inherit the chat's model (preferred). When set, the run
+   * uses this (typically cheaper) model instead, while still resuming the chat
+   * session (restricted to the same backend so continuity is preserved).
+   */
+  model?: string;
 };
 
 type CronStoreShape = Record<string, CronJob>;

--- a/src/storage/trigger-store.ts
+++ b/src/storage/trigger-store.ts
@@ -79,6 +79,14 @@ export type Trigger = {
    *  by Talon shutdown or crash. (Persistent triggers have no hard timeout,
    *  so timed_out is unreachable for them — see spawnTrigger.) */
   persistent?: boolean;
+  /**
+   * Optional model override for the wake-up turn — a model id valid on the
+   * chat's own backend. Unset = inherit the chat's model (preferred). When set,
+   * the fired wake-up runs on this (typically cheaper) model instead, while
+   * still resuming the chat session (restricted to the same backend so
+   * continuity is preserved).
+   */
+  model?: string;
 };
 
 // ── Constants ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Supersedes #354.** Lets a trigger or cron `query` job run on a **cheaper model** than the chat's, without losing session continuity. Where #354 shipped two tiers, this keeps only the **same-backend** tier — the override resumes the chat's existing session on a different model — and drops the cross-provider isolated one-shot machinery (`job-oneshot.ts`, `isolated-agent.ts`, `job-prompt.ts`, `acquireBackendInstance`, `runJobOneShot`, the `decoupledJobs` gate, the `provider`/`instructions` fields). A different backend can't resume the session (session ids are backend-specific), so cross-provider is intentionally out of scope.

## Why same-backend only
The whole point of the override is to keep the wake-up in the chat's existing session — it just swaps which model serves that turn. That's only possible on the chat's own backend, so the override is **restricted to a model selectable on the chat's current backend**, validated at create time and falling back to the chat model at fire time.

## The override path
- **`resolveExplicitModelRef`** (`core/models/active-model.ts`) — validate + materialise an explicit model id against a backend; `null` if not selectable. Reuses the existing `validateModelOnBackend` / `materialiseRef` helpers.
- **`ExecuteParams.modelOverride`** + an optional **`resolveModelOverride`** dispatcher dep — swap the `ModelRef` for that turn only; on a stale/unresolvable id, fall back to the chat model so an override never kills the run.
- **cron `executeJob` / trigger `fireWake`** pass `modelOverride` only when the job carries a `model`; the no-override common path is byte-for-byte unchanged.
- **`model?`** on `CronJob` / `Trigger` stores + the `create_cron_job` / `trigger_create` schemas. Create-time validation rejects an unselectable id (cron: `query` jobs only; a `model` on a non-query job is rejected up front).

## Model discovery tools (new `models` tag)
So the model can actually pick a valid override id:
- **`list_models(backend?)`** — selectable models on the chat's current backend (or a named, currently-active backend). No-arg is the common case and exactly the set a job override can use.
- **`list_backends()`** — available backends, flagging the current one.
- `backend-controller` captures config at init and exposes `getAvailableBackends` / `getPooledBackend` for these read-only lookups — it **never boots** a backend just to read a catalog; a non-active named backend degrades to a clear message.

The per-job `model` field descriptions point at `list_models` for valid ids.

## Decisions (vs #354)
- **No feature gate.** The same-backend path is low-risk and falls back gracefully, so it ships on by default — no `decoupledJobs` config flag.
- **No `instructions` field.** The resumed session already carries full chat context, so a separate brief is redundant.

## Tests
- `resolveExplicitModelRef`: valid / missing / non-selectable / empty / no-catalog.
- dispatcher override: applied / fallback-when-null / ignored-when-unset.
- gateway: invalid query model rejected, valid model persisted, model-on-non-query rejected; `list_models` (selectable filter, fixed-model backend, unknown backend), `list_backends` (current flag).
- `tsc --noEmit` + `prettier` clean; targeted suites green (145). Full suite runs in CI.

## Footprint
18 files, +637/−5 (vs #354's 23 files, +1096/−15). No new background runtime, no on-demand backend init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)