### PR TITLE
feat(dist): self-contained standalone binary + multi-platform release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,14 +201,23 @@ jobs:
           path: integration-results.json
           retention-days: 14
 
-  # ── Bun compiled-binary sanity ─────────────────────────────────
-  # Compiles Talon to a standalone bun binary and verifies the MCP
-  # supervisor self-reinvocation path (`_mcp-launch`) works compiled —
-  # the install type with no source tree on disk and no system node.
-  bun-compile:
-    name: Bun Compile Sanity
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+  # ── Compiled-binary smoke (all OSes) ───────────────────────────
+  # Compiles Talon to a standalone bun binary on every supported OS and
+  # smoke-tests the REAL artifact from an isolated directory with no
+  # source tree on disk — the install shape a published binary ships as.
+  # Proves: prompts + version travel inside the binary (not read from a
+  # missing source tree), the CLI boots (--version / --help / doctor),
+  # and the MCP supervisor self-reinvocation (`_mcp-launch`) works
+  # compiled. The prompt-manifest drift guard lives in the test job
+  # (prompts-embed.test.ts), same as the SQL embed.
+  compile-smoke:
+    name: Compile Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
 
@@ -224,19 +233,53 @@ jobs:
       - run: npm ci
 
       - name: Compile standalone binary
-        run: bun build --compile src/index.ts --outfile talon-bin
+        # The user-facing CLI entry (src/cli.ts) — same dispatcher the npm
+        # `talon` bin runs — not src/index.ts (the daemon that eagerly
+        # boots the agent). bun appends `.exe` on Windows.
+        shell: bash
+        run: bun build --compile src/cli.ts --outfile "$RUNNER_TEMP/talon"
+
+      - name: CLI smoke (version / help / doctor) from an isolated cwd
+        shell: bash
+        run: |
+          ext=""; [[ "$RUNNER_OS" == "Windows" ]] && ext=".exe"
+          BIN="$RUNNER_TEMP/talon$ext"
+          # Run from a directory with no prompts/ or package.json on disk:
+          # anything the binary needs must be embedded.
+          cd "$RUNNER_TEMP"
+          ver=$("$BIN" --version)
+          echo "version: $ver"
+          expected=$(node -p "require('$GITHUB_WORKSPACE/package.json').version")
+          [[ "$ver" == "$expected" ]] || { echo "::error::--version printed '$ver', expected '$expected'"; exit 1; }
+          "$BIN" --help | grep -q "Talon" || { echo "::error::--help missing banner"; exit 1; }
+          # doctor exits non-zero without a config (no config file is a
+          # "fail" check), so tolerate that and assert on the embedded
+          # prompt-template check instead — that line only prints if the
+          # embedded prompts loaded.
+          out=$("$BIN" doctor || true)
+          echo "$out"
+          echo "$out" | grep -q "Prompt templates loaded" \
+            || { echo "::error::embedded prompts did not load in the compiled binary"; exit 1; }
 
       - name: Supervisor sanity (_mcp-launch supervises a child)
+        # Unix only: Git Bash on Windows shadows `timeout` with the
+        # incompatible Windows timeout.exe. The supervisor's Windows
+        # process path is exercised by the warden/Job-Object tests.
+        if: runner.os != 'Windows'
+        shell: bash
         run: |
+          ext=""
+          BIN="$RUNNER_TEMP/talon$ext"
+          # `timeout` is GNU coreutils — present on ubuntu, often absent on
+          # macOS runners; fall back to running without it (the closing
+          # pipe gives `cat` EOF, so the supervisor exits on its own).
+          run_to() { if command -v timeout >/dev/null 2>&1; then timeout "$@"; else shift; "$@"; fi; }
           # Hold stdin open briefly: closing it instantly can SIGTERM the
           # child before the line round-trips through the supervisor.
-          out=$({ echo '{"jsonrpc":"2.0","id":1,"method":"ping"}'; sleep 2; } | timeout 30 ./talon-bin _mcp-launch cat)
+          out=$({ echo '{"jsonrpc":"2.0","id":1,"method":"ping"}'; sleep 2; } | run_to 30 "$BIN" _mcp-launch cat)
           echo "supervisor stdout: $out"
           [[ "$out" == *'"method":"ping"'* ]] || { echo "::error::JSON line did not pass through supervisor"; exit 1; }
-
-      - name: Supervisor filters non-JSON stdout to stderr
-        run: |
-          err=$({ echo 'plain banner line'; sleep 2; } | timeout 30 ./talon-bin _mcp-launch cat 2>&1 >/dev/null)
+          err=$({ echo 'plain banner line'; sleep 2; } | run_to 30 "$BIN" _mcp-launch cat 2>&1 >/dev/null)
           echo "supervisor stderr: $err"
           [[ "$err" == *'mcp-launcher: stdout'* ]] || { echo "::error::non-JSON line was not rerouted to stderr"; exit 1; }
 
@@ -736,7 +779,7 @@ jobs:
       - test
       - functional-cross-platform
       - integration
-      - bun-compile
+      - compile-smoke
       - gleam-artifact
       - zig-artifact
       - wasm-artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,10 +246,13 @@ jobs:
           BIN="$RUNNER_TEMP/talon$ext"
           # Run from a directory with no prompts/ or package.json on disk:
           # anything the binary needs must be embedded.
+          # Read the expected version BEFORE leaving the workspace, via a
+          # relative path — a Windows $GITHUB_WORKSPACE (D:\a\talon\talon)
+          # interpolated into a JS string mangles its backslashes (\t, \a).
+          expected=$(node -p "require('./package.json').version")
           cd "$RUNNER_TEMP"
           ver=$("$BIN" --version)
-          echo "version: $ver"
-          expected=$(node -p "require('$GITHUB_WORKSPACE/package.json').version")
+          echo "version: $ver (expected $expected)"
           [[ "$ver" == "$expected" ]] || { echo "::error::--version printed '$ver', expected '$expected'"; exit 1; }
           "$BIN" --help | grep -q "Talon" || { echo "::error::--help missing banner"; exit 1; }
           # doctor exits non-zero without a config (no config file is a

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -238,8 +238,8 @@ jobs:
   # ── Homebrew tap bump ──────────────────────────────────────────
   # Bumps Formula/talon.rb in dylanneve1/homebrew-talon to this version
   # with fresh per-os/arch SHA256s, so `brew install dylanneve1/talon/talon`
-  # tracks the latest release. Needs a tap-write token (HOMEBREW_TAP_TOKEN);
-  # skips cleanly if the secret isn't configured.
+  # tracks the latest release. Uses the cross-repo PAT (same secret
+  # release-please uses); skips cleanly if it isn't configured.
   homebrew:
     name: Homebrew tap
     needs: [binaries]
@@ -249,10 +249,10 @@ jobs:
     steps:
       - name: Bump tap formula
         env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "HOMEBREW_TAP_TOKEN not set — skipping tap bump"
+            echo "PAT not set — skipping tap bump"
             exit 0
           fi
           set -euo pipefail

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,3 +124,200 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ── Standalone binaries → release assets ───────────────────────
+  # Bun cross-compiles every target from one Linux host (verified: the
+  # `with { type: "file" }` prompt assets embed for cross targets too).
+  # The CLI entry is src/cli.ts — the dispatcher the npm `talon` bin runs,
+  # NOT src/index.ts (the daemon). Compile Smoke (ci.yml) already proved
+  # the artifact boots on all three OSes; this job ships it.
+  binaries:
+    name: Binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: npm ci
+
+      - name: Verify package version matches tag
+        run: |
+          PKG_VERSION=$(node -e "console.log(require('./package.json').version)")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match release tag ($TAG_VERSION)"
+            exit 1
+          fi
+
+      - name: Cross-compile all targets
+        run: |
+          mkdir -p dist
+          # bun target triple → published asset name (os-arch[.exe]).
+          declare -A TARGETS=(
+            [bun-linux-x64]=talon-linux-x64
+            [bun-linux-arm64]=talon-linux-arm64
+            [bun-darwin-x64]=talon-darwin-x64
+            [bun-darwin-arm64]=talon-darwin-arm64
+            [bun-windows-x64]=talon-windows-x64.exe
+          )
+          for triple in "${!TARGETS[@]}"; do
+            out="dist/${TARGETS[$triple]}"
+            echo "── $triple → $out"
+            bun build --compile --target="$triple" src/cli.ts --outfile "$out"
+          done
+          ls -la dist
+
+      - name: Generate checksums
+        working-directory: dist
+        run: sha256sum talon-* > SHA256SUMS
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+
+  # ── Debian packages (.deb) → release assets ────────────────────
+  # Wraps the already-built linux binaries with nfpm (nfpm.yaml). Users
+  # install with `apt install ./talon_<ver>_<arch>.deb` (or `dpkg -i`).
+  deb:
+    name: Debian package
+    needs: [binaries]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download release binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p bin
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern 'talon-linux-x64' --pattern 'talon-linux-arm64' --dir bin
+          chmod +x bin/talon-linux-*
+
+      - name: Install nfpm
+        run: |
+          VER=2.43.0
+          curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v${VER}/nfpm_${VER}_Linux_x86_64.tar.gz" -o /tmp/nfpm.tgz
+          mkdir -p "$HOME/.nfpm-bin"
+          tar -xzf /tmp/nfpm.tgz -C "$HOME/.nfpm-bin" nfpm
+          echo "$HOME/.nfpm-bin" >> "$GITHUB_PATH"
+
+      - name: Build .deb for each arch
+        run: |
+          export VERSION="${GITHUB_REF_NAME#v}"
+          mkdir -p dist
+          # nfpm arch (Debian naming) → the matching linux binary.
+          build_deb() {
+            export ARCH="$1" BIN="$2"
+            nfpm package -f nfpm.yaml -p deb -t "dist/talon_${VERSION}_${ARCH}.deb"
+          }
+          build_deb amd64 bin/talon-linux-x64
+          build_deb arm64 bin/talon-linux-arm64
+          ls -la dist
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$GITHUB_REF_NAME" dist/*.deb --clobber
+
+  # ── Homebrew tap bump ──────────────────────────────────────────
+  # Bumps Formula/talon.rb in dylanneve1/homebrew-talon to this version
+  # with fresh per-os/arch SHA256s, so `brew install dylanneve1/talon/talon`
+  # tracks the latest release. Needs a tap-write token (HOMEBREW_TAP_TOKEN);
+  # skips cleanly if the secret isn't configured.
+  homebrew:
+    name: Homebrew tap
+    needs: [binaries]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ !github.event.release.prerelease }}
+    steps:
+      - name: Bump tap formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "HOMEBREW_TAP_TOKEN not set — skipping tap bump"
+            exit 0
+          fi
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          REPO="dylanneve1/talon"
+          TAP="dylanneve1/homebrew-talon"
+          BASE="https://github.com/${REPO}/releases/download/${TAG}"
+
+          # Fetch the checksums published by the `binaries` job and pull each
+          # per-asset sha256 (keyed by the asset filename).
+          gh release download "$TAG" --repo "$REPO" --pattern SHA256SUMS --dir /tmp --clobber
+          sha() { grep " $1\$" /tmp/SHA256SUMS | cut -d' ' -f1; }
+          SHA_LINUX_X64=$(sha talon-linux-x64)
+          SHA_LINUX_ARM64=$(sha talon-linux-arm64)
+          SHA_DARWIN_X64=$(sha talon-darwin-x64)
+          SHA_DARWIN_ARM64=$(sha talon-darwin-arm64)
+
+          cat > /tmp/talon.rb <<EOF
+          # typed: false
+          # frozen_string_literal: true
+
+          # Homebrew formula for Talon — auto-bumped by the talon publish workflow.
+          class Talon < Formula
+            desc "Multi-frontend AI agent with full tool access, streaming, cron jobs, and plugins"
+            homepage "https://github.com/dylanneve1/talon"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "${BASE}/talon-darwin-arm64"
+                sha256 "${SHA_DARWIN_ARM64}"
+              else
+                url "${BASE}/talon-darwin-x64"
+                sha256 "${SHA_DARWIN_X64}"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.arm?
+                url "${BASE}/talon-linux-arm64"
+                sha256 "${SHA_LINUX_ARM64}"
+              else
+                url "${BASE}/talon-linux-x64"
+                sha256 "${SHA_LINUX_X64}"
+              end
+            end
+
+            def install
+              # Homebrew downloads the bare binary asset under its remote
+              # basename (talon-<os>-<arch>); install it as `talon`.
+              bin.install Dir["talon-*"].first => "talon"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/talon --version")
+            end
+          end
+          EOF
+
+          # Commit the regenerated formula to the tap via the contents API.
+          gh api "repos/${TAP}/contents/Formula/talon.rb" --jq '.sha' > /tmp/sha.txt 2>/dev/null || echo "" > /tmp/sha.txt
+          PREV_SHA=$(cat /tmp/sha.txt)
+          ARGS=(-f message="talon ${VERSION}" -f content="$(base64 -w0 /tmp/talon.rb)")
+          if [ -n "$PREV_SHA" ]; then ARGS+=(-f sha="$PREV_SHA"); fi
+          gh api --method PUT "repos/${TAP}/contents/Formula/talon.rb" "${ARGS[@]}"
+          echo "Bumped ${TAP} formula to ${VERSION}"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,33 @@ npx talon chat        # terminal chat mode
   - `kilo` backend: nothing extra — `@kilocode/sdk` spawns a local server. Free models are accessible without auth; routed models use Kilo's own credentials.
   - `opencode` backend: nothing extra — `@opencode-ai/sdk` spawns a local server.
   - `codex` backend: install the `codex` CLI (`npm i -g @openai/codex`) and authenticate with `codex login`, `CODEX_API_KEY`, `TALON_CODEX_KEY`, or `codexApiKey`. `OPENAI_API_KEY` is used only as a fallback when no Codex login exists.
-- Talon runs from a normal source or package install; standalone compiled binaries are not supported.
+
+### Standalone binary
+
+Each release also ships self-contained binaries (no Node.js required) for
+Linux and macOS (x64 + arm64) and Windows (x64). Prompts and all native
+modules are embedded in the binary.
+
+```bash
+# Homebrew (macOS / Linux)
+brew install dylanneve1/talon/talon
+
+# Debian / Ubuntu — download the .deb for your arch from the release, then:
+sudo apt install ./talon_<version>_amd64.deb     # or _arm64.deb
+
+# Direct download — grab talon-<os>-<arch> from the release, verify, run:
+chmod +x talon-linux-x64 && ./talon-linux-x64 --version
+# macOS, if Gatekeeper blocks an unsigned binary:
+xattr -d com.apple.quarantine ./talon-darwin-arm64
+```
+
+Verify a direct download against the release `SHA256SUMS`:
+`sha256sum -c SHA256SUMS --ignore-missing`.
+
+> The binary runs the full interactive/agent CLI (`setup`, `start`, `chat`,
+> `doctor`, …). Hosting Talon's _own_ MCP server (`talon` as an MCP stdio
+> server for another client) still needs the npm/Node install — it spawns a
+> `tsx` loader that isn't present in a compiled binary.
 
 ---
 

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,24 @@
+# nfpm packaging manifest for the standalone Talon binary (.deb).
+# Built per-arch in the `deb` job of publish.yml; VERSION / ARCH / BIN are
+# supplied via the environment (nfpm expands ${VAR} natively).
+#
+# Talon is a self-contained `bun build --compile` binary — no Node runtime
+# dependency — so there are no Debian `depends`. Backends (claude, codex,
+# …) are still expected on PATH at runtime, same as the npm install.
+name: talon
+arch: ${ARCH}
+version: ${VERSION}
+section: utils
+priority: optional
+maintainer: Dylan Neve <noreply@github.com>
+description: |
+  Multi-frontend AI agent with full tool access, streaming, cron jobs, and plugins.
+  Self-contained standalone binary (no Node.js runtime required).
+vendor: Dylan Neve
+homepage: https://github.com/dylanneve1/talon
+license: MIT
+contents:
+  - src: ${BIN}
+    dst: /usr/bin/talon
+    file_info:
+      mode: 0755

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "imports": {
+    "#prompt-assets": {
+      "bun": "./src/core/prompt/embedded-prompts.ts",
+      "default": "./src/core/prompt/disk-prompts.ts"
+    }
+  },
   "bin": {
     "talon": "./bin/talon.js"
   },
@@ -63,6 +69,7 @@
     "test:codex:backend": "vitest run --reporter=verbose --reporter=json --outputFile=codex-backend-results.json src/__tests__/integration/codex-live-discovery.test.ts",
     "test:openai-agents:backend": "vitest run --reporter=verbose --reporter=json --outputFile=openai-agents-backend-results.json src/__tests__/integration/openai-agents-live-discovery.test.ts",
     "build:sql": "tsx scripts/embed-sql.ts",
+    "build:prompts": "tsx scripts/embed-prompts.ts",
     "build:wasm": "node native/blake3-wasm/build.mjs",
     "tarball:check": "node .github/scripts/tarball-check.mjs",
     "build:stub-sea": "node src/__tests__/integration/stub-claude/build-sea.mjs",

--- a/scripts/embed-prompts.ts
+++ b/scripts/embed-prompts.ts
@@ -1,0 +1,20 @@
+/**
+ * `npm run build:prompts` — regenerate
+ * src/core/prompt/embedded-prompts.ts from the .md files under prompts/.
+ * See src/core/prompt/embed.ts.
+ */
+
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  buildEmbeddedPromptsModule,
+  listPromptAssets,
+} from "../src/core/prompt/embed.js";
+
+const promptsDir = fileURLToPath(new URL("../prompts", import.meta.url));
+const target = fileURLToPath(
+  new URL("../src/core/prompt/embedded-prompts.ts", import.meta.url),
+);
+
+writeFileSync(target, buildEmbeddedPromptsModule(listPromptAssets(promptsDir)));
+console.log(`wrote ${target}`);

--- a/src/__tests__/log-init.test.ts
+++ b/src/__tests__/log-init.test.ts
@@ -11,6 +11,22 @@ describe("log.ts — module-level initialization branches", () => {
   const mockUnlinkSync = vi.fn();
   const mockLogFn = vi.fn();
 
+  // pino is called as `pino(opts, multistream(streams))` and exposes
+  // `pino.multistream` — the mock must provide both the callable default
+  // and the multistream factory.
+  const mockPino = () => {
+    const fn = Object.assign(
+      () => ({
+        info: mockLogFn,
+        error: mockLogFn,
+        warn: mockLogFn,
+        debug: mockLogFn,
+      }),
+      { multistream: vi.fn(() => ({ write: vi.fn() })) },
+    );
+    return { default: fn };
+  };
+
   beforeEach(() => {
     vi.resetModules();
     mockMkdirSync.mockClear();
@@ -39,15 +55,10 @@ describe("log.ts — module-level initialization branches", () => {
       renameSync: mockRenameSync,
       unlinkSync: mockUnlinkSync,
       readFileSync: vi.fn(() => "{}"),
+      createWriteStream: vi.fn(() => ({ write: vi.fn() })),
     }));
-    vi.doMock("pino", () => ({
-      default: () => ({
-        info: mockLogFn,
-        error: mockLogFn,
-        warn: mockLogFn,
-        debug: mockLogFn,
-      }),
-    }));
+    vi.doMock("pino-pretty", () => ({ default: () => ({ write: vi.fn() }) }));
+    vi.doMock("pino", () => mockPino());
 
     await import("../util/log.js");
 
@@ -72,15 +83,10 @@ describe("log.ts — module-level initialization branches", () => {
       renameSync: mockRenameSync,
       unlinkSync: mockUnlinkSync,
       readFileSync: vi.fn(() => "{}"),
+      createWriteStream: vi.fn(() => ({ write: vi.fn() })),
     }));
-    vi.doMock("pino", () => ({
-      default: () => ({
-        info: mockLogFn,
-        error: mockLogFn,
-        warn: mockLogFn,
-        debug: mockLogFn,
-      }),
-    }));
+    vi.doMock("pino-pretty", () => ({ default: () => ({ write: vi.fn() }) }));
+    vi.doMock("pino", () => mockPino());
 
     await import("../util/log.js");
 
@@ -108,15 +114,10 @@ describe("log.ts — module-level initialization branches", () => {
       renameSync: mockRenameSync,
       unlinkSync: mockUnlinkSync,
       readFileSync: readFileSyncMock,
+      createWriteStream: vi.fn(() => ({ write: vi.fn() })),
     }));
-    vi.doMock("pino", () => ({
-      default: () => ({
-        info: mockLogFn,
-        error: mockLogFn,
-        warn: mockLogFn,
-        debug: mockLogFn,
-      }),
-    }));
+    vi.doMock("pino-pretty", () => ({ default: () => ({ write: vi.fn() }) }));
+    vi.doMock("pino", () => mockPino());
 
     await import("../util/log.js");
 

--- a/src/__tests__/log.test.ts
+++ b/src/__tests__/log.test.ts
@@ -6,14 +6,21 @@ const mockError = vi.fn();
 const mockWarn = vi.fn();
 const mockDebug = vi.fn();
 
+// log.ts builds the logger as `pino(opts, pino.multistream(streams))` with
+// a pino-pretty console stream, so the mock must expose both the callable
+// default and `multistream`, and pino-pretty must be stubbed.
 vi.mock("pino", () => ({
-  default: () => ({
-    info: mockInfo,
-    error: mockError,
-    warn: mockWarn,
-    debug: mockDebug,
-  }),
+  default: Object.assign(
+    () => ({
+      info: mockInfo,
+      error: mockError,
+      warn: mockWarn,
+      debug: mockDebug,
+    }),
+    { multistream: vi.fn(() => ({ write: vi.fn() })) },
+  ),
 }));
+vi.mock("pino-pretty", () => ({ default: () => ({ write: vi.fn() }) }));
 
 const { log, logError, logWarn, logDebug } = await import("../util/log.js");
 

--- a/src/__tests__/prompts-embed.test.ts
+++ b/src/__tests__/prompts-embed.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Drift guard for the embedded prompt manifest — rebuilds
+ * core/prompt/embedded-prompts.ts from the .md sources under prompts/ and
+ * fails if the committed artifact doesn't match (same idiom as the SQL
+ * embed / Gleam artifact guards). Run `npm run build:prompts` to refresh.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  buildEmbeddedPromptsModule,
+  listPromptAssets,
+} from "../core/prompt/embed.js";
+
+const promptsDir = fileURLToPath(new URL("../../prompts", import.meta.url));
+const generatedPath = fileURLToPath(
+  new URL("../core/prompt/embedded-prompts.ts", import.meta.url),
+);
+
+describe("prompts embed", () => {
+  it("embedded-prompts.ts matches the .md sources (run `npm run build:prompts`)", () => {
+    const expected = buildEmbeddedPromptsModule(listPromptAssets(promptsDir));
+    // CRLF-normalize the committed artifact so a Windows checkout without
+    // a line-ending pin doesn't diff on EOLs alone.
+    const committed = readFileSync(generatedPath, "utf8").replaceAll(
+      "\r\n",
+      "\n",
+    );
+    expect(committed).toBe(expected);
+  });
+
+  it("embeds every system template and the dream prompt", () => {
+    const rels = listPromptAssets(promptsDir);
+    expect(rels).toContain("dream.md");
+    expect(rels).toContain("system/cron.md");
+    expect(rels).toContain("system/persistent-memory.md");
+    // System templates referenced by loadSystemTemplate() must be present.
+    expect(rels.filter((r) => r.startsWith("system/")).length).toBeGreaterThan(
+      0,
+    );
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,9 +16,11 @@
  *   - `menu`        — interactive main menu (no-subcommand default)
  */
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import pc from "picocolors";
+// Imported (not read from disk) so `--version` works in a standalone
+// `bun build --compile` binary, which has no package.json on disk — bun
+// inlines the JSON at compile time; tsx/node resolve it from the package.
+import pkg from "../../package.json" with { type: "json" };
 import { PKG_ROOT } from "./context.js";
 import { printBanner } from "./config.js";
 import { runSetup } from "./setup.js";
@@ -96,12 +98,6 @@ export async function runCli(): Promise<void> {
       break;
     case "--version":
     case "-v": {
-      // Read at invocation (not import) so `--version` stays dependency-free
-      // and works before any config exists — the publish smoke test runs it
-      // against the freshly installed package.
-      const pkg = JSON.parse(
-        readFileSync(resolve(PKG_ROOT, "package.json"), "utf-8"),
-      ) as { version: string };
       console.log(pkg.version);
       break;
     }

--- a/src/core/background/dream.ts
+++ b/src/core/background/dream.ts
@@ -15,7 +15,7 @@ import { existsSync, readFileSync, mkdirSync, appendFileSync } from "node:fs";
 import { resolve } from "node:path";
 import writeFileAtomic from "write-file-atomic";
 import { files as pathFiles, dirs } from "../../util/paths.js";
-import { PACKAGE_PROMPTS_DIR } from "../prompt/templates.js";
+import { readPromptAsset } from "#prompt-assets";
 import { log, logError, logWarn } from "../../util/log.js";
 import { getDefaultModel } from "../models/catalog.js";
 import type { OneShotAgentParams } from "../types.js";
@@ -159,11 +159,9 @@ async function runDreamAgent(lastRunTimestamp: number): Promise<string> {
   const memoryFile = pathFiles.memory;
   const dreamStateFile = DREAM_STATE_FILE;
 
-  // Load prompt template from the package prompts/ dir and interpolate
-  // variables (PACKAGE_PROMPTS_DIR is the canonical resolver — no
-  // module-relative "../.." that breaks when this file moves).
-  const promptPath = resolve(PACKAGE_PROMPTS_DIR, "dream.md");
-
+  // Load the dream prompt template from the package prompts/ (via the
+  // #prompt-assets seam — disk under tsx, embedded under a compiled
+  // binary) and interpolate variables.
   let prompt: string;
   try {
     // Build optional mempalace mining section
@@ -192,7 +190,7 @@ Keep the diary authentic. Write in first person. Be honest. This is for you, not
 If commands fail, log the error and continue — this stage is optional.`
       : "MemPalace is not configured. Skip this stage.";
 
-    prompt = readFileSync(promptPath, "utf-8")
+    prompt = readPromptAsset("dream.md")
       .replace(/\{\{dreamStateFile\}\}/g, dreamStateFile)
       .replace(/\{\{logsDir\}\}/g, logsDir)
       .replace(/\{\{lastRunIso\}\}/g, lastRunIso)
@@ -200,7 +198,7 @@ If commands fail, log the error and continue — this stage is optional.`
       .replace(/\{\{dailyMemoryDir\}\}/g, dirs.dailyMemory)
       .replace(/\{\{mempalaceSection\}\}/g, mempalaceSection);
   } catch {
-    throw new Error(`Failed to read dream prompt from ${promptPath}`);
+    throw new Error("Failed to read dream prompt (dream.md)");
   }
 
   const model = configRef.dreamModel ?? configRef.model ?? getDefaultModel();

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -322,6 +322,37 @@ export async function collectDoctorReport(opts: {
     );
   }
 
+  // Package-owned prompt templates must be loadable. On a standalone
+  // `bun build --compile` binary these are embedded file assets (no
+  // source tree on disk); a failure here means the embed manifest is
+  // stale or the package is incomplete — caught at check time, not
+  // mid-message when a backend assembles its system prompt.
+  {
+    const { loadSystemTemplate } = await import("./prompt/index.js");
+    try {
+      const sample = loadSystemTemplate("workspace");
+      checks.push(
+        sample.trim().length > 0
+          ? {
+              label: "Prompt templates loaded",
+              status: "ok",
+            }
+          : {
+              label: "Prompt templates empty",
+              status: "fail",
+              issue: true,
+            },
+      );
+    } catch (err) {
+      checks.push({
+        label: "Prompt templates unavailable",
+        status: "fail",
+        detail: errorNote(err),
+        issue: true,
+      });
+    }
+  }
+
   const native = await checkNativeModules();
   checks.push(...(await checkBackend(opts.config)));
 

--- a/src/core/prompt/disk-prompts.ts
+++ b/src/core/prompt/disk-prompts.ts
@@ -1,0 +1,41 @@
+/**
+ * Disk-backed prompt assets — the `default` condition of the
+ * `#prompt-assets` package import. Used by tsx / node / npm installs,
+ * where the package source tree (and `prompts/`) is on disk.
+ *
+ * The Bun twin (`embedded-prompts.ts`, the `bun` condition) reads the same
+ * files back from inside a `bun build --compile` binary. Both expose the
+ * identical interface so consumers stay condition-agnostic.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Absolute path to the package's `prompts/` directory. */
+const PROMPTS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../prompts",
+);
+
+/** Read a package prompt by its rel path (e.g. "system/cron.md"). */
+export function readPromptAsset(rel: string): string {
+  return readFileSync(resolve(PROMPTS_DIR, rel), "utf8");
+}
+
+/** Whether a package prompt exists for `rel`. */
+export function promptAssetExists(rel: string): boolean {
+  return existsSync(resolve(PROMPTS_DIR, rel));
+}
+
+/**
+ * Top-level user-editable prompts to seed into ~/.talon/prompts/
+ * (every top-level `*.md` except the architecture README; the system/
+ * subdirectory is package-owned and read in place).
+ */
+export function listSeedPrompts(): string[] {
+  if (!existsSync(PROMPTS_DIR)) return [];
+  return readdirSync(PROMPTS_DIR).filter(
+    (f) => f.endsWith(".md") && f !== "README.md",
+  );
+}

--- a/src/core/prompt/embed.ts
+++ b/src/core/prompt/embed.ts
@@ -1,0 +1,107 @@
+/**
+ * Prompt embedding — turns the `.md` files under `prompts/` into the
+ * committed `embedded-prompts.ts` manifest.
+ *
+ * Unlike the SQL/WASM embeds, prose is NOT stringified into source: the
+ * manifest is a list of Bun file-asset imports
+ * (`import p from "../../../prompts/x.md" with { type: "file" }`), so the
+ * `.md` files stay the source of truth (editor highlighting, user-diffable
+ * prompt text) while `bun build --compile` carries their bytes inside the
+ * binary — read back with `readFileSync` at runtime.
+ *
+ * The manifest is reached ONLY through the `bun` condition of the
+ * `#prompt-assets` import in package.json. tsx/node/tsc resolve the
+ * `default` condition (`disk-prompts.ts`) and never parse the Bun-only
+ * import attribute. Same committed-artifact idiom as the Gleam scheduler
+ * core and the BLAKE3 WASM module: edit the `.md`, run
+ * `npm run build:prompts`, commit both; prompts-embed.test.ts fails CI on
+ * drift.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/** Import specifier prefix from src/core/prompt/ up to the repo `prompts/`. */
+const IMPORT_PREFIX = "../../../prompts";
+
+/**
+ * Every `.md` under `promptsDir`, as posix paths relative to it, sorted
+ * for deterministic output (the drift guard compares byte-for-byte).
+ */
+export function listPromptAssets(promptsDir: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string, prefix: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(join(dir, entry.name), rel);
+      } else if (entry.name.endsWith(".md")) {
+        out.push(rel);
+      }
+    }
+  };
+  walk(promptsDir, "");
+  return out.sort();
+}
+
+/** Render the generated `embedded-prompts.ts` source for the given rel paths. */
+export function buildEmbeddedPromptsModule(rels: string[]): string {
+  const sorted = [...rels].sort();
+  const ident = (i: number): string => `asset${i}`;
+
+  const imports = sorted
+    .map(
+      (rel, i) =>
+        `import ${ident(i)} from "${IMPORT_PREFIX}/${rel}" with { type: "file" };`,
+    )
+    .join("\n");
+
+  const entries = sorted
+    .map((rel, i) => `  ${JSON.stringify(rel)}: ${ident(i)},`)
+    .join("\n");
+
+  return `// AUTO-GENERATED FILE — DO NOT EDIT.
+// Source of truth: the .md files under prompts/.
+// Regenerate with \`npm run build:prompts\` (drift-guarded by prompts-embed.test.ts).
+//
+// Each prompt is embedded as a real file asset via the Bun-only
+// \`with { type: "file" }\` import attribute, so \`bun build --compile\`
+// carries the .md bytes inside the binary (read back with readFileSync)
+// without stringifying prose into source. Reached ONLY through the \`bun\`
+// condition of the \`#prompt-assets\` import in package.json — tsx/node/tsc
+// load disk-prompts.ts instead.
+import { readFileSync } from "node:fs";
+
+${imports}
+
+/** rel path (posix, under prompts/) → embedded file path (/$bunfs/… when compiled). */
+const ASSETS: Record<string, string> = {
+${entries}
+};
+
+/** Read an embedded prompt by its rel path (e.g. "system/cron.md"). */
+export function readPromptAsset(rel: string): string {
+  const path = ASSETS[rel];
+  if (path === undefined) {
+    throw new Error(\`embedded prompt asset not found: \${rel}\`);
+  }
+  return readFileSync(path, "utf8");
+}
+
+/** Whether an embedded prompt exists for \`rel\`. */
+export function promptAssetExists(rel: string): boolean {
+  return Object.prototype.hasOwnProperty.call(ASSETS, rel);
+}
+
+/**
+ * Top-level user-editable prompts to seed into ~/.talon/prompts/
+ * (every top-level \`*.md\` except the architecture README; the system/
+ * subdirectory is package-owned and read in place).
+ */
+export function listSeedPrompts(): string[] {
+  return Object.keys(ASSETS).filter(
+    (rel) => !rel.includes("/") && rel !== "README.md",
+  );
+}
+`;
+}

--- a/src/core/prompt/embedded-prompts.ts
+++ b/src/core/prompt/embedded-prompts.ts
@@ -1,0 +1,85 @@
+// AUTO-GENERATED FILE — DO NOT EDIT.
+// Source of truth: the .md files under prompts/.
+// Regenerate with `npm run build:prompts` (drift-guarded by prompts-embed.test.ts).
+//
+// Each prompt is embedded as a real file asset via the Bun-only
+// `with { type: "file" }` import attribute, so `bun build --compile`
+// carries the .md bytes inside the binary (read back with readFileSync)
+// without stringifying prose into source. Reached ONLY through the `bun`
+// condition of the `#prompt-assets` import in package.json — tsx/node/tsc
+// load disk-prompts.ts instead.
+import { readFileSync } from "node:fs";
+
+import asset0 from "../../../prompts/README.md" with { type: "file" };
+import asset1 from "../../../prompts/base.md" with { type: "file" };
+import asset2 from "../../../prompts/discord.md" with { type: "file" };
+import asset3 from "../../../prompts/dream.md" with { type: "file" };
+import asset4 from "../../../prompts/heartbeat.md" with { type: "file" };
+import asset5 from "../../../prompts/identity.md" with { type: "file" };
+import asset6 from "../../../prompts/mempalace.md" with { type: "file" };
+import asset7 from "../../../prompts/native.md" with { type: "file" };
+import asset8 from "../../../prompts/system/contract-text-or-tools.md" with { type: "file" };
+import asset9 from "../../../prompts/system/contract-text-preferred.md" with { type: "file" };
+import asset10 from "../../../prompts/system/contract-tool-only.md" with { type: "file" };
+import asset11 from "../../../prompts/system/cron.md" with { type: "file" };
+import asset12 from "../../../prompts/system/daily-memory.md" with { type: "file" };
+import asset13 from "../../../prompts/system/goals.md" with { type: "file" };
+import asset14 from "../../../prompts/system/heartbeat-agent.md" with { type: "file" };
+import asset15 from "../../../prompts/system/persistent-memory.md" with { type: "file" };
+import asset16 from "../../../prompts/system/skills.md" with { type: "file" };
+import asset17 from "../../../prompts/system/triggers.md" with { type: "file" };
+import asset18 from "../../../prompts/system/workspace.md" with { type: "file" };
+import asset19 from "../../../prompts/teams.md" with { type: "file" };
+import asset20 from "../../../prompts/telegram.md" with { type: "file" };
+import asset21 from "../../../prompts/terminal.md" with { type: "file" };
+
+/** rel path (posix, under prompts/) → embedded file path (/$bunfs/… when compiled). */
+const ASSETS: Record<string, string> = {
+  "README.md": asset0,
+  "base.md": asset1,
+  "discord.md": asset2,
+  "dream.md": asset3,
+  "heartbeat.md": asset4,
+  "identity.md": asset5,
+  "mempalace.md": asset6,
+  "native.md": asset7,
+  "system/contract-text-or-tools.md": asset8,
+  "system/contract-text-preferred.md": asset9,
+  "system/contract-tool-only.md": asset10,
+  "system/cron.md": asset11,
+  "system/daily-memory.md": asset12,
+  "system/goals.md": asset13,
+  "system/heartbeat-agent.md": asset14,
+  "system/persistent-memory.md": asset15,
+  "system/skills.md": asset16,
+  "system/triggers.md": asset17,
+  "system/workspace.md": asset18,
+  "teams.md": asset19,
+  "telegram.md": asset20,
+  "terminal.md": asset21,
+};
+
+/** Read an embedded prompt by its rel path (e.g. "system/cron.md"). */
+export function readPromptAsset(rel: string): string {
+  const path = ASSETS[rel];
+  if (path === undefined) {
+    throw new Error(`embedded prompt asset not found: ${rel}`);
+  }
+  return readFileSync(path, "utf8");
+}
+
+/** Whether an embedded prompt exists for `rel`. */
+export function promptAssetExists(rel: string): boolean {
+  return Object.prototype.hasOwnProperty.call(ASSETS, rel);
+}
+
+/**
+ * Top-level user-editable prompts to seed into ~/.talon/prompts/
+ * (every top-level `*.md` except the architecture README; the system/
+ * subdirectory is package-owned and read in place).
+ */
+export function listSeedPrompts(): string[] {
+  return Object.keys(ASSETS).filter(
+    (rel) => !rel.includes("/") && rel !== "README.md",
+  );
+}

--- a/src/core/prompt/index.ts
+++ b/src/core/prompt/index.ts
@@ -24,7 +24,6 @@ export {
   loadSystemTemplate,
   renderTemplate,
   clearTemplateCache,
-  PACKAGE_PROMPTS_DIR,
   type TemplateVars,
 } from "./templates.js";
 

--- a/src/core/prompt/templates.ts
+++ b/src/core/prompt/templates.ts
@@ -31,34 +31,52 @@
  * vars is pure in-memory work.
  */
 
-import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import type { FS } from "liquidjs";
 import { Liquid, type Template } from "liquidjs";
-
-// ── Package prompt directory ────────────────────────────────────────────────
-
-/** Absolute path to the package's `prompts/` directory. */
-export const PACKAGE_PROMPTS_DIR = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  "../../../prompts",
-);
-
-const SYSTEM_DIR = resolve(PACKAGE_PROMPTS_DIR, "system");
+import { promptAssetExists, readPromptAsset } from "#prompt-assets";
 
 // ── Renderer ────────────────────────────────────────────────────────────────
 
 export type TemplateVars = Record<string, string | undefined>;
 
 /**
- * One engine instance per process. `root` lets templates compose via
- * `{% render 'partial-name' %}` against `prompts/system/`. Variables
+ * Map a Liquid lookup (a bare partial name or `<name>.md`) to its rel path
+ * under the package `prompts/system/` directory. System templates live
+ * flat there and are referenced by bare name in `{% render %}`.
+ */
+const systemRel = (file: string): string => {
+  const base = file.split(/[\\/]/).pop() ?? file;
+  return `system/${base.endsWith(".md") ? base : `${base}.md`}`;
+};
+
+/**
+ * A Liquid filesystem backed by the `#prompt-assets` seam instead of the
+ * real disk, so `{% render 'partial' %}` includes resolve identically
+ * under tsx (reads `prompts/system/*.md` from disk) and a
+ * `bun build --compile` binary (reads the same files embedded in the
+ * binary). System templates are flat, so resolution is by basename.
+ */
+const liquidFs: FS = {
+  sep: "/",
+  dirname: () => ".",
+  resolve: (_dir, file, ext) => (file.endsWith(ext) ? file : `${file}${ext}`),
+  existsSync: (file) => promptAssetExists(systemRel(file)),
+  readFileSync: (file) => readPromptAsset(systemRel(file)),
+  exists: (file) => Promise.resolve(promptAssetExists(systemRel(file))),
+  readFile: (file) => Promise.resolve(readPromptAsset(systemRel(file))),
+  contains: () => Promise.resolve(true),
+  containsSync: () => true,
+};
+
+/**
+ * One engine instance per process. The custom `fs` lets templates compose
+ * via `{% render 'partial-name' %}` against `prompts/system/`. Variables
  * stay lenient (unknown → empty string) — a template must degrade to
  * readable prose when an optional var (e.g. a frontend without
  * reactions) is absent.
  */
 const liquid = new Liquid({
-  root: SYSTEM_DIR,
+  fs: liquidFs,
   extname: ".md",
   // JS truthiness, not Shopify's: `""` and `0` are falsy. The legacy
   // renderer treated empty-string vars as "absent", and callers rely
@@ -89,12 +107,13 @@ export function loadSystemTemplate(
   name: string,
   vars: TemplateVars = {},
 ): string {
-  const path = resolve(SYSTEM_DIR, `${name}.md`);
-  let parsed = parseCache.get(path);
+  const file = `${name}.md`;
+  let parsed = parseCache.get(file);
   if (parsed === undefined) {
-    // The filepath argument anchors relative {% render %} resolution.
-    parsed = liquid.parse(readFileSync(path, "utf-8").trim(), path);
-    parseCache.set(path, parsed);
+    // The filepath argument anchors relative {% render %} resolution
+    // (resolved against the prompt-asset seam, not the disk).
+    parsed = liquid.parse(readPromptAsset(`system/${file}`).trim(), file);
+    parseCache.set(file, parsed);
   }
   return liquid.renderSync(parsed, vars) as string;
 }

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,0 +1,9 @@
+// Ambient declaration for prompt file-asset imports. The Bun-only
+// `import x from "./foo.md" with { type: "file" }` form (used only by the
+// generated embedded-prompts.ts, reached through the `bun` condition of
+// the `#prompt-assets` package import) resolves to the embedded file path
+// as a string. tsx/node never load that module — they use disk-prompts.ts.
+declare module "*.md" {
+  const path: string;
+  export default path;
+}

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -8,6 +8,7 @@
  */
 
 import pino from "pino";
+import prettyStream from "pino-pretty";
 import {
   existsSync,
   readFileSync,
@@ -15,6 +16,7 @@ import {
   statSync,
   renameSync,
   unlinkSync,
+  createWriteStream,
 } from "node:fs";
 import { dirs, files } from "./paths.js";
 
@@ -103,39 +105,38 @@ if (!quiet) {
 // suites that don't mock this module.
 const IS_VITEST = process.env.VITEST === "true";
 
-const targets = [
-  // Console output (disabled in quiet mode)
-  ...(!quiet
-    ? [
-        {
-          target: "pino-pretty",
-          level: "trace" as const,
-          options: {
-            colorize: true,
-            ignore: "pid,hostname",
-            translateTime: "HH:MM:ss",
-          },
-        },
-      ]
-    : []),
-  // JSON file output (always active outside test runs)
-  ...(!IS_VITEST
-    ? [
-        {
-          target: "pino/file",
-          level: "trace" as const,
-          options: {
-            destination: LOG_FILE,
-            mkdir: true,
-          },
-        },
-      ]
-    : []),
-];
+// In-process streams (pino.multistream), NOT worker-thread transports.
+// `transport: { targets }` spawns a thread-stream worker that resolves the
+// target module ("pino-pretty", "pino/file") by name at runtime — which
+// fails in a `bun build --compile` standalone binary (no node_modules on
+// disk: "unable to determine transport target for pino-pretty"). Wiring
+// the same destinations as direct streams keeps formatting identical and
+// runs everywhere, with no worker.
+const streams: pino.StreamEntry[] = [];
+
+// Console output (disabled in quiet mode), pretty-printed.
+if (!quiet) {
+  streams.push({
+    level: "trace",
+    stream: prettyStream({
+      colorize: true,
+      ignore: "pid,hostname",
+      translateTime: "HH:MM:ss",
+    }),
+  });
+}
+
+// JSON file output (always active outside test runs).
+if (!IS_VITEST) {
+  streams.push({
+    level: "trace",
+    stream: createWriteStream(LOG_FILE, { flags: "a" }),
+  });
+}
 
 const logger =
-  targets.length > 0
-    ? pino({ level: "trace", transport: { targets } })
+  streams.length > 0
+    ? pino({ level: "trace" }, pino.multistream(streams))
     : pino({ level: "silent" });
 
 export function log(component: LogComponent, message: string): void {

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -20,7 +20,7 @@ import {
 import { join, resolve } from "node:path";
 import { log } from "./log.js";
 import { dirs, files as pathFiles } from "./paths.js";
-import { PACKAGE_PROMPTS_DIR } from "../core/prompt/templates.js";
+import { listSeedPrompts, readPromptAsset } from "#prompt-assets";
 
 const IDENTITY_SEED = `# Identity
 
@@ -151,22 +151,18 @@ export function initWorkspace(root: string): void {
   }
 
   // Seed user-editable prompt files from the package into
-  // ~/.talon/prompts/. Only copies files that don't already exist —
-  // user edits are preserved. Resolved relative to the package (NOT
-  // process.cwd(): a daemon launched from any other directory used to
-  // silently seed nothing). Skipped: the architecture README (docs,
-  // not a prompt) and the system/ subdirectory (package-owned
-  // templates read in place — a seeded copy would go stale; see
-  // prompts/README.md).
-  const packagePrompts = PACKAGE_PROMPTS_DIR;
-  if (existsSync(packagePrompts)) {
-    for (const file of readdirSync(packagePrompts)) {
-      if (!file.endsWith(".md") || file === "README.md") continue;
-      const dst = join(dirs.prompts, file);
-      if (!existsSync(dst)) {
-        copyFileSync(join(packagePrompts, file), dst);
-        log("workspace", `Seeded prompt: ${file}`);
-      }
+  // ~/.talon/prompts/. Only writes files that don't already exist —
+  // user edits are preserved. Sourced through the #prompt-assets seam
+  // (disk under tsx, embedded under a compiled binary), so seeding works
+  // even when there is no package source tree on disk. listSeedPrompts()
+  // already skips the architecture README and the system/ subdirectory
+  // (package-owned templates read in place — a seeded copy would go
+  // stale; see prompts/README.md).
+  for (const file of listSeedPrompts()) {
+    const dst = join(dirs.prompts, file);
+    if (!existsSync(dst)) {
+      writeFileSync(dst, readPromptAsset(file));
+      log("workspace", `Seeded prompt: ${file}`);
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## What

Makes Talon compilable into a **working** `bun build --compile` binary and publishes binaries / `.deb` / Homebrew on release.

## Why

`bun build --compile src/index.ts` already produced a binary, but it was **broken** — even `--version`/`--help` crashed, because early bootstrap reads `prompts/system/*.md` from disk via `import.meta.url`. In a standalone binary those files aren't on disk, so it ENOENTed. The existing `bun-compile` CI job only tested the `_mcp-launch` supervisor precisely because the full app couldn't boot compiled.

## How — prompt assets, embedded without stringifying prose

A `#prompt-assets` package-imports seam with two implementations:

| condition | module | used by |
| --- | --- | --- |
| `default` | `disk-prompts.ts` | tsx / node / npm — reads `prompts/` from disk (today's behavior) |
| `bun` | `embedded-prompts.ts` *(generated)* | Bun runtime + `--compile` — `.md` files embedded as real file assets via `with { type: "file" }` |

The Bun-only import attribute never enters the tsx/node/`tsc` module graph, so the npm package is unaffected. Prose stays in `.md` — **nothing is base64'd into source**. `readPromptAsset`/`listSeedPrompts` is the shared interface:

- `templates.ts` routes Liquid `{% render %}` includes through it via a custom `fs`
- `dream.ts` and `workspace.ts` seeding switch over
- `cli.ts` `--version` uses a static JSON import (no disk read)

Generated manifest follows the existing SQL/WASM embed idiom: `scripts/embed-prompts.ts` + `npm run build:prompts`, drift-guarded by `prompts-embed.test.ts`. `doctor` gains a **"Prompt templates loaded"** check that proves embedding works in the binary.

## CI

`bun-compile` → **Compile Smoke** matrix (ubuntu / macos / windows, `fail-fast: false`): compiles `src/cli.ts` into an **isolated dir** and runs `--version` / `--help` / `doctor` + the `_mcp-launch` supervisor against the real artifact — the install shape a published binary ships as.

## Release (`publish.yml`, on `release: published`)

- **binaries**: Bun cross-compiles 5 targets (linux/macOS x64+arm64, windows x64) from one host + `SHA256SUMS` → release assets
- **deb**: `.deb` via nfpm for amd64 + arm64 → release assets
- **homebrew**: bumps `Formula/talon.rb` in `dylanneve1/homebrew-talon` (skips cleanly without `HOMEBREW_TAP_TOKEN`)

## Out of scope / limitations (documented)

- Hosting Talon's **own** MCP server from the compiled binary still needs npm/Node (it spawns a `tsx` loader). The interactive/agent CLI works fully.
- macOS binaries are unsigned → `xattr -d com.apple.quarantine` (brew install avoids this).

## Prerequisites for the release jobs

- Create tap repo `dylanneve1/homebrew-talon`
- Add `HOMEBREW_TAP_TOKEN` secret (tap-write)

## Verification

- Full suite: **3389 passed**, 40 skipped; `tsc` / `oxlint` / `prettier` clean
- A compiled binary boots from an empty cwd (`--version`/`--help`/`doctor` all green, "All checks passed")
- Cross-compiled windows/darwin/linux-arm64 binaries contain the embedded prompt bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)