### PR TITLE
fix: stop double startup on port retry and end_turn nag in terminal mode

### DIFF
--- a/src/__tests__/claude-sdk-terminal-flow-gate.test.ts
+++ b/src/__tests__/claude-sdk-terminal-flow-gate.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Regression coverage for the Claude SDK terminal-mode flow-violation gate.
+ *
+ * Terminal mode has no outbound delivery tools, so a trailing assistant text
+ * block is the reply and must not be passed through detectFlowViolation().
+ * Messaging frontends still enforce the tool-only delivery contract.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface SystemInit {
+  type: "system";
+  subtype: "init";
+  session_id: string;
+}
+
+interface AssistantTextMsg {
+  type: "assistant";
+  message: {
+    content: Array<{ type: "text"; text: string }>;
+  };
+}
+
+interface ResultMsg {
+  type: "result";
+  subtype: "success";
+  result: string;
+  duration_ms: number;
+  duration_api_ms: number;
+  is_error: boolean;
+  num_turns: number;
+  session_id: string;
+  total_cost_usd: number;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens: number;
+    cache_read_input_tokens: number;
+  };
+  modelUsage: Record<
+    string,
+    {
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadInputTokens: number;
+      cacheCreationInputTokens: number;
+      contextWindow: number;
+    }
+  >;
+}
+
+type SdkMsg = SystemInit | AssistantTextMsg | ResultMsg;
+
+let activeFrontends: string[] = [];
+let mockMessages: SdkMsg[] = [];
+
+const detectFlowViolationSpy = vi.fn(() => ({ violated: false }) as const);
+
+const mockSdkScript = (messages: SdkMsg[]): void => {
+  mockMessages = messages;
+};
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(
+    (_args: {
+      prompt: string;
+      options: { abortController?: AbortController };
+    }) => {
+      let i = 0;
+      const iter = {
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+        [Symbol.asyncDispose]: async () => {
+          /* no-op for tests */
+        },
+        async next(): Promise<IteratorResult<SdkMsg, void>> {
+          if (i < mockMessages.length) {
+            return { done: false, value: mockMessages[i++] };
+          }
+          return { done: true, value: undefined };
+        },
+        async return(): Promise<IteratorResult<SdkMsg, void>> {
+          return { done: true, value: undefined };
+        },
+        async throw(err: unknown): Promise<IteratorResult<SdkMsg, void>> {
+          throw err;
+        },
+      };
+      return iter as unknown as AsyncGenerator<SdkMsg, void>;
+    },
+  ),
+}));
+
+vi.mock("../storage/sessions.js", () => ({
+  getSession: () => ({ sessionId: null, turns: 0 }),
+  incrementTurns: vi.fn(),
+  recordUsage: vi.fn(),
+  resetSession: vi.fn(),
+  setSessionId: vi.fn(),
+  setSessionName: vi.fn(),
+  updateLiveTurn: vi.fn(),
+}));
+
+vi.mock("../storage/chat-settings.js", () => ({
+  getChatSettings: () => ({}),
+  setChatModel: vi.fn(),
+}));
+
+vi.mock("../core/plugin.js", () => ({
+  getPluginMcpServers: () => ({}),
+  getPluginPromptAdditions: () => [],
+}));
+
+vi.mock("../backend/claude-sdk/state.js", () => ({
+  getConfig: () => ({
+    model: "claude-sonnet-4-6",
+    frontend: "terminal",
+    systemPrompt: "test prompt",
+    workspace: "/tmp/workspace",
+  }),
+  getBridgePort: () => 19876,
+}));
+
+vi.mock("../backend/claude-sdk/options.js", async (importActual) => ({
+  ...((await importActual()) as Record<string, unknown>),
+  getActiveFrontends: () => activeFrontends,
+}));
+
+vi.mock("../util/trace.js", () => ({
+  traceMessage: vi.fn(),
+}));
+
+vi.mock("../util/metrics.js", () => ({
+  incrementCounter: vi.fn(),
+  recordHistogram: vi.fn(),
+}));
+
+vi.mock("../backend/shared/index.js", () => ({
+  formatUserPrompt: ({ text }: { text: string }) => text,
+  prepareSystemPrompt: vi.fn(),
+  extractSessionName: () => null,
+  detectFlowViolation: (...args: Parameters<typeof detectFlowViolationSpy>) =>
+    detectFlowViolationSpy(...args),
+  FLOW_VIOLATION_MAX_RETRIES: 3,
+  captureDeliveredText: () => null,
+  summarizeUsage: () => "0ms in=0 out=0 cache=0% tools=0",
+  buildDeliveryContract: () => "",
+  buildFlowViolationReminder: () => "",
+  buildFirstTurnReminder: () => "",
+  recordToolCall: vi.fn(),
+  recordTurnMetrics: vi.fn(),
+  recordFailedTurnAccounting: vi.fn(),
+  recordFlowViolation: vi.fn(),
+  applyRetryDecision: async ({ err }: { err: unknown }) => ({
+    retry: undefined,
+    classified: err instanceof Error ? err : new Error(String(err)),
+  }),
+}));
+
+async function drainChatTurn(chatId: string, text: string) {
+  const { runChatTurn } = await import("../backend/claude-sdk/handler.js");
+  const { makeBareModelRef } =
+    await import("../core/agent-runtime/model-ref.js");
+  const events = [];
+  for await (const event of runChatTurn({
+    chatId,
+    model: makeBareModelRef("claude", "default"),
+    text,
+    senderName: "Dylan",
+    isGroup: false,
+  })) {
+    events.push(event);
+  }
+  return events;
+}
+
+const assistantText = (text: string): AssistantTextMsg => ({
+  type: "assistant",
+  message: {
+    content: [{ type: "text", text }],
+  },
+});
+
+const stdResult: ResultMsg = {
+  type: "result",
+  subtype: "success",
+  result: "",
+  duration_ms: 0,
+  duration_api_ms: 0,
+  is_error: false,
+  num_turns: 1,
+  session_id: "sess-1",
+  total_cost_usd: 0,
+  usage: {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+  },
+  modelUsage: {
+    "claude-sonnet-4-6": {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      contextWindow: 200_000,
+    },
+  },
+};
+
+function installTrailingTextScript(): void {
+  mockSdkScript([
+    { type: "system", subtype: "init", session_id: "sess-1" },
+    assistantText("This is the terminal reply."),
+    stdResult,
+  ]);
+}
+
+describe("Claude SDK terminal flow-violation gate", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    activeFrontends = [];
+    mockMessages = [];
+    detectFlowViolationSpy.mockReset();
+    detectFlowViolationSpy.mockReturnValue({ violated: false });
+
+    const { clearModels, registerModels } =
+      await import("../core/models/catalog.js");
+    clearModels();
+    registerModels([
+      {
+        id: "default",
+        displayName: "Default",
+        description: "test",
+        aliases: ["claude-sonnet-4-6"],
+        provider: "anthropic",
+      },
+    ]);
+  });
+
+  it("does not check flow violations in terminal mode", async () => {
+    activeFrontends = [];
+    installTrailingTextScript();
+
+    const events = await drainChatTurn("terminal-chat", "hello");
+
+    expect(events.some((e) => e.type === "completed")).toBe(true);
+    expect(detectFlowViolationSpy).not.toHaveBeenCalled();
+  });
+
+  it("checks flow violations for messaging frontends", async () => {
+    activeFrontends = ["telegram"];
+    installTrailingTextScript();
+
+    const events = await drainChatTurn("telegram-chat", "hello");
+
+    expect(events.some((e) => e.type === "completed")).toBe(true);
+    expect(detectFlowViolationSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/gateway-http.test.ts
+++ b/src/__tests__/gateway-http.test.ts
@@ -571,4 +571,31 @@ describe("gateway port retry — EADDRINUSE", () => {
       }
     }
   });
+
+  it("runs the startup body exactly once after retrying past a busy port", async () => {
+    // Occupy the first port so start() retries onto the next one. The stale
+    // 'listening' callback from the failed bind must not also fire on the
+    // successful bind, or onStarted listeners (and the startup log) run twice.
+    const { createServer } = await import("node:http");
+    const blocker = createServer();
+    await new Promise<void>((resolve) =>
+      blocker.listen(19960, "127.0.0.1", resolve),
+    );
+
+    const gw = new Gateway();
+    gw.setFrontendHandler(async () => null);
+    let startedCount = 0;
+    gw.onStarted(() => {
+      startedCount++;
+    });
+
+    try {
+      const boundPort = await gw.start(19960);
+      expect(boundPort).toBe(19961); // retried past the blocked port
+      expect(startedCount).toBe(1); // startup body ran exactly once
+    } finally {
+      await gw.stop();
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
+  });
 });

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -427,16 +427,26 @@ export async function* runChatTurn(
 
   // ── Trailing-prose contract + flow-violation retry ──────────────────────
 
-  const violation = detectFlowViolation({
-    trailingText: state.lastTrailingText,
-    turnTerminated: state.turnTerminated,
-    deliveredTextNorms: state.deliveredTextNorms,
-    toolCalls: state.toolCalls,
-    retried: (_internal.flowRetries ?? 0) > 0,
-    retryCount: _internal.flowRetries ?? 0,
-    maxRetries: FLOW_VIOLATION_MAX_RETRIES,
-    ...(frontend ? { reminder: buildFlowViolationReminder(frontend) } : {}),
-  });
+  // Only messaging frontends have a tool-only delivery contract to enforce.
+  // In terminal mode (`frontend` undefined) there are no delivery tools and
+  // trailing prose IS the reply — the terminal renderer surfaces it via
+  // `result.text` when nothing came through the bridge (see
+  // frontend/terminal/index.ts). Running the check there would flag the
+  // model's natural prose as a violation and re-prompt it to call `end_turn`,
+  // a tool that mode doesn't even register. Mirrors the `frontend`-gated
+  // delivery-contract suffix above.
+  const violation = frontend
+    ? detectFlowViolation({
+        trailingText: state.lastTrailingText,
+        turnTerminated: state.turnTerminated,
+        deliveredTextNorms: state.deliveredTextNorms,
+        toolCalls: state.toolCalls,
+        retried: (_internal.flowRetries ?? 0) > 0,
+        retryCount: _internal.flowRetries ?? 0,
+        maxRetries: FLOW_VIOLATION_MAX_RETRIES,
+        reminder: buildFlowViolationReminder(frontend),
+      })
+    : ({ violated: false } as const);
 
   if (violation.violated) {
     recordFlowViolation(violation.shouldRetry ? "retried" : "cap_exhausted");

--- a/src/core/engine/gateway.ts
+++ b/src/core/engine/gateway.ts
@@ -393,6 +393,12 @@ export class Gateway {
           if (err.code === "EADDRINUSE" && attempt < 5) {
             attempt++;
             httpServer.removeAllListeners("error");
+            // The failed listen() left its one-shot 'listening' success
+            // callback registered (Node attaches it via once('listening')).
+            // Drop it before retrying — otherwise every stale callback also
+            // fires when a later port finally binds, running the startup body
+            // (and logging "Action gateway on :…") once per attempted port.
+            httpServer.removeAllListeners("listening");
             tryPort(p + 1);
           } else {
             reject(err);


### PR DESCRIPTION
Two startup/terminal-mode correctness fixes surfaced by a single run log — one duplicate `Action gateway on :19878` line, and the model scrambling through `ToolSearch` to find `end_turn` after a "flow violation: trailing prose" re-prompt in CLI mode.

## 1. Gateway double-start on port retry

`Gateway.start()` passes the success callback to `httpServer.listen(p, host, cb)`, which Node registers via `once("listening", cb)`. On `EADDRINUSE` the retry path removed the stale `"error"` listener but **not** the stale `"listening"` one, so the failed attempt's success callback stayed attached. When a later port finally bound, *every* accumulated callback fired — running the startup body (`onStarted` listeners + the `Action gateway on :…` log) **once per attempted port**.

That's exactly the log: a first daemon grabbed `19877` on the first try (one log line); the second process found `19877` busy, retried to `19878`, and logged it **twice**.

Fix: also drop `"listening"` listeners on retry. Adds a regression test asserting the startup body runs exactly once after retrying past a busy port.

## 2. `end_turn` nag in terminal/CLI mode

`talon chat` sets `frontend: "terminal"` (`cli.ts`), so `getActiveFrontends()` is empty and no delivery-tool MCP server spawns. The delivery-contract suffix is already gated on `frontend`, but `detectFlowViolation` ran **unconditionally** — flagging the model's natural trailing prose as a violation and re-prompting it to call `end_turn`, a tool that mode doesn't even register. The model then burns round-trips `ToolSearch`-ing for it (visible in the CLI log).

The terminal renderer already surfaces trailing prose via `result.text` when nothing came through the bridge (`frontend/terminal/index.ts`), so the reply is delivered regardless. Fix: gate the violation check on `frontend`, matching the `openai-agents` backend which already skips it when no delivery tools are registered.

## Testing
- `tsc --noEmit` clean
- New gateway regression test + existing gateway/flow-violation/handler suites pass (`gateway-http`, `shared-flow-violation`, `delivery-contract`, `claude-sdk-handler-watchdog`, `handlers`, `handlers-stream`, `integration`, `gateway-actions`, `gateway-context` — 56 + 237 + … all green)
- `oxlint` / `prettier` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)