### PR TITLE
feat(desktop): client-bridge frontend + Flutter companion app

### DIFF
--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -1,0 +1,108 @@
+name: Companion Apps
+
+# Builds the Flutter companion for Windows, macOS, Linux, and Android.
+# On a published Release, the artifacts are attached to it. On PRs touching
+# the app (or manual dispatch) it just builds + uploads workflow artifacts so
+# the pipeline can be verified before a real release.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/companion/**"
+      - ".github/workflows/companion.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: companion-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  FLUTTER_VERSION: "3.32.0"
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: apps/companion
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows
+            os: windows-latest
+            platform: windows
+            build: flutter build windows --release
+          - name: macOS
+            os: macos-latest
+            platform: macos
+            build: flutter build macos --release
+          - name: Linux
+            os: ubuntu-latest
+            platform: linux
+            build: flutter build linux --release
+          - name: Android
+            os: ubuntu-latest
+            platform: android
+            build: flutter build apk --release
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Linux desktop deps
+        if: matrix.platform == 'linux'
+        working-directory: .
+        run: sudo apt-get update && sudo apt-get install -y ninja-build libgtk-3-dev
+
+      - name: Set up Java
+        if: matrix.platform == 'android'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Regenerate platform scaffolding
+        run: flutter create --platforms=${{ matrix.platform }} --project-name=talon_companion .
+
+      - name: Build
+        run: ${{ matrix.build }}
+
+      - name: Package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          DEST="$GITHUB_WORKSPACE/apps/companion/dist"
+          case "${{ matrix.platform }}" in
+            windows) ( cd build/windows/x64/runner/Release && 7z a "$DEST/talon-companion-windows.zip" ./* ) ;;
+            macos)   ( cd build/macos/Build/Products/Release && zip -r -y "$DEST/talon-companion-macos.zip" talon_companion.app ) ;;
+            linux)   ( cd build/linux/x64/release/bundle && tar czf "$DEST/talon-companion-linux.tar.gz" . ) ;;
+            android) cp build/app/outputs/flutter-apk/app-release.apk "$DEST/talon-companion-android.apk" ;;
+          esac
+          ls -la "$DEST"
+
+      - name: Upload workflow artifact
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: talon-companion-${{ matrix.platform }}
+          path: apps/companion/dist/*
+
+      - name: Attach to Release
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" dist/* --clobber

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/dylanneve1/talon/actions/workflows/ci.yml/badge.svg)](https://github.com/dylanneve1/talon/actions/workflows/ci.yml)
 
-Multi-platform agentic AI harness. Runs on **Telegram**, **Discord**, **Microsoft Teams**, and the **Terminal**, with a pluggable backend (**Claude Agent SDK**, **Kilo**, **OpenCode**, **Codex**, or **OpenAI Agents**) and full tool access through MCP.
+Multi-platform agentic AI harness. Runs on **Telegram**, **Discord**, **Microsoft Teams**, the **Terminal**, and a **cross-platform Desktop/Mobile companion app** (Flutter), with a pluggable backend (**Claude Agent SDK**, **Kilo**, **OpenCode**, **Codex**, or **OpenAI Agents**) and full tool access through MCP.
 
 ---
 
@@ -14,7 +14,7 @@ Multi-platform agentic AI harness. Runs on **Telegram**, **Discord**, **Microsof
 
 |                       |                                                                                                                                              |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Multi-frontend**    | Telegram (Grammy + GramJS userbot), Discord (discord.js), Microsoft Teams (Bot Framework), Terminal with live tool visibility                |
+| **Multi-frontend**    | Telegram (Grammy + GramJS userbot), Discord (discord.js), Microsoft Teams (Bot Framework), Terminal with live tool visibility, and a **Desktop/Mobile app** (Flutter) over a local/remote bridge |
 | **Pluggable backend** | Claude Agent SDK, Kilo, OpenCode, Codex, OpenAI Agents — selectable per-process via `backend` config. Streaming, model fallback, context-overflow recovery. |
 | **MCP tools**         | Messaging, media, history, search, web fetch, cron jobs, triggers, goals, stickers, file system, admin controls                              |
 | **Plugins**           | Hot-reloadable plugin system. Built-in: GitHub, MemPalace, Playwright, Brave Search                                                          |
@@ -90,6 +90,7 @@ index.ts                    Composition root
   |   +-- discord/          discord.js v14
   |   +-- teams/            Bot Framework + Graph API
   |   +-- terminal/         Readline CLI with tool call visibility
+  |   +-- desktop/          Client bridge (HTTP + SSE) for the companion app
   |
   +-- storage/              Sessions, history, chat settings,
   |                         cron jobs, media index, daily logs
@@ -115,6 +116,26 @@ Select via the `backend` field in `~/.talon/config.json`. All backends implement
 | OpenAI Agents | `"openai-agents"` | In-process via `@openai/agents` | Responses API (or any OpenAI-compatible endpoint via `TALON_AGENTS_URL` / `openaiBaseUrl`). Persistent per-chat MCP bundles. |
 
 The Kilo and OpenCode backends share infrastructure (`backend/remote-server/`) since the upstream HTTP API is the same; each backend supplies its own SDK client, port, and delivery suffix. Codex is its own integration on top of the Codex CLI's JSONL event stream.
+
+---
+
+## Desktop & mobile app
+
+The `desktop` frontend turns the daemon into a **client bridge** — a versioned HTTP + Server-Sent-Events JSON API (the _Talon Client Bridge Protocol_, `src/frontend/desktop/protocol.ts`) that any GUI client can speak. The reference client is **[Talon Companion](apps/companion/)**, a single Flutter codebase that runs on **Windows, macOS, Linux, and Android**.
+
+```jsonc
+// ~/.talon/config.json
+{
+  "frontend": "desktop",
+  "desktop": { "host": "127.0.0.1", "port": 19880 }
+  // For remote (e.g. a phone): "host": "0.0.0.0", "token": "your-secret"
+}
+```
+
+- **Local (desktop):** the app connects to a Talon on the same machine and launches one if needed (`TALON_FRONTEND_OVERRIDE=desktop`).
+- **Remote (mobile/LAN):** point the app at `host:port` + token; the bridge requires `Authorization: Bearer …` (or `?token=` on the SSE stream) whenever a token is set.
+
+The app provides multi-chat history, live streaming with reasoning + tool-call visibility, per-chat model/effort/pulse/reset, and **settings sync** — read and change the daemon's own config (default model, display name, timezone, pulse/heartbeat/dream) and restart it. See [apps/companion/README.md](apps/companion/README.md).
 
 ---
 

--- a/apps/companion/.gitignore
+++ b/apps/companion/.gitignore
@@ -5,6 +5,8 @@
 .pub/
 build/
 pubspec.lock
+.flutter-plugins
+.flutter-plugins-dependencies
 
 # Generated platform runners (regenerate with `flutter create .`)
 # Tracked lib/ + pubspec.yaml are the source of record; the per-OS

--- a/apps/companion/.gitignore
+++ b/apps/companion/.gitignore
@@ -1,0 +1,26 @@
+# Flutter / Dart
+.dart_tool/
+.packages
+.pub-cache/
+.pub/
+build/
+pubspec.lock
+
+# Generated platform runners (regenerate with `flutter create .`)
+# Tracked lib/ + pubspec.yaml are the source of record; the per-OS
+# runner folders are scaffolding and rebuilt on demand.
+/android/
+/ios/
+/linux/
+/macos/
+/windows/
+/web/
+
+# IDE
+.idea/
+*.iml
+.vscode/
+
+# Misc
+*.log
+.DS_Store

--- a/apps/companion/.metadata
+++ b/apps/companion/.metadata
@@ -1,0 +1,36 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "be698c48a6750c8cb8e61c740ca9991bb947aba2"
+  channel: "stable"
+
+project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+    - platform: android
+      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+    - platform: linux
+      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+    - platform: macos
+      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'

--- a/apps/companion/README.md
+++ b/apps/companion/README.md
@@ -1,0 +1,69 @@
+# Talon Companion
+
+A beautiful, cross-platform client for [Talon](../../README.md) — one Flutter
+codebase for **Windows, macOS, Linux, and Android** (iOS/web build too).
+
+It speaks the **Talon Client Bridge Protocol** (HTTP + Server-Sent Events) to a
+Talon daemon running the `desktop` frontend:
+
+- **Desktop** — connects to a Talon on the same machine and, if one isn't
+  running, launches it for you (`TALON_FRONTEND_OVERRIDE=desktop`).
+- **Mobile / remote** — connects to a Talon bridge over the network by host/IP
+  + token, so your phone can drive a Talon running on your desktop or a server.
+
+The bridge is client-agnostic: this app is the reference client, but anything
+that speaks the protocol works.
+
+## Features
+
+- Multiple chats with a time-grouped, searchable history sidebar (ChatGPT-style)
+- Live streaming replies, with the model's reasoning and tool calls shown inline
+- Full Markdown rendering (code blocks, tables, lists, links)
+- Per-chat **model** + **reasoning effort** + **pulse** + **session reset**
+- **Settings sync** — read and change the daemon's own config (default model,
+  display name, timezone, pulse/heartbeat/dream) and see live status
+- Restart the local daemon from the app
+- Modern dark, glassy theme
+
+## Running it
+
+Requires the [Flutter SDK](https://docs.flutter.dev/get-started/install)
+(3.27+). The per-OS runner folders are generated, not committed:
+
+```bash
+cd apps/companion
+flutter create --platforms=windows,macos,linux,android .   # one-time scaffold
+flutter pub get
+flutter run -d windows     # or macos / linux
+flutter run -d <android-device>
+```
+
+On first launch, pick **This computer** (desktop) or **Remote bridge** (enter a
+host/IP + token). For remote access, run the daemon with a reachable bridge:
+
+```jsonc
+// ~/.talon/config.json
+{
+  "frontend": "desktop",
+  "desktop": { "host": "0.0.0.0", "port": 19880, "token": "your-secret" }
+}
+```
+
+## Protocol
+
+The wire contract lives on the daemon side in
+[`src/frontend/desktop/protocol.ts`](../../src/frontend/desktop/protocol.ts)
+and is mirrored in Dart under [`lib/src/models/`](lib/src/models). Endpoints:
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| GET  | `/health` | Identity + status (unauthenticated) |
+| GET  | `/events` | SSE stream of all events |
+| GET/POST | `/chats` `/chats/rename` `/chats/delete` `/chats/reset` `/chats/pulse` | Chat management |
+| GET  | `/history?chatId=` | Recent messages |
+| POST | `/send` | Send a user message |
+| GET/POST | `/models` `/model` `/effort` | Model + effort |
+| GET/POST | `/config` | Read / change daemon settings |
+
+All non-`/health` routes accept a bearer token (`Authorization: Bearer …`, or
+`?token=` for the SSE stream) when the daemon is configured with one.

--- a/apps/companion/analysis_options.yaml
+++ b/apps/companion/analysis_options.yaml
@@ -1,0 +1,7 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true
+    prefer_const_declarations: true
+    avoid_print: false

--- a/apps/companion/lib/main.dart
+++ b/apps/companion/lib/main.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import 'src/services/prefs.dart';
+import 'src/state/app_state.dart';
+import 'src/theme.dart';
+import 'src/ui/root_view.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await Prefs.load();
+  final state = AppState(prefs);
+  runApp(TalonApp(state: state));
+}
+
+class TalonApp extends StatefulWidget {
+  final AppState state;
+  const TalonApp({super.key, required this.state});
+
+  @override
+  State<TalonApp> createState() => _TalonAppState();
+}
+
+class _TalonAppState extends State<TalonApp> {
+  @override
+  void initState() {
+    super.initState();
+    // Connect on launch using the saved profile (or platform default).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (widget.state.prefs.onboarded) widget.state.start();
+    });
+  }
+
+  @override
+  void dispose() {
+    widget.state.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Talon',
+      debugShowCheckedModeBanner: false,
+      theme: buildTalonTheme(),
+      home: RootView(state: widget.state),
+    );
+  }
+}

--- a/apps/companion/lib/src/models/bridge_models.dart
+++ b/apps/companion/lib/src/models/bridge_models.dart
@@ -42,6 +42,11 @@ class ClientMessage {
   final List<List<ClientButton>> buttons;
   final List<String> reactions;
 
+  /// Tools that ran during this assistant turn (client-only — snapshot from
+  /// the live turn when the canonical message arrives, so the history pane
+  /// can show what the model did).
+  final List<ToolActivity> tools;
+
   /// True while assistant text is still streaming into this bubble (client-only).
   bool streaming;
 
@@ -53,8 +58,10 @@ class ClientMessage {
     required this.ts,
     this.buttons = const [],
     List<String>? reactions,
+    List<ToolActivity>? tools,
     this.streaming = false,
-  }) : reactions = reactions ?? <String>[];
+  })  : reactions = reactions ?? <String>[],
+        tools = tools ?? <ToolActivity>[];
 
   factory ClientMessage.fromJson(Map<String, dynamic> j) {
     final rawButtons = (j['buttons'] as List?) ?? const [];
@@ -243,6 +250,8 @@ class ToolActivity {
   bool done;
   String? error;
   Map<String, dynamic> input;
+  final DateTime startedAt;
+  DateTime? finishedAt;
 
   ToolActivity({
     required this.id,
@@ -250,5 +259,10 @@ class ToolActivity {
     this.done = false,
     this.error,
     Map<String, dynamic>? input,
-  }) : input = input ?? <String, dynamic>{};
+    DateTime? startedAt,
+    this.finishedAt,
+  })  : input = input ?? <String, dynamic>{},
+        startedAt = startedAt ?? DateTime.now();
+
+  Duration get elapsed => (finishedAt ?? DateTime.now()).difference(startedAt);
 }

--- a/apps/companion/lib/src/models/bridge_models.dart
+++ b/apps/companion/lib/src/models/bridge_models.dart
@@ -1,0 +1,254 @@
+/// Dart mirror of the Talon Client Bridge Protocol (v1).
+///
+/// These types match `src/frontend/desktop/protocol.ts` on the daemon side.
+/// Keep them in sync; the bridge advertises its protocol version in `/health`
+/// and the `hello` event so a mismatch can be detected.
+library;
+
+const int kBridgeProtocolVersion = 1;
+
+enum Role { user, assistant, system }
+
+Role _roleFrom(String? s) {
+  switch (s) {
+    case 'assistant':
+      return Role.assistant;
+    case 'system':
+      return Role.system;
+    default:
+      return Role.user;
+  }
+}
+
+class ClientButton {
+  final String text;
+  final String? url;
+  final String? data;
+  const ClientButton({required this.text, this.url, this.data});
+
+  factory ClientButton.fromJson(Map<String, dynamic> j) => ClientButton(
+        text: (j['text'] ?? '') as String,
+        url: j['url'] as String?,
+        data: j['data'] as String?,
+      );
+}
+
+class ClientMessage {
+  final String id;
+  final String chatId;
+  final Role role;
+  String text;
+  final int ts;
+  final List<List<ClientButton>> buttons;
+  final List<String> reactions;
+
+  /// True while assistant text is still streaming into this bubble (client-only).
+  bool streaming;
+
+  ClientMessage({
+    required this.id,
+    required this.chatId,
+    required this.role,
+    required this.text,
+    required this.ts,
+    this.buttons = const [],
+    List<String>? reactions,
+    this.streaming = false,
+  }) : reactions = reactions ?? <String>[];
+
+  factory ClientMessage.fromJson(Map<String, dynamic> j) {
+    final rawButtons = (j['buttons'] as List?) ?? const [];
+    return ClientMessage(
+      id: j['id'].toString(),
+      chatId: (j['chatId'] ?? '') as String,
+      role: _roleFrom(j['role'] as String?),
+      text: (j['text'] ?? '') as String,
+      ts: (j['ts'] ?? 0) as int,
+      buttons: rawButtons
+          .map<List<ClientButton>>((row) => ((row as List?) ?? const [])
+              .map((c) => ClientButton.fromJson((c as Map).cast<String, dynamic>()))
+              .toList())
+          .toList(),
+      reactions:
+          ((j['reactions'] as List?) ?? const []).map((e) => e.toString()).toList(),
+    );
+  }
+
+  DateTime get time => DateTime.fromMillisecondsSinceEpoch(ts);
+}
+
+class ClientChat {
+  final String id;
+  String title;
+  final int createdAt;
+  int lastActive;
+  String preview;
+  String? model;
+  String? effort;
+  bool? pulse;
+
+  ClientChat({
+    required this.id,
+    required this.title,
+    required this.createdAt,
+    required this.lastActive,
+    required this.preview,
+    this.model,
+    this.effort,
+    this.pulse,
+  });
+
+  factory ClientChat.fromJson(Map<String, dynamic> j) => ClientChat(
+        id: (j['id'] ?? '') as String,
+        title: (j['title'] ?? 'New chat') as String,
+        createdAt: (j['createdAt'] ?? 0) as int,
+        lastActive: (j['lastActive'] ?? 0) as int,
+        preview: (j['preview'] ?? '') as String,
+        model: j['model'] as String?,
+        effort: j['effort'] as String?,
+        pulse: j['pulse'] as bool?,
+      );
+
+  DateTime get lastActiveTime =>
+      DateTime.fromMillisecondsSinceEpoch(lastActive);
+}
+
+/// Snapshot of the daemon's own (editable) settings + health — the payload of
+/// `GET /config`.
+class ConfigSnapshot {
+  final String backend;
+  final String frontend;
+  final String model;
+  final String modelDisplay;
+  final String botDisplayName;
+  final String timezone;
+  final bool pulse;
+  final int pulseIntervalMs;
+  final bool heartbeat;
+  final int heartbeatIntervalMinutes;
+  final bool dream;
+  final List<String> editable;
+  final bool healthy;
+  final int uptimeMs;
+  final int sessions;
+  final int messages;
+  final int memoryMb;
+
+  const ConfigSnapshot({
+    required this.backend,
+    required this.frontend,
+    required this.model,
+    required this.modelDisplay,
+    required this.botDisplayName,
+    required this.timezone,
+    required this.pulse,
+    required this.pulseIntervalMs,
+    required this.heartbeat,
+    required this.heartbeatIntervalMinutes,
+    required this.dream,
+    required this.editable,
+    required this.healthy,
+    required this.uptimeMs,
+    required this.sessions,
+    required this.messages,
+    required this.memoryMb,
+  });
+
+  factory ConfigSnapshot.fromJson(Map<String, dynamic> j) {
+    final health = ((j['health'] as Map?) ?? const {}).cast<String, dynamic>();
+    return ConfigSnapshot(
+      backend: (j['backend'] ?? '') as String,
+      frontend: (j['frontend'] ?? '') as String,
+      model: (j['model'] ?? '') as String,
+      modelDisplay: (j['modelDisplay'] ?? '') as String,
+      botDisplayName: (j['botDisplayName'] ?? 'Talon') as String,
+      timezone: (j['timezone'] ?? '') as String,
+      pulse: (j['pulse'] ?? false) as bool,
+      pulseIntervalMs: (j['pulseIntervalMs'] ?? 300000) as int,
+      heartbeat: (j['heartbeat'] ?? false) as bool,
+      heartbeatIntervalMinutes: (j['heartbeatIntervalMinutes'] ?? 60) as int,
+      dream: (j['dream'] ?? false) as bool,
+      editable:
+          ((j['editable'] as List?) ?? const []).map((e) => e.toString()).toList(),
+      healthy: (health['healthy'] ?? false) as bool,
+      uptimeMs: (health['uptimeMs'] ?? 0) as int,
+      sessions: (health['sessions'] ?? 0) as int,
+      messages: (health['messages'] ?? 0) as int,
+      memoryMb: (health['memoryMb'] ?? 0) as int,
+    );
+  }
+}
+
+class BridgeStatus {
+  final int protocol;
+  final String botName;
+  final String backend;
+  final String model;
+  final int activeChats;
+  final String startedAt;
+
+  const BridgeStatus({
+    required this.protocol,
+    required this.botName,
+    required this.backend,
+    required this.model,
+    required this.activeChats,
+    required this.startedAt,
+  });
+
+  factory BridgeStatus.fromJson(Map<String, dynamic> j) => BridgeStatus(
+        protocol: (j['protocol'] ?? 1) as int,
+        botName: (j['botName'] ?? 'Talon') as String,
+        backend: (j['backend'] ?? '') as String,
+        model: (j['model'] ?? '') as String,
+        activeChats: (j['activeChats'] ?? 0) as int,
+        startedAt: (j['startedAt'] ?? '') as String,
+      );
+
+  static const empty = BridgeStatus(
+    protocol: kBridgeProtocolVersion,
+    botName: 'Talon',
+    backend: '',
+    model: '',
+    activeChats: 0,
+    startedAt: '',
+  );
+}
+
+class ModelOption {
+  final String id;
+  final String displayName;
+  final String provider;
+  final bool reasoning;
+
+  const ModelOption({
+    required this.id,
+    required this.displayName,
+    required this.provider,
+    required this.reasoning,
+  });
+
+  factory ModelOption.fromJson(Map<String, dynamic> j) => ModelOption(
+        id: (j['id'] ?? '') as String,
+        displayName: (j['displayName'] ?? '') as String,
+        provider: (j['provider'] ?? '') as String,
+        reasoning: (j['reasoning'] ?? false) as bool,
+      );
+}
+
+/// A live tool invocation surfaced under the streaming reply.
+class ToolActivity {
+  final String id;
+  final String name;
+  bool done;
+  String? error;
+  Map<String, dynamic> input;
+
+  ToolActivity({
+    required this.id,
+    required this.name,
+    this.done = false,
+    this.error,
+    Map<String, dynamic>? input,
+  }) : input = input ?? <String, dynamic>{};
+}

--- a/apps/companion/lib/src/models/connection.dart
+++ b/apps/companion/lib/src/models/connection.dart
@@ -1,0 +1,103 @@
+import 'dart:io' show Platform;
+
+/// How the companion reaches a Talon daemon.
+///
+/// - On desktop the default is a *managed local* daemon: connect to
+///   `127.0.0.1`, and if nothing answers, launch one ourselves.
+/// - On mobile (or when pointing at another machine) it's a *remote* bridge:
+///   a host/IP + port and, for anything off-loopback, a shared token.
+class ConnectionConfig {
+  final String host;
+  final int port;
+  final String? token;
+
+  /// Desktop only: try to spawn/attach a local daemon instead of assuming one.
+  final bool manageLocalDaemon;
+
+  /// Command used to launch the daemon when [manageLocalDaemon] is on.
+  /// Defaults to the globally-installed `talon` CLI on PATH.
+  final String launchCommand;
+  final List<String> launchArgs;
+
+  const ConnectionConfig({
+    this.host = '127.0.0.1',
+    this.port = 19880,
+    this.token,
+    this.manageLocalDaemon = true,
+    this.launchCommand = 'talon',
+    this.launchArgs = const ['start'],
+  });
+
+  bool get isLoopback => host == '127.0.0.1' || host == 'localhost' || host == '::1';
+
+  /// We only ever supervise a daemon for a local, loopback connection.
+  bool get canManageDaemon =>
+      manageLocalDaemon && isLoopback && _desktopPlatform;
+
+  String get baseUrl => 'http://$host:$port';
+
+  String eventsUrl() {
+    final t = token;
+    return t == null || t.isEmpty
+        ? '$baseUrl/events'
+        : '$baseUrl/events?token=${Uri.encodeQueryComponent(t)}';
+  }
+
+  Map<String, String> authHeaders([Map<String, String>? extra]) {
+    final h = <String, String>{...?extra};
+    final t = token;
+    if (t != null && t.isNotEmpty) h['Authorization'] = 'Bearer $t';
+    return h;
+  }
+
+  ConnectionConfig copyWith({
+    String? host,
+    int? port,
+    String? token,
+    bool clearToken = false,
+    bool? manageLocalDaemon,
+    String? launchCommand,
+    List<String>? launchArgs,
+  }) =>
+      ConnectionConfig(
+        host: host ?? this.host,
+        port: port ?? this.port,
+        token: clearToken ? null : (token ?? this.token),
+        manageLocalDaemon: manageLocalDaemon ?? this.manageLocalDaemon,
+        launchCommand: launchCommand ?? this.launchCommand,
+        launchArgs: launchArgs ?? this.launchArgs,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'host': host,
+        'port': port,
+        'token': token,
+        'manageLocalDaemon': manageLocalDaemon,
+        'launchCommand': launchCommand,
+        'launchArgs': launchArgs,
+      };
+
+  factory ConnectionConfig.fromJson(Map<String, dynamic> j) => ConnectionConfig(
+        host: (j['host'] ?? '127.0.0.1') as String,
+        port: (j['port'] ?? 19880) as int,
+        token: j['token'] as String?,
+        manageLocalDaemon: (j['manageLocalDaemon'] ?? true) as bool,
+        launchCommand: (j['launchCommand'] ?? 'talon') as String,
+        launchArgs:
+            ((j['launchArgs'] as List?) ?? const ['start']).map((e) => e.toString()).toList(),
+      );
+
+  /// First-run default tuned to the platform: desktop manages a local daemon;
+  /// mobile starts in remote mode (the user supplies a host + token).
+  factory ConnectionConfig.defaults() => ConnectionConfig(
+        manageLocalDaemon: _desktopPlatform,
+      );
+}
+
+bool get _desktopPlatform {
+  try {
+    return Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+  } catch (_) {
+    return false; // web — treat as non-desktop
+  }
+}

--- a/apps/companion/lib/src/services/bridge_client.dart
+++ b/apps/companion/lib/src/services/bridge_client.dart
@@ -1,0 +1,210 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/bridge_models.dart';
+import '../models/connection.dart';
+
+/// Client for the Talon Client Bridge Protocol (v1).
+///
+/// REST for commands, a long-lived Server-Sent Events stream for everything the
+/// daemon pushes. Transport-only: it parses frames and exposes typed futures +
+/// a broadcast [events] stream. Reconnection/backoff lives in the caller
+/// (AppState) so UI can reflect connection state.
+class BridgeClient {
+  ConnectionConfig config;
+  final http.Client _http = http.Client();
+
+  final _events = StreamController<Map<String, dynamic>>.broadcast();
+  StreamSubscription<String>? _sseSub;
+  http.Client? _sseClient;
+  bool _closed = false;
+
+  BridgeClient(this.config);
+
+  /// Decoded SSE payloads (`{kind: ...}` objects).
+  Stream<Map<String, dynamic>> get events => _events.stream;
+
+  Uri _u(String path, [Map<String, String>? q]) =>
+      Uri.parse('${config.baseUrl}$path').replace(queryParameters: q);
+
+  // ── Health / discovery ─────────────────────────────────────────────────────
+
+  /// Probe `/health`. Returns the parsed body if it's a Talon bridge, else null.
+  Future<Map<String, dynamic>?> health({Duration? timeout}) async {
+    try {
+      final res = await _http
+          .get(_u('/health'))
+          .timeout(timeout ?? const Duration(milliseconds: 1200));
+      if (res.statusCode != 200) return null;
+      final body = (jsonDecode(res.body) as Map).cast<String, dynamic>();
+      return body['app'] == 'talon-bridge' ? body : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // ── SSE stream ──────────────────────────────────────────────────────────────
+
+  /// Open the event stream. Completes once the response headers arrive (i.e.
+  /// the connection is live); individual events flow through [events].
+  Future<void> connect() async {
+    await _sseSub?.cancel();
+    _sseClient?.close();
+    final client = http.Client();
+    _sseClient = client;
+
+    final req = http.Request('GET', Uri.parse(config.eventsUrl()))
+      ..headers['Accept'] = 'text/event-stream'
+      ..headers.addAll(config.authHeaders());
+
+    final res = await client.send(req);
+    if (res.statusCode != 200) {
+      client.close();
+      throw BridgeException('Event stream rejected (${res.statusCode})');
+    }
+
+    final buffer = StringBuffer();
+    _sseSub = res.stream
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(
+      (line) {
+        if (line.startsWith(':')) return; // keep-alive comment
+        if (line.isEmpty) {
+          _flush(buffer);
+          return;
+        }
+        if (line.startsWith('data:')) {
+          buffer.writeln(line.substring(5).trimLeft());
+        }
+      },
+      onError: (Object e) => _events.addError(e),
+      onDone: () {
+        if (!_closed) _events.addError(BridgeException('Stream closed'));
+      },
+      cancelOnError: true,
+    );
+  }
+
+  void _flush(StringBuffer buffer) {
+    final raw = buffer.toString().trim();
+    buffer.clear();
+    if (raw.isEmpty) return;
+    try {
+      final obj = (jsonDecode(raw) as Map).cast<String, dynamic>();
+      _events.add(obj);
+    } catch (_) {
+      /* ignore malformed frame */
+    }
+  }
+
+  // ── REST commands ──────────────────────────────────────────────────────────
+
+  Future<List<ClientChat>> listChats() async {
+    final j = await _getJson('/chats');
+    return ((j['chats'] as List?) ?? const [])
+        .map((c) => ClientChat.fromJson((c as Map).cast<String, dynamic>()))
+        .toList();
+  }
+
+  Future<ClientChat> createChat([String? title]) async {
+    final j = await _postJson('/chats', {if (title != null) 'title': title});
+    return ClientChat.fromJson((j['chat'] as Map).cast<String, dynamic>());
+  }
+
+  Future<void> renameChat(String chatId, String title) =>
+      _postJson('/chats/rename', {'chatId': chatId, 'title': title});
+
+  Future<void> deleteChat(String chatId) =>
+      _postJson('/chats/delete', {'chatId': chatId});
+
+  Future<void> resetChat(String chatId) =>
+      _postJson('/chats/reset', {'chatId': chatId});
+
+  Future<void> setPulse(String chatId, bool on) =>
+      _postJson('/chats/pulse', {'chatId': chatId, 'on': on});
+
+  Future<ConfigSnapshot> getConfig() async =>
+      ConfigSnapshot.fromJson(await _getJson('/config'));
+
+  Future<ConfigSnapshot> setConfig(Map<String, dynamic> update) async =>
+      ConfigSnapshot.fromJson(await _postJson('/config', update));
+
+  Future<List<ClientMessage>> history(String chatId) async {
+    final j = await _getJson('/history', {'chatId': chatId});
+    return ((j['messages'] as List?) ?? const [])
+        .map((m) => ClientMessage.fromJson((m as Map).cast<String, dynamic>()))
+        .toList();
+  }
+
+  Future<void> send(String chatId, String text) =>
+      _postJson('/send', {'chatId': chatId, 'text': text});
+
+  Future<(String active, List<ModelOption> models)> models() async {
+    final j = await _getJson('/models');
+    final list = ((j['models'] as List?) ?? const [])
+        .map((m) => ModelOption.fromJson((m as Map).cast<String, dynamic>()))
+        .toList();
+    return ((j['active'] ?? '') as String, list);
+  }
+
+  Future<void> setModel(String chatId, String model) =>
+      _postJson('/model', {'chatId': chatId, 'model': model});
+
+  Future<void> setEffort(String chatId, String effort) =>
+      _postJson('/effort', {'chatId': chatId, 'effort': effort});
+
+  Future<(String active, List<String> levels)> effortLevels(String chatId) async {
+    final j = await _getJson('/effort', {'chatId': chatId});
+    return (
+      (j['active'] ?? 'adaptive') as String,
+      ((j['levels'] as List?) ?? const []).map((e) => e.toString()).toList(),
+    );
+  }
+
+  // ── Internals ──────────────────────────────────────────────────────────────
+
+  Future<Map<String, dynamic>> _getJson(String path,
+      [Map<String, String>? q]) async {
+    final res = await _http
+        .get(_u(path, q), headers: config.authHeaders())
+        .timeout(const Duration(seconds: 12));
+    return _decode(res);
+  }
+
+  Future<Map<String, dynamic>> _postJson(
+      String path, Map<String, dynamic> body) async {
+    final res = await _http
+        .post(_u(path),
+            headers: config.authHeaders({'Content-Type': 'application/json'}),
+            body: jsonEncode(body))
+        .timeout(const Duration(seconds: 12));
+    return _decode(res);
+  }
+
+  Map<String, dynamic> _decode(http.Response res) {
+    if (res.statusCode == 401) throw BridgeException('Unauthorized — check token');
+    if (res.statusCode >= 400) {
+      throw BridgeException('Request failed (${res.statusCode})');
+    }
+    if (res.body.isEmpty) return const {};
+    return (jsonDecode(res.body) as Map).cast<String, dynamic>();
+  }
+
+  void dispose() {
+    _closed = true;
+    _sseSub?.cancel();
+    _sseClient?.close();
+    _http.close();
+    _events.close();
+  }
+}
+
+class BridgeException implements Exception {
+  final String message;
+  BridgeException(this.message);
+  @override
+  String toString() => message;
+}

--- a/apps/companion/lib/src/services/daemon_supervisor.dart
+++ b/apps/companion/lib/src/services/daemon_supervisor.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+import 'dart:io';
+
+import '../models/connection.dart';
+import 'bridge_client.dart';
+
+enum DaemonPhase { unknown, probing, launching, attached, failed }
+
+class DaemonState {
+  final DaemonPhase phase;
+  final String? detail;
+  const DaemonState(this.phase, [this.detail]);
+}
+
+/// Desktop-only supervisor that realises the "auto-start if not running, else
+/// attach" behaviour. On mobile this is never used — the app connects to a
+/// remote bridge instead.
+///
+/// It launches the daemon with `TALON_FRONTEND_OVERRIDE=desktop` so a user who
+/// normally runs Telegram/Discord still gets a desktop bridge for the app,
+/// without their saved config being rewritten.
+class DaemonSupervisor {
+  final ConnectionConfig config;
+  Process? _process;
+
+  DaemonSupervisor(this.config);
+
+  /// Returns true if a desktop bridge is reachable, launching one if needed.
+  /// Emits progress through [onPhase].
+  Future<bool> ensureRunning(void Function(DaemonState) onPhase) async {
+    final probe = BridgeClient(config);
+    try {
+      onPhase(const DaemonState(DaemonPhase.probing, 'Looking for Talon…'));
+      if (await probe.health() != null) {
+        onPhase(const DaemonState(DaemonPhase.attached, 'Attached'));
+        return true;
+      }
+
+      if (!config.canManageDaemon) {
+        onPhase(const DaemonState(
+            DaemonPhase.failed, 'No daemon and not managing one here'));
+        return false;
+      }
+
+      onPhase(const DaemonState(DaemonPhase.launching, 'Starting Talon…'));
+      final launched = await _launch();
+      if (!launched.ok) {
+        onPhase(DaemonState(DaemonPhase.failed, launched.detail));
+        return false;
+      }
+
+      // Poll for the bridge to come up (plugins/backends can take a while).
+      final deadline = DateTime.now().add(const Duration(seconds: 35));
+      while (DateTime.now().isBefore(deadline)) {
+        if (await probe.health() != null) {
+          onPhase(const DaemonState(DaemonPhase.attached, 'Started'));
+          return true;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 600));
+      }
+      onPhase(const DaemonState(
+          DaemonPhase.failed, 'Talon did not come up in time'));
+      return false;
+    } finally {
+      probe.dispose();
+    }
+  }
+
+  Future<({bool ok, String? detail})> _launch() async {
+    try {
+      _process = await Process.start(
+        config.launchCommand,
+        config.launchArgs,
+        environment: {'TALON_FRONTEND_OVERRIDE': 'desktop'},
+        mode: ProcessStartMode.detachedWithStdio,
+        runInShell: true,
+      );
+      return (ok: true, detail: null);
+    } on ProcessException catch (e) {
+      return (
+        ok: false,
+        detail: 'Could not run "${config.launchCommand}": ${e.message}. '
+            'Install the Talon CLI or set a launch command in Settings.'
+      );
+    } catch (e) {
+      return (ok: false, detail: e.toString());
+    }
+  }
+
+  /// Restart the daemon via the CLI (`talon restart`), preserving the desktop
+  /// frontend override. Used by the Settings "Restart Talon" action so config
+  /// changes that need a fresh boot take effect.
+  Future<({bool ok, String? detail})> restart() async {
+    if (!config.canManageDaemon) {
+      return (ok: false, detail: 'Restart is only available for a local daemon');
+    }
+    try {
+      await Process.start(
+        config.launchCommand,
+        const ['restart'],
+        environment: {'TALON_FRONTEND_OVERRIDE': 'desktop'},
+        mode: ProcessStartMode.detachedWithStdio,
+        runInShell: true,
+      );
+      return (ok: true, detail: null);
+    } catch (e) {
+      return (ok: false, detail: e.toString());
+    }
+  }
+
+  /// Best-effort: lets go of any child we spawned (we don't own an attached
+  /// daemon's lifecycle).
+  void detach() {
+    _process = null;
+  }
+}

--- a/apps/companion/lib/src/services/prefs.dart
+++ b/apps/companion/lib/src/services/prefs.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/connection.dart';
+
+/// Thin wrapper over [SharedPreferences] for the one thing we persist:
+/// the connection profile (local-managed vs remote, host/port/token).
+class Prefs {
+  static const _kConnection = 'connection.v1';
+  static const _kOnboarded = 'onboarded.v1';
+
+  final SharedPreferences _sp;
+  Prefs(this._sp);
+
+  static Future<Prefs> load() async => Prefs(await SharedPreferences.getInstance());
+
+  ConnectionConfig get connection {
+    final raw = _sp.getString(_kConnection);
+    if (raw == null) return ConnectionConfig.defaults();
+    try {
+      return ConnectionConfig.fromJson(
+          (jsonDecode(raw) as Map).cast<String, dynamic>());
+    } catch (_) {
+      return ConnectionConfig.defaults();
+    }
+  }
+
+  Future<void> setConnection(ConnectionConfig c) =>
+      _sp.setString(_kConnection, jsonEncode(c.toJson()));
+
+  bool get onboarded => _sp.getBool(_kOnboarded) ?? false;
+  Future<void> setOnboarded(bool v) => _sp.setBool(_kOnboarded, v);
+}

--- a/apps/companion/lib/src/state/app_state.dart
+++ b/apps/companion/lib/src/state/app_state.dart
@@ -314,11 +314,27 @@ class AppState extends ChangeNotifier {
     final list = _messages.putIfAbsent(chatId, () => []);
     if (list.any((x) => x.id == m.id)) return; // dedupe re-delivery
     list.add(m);
-    // The canonical reply supersedes the streaming draft.
-    if (m.role == Role.assistant) turnFor(chatId).draft = '';
+    // Canonical reply supersedes the live turn. End it now so we don't flash
+    // typing dots / orphan tool chips while waiting for the trailing turn_end.
+    if (m.role == Role.assistant) {
+      final t = turnFor(chatId);
+      // Hand the live tools to the message so the bubble can show a history.
+      m.tools.addAll(t.tools);
+      t.active = false;
+      t.typing = false;
+      t.draft = '';
+      t.reasoning.clear();
+      t.tools.clear();
+    }
   }
 
   void _onTool(Map<String, dynamic> e) {
+    final name = (e['name'] ?? 'tool') as String;
+    // `end_turn` is the canonical delivery tool — its "result" is the assistant
+    // message that arrives separately, so no tool_result event ever lands for
+    // it. Showing it as a chip means an eternally-spinning row of noise.
+    if (_isInternalTool(name)) return;
+
     final t = turnFor(e['chatId'] as String);
     final id = e['id'].toString();
     final phase = e['phase'] as String?;
@@ -326,6 +342,7 @@ class AppState extends ChangeNotifier {
     if (phase == 'result') {
       if (existing.isNotEmpty) {
         existing.first.done = true;
+        existing.first.finishedAt = DateTime.now();
         existing.first.error = e['error'] as String?;
       }
       return;
@@ -333,11 +350,13 @@ class AppState extends ChangeNotifier {
     if (existing.isEmpty) {
       t.tools.add(ToolActivity(
         id: id,
-        name: (e['name'] ?? 'tool') as String,
+        name: name,
         input: ((e['input'] as Map?) ?? const {}).cast<String, dynamic>(),
       ));
     }
   }
+
+  static bool _isInternalTool(String name) => name == 'end_turn';
 
   // ── Store helpers ────────────────────────────────────────────────────────--
 

--- a/apps/companion/lib/src/state/app_state.dart
+++ b/apps/companion/lib/src/state/app_state.dart
@@ -1,0 +1,448 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/bridge_models.dart';
+import '../models/connection.dart';
+import '../services/bridge_client.dart';
+import '../services/daemon_supervisor.dart';
+import '../services/prefs.dart';
+
+enum ConnState { idle, connecting, connected, error }
+
+/// Transient per-turn state: the streaming draft, the model's reasoning, and
+/// any live tool calls. Cleared when the turn ends.
+class TurnState {
+  String draft = '';
+  final List<String> reasoning = [];
+  final List<ToolActivity> tools = [];
+  bool active = false;
+  bool typing = false;
+
+  void reset() {
+    draft = '';
+    reasoning.clear();
+    tools.clear();
+    active = true;
+    typing = true;
+  }
+}
+
+/// Single source of truth for the UI. Owns the bridge client, the daemon
+/// supervisor (desktop), the chat/message stores, and reconnection.
+class AppState extends ChangeNotifier {
+  final Prefs prefs;
+  ConnectionConfig config;
+
+  AppState(this.prefs) : config = prefs.connection;
+
+  BridgeClient? _client;
+  DaemonSupervisor? _supervisor;
+  StreamSubscription<Map<String, dynamic>>? _sub;
+  Timer? _reconnect;
+  int _backoffMs = 800;
+  bool _disposed = false;
+
+  // Connection
+  ConnState conn = ConnState.idle;
+  String? connError;
+  DaemonState daemon = const DaemonState(DaemonPhase.unknown);
+  BridgeStatus status = BridgeStatus.empty;
+
+  // Data
+  final List<ClientChat> chats = [];
+  String? selectedChatId;
+  final Map<String, List<ClientMessage>> _messages = {};
+  final Map<String, TurnState> _turns = {};
+  final Set<String> _loadedHistory = {};
+
+  // Models
+  List<ModelOption> models = [];
+
+  // Daemon settings (synced from the bridge)
+  ConfigSnapshot? appConfig;
+
+  List<ClientMessage> messagesFor(String chatId) =>
+      _messages[chatId] ?? const [];
+  TurnState turnFor(String chatId) => _turns.putIfAbsent(chatId, TurnState.new);
+  ClientChat? get selectedChat {
+    for (final c in chats) {
+      if (c.id == selectedChatId) return c;
+    }
+    return null;
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+  /// Connect using the current [config]: on desktop, ensure a daemon is up
+  /// first; everywhere, open the event stream and load chats.
+  Future<void> start() async {
+    _reconnect?.cancel();
+    _setConn(ConnState.connecting, null);
+
+    if (config.canManageDaemon) {
+      _supervisor = DaemonSupervisor(config);
+      final ok = await _supervisor!.ensureRunning((d) {
+        daemon = d;
+        notifyListeners();
+      });
+      if (!ok) {
+        _setConn(ConnState.error,
+            daemon.detail ?? 'Could not reach or start Talon');
+        _scheduleReconnect();
+        return;
+      }
+    } else {
+      daemon = const DaemonState(DaemonPhase.unknown);
+    }
+
+    await _openStream();
+  }
+
+  Future<void> _openStream() async {
+    await _sub?.cancel();
+    _client?.dispose();
+    final client = BridgeClient(config);
+    _client = client;
+
+    try {
+      // Verify identity before committing to the stream — gives a crisp error
+      // when the host/token is wrong rather than a silent dead stream.
+      final h = await client.health();
+      if (h == null) throw BridgeException('No Talon bridge at ${config.host}:${config.port}');
+
+      _sub = client.events.listen(_onEvent, onError: (Object e) {
+        _setConn(ConnState.error, e.toString());
+        _scheduleReconnect();
+      });
+      await client.connect();
+
+      _setConn(ConnState.connected, null);
+      _backoffMs = 800;
+      await _refreshChats();
+      unawaited(_refreshModels());
+    } catch (e) {
+      _setConn(ConnState.error, e.toString());
+      _scheduleReconnect();
+    }
+  }
+
+  void _scheduleReconnect() {
+    if (_disposed) return;
+    _reconnect?.cancel();
+    _reconnect = Timer(Duration(milliseconds: _backoffMs), () {
+      _backoffMs = (_backoffMs * 1.7).clamp(800, 15000).toInt();
+      start();
+    });
+  }
+
+  /// Apply a new connection profile and reconnect from scratch.
+  Future<void> applyConfig(ConnectionConfig next) async {
+    config = next;
+    await prefs.setConnection(next);
+    chats.clear();
+    _messages.clear();
+    _turns.clear();
+    _loadedHistory.clear();
+    selectedChatId = null;
+    await start();
+  }
+
+  // ── Commands ────────────────────────────────────────────────────────────────
+
+  Future<void> selectChat(String chatId) async {
+    selectedChatId = chatId;
+    notifyListeners();
+    if (!_loadedHistory.contains(chatId)) await _loadHistory(chatId);
+  }
+
+  /// Narrow layout: return to the chat list.
+  void clearSelection() {
+    selectedChatId = null;
+    notifyListeners();
+  }
+
+  Future<void> newChat() async {
+    final c = await _client?.createChat();
+    if (c == null) return;
+    // chat_created event will also arrive; select eagerly for snappiness.
+    _upsertChat(c);
+    selectedChatId = c.id;
+    _loadedHistory.add(c.id);
+    notifyListeners();
+  }
+
+  Future<void> renameChat(String chatId, String title) =>
+      _client?.renameChat(chatId, title) ?? Future.value();
+
+  Future<void> deleteChat(String chatId) async {
+    await _client?.deleteChat(chatId);
+    // chat_deleted event reconciles state.
+  }
+
+  Future<void> sendMessage(String text) async {
+    final chatId = selectedChatId;
+    final client = _client;
+    if (chatId == null || client == null || text.trim().isEmpty) return;
+    try {
+      await client.send(chatId, text.trim());
+    } catch (e) {
+      _appendSystem(chatId, 'Failed to send: $e');
+    }
+  }
+
+  Future<void> setModel(String chatId, String model) async {
+    await _client?.setModel(chatId, model);
+  }
+
+  Future<void> setEffort(String chatId, String effort) async {
+    await _client?.setEffort(chatId, effort);
+  }
+
+  Future<(String, List<String>)> effortLevels(String chatId) async =>
+      await _client?.effortLevels(chatId) ?? ('adaptive', const <String>[]);
+
+  Future<void> resetChat(String chatId) async {
+    await _client?.resetChat(chatId);
+  }
+
+  Future<void> setPulse(String chatId, bool on) async {
+    await _client?.setPulse(chatId, on);
+  }
+
+  Future<ConfigSnapshot?> loadConfig() async {
+    final c = await _client?.getConfig();
+    if (c != null) {
+      appConfig = c;
+      notifyListeners();
+    }
+    return c;
+  }
+
+  Future<ConfigSnapshot?> updateConfig(Map<String, dynamic> update) async {
+    final c = await _client?.setConfig(update);
+    if (c != null) {
+      appConfig = c;
+      notifyListeners();
+    }
+    return c;
+  }
+
+  /// Desktop only: restart the managed daemon, then reconnect.
+  Future<({bool ok, String? detail})> restartDaemon() async {
+    if (!config.canManageDaemon) {
+      return (ok: false, detail: 'Restart needs a local managed daemon');
+    }
+    _setConn(ConnState.connecting, null);
+    final result = await DaemonSupervisor(config).restart();
+    if (result.ok) {
+      // Give the old process a moment to release the port before reattaching.
+      await Future<void>.delayed(const Duration(seconds: 2));
+      await start();
+    } else {
+      _setConn(ConnState.error, result.detail);
+    }
+    return result;
+  }
+
+  // ── Event handling ───────────────────────────────────────────────────────--
+
+  void _onEvent(Map<String, dynamic> e) {
+    switch (e['kind'] as String?) {
+      case 'hello':
+        status = BridgeStatus.fromJson((e['status'] as Map).cast());
+        _setChats((e['chats'] as List?) ?? const []);
+        break;
+      case 'status':
+        status = BridgeStatus.fromJson((e['status'] as Map).cast());
+        break;
+      case 'chat_created':
+      case 'chat_updated':
+        _upsertChat(ClientChat.fromJson((e['chat'] as Map).cast()));
+        break;
+      case 'chat_deleted':
+        _removeChat(e['chatId'] as String);
+        break;
+      case 'message':
+        _onMessage(e['chatId'] as String,
+            ClientMessage.fromJson((e['message'] as Map).cast()));
+        break;
+      case 'message_edited':
+        _editMessage(e['chatId'] as String, e['messageId'].toString(),
+            (e['text'] ?? '') as String);
+        break;
+      case 'message_deleted':
+        _deleteMessage(e['chatId'] as String, e['messageId'].toString());
+        break;
+      case 'reaction':
+        _addReaction(e['chatId'] as String, e['messageId'].toString(),
+            (e['emoji'] ?? '') as String);
+        break;
+      case 'turn_start':
+        turnFor(e['chatId'] as String).reset();
+        break;
+      case 'reasoning':
+        final t = turnFor(e['chatId'] as String);
+        t.reasoning.add((e['text'] ?? '') as String);
+        break;
+      case 'delta':
+        turnFor(e['chatId'] as String).draft += (e['text'] ?? '') as String;
+        break;
+      case 'tool':
+        _onTool(e);
+        break;
+      case 'typing':
+        turnFor(e['chatId'] as String).typing = (e['on'] ?? false) as bool;
+        break;
+      case 'turn_end':
+        final t = turnFor(e['chatId'] as String);
+        t.active = false;
+        t.typing = false;
+        t.draft = '';
+        t.reasoning.clear();
+        t.tools.clear();
+        break;
+      case 'error':
+        final chatId = e['chatId'] as String?;
+        if (chatId != null) _appendSystem(chatId, (e['message'] ?? '') as String);
+        break;
+    }
+    notifyListeners();
+  }
+
+  void _onMessage(String chatId, ClientMessage m) {
+    final list = _messages.putIfAbsent(chatId, () => []);
+    if (list.any((x) => x.id == m.id)) return; // dedupe re-delivery
+    list.add(m);
+    // The canonical reply supersedes the streaming draft.
+    if (m.role == Role.assistant) turnFor(chatId).draft = '';
+  }
+
+  void _onTool(Map<String, dynamic> e) {
+    final t = turnFor(e['chatId'] as String);
+    final id = e['id'].toString();
+    final phase = e['phase'] as String?;
+    final existing = t.tools.where((x) => x.id == id);
+    if (phase == 'result') {
+      if (existing.isNotEmpty) {
+        existing.first.done = true;
+        existing.first.error = e['error'] as String?;
+      }
+      return;
+    }
+    if (existing.isEmpty) {
+      t.tools.add(ToolActivity(
+        id: id,
+        name: (e['name'] ?? 'tool') as String,
+        input: ((e['input'] as Map?) ?? const {}).cast<String, dynamic>(),
+      ));
+    }
+  }
+
+  // ── Store helpers ────────────────────────────────────────────────────────--
+
+  Future<void> _refreshChats() async {
+    final list = await _client?.listChats() ?? const [];
+    chats
+      ..clear()
+      ..addAll(list);
+    _sortChats();
+    selectedChatId ??= chats.isNotEmpty ? chats.first.id : null;
+    if (selectedChatId != null && !_loadedHistory.contains(selectedChatId)) {
+      await _loadHistory(selectedChatId!);
+    }
+    notifyListeners();
+  }
+
+  Future<void> _refreshModels() async {
+    final r = await _client?.models();
+    if (r != null) {
+      models = r.$2;
+      notifyListeners();
+    }
+  }
+
+  Future<void> _loadHistory(String chatId) async {
+    try {
+      final msgs = await _client?.history(chatId) ?? const [];
+      _messages[chatId] = msgs;
+      _loadedHistory.add(chatId);
+      notifyListeners();
+    } catch (_) {
+      /* leave empty; stream will fill in */
+    }
+  }
+
+  void _setChats(List<dynamic> raw) {
+    chats
+      ..clear()
+      ..addAll(raw.map((c) => ClientChat.fromJson((c as Map).cast())));
+    _sortChats();
+    selectedChatId ??= chats.isNotEmpty ? chats.first.id : null;
+  }
+
+  void _upsertChat(ClientChat c) {
+    final i = chats.indexWhere((x) => x.id == c.id);
+    if (i >= 0) {
+      chats[i] = c;
+    } else {
+      chats.add(c);
+    }
+    _sortChats();
+  }
+
+  void _removeChat(String chatId) {
+    chats.removeWhere((c) => c.id == chatId);
+    _messages.remove(chatId);
+    _turns.remove(chatId);
+    _loadedHistory.remove(chatId);
+    if (selectedChatId == chatId) {
+      selectedChatId = chats.isNotEmpty ? chats.first.id : null;
+    }
+  }
+
+  void _sortChats() => chats.sort((a, b) => b.lastActive.compareTo(a.lastActive));
+
+  void _editMessage(String chatId, String messageId, String text) {
+    for (final m in _messages[chatId] ?? const <ClientMessage>[]) {
+      if (m.id == messageId) m.text = text;
+    }
+  }
+
+  void _deleteMessage(String chatId, String messageId) {
+    _messages[chatId]?.removeWhere((m) => m.id == messageId);
+  }
+
+  void _addReaction(String chatId, String messageId, String emoji) {
+    for (final m in _messages[chatId] ?? const <ClientMessage>[]) {
+      if (m.id == messageId && !m.reactions.contains(emoji)) {
+        m.reactions.add(emoji);
+      }
+    }
+  }
+
+  void _appendSystem(String chatId, String text) {
+    _messages.putIfAbsent(chatId, () => []).add(ClientMessage(
+          id: 'sys-${DateTime.now().microsecondsSinceEpoch}',
+          chatId: chatId,
+          role: Role.system,
+          text: text,
+          ts: DateTime.now().millisecondsSinceEpoch,
+        ));
+  }
+
+  void _setConn(ConnState s, String? err) {
+    conn = s;
+    connError = err;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _reconnect?.cancel();
+    _sub?.cancel();
+    _client?.dispose();
+    super.dispose();
+  }
+}

--- a/apps/companion/lib/src/theme.dart
+++ b/apps/companion/lib/src/theme.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+/// The Talon visual language: a deep, near-black canvas under a soft indigo→cyan
+/// glow, frosted glass panels, and a single vivid accent. Tuned for the "modern
+/// dark, glassy" look — gradients, translucency, rounded geometry.
+class TalonColors {
+  TalonColors._();
+
+  // Base canvas
+  static const Color void0 = Color(0xFF07070C); // deepest background
+  static const Color void1 = Color(0xFF0C0D16); // panels base
+  static const Color surface = Color(0xFF13141F); // raised surface
+  static const Color surfaceHi = Color(0xFF1B1D2B); // hover / selected
+
+  // Glass strokes & fills (used with opacity over the gradient backdrop)
+  static const Color glassFill = Color(0x14FFFFFF);
+  static const Color glassStroke = Color(0x1FFFFFFF);
+
+  // Accent — electric indigo with a cyan partner for gradients/glow
+  static const Color accent = Color(0xFF7C8CFF);
+  static const Color accent2 = Color(0xFF54E6FF);
+  static const Color accentDeep = Color(0xFF5B6BF0);
+
+  // Text
+  static const Color text = Color(0xFFEDEEF7);
+  static const Color textDim = Color(0xFFA6A9C2);
+  static const Color textFaint = Color(0xFF6F7392);
+
+  // Status
+  static const Color ok = Color(0xFF49E2A0);
+  static const Color warn = Color(0xFFFFC56B);
+  static const Color bad = Color(0xFFFF6B81);
+
+  // Bubbles
+  static const Color userBubbleA = Color(0xFF6B79F5);
+  static const Color userBubbleB = Color(0xFF7C8CFF);
+  static const Color assistantBubble = Color(0xFF161826);
+
+  /// Backdrop gradient painted behind everything.
+  static const LinearGradient backdrop = LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [Color(0xFF0A0B13), Color(0xFF07070C), Color(0xFF0B0A12)],
+  );
+
+  static const LinearGradient accentGradient = LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [accent, accent2],
+  );
+}
+
+ThemeData buildTalonTheme() {
+  final base = ThemeData.dark(useMaterial3: true);
+  const accent = TalonColors.accent;
+
+  return base.copyWith(
+    scaffoldBackgroundColor: TalonColors.void0,
+    colorScheme: base.colorScheme.copyWith(
+      brightness: Brightness.dark,
+      primary: accent,
+      secondary: TalonColors.accent2,
+      surface: TalonColors.surface,
+      onSurface: TalonColors.text,
+      error: TalonColors.bad,
+    ),
+    textTheme: base.textTheme
+        .apply(
+          bodyColor: TalonColors.text,
+          displayColor: TalonColors.text,
+          fontFamily: _fontFamily,
+        )
+        .copyWith(
+          bodyMedium: const TextStyle(fontSize: 14.5, height: 1.5),
+          titleMedium: const TextStyle(fontWeight: FontWeight.w600),
+        ),
+    splashFactory: InkSparkle.splashFactory,
+    dividerColor: TalonColors.glassStroke,
+    iconTheme: const IconThemeData(color: TalonColors.textDim, size: 20),
+    tooltipTheme: const TooltipThemeData(
+      decoration: BoxDecoration(
+        color: TalonColors.surfaceHi,
+        borderRadius: BorderRadius.all(Radius.circular(8)),
+      ),
+      textStyle: TextStyle(color: TalonColors.text, fontSize: 12),
+    ),
+    scrollbarTheme: ScrollbarThemeData(
+      thumbColor: WidgetStatePropertyAll(Colors.white.withValues(alpha: 0.12)),
+      thickness: const WidgetStatePropertyAll(6),
+      radius: const Radius.circular(8),
+    ),
+  );
+}
+
+/// Prefer a clean system UI font; Flutter falls back per-platform when absent.
+const String? _fontFamily = null;

--- a/apps/companion/lib/src/ui/activity_card.dart
+++ b/apps/companion/lib/src/ui/activity_card.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+
+import '../models/bridge_models.dart';
+import '../state/app_state.dart';
+import '../theme.dart';
+import 'brand.dart';
+import 'markdown.dart';
+
+/// The in-progress turn, rendered in the assistant-row layout: the Talon
+/// avatar, the model's reasoning, live tool calls, and the streaming reply.
+class LiveTurn extends StatelessWidget {
+  final TurnState turn;
+  final String botName;
+  const LiveTurn({super.key, required this.turn, required this.botName});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.only(top: 2),
+            child: BrandMark(size: 28),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  botName,
+                  style: const TextStyle(
+                      fontWeight: FontWeight.w700, fontSize: 13.5),
+                ),
+                const SizedBox(height: 6),
+                if (turn.reasoning.isNotEmpty)
+                  _ReasoningStrip(text: turn.reasoning.join('')),
+                for (final t in turn.tools) _ToolChip(tool: t),
+                if (turn.draft.isNotEmpty)
+                  MarkdownBody(data: turn.draft, styleSheet: talonMarkdownStyle())
+                else if (turn.typing)
+                  const _TypingDots(),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ToolChip extends StatelessWidget {
+  final ToolActivity tool;
+  const _ToolChip({required this.tool});
+
+  @override
+  Widget build(BuildContext context) {
+    final failed = tool.error != null;
+    final color = failed
+        ? TalonColors.bad
+        : (tool.done ? TalonColors.ok : TalonColors.accent2);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+        decoration: BoxDecoration(
+          color: TalonColors.glassFill,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: color.withValues(alpha: 0.30)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: 14,
+              height: 14,
+              child: tool.done || failed
+                  ? Icon(
+                      failed ? Icons.error_outline : Icons.check_circle_outline,
+                      size: 14,
+                      color: color,
+                    )
+                  : CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor: AlwaysStoppedAnimation(color),
+                    ),
+            ),
+            const SizedBox(width: 9),
+            Text(
+              tool.name,
+              style: const TextStyle(
+                color: TalonColors.text,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                fontFamily: 'monospace',
+              ),
+            ),
+            if (_arg(tool) != null) ...[
+              const SizedBox(width: 8),
+              Flexible(
+                child: Text(
+                  _arg(tool)!,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: TalonColors.textFaint,
+                    fontSize: 12,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  String? _arg(ToolActivity t) {
+    if (t.input.isEmpty) return null;
+    for (final key in const ['query', 'url', 'path', 'text', 'name', 'command']) {
+      final v = t.input[key];
+      if (v is String && v.isNotEmpty) {
+        return v.length > 64 ? '${v.substring(0, 63)}…' : v;
+      }
+    }
+    return null;
+  }
+}
+
+class _ReasoningStrip extends StatelessWidget {
+  final String text;
+  const _ReasoningStrip({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          border: const Border(
+            left: BorderSide(color: TalonColors.accent, width: 2.5),
+          ),
+          color: TalonColors.glassFill,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Icon(Icons.bubble_chart_outlined,
+                size: 15, color: TalonColors.textFaint),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                text.trim(),
+                maxLines: 5,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: TalonColors.textDim,
+                  fontSize: 12.5,
+                  height: 1.45,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TypingDots extends StatefulWidget {
+  const _TypingDots();
+
+  @override
+  State<_TypingDots> createState() => _TypingDotsState();
+}
+
+class _TypingDotsState extends State<_TypingDots>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _c =
+      AnimationController(vsync: this, duration: const Duration(milliseconds: 1100))
+        ..repeat();
+
+  @override
+  void dispose() {
+    _c.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 20,
+      child: AnimatedBuilder(
+        animation: _c,
+        builder: (context, _) {
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            children: List.generate(3, (i) {
+              final phase = (_c.value + i * 0.2) % 1.0;
+              final o = 0.3 + 0.7 * (0.5 - (phase - 0.5).abs()) * 2;
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 3),
+                child: Container(
+                  width: 7,
+                  height: 7,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: TalonColors.textDim.withValues(alpha: o.clamp(0, 1)),
+                  ),
+                ),
+              );
+            }),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/activity_card.dart
+++ b/apps/companion/lib/src/ui/activity_card.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
@@ -38,11 +40,35 @@ class LiveTurn extends StatelessWidget {
                 const SizedBox(height: 6),
                 if (turn.reasoning.isNotEmpty)
                   _ReasoningStrip(text: turn.reasoning.join('')),
-                for (final t in turn.tools) _ToolChip(tool: t),
-                if (turn.draft.isNotEmpty)
-                  MarkdownBody(data: turn.draft, styleSheet: talonMarkdownStyle())
-                else if (turn.typing)
-                  const _TypingDots(),
+                AnimatedSize(
+                  duration: const Duration(milliseconds: 160),
+                  curve: Curves.easeOut,
+                  alignment: Alignment.topLeft,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      for (final t in turn.tools)
+                        ToolChip(key: ValueKey(t.id), tool: t),
+                    ],
+                  ),
+                ),
+                AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 140),
+                  switchInCurve: Curves.easeOut,
+                  switchOutCurve: Curves.easeIn,
+                  child: turn.draft.isNotEmpty
+                      ? MarkdownBody(
+                          key: const ValueKey('draft'),
+                          data: turn.draft,
+                          styleSheet: talonMarkdownStyle())
+                      : turn.typing
+                          ? const Padding(
+                              key: ValueKey('typing'),
+                              padding: EdgeInsets.only(top: 2),
+                              child: _TypingDots(),
+                            )
+                          : const SizedBox.shrink(key: ValueKey('idle')),
+                ),
               ],
             ),
           ),
@@ -52,41 +78,107 @@ class LiveTurn extends StatelessWidget {
   }
 }
 
-class _ToolChip extends StatelessWidget {
+/// One row per tool call. Pulses while running, animates to a calm "done"
+/// state when finished, shows live elapsed time.
+class ToolChip extends StatefulWidget {
   final ToolActivity tool;
-  const _ToolChip({required this.tool});
+  const ToolChip({super.key, required this.tool});
+
+  @override
+  State<ToolChip> createState() => _ToolChipState();
+}
+
+class _ToolChipState extends State<ToolChip>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulse = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1400),
+  )..repeat(reverse: true);
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    _ticker = Timer.periodic(const Duration(milliseconds: 100), (_) {
+      if (!mounted) return;
+      if (!widget.tool.done) setState(() {});
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant ToolChip old) {
+    super.didUpdateWidget(old);
+    if (widget.tool.done && _pulse.isAnimating) _pulse.stop();
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    _pulse.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
+    final tool = widget.tool;
     final failed = tool.error != null;
     final color = failed
         ? TalonColors.bad
         : (tool.done ? TalonColors.ok : TalonColors.accent2);
+    final running = !tool.done && !failed;
+
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
-        decoration: BoxDecoration(
-          color: TalonColors.glassFill,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: color.withValues(alpha: 0.30)),
-        ),
+      child: AnimatedBuilder(
+        animation: _pulse,
+        builder: (context, child) {
+          final glow = running
+              ? 0.18 + 0.18 * _pulse.value
+              : 0.0;
+          return Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+            decoration: BoxDecoration(
+              color: TalonColors.glassFill,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: color.withValues(alpha: running ? 0.55 : 0.30),
+              ),
+              boxShadow: running
+                  ? [
+                      BoxShadow(
+                        color: color.withValues(alpha: glow),
+                        blurRadius: 14,
+                        spreadRadius: 0.5,
+                      ),
+                    ]
+                  : null,
+            ),
+            child: child,
+          );
+        },
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
             SizedBox(
               width: 14,
               height: 14,
-              child: tool.done || failed
-                  ? Icon(
-                      failed ? Icons.error_outline : Icons.check_circle_outline,
-                      size: 14,
-                      color: color,
-                    )
-                  : CircularProgressIndicator(
-                      strokeWidth: 2,
-                      valueColor: AlwaysStoppedAnimation(color),
-                    ),
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 220),
+                transitionBuilder: (c, a) =>
+                    ScaleTransition(scale: a, child: FadeTransition(opacity: a, child: c)),
+                child: running
+                    ? CircularProgressIndicator(
+                        key: const ValueKey('run'),
+                        strokeWidth: 2,
+                        valueColor: AlwaysStoppedAnimation(color),
+                      )
+                    : Icon(
+                        failed ? Icons.error_outline : Icons.check_circle,
+                        key: ValueKey(failed ? 'err' : 'ok'),
+                        size: 14,
+                        color: color,
+                      ),
+              ),
             ),
             const SizedBox(width: 9),
             Text(
@@ -113,6 +205,15 @@ class _ToolChip extends StatelessWidget {
                 ),
               ),
             ],
+            const SizedBox(width: 10),
+            Text(
+              _fmt(tool.elapsed),
+              style: const TextStyle(
+                color: TalonColors.textFaint,
+                fontSize: 11.5,
+                fontFeatures: [FontFeature.tabularFigures()],
+              ),
+            ),
           ],
         ),
       ),
@@ -128,6 +229,16 @@ class _ToolChip extends StatelessWidget {
       }
     }
     return null;
+  }
+
+  String _fmt(Duration d) {
+    final ms = d.inMilliseconds;
+    if (ms < 1000) return '${ms}ms';
+    final s = ms / 1000;
+    if (s < 10) return '${s.toStringAsFixed(1)}s';
+    if (s < 60) return '${s.toStringAsFixed(0)}s';
+    final m = (s / 60).floor();
+    return '${m}m${(s - m * 60).toStringAsFixed(0)}s';
   }
 }
 
@@ -155,15 +266,20 @@ class _ReasoningStrip extends StatelessWidget {
                 size: 15, color: TalonColors.textFaint),
             const SizedBox(width: 8),
             Expanded(
-              child: Text(
-                text.trim(),
-                maxLines: 5,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  color: TalonColors.textDim,
-                  fontSize: 12.5,
-                  height: 1.45,
-                  fontStyle: FontStyle.italic,
+              child: AnimatedSize(
+                duration: const Duration(milliseconds: 180),
+                curve: Curves.easeOut,
+                alignment: Alignment.topLeft,
+                child: Text(
+                  text.trim(),
+                  maxLines: 5,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: TalonColors.textDim,
+                    fontSize: 12.5,
+                    height: 1.45,
+                    fontStyle: FontStyle.italic,
+                  ),
                 ),
               ),
             ),

--- a/apps/companion/lib/src/ui/app_shell.dart
+++ b/apps/companion/lib/src/ui/app_shell.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../state/app_state.dart';
+import 'chat_view.dart';
+import 'sidebar.dart';
+
+/// The main two-pane layout. Side-by-side on desktop/tablet; on a phone it
+/// collapses to one pane (chat list ⇄ conversation) driven by selection.
+class AppShell extends StatelessWidget {
+  final AppState state;
+  const AppShell({super.key, required this.state});
+
+  static const double _wideBreakpoint = 820;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final wide = constraints.maxWidth >= _wideBreakpoint;
+          if (wide) {
+            return Padding(
+              padding: const EdgeInsets.all(10),
+              child: Row(
+                children: [
+                  SizedBox(
+                    width: 308,
+                    child: Sidebar(state: state, onSelect: null),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(child: ChatView(state: state, showBack: false)),
+                ],
+              ),
+            );
+          }
+
+          // Narrow: list until a chat is chosen, then the conversation.
+          return ListenableBuilder(
+            listenable: state,
+            builder: (context, _) {
+              final showChat = state.selectedChatId != null;
+              return AnimatedSwitcher(
+                duration: const Duration(milliseconds: 220),
+                switchInCurve: Curves.easeOutCubic,
+                transitionBuilder: (child, anim) => FadeTransition(
+                  opacity: anim,
+                  child: SlideTransition(
+                    position: Tween(
+                      begin: const Offset(0.04, 0),
+                      end: Offset.zero,
+                    ).animate(anim),
+                    child: child,
+                  ),
+                ),
+                child: showChat
+                    ? Padding(
+                        key: const ValueKey('chat'),
+                        padding: const EdgeInsets.all(8),
+                        child: ChatView(
+                          state: state,
+                          showBack: true,
+                          onBack: state.clearSelection,
+                        ),
+                      )
+                    : Padding(
+                        key: const ValueKey('list'),
+                        padding: const EdgeInsets.all(8),
+                        child: Sidebar(
+                          state: state,
+                          onSelect: (id) => state.selectChat(id),
+                        ),
+                      ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/brand.dart
+++ b/apps/companion/lib/src/ui/brand.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import '../theme.dart';
+
+/// The Talon glyph: a gradient rounded-square holding three converging talon
+/// strokes. Drawn, not an asset, so it stays crisp at any size on any platform.
+class BrandMark extends StatelessWidget {
+  final double size;
+  const BrandMark({super.key, this.size = 36});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(size * 0.28),
+        gradient: TalonColors.accentGradient,
+        boxShadow: [
+          BoxShadow(
+            color: TalonColors.accent.withValues(alpha: 0.45),
+            blurRadius: size * 0.5,
+            offset: Offset(0, size * 0.14),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(size * 0.24),
+        child: CustomPaint(painter: _TalonPainter()),
+      ),
+    );
+  }
+}
+
+class _TalonPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = size.width * 0.14
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    final w = size.width, h = size.height;
+    // Three curved claws converging toward the lower point.
+    for (final dx in [0.0, 0.32, 0.64]) {
+      final path = Path()
+        ..moveTo(w * (0.08 + dx), h * 0.05)
+        ..quadraticBezierTo(
+          w * (0.12 + dx),
+          h * 0.62,
+          w * (0.40 + dx * 0.4),
+          h * 0.95,
+        );
+      canvas.drawPath(path, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/apps/companion/lib/src/ui/chat_view.dart
+++ b/apps/companion/lib/src/ui/chat_view.dart
@@ -1,0 +1,393 @@
+import 'package:flutter/material.dart';
+
+import '../models/bridge_models.dart';
+import '../state/app_state.dart';
+import '../theme.dart';
+import 'activity_card.dart';
+import 'brand.dart';
+import 'composer.dart';
+import 'message_bubble.dart';
+import 'model_sheet.dart';
+
+const double _columnMax = 768;
+
+class ChatView extends StatefulWidget {
+  final AppState state;
+  final bool showBack;
+  final VoidCallback? onBack;
+
+  const ChatView({
+    super.key,
+    required this.state,
+    required this.showBack,
+    this.onBack,
+  });
+
+  @override
+  State<ChatView> createState() => _ChatViewState();
+}
+
+class _ChatViewState extends State<ChatView> {
+  final _scroll = ScrollController();
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  void _autoScroll() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_scroll.hasClients) return;
+      final pos = _scroll.position;
+      if (pos.maxScrollExtent - pos.pixels < 260) {
+        _scroll.animateTo(
+          pos.maxScrollExtent,
+          duration: const Duration(milliseconds: 160),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(22),
+      child: Container(
+        color: TalonColors.void1.withValues(alpha: 0.55),
+        child: ListenableBuilder(
+          listenable: widget.state,
+          builder: (context, _) {
+            final chat = widget.state.selectedChat;
+            if (chat == null) return const _EmptyState();
+            _autoScroll();
+            return Column(
+              children: [
+                _Header(
+                  state: widget.state,
+                  chat: chat,
+                  showBack: widget.showBack,
+                  onBack: widget.onBack,
+                ),
+                Expanded(child: _messages(chat.id)),
+                Center(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: _columnMax),
+                    child: Composer(
+                      onSend: widget.state.sendMessage,
+                      enabled: widget.state.conn == ConnState.connected,
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _messages(String chatId) {
+    final msgs = widget.state.messagesFor(chatId);
+    final turn = widget.state.turnFor(chatId);
+    final showActivity = turn.active &&
+        (turn.draft.isNotEmpty ||
+            turn.reasoning.isNotEmpty ||
+            turn.tools.isNotEmpty ||
+            turn.typing);
+
+    if (msgs.isEmpty && !showActivity) return const _ConversationEmpty();
+
+    final itemCount = msgs.length + (showActivity ? 1 : 0);
+    return Align(
+      alignment: Alignment.topCenter,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: _columnMax),
+        child: ListView.builder(
+          controller: _scroll,
+          padding: const EdgeInsets.fromLTRB(20, 18, 20, 10),
+          itemCount: itemCount,
+          itemBuilder: (context, i) {
+            if (i < msgs.length) {
+              return MessageBubble(
+                  message: msgs[i], botName: widget.state.status.botName);
+            }
+            return LiveTurn(turn: turn, botName: widget.state.status.botName);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  final AppState state;
+  final ClientChat chat;
+  final bool showBack;
+  final VoidCallback? onBack;
+
+  const _Header({
+    required this.state,
+    required this.chat,
+    required this.showBack,
+    this.onBack,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final model = chat.model ?? state.status.model;
+    final effort = chat.effort ?? 'adaptive';
+    return Container(
+      padding: const EdgeInsets.fromLTRB(12, 10, 8, 10),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: TalonColors.glassStroke)),
+      ),
+      child: Row(
+        children: [
+          if (showBack)
+            IconButton(
+              onPressed: onBack,
+              icon: const Icon(Icons.arrow_back_ios_new, size: 18),
+            ),
+          Expanded(
+            child: Text(
+              chat.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 15.5, fontWeight: FontWeight.w700),
+            ),
+          ),
+          _Chip(
+            icon: Icons.memory,
+            label: model.isEmpty ? 'model' : model,
+            onTap: () => openModelSheet(context, state, chat),
+          ),
+          const SizedBox(width: 6),
+          _Chip(
+            icon: Icons.tune,
+            label: effort,
+            onTap: () => openModelSheet(context, state, chat),
+          ),
+          _ChatMenu(state: state, chat: chat),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChatMenu extends StatelessWidget {
+  final AppState state;
+  final ClientChat chat;
+  const _ChatMenu({required this.state, required this.chat});
+
+  @override
+  Widget build(BuildContext context) {
+    final pulseOn = chat.pulse ?? false;
+    return PopupMenuButton<String>(
+      icon: const Icon(Icons.more_vert, size: 20, color: TalonColors.textDim),
+      color: TalonColors.surfaceHi,
+      onSelected: (v) async {
+        switch (v) {
+          case 'reset':
+            await state.resetChat(chat.id);
+            break;
+          case 'pulse':
+            await state.setPulse(chat.id, !pulseOn);
+            break;
+          case 'rename':
+            await _rename(context);
+            break;
+          case 'delete':
+            await _delete(context);
+            break;
+        }
+      },
+      itemBuilder: (_) => [
+        const PopupMenuItem(
+          value: 'reset',
+          child: _MenuRow(icon: Icons.refresh, label: 'Reset session'),
+        ),
+        PopupMenuItem(
+          value: 'pulse',
+          child: _MenuRow(
+            icon: pulseOn ? Icons.notifications_active : Icons.notifications_off,
+            label: pulseOn ? 'Disable pulse' : 'Enable pulse',
+          ),
+        ),
+        const PopupMenuItem(
+          value: 'rename',
+          child: _MenuRow(icon: Icons.edit_outlined, label: 'Rename'),
+        ),
+        const PopupMenuItem(
+          value: 'delete',
+          child: _MenuRow(
+              icon: Icons.delete_outline, label: 'Delete', danger: true),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _rename(BuildContext context) async {
+    final controller = TextEditingController(text: chat.title);
+    final name = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: TalonColors.surface,
+        title: const Text('Rename chat'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          onSubmitted: (v) => Navigator.pop(ctx, v),
+          decoration: const InputDecoration(hintText: 'Chat name'),
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, controller.text),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (name != null && name.trim().isNotEmpty) {
+      await state.renameChat(chat.id, name.trim());
+    }
+  }
+
+  Future<void> _delete(BuildContext context) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: TalonColors.surface,
+        title: const Text('Delete chat?'),
+        content: Text('"${chat.title}" and its history will be removed.'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          FilledButton(
+            style: FilledButton.styleFrom(backgroundColor: TalonColors.bad),
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (ok == true) await state.deleteChat(chat.id);
+  }
+}
+
+class _MenuRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool danger;
+  const _MenuRow(
+      {required this.icon, required this.label, this.danger = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = danger ? TalonColors.bad : TalonColors.text;
+    return Row(
+      children: [
+        Icon(icon, size: 17, color: color),
+        const SizedBox(width: 10),
+        Text(label, style: TextStyle(color: color, fontSize: 13.5)),
+      ],
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  const _Chip({required this.icon, required this.label, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(999),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 170),
+        padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 7),
+        decoration: BoxDecoration(
+          color: TalonColors.glassFill,
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: TalonColors.glassStroke),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 14, color: TalonColors.textDim),
+            const SizedBox(width: 6),
+            Flexible(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(fontSize: 12, color: TalonColors.textDim),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          BrandMark(size: 64),
+          SizedBox(height: 18),
+          Text('Talon', style: TextStyle(fontSize: 22, fontWeight: FontWeight.w700)),
+          SizedBox(height: 6),
+          Text('Select a chat, or start a new one.',
+              style: TextStyle(color: TalonColors.textFaint)),
+        ],
+      ),
+    );
+  }
+}
+
+class _ConversationEmpty extends StatelessWidget {
+  const _ConversationEmpty();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(28),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const BrandMark(size: 52),
+            const SizedBox(height: 18),
+            Text(
+              'How can I help?',
+              style: TextStyle(
+                fontSize: 19,
+                fontWeight: FontWeight.w600,
+                color: TalonColors.text.withValues(alpha: 0.92),
+              ),
+            ),
+            const SizedBox(height: 6),
+            const Text(
+              'Send a message to begin.',
+              style: TextStyle(color: TalonColors.textFaint),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/composer.dart
+++ b/apps/companion/lib/src/ui/composer.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../theme.dart';
+
+/// The message input. Enter sends; Shift+Enter inserts a newline. Grows with
+/// content up to a cap, then scrolls.
+class Composer extends StatefulWidget {
+  final Future<void> Function(String text) onSend;
+  final bool enabled;
+  const Composer({super.key, required this.onSend, required this.enabled});
+
+  @override
+  State<Composer> createState() => _ComposerState();
+}
+
+class _ComposerState extends State<Composer> {
+  final _controller = TextEditingController();
+  final _focus = FocusNode();
+  bool _canSend = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() {
+      final can = _controller.text.trim().isNotEmpty;
+      if (can != _canSend) setState(() => _canSend = can);
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focus.dispose();
+    super.dispose();
+  }
+
+  Future<void> _send() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty || !widget.enabled) return;
+    _controller.clear();
+    setState(() => _canSend = false);
+    _focus.requestFocus();
+    await widget.onSend(text);
+  }
+
+  KeyEventResult _onKey(FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent &&
+        event.logicalKey == LogicalKeyboardKey.enter &&
+        !HardwareKeyboard.instance.isShiftPressed) {
+      _send();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final canSend = _canSend && widget.enabled;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(14, 8, 14, 14),
+      child: Container(
+        decoration: BoxDecoration(
+          color: TalonColors.void1.withValues(alpha: 0.7),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: TalonColors.glassStroke),
+        ),
+        padding: const EdgeInsets.fromLTRB(16, 4, 6, 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Expanded(
+              child: Focus(
+                onKeyEvent: _onKey,
+                child: TextField(
+                  controller: _controller,
+                  focusNode: _focus,
+                  enabled: widget.enabled,
+                  minLines: 1,
+                  maxLines: 6,
+                  textInputAction: TextInputAction.newline,
+                  keyboardType: TextInputType.multiline,
+                  style: const TextStyle(fontSize: 14.5, height: 1.4),
+                  decoration: InputDecoration(
+                    isCollapsed: true,
+                    border: InputBorder.none,
+                    contentPadding: const EdgeInsets.symmetric(vertical: 12),
+                    hintText: widget.enabled
+                        ? 'Message Talon…'
+                        : 'Connecting…',
+                    hintStyle: const TextStyle(color: TalonColors.textFaint),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 6),
+            _SendButton(enabled: canSend, onTap: _send),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SendButton extends StatelessWidget {
+  final bool enabled;
+  final VoidCallback onTap;
+  const _SendButton({required this.enabled, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedOpacity(
+      duration: const Duration(milliseconds: 150),
+      opacity: enabled ? 1 : 0.4,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: enabled ? onTap : null,
+          borderRadius: BorderRadius.circular(13),
+          child: Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              gradient: TalonColors.accentGradient,
+              borderRadius: BorderRadius.circular(13),
+            ),
+            child: const Icon(Icons.arrow_upward_rounded,
+                color: Colors.white, size: 20),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/connect_screen.dart
+++ b/apps/companion/lib/src/ui/connect_screen.dart
@@ -1,0 +1,357 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/connection.dart';
+import '../state/app_state.dart';
+import '../theme.dart';
+import 'brand.dart';
+import 'glass.dart';
+
+/// First-run onboarding and the Settings page for the connection profile.
+///
+/// Two modes: connect to a Talon on *this computer* (desktop can also launch
+/// it), or to a *remote bridge* by host/IP + token — the path a phone takes to
+/// reach a Talon running on your desktop or server.
+class ConnectScreen extends StatefulWidget {
+  final AppState state;
+  final bool firstRun;
+  const ConnectScreen({super.key, required this.state, required this.firstRun});
+
+  @override
+  State<ConnectScreen> createState() => _ConnectScreenState();
+}
+
+class _ConnectScreenState extends State<ConnectScreen> {
+  late bool _remote;
+  late final TextEditingController _host;
+  late final TextEditingController _port;
+  late final TextEditingController _token;
+  late final TextEditingController _launch;
+  bool _manage = true;
+
+  bool get _isDesktop {
+    try {
+      return Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    final c = widget.state.config;
+    _remote = !c.isLoopback || !_isDesktop;
+    _manage = c.manageLocalDaemon;
+    _host = TextEditingController(text: c.isLoopback ? '' : c.host);
+    _port = TextEditingController(text: c.port.toString());
+    _token = TextEditingController(text: c.token ?? '');
+    _launch = TextEditingController(text: c.launchCommand);
+  }
+
+  @override
+  void dispose() {
+    _host.dispose();
+    _port.dispose();
+    _token.dispose();
+    _launch.dispose();
+    super.dispose();
+  }
+
+  Future<void> _connect() async {
+    final port = int.tryParse(_port.text.trim()) ?? 19880;
+    final token = _token.text.trim();
+    final config = ConnectionConfig(
+      host: _remote ? _host.text.trim() : '127.0.0.1',
+      port: port,
+      token: token.isEmpty ? null : token,
+      manageLocalDaemon: !_remote && _isDesktop && _manage,
+      launchCommand: _launch.text.trim().isEmpty ? 'talon' : _launch.text.trim(),
+    );
+    await widget.state.prefs.setOnboarded(true);
+    await widget.state.applyConfig(config);
+    if (mounted && !widget.firstRun) Navigator.of(context).maybePop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final body = Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 460),
+          child: Glass(
+            radius: 26,
+            blur: 26,
+            padding: const EdgeInsets.all(26),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Row(
+                  children: [
+                    const BrandMark(size: 44),
+                    const SizedBox(width: 14),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          widget.firstRun ? 'Welcome to Talon' : 'Connection',
+                          style: const TextStyle(
+                              fontSize: 20, fontWeight: FontWeight.w700),
+                        ),
+                        const Text(
+                          'Connect your companion',
+                          style: TextStyle(
+                              color: TalonColors.textFaint, fontSize: 12.5),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 22),
+                _modeToggle(),
+                const SizedBox(height: 18),
+                if (_remote) ..._remoteFields() else ..._localFields(),
+                const SizedBox(height: 22),
+                _ConnectButton(onTap: _connect),
+                if (widget.state.conn == ConnState.error &&
+                    widget.state.connError != null) ...[
+                  const SizedBox(height: 14),
+                  Text(
+                    widget.state.connError!,
+                    style: const TextStyle(
+                        color: TalonColors.bad, fontSize: 12.5),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    if (widget.firstRun) return body;
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        title: const Text('Settings'),
+      ),
+      body: body,
+    );
+  }
+
+  Widget _modeToggle() {
+    return Container(
+      padding: const EdgeInsets.all(4),
+      decoration: BoxDecoration(
+        color: TalonColors.void0.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: TalonColors.glassStroke),
+      ),
+      child: Row(
+        children: [
+          _modeButton(
+            label: 'This computer',
+            icon: Icons.computer,
+            selected: !_remote,
+            enabled: _isDesktop,
+            onTap: () => setState(() => _remote = false),
+          ),
+          _modeButton(
+            label: 'Remote bridge',
+            icon: Icons.lan_outlined,
+            selected: _remote,
+            enabled: true,
+            onTap: () => setState(() => _remote = true),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _modeButton({
+    required String label,
+    required IconData icon,
+    required bool selected,
+    required bool enabled,
+    required VoidCallback onTap,
+  }) {
+    return Expanded(
+      child: Opacity(
+        opacity: enabled ? 1 : 0.4,
+        child: GestureDetector(
+          onTap: enabled ? onTap : null,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 160),
+            padding: const EdgeInsets.symmetric(vertical: 11),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(11),
+              gradient: selected ? TalonColors.accentGradient : null,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(icon,
+                    size: 16,
+                    color: selected ? Colors.white : TalonColors.textDim),
+                const SizedBox(width: 7),
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: selected ? Colors.white : TalonColors.textDim,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _localFields() => [
+        const _Hint(
+          'The app will connect to Talon on this machine and, if it isn\'t '
+          'running, start it for you.',
+        ),
+        const SizedBox(height: 14),
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          value: _manage,
+          onChanged: (v) => setState(() => _manage = v),
+          activeColor: TalonColors.accent,
+          title: const Text('Launch Talon automatically',
+              style: TextStyle(fontSize: 14)),
+          subtitle: const Text('Start the daemon if it isn\'t already running',
+              style: TextStyle(fontSize: 12, color: TalonColors.textFaint)),
+        ),
+        if (_manage) ...[
+          const SizedBox(height: 6),
+          _field(_launch, 'Launch command', hint: 'talon',
+              mono: true),
+        ],
+        const SizedBox(height: 12),
+        _field(_port, 'Port', hint: '19880', number: true),
+      ];
+
+  List<Widget> _remoteFields() => [
+        const _Hint(
+          'Point at a Talon bridge running elsewhere — your desktop or a '
+          'server. Set its host to 0.0.0.0 and a token to allow remote access.',
+        ),
+        const SizedBox(height: 14),
+        _field(_host, 'Host or IP', hint: '192.168.1.20'),
+        const SizedBox(height: 12),
+        _field(_port, 'Port', hint: '19880', number: true),
+        const SizedBox(height: 12),
+        _field(_token, 'Token', hint: 'shared secret', obscure: true),
+      ];
+
+  Widget _field(
+    TextEditingController c,
+    String label, {
+    String? hint,
+    bool number = false,
+    bool obscure = false,
+    bool mono = false,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label,
+            style: const TextStyle(
+                fontSize: 12, color: TalonColors.textDim, fontWeight: FontWeight.w600)),
+        const SizedBox(height: 6),
+        TextField(
+          controller: c,
+          obscureText: obscure,
+          keyboardType: number ? TextInputType.number : null,
+          inputFormatters:
+              number ? [FilteringTextInputFormatter.digitsOnly] : null,
+          style: TextStyle(
+              fontSize: 14,
+              fontFamily: mono ? 'monospace' : null),
+          decoration: InputDecoration(
+            hintText: hint,
+            filled: true,
+            fillColor: TalonColors.void0.withValues(alpha: 0.5),
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: const BorderSide(color: TalonColors.glassStroke),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: const BorderSide(color: TalonColors.glassStroke),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: const BorderSide(color: TalonColors.accent),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Hint extends StatelessWidget {
+  final String text;
+  const _Hint(this.text);
+
+  @override
+  Widget build(BuildContext context) => Text(
+        text,
+        style: const TextStyle(
+            fontSize: 12.5, color: TalonColors.textFaint, height: 1.5),
+      );
+}
+
+class _ConnectButton extends StatelessWidget {
+  final VoidCallback onTap;
+  const _ConnectButton({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(14),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 14),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(14),
+          gradient: TalonColors.accentGradient,
+          boxShadow: [
+            BoxShadow(
+              color: TalonColors.accent.withValues(alpha: 0.4),
+              blurRadius: 20,
+              offset: const Offset(0, 8),
+            ),
+          ],
+        ),
+        child: const Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.bolt, color: Colors.white, size: 19),
+            SizedBox(width: 8),
+            Text(
+              'Connect',
+              style: TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w700,
+                fontSize: 15,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/glass.dart
+++ b/apps/companion/lib/src/ui/glass.dart
@@ -1,0 +1,86 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import '../theme.dart';
+
+/// A frosted-glass panel: blurred translucent fill, hairline stroke, soft
+/// rounding. The building block of the whole UI.
+class Glass extends StatelessWidget {
+  final Widget child;
+  final double radius;
+  final EdgeInsetsGeometry? padding;
+  final double blur;
+  final Color? fill;
+  final Color? stroke;
+  final Gradient? glow;
+
+  const Glass({
+    super.key,
+    required this.child,
+    this.radius = 18,
+    this.padding,
+    this.blur = 18,
+    this.fill,
+    this.stroke,
+    this.glow,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final r = BorderRadius.circular(radius);
+    return ClipRRect(
+      borderRadius: r,
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: blur, sigmaY: blur),
+        child: Container(
+          padding: padding,
+          decoration: BoxDecoration(
+            gradient: glow,
+            color: glow == null ? (fill ?? TalonColors.glassFill) : null,
+            borderRadius: r,
+            border: Border.all(
+              color: stroke ?? TalonColors.glassStroke,
+              width: 1,
+            ),
+          ),
+          child: child,
+        ),
+      ),
+    );
+  }
+}
+
+/// A soft radial glow used behind the backdrop to give the dark canvas depth.
+class AmbientGlow extends StatelessWidget {
+  const AmbientGlow({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Stack(
+        children: [
+          Positioned(
+            top: -160,
+            left: -120,
+            child: _blob(TalonColors.accent.withValues(alpha: 0.20), 420),
+          ),
+          Positioned(
+            bottom: -180,
+            right: -120,
+            child: _blob(TalonColors.accent2.withValues(alpha: 0.12), 460),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _blob(Color color, double size) => Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: RadialGradient(colors: [color, color.withValues(alpha: 0)]),
+        ),
+      );
+}

--- a/apps/companion/lib/src/ui/markdown.dart
+++ b/apps/companion/lib/src/ui/markdown.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+
+import '../theme.dart';
+
+/// Shared Markdown style for assistant content — dark, readable, with framed
+/// code blocks and accent links. Used by finalized messages and the live draft.
+MarkdownStyleSheet talonMarkdownStyle() {
+  return MarkdownStyleSheet(
+    p: const TextStyle(color: TalonColors.text, fontSize: 14.5, height: 1.6),
+    a: const TextStyle(
+        color: TalonColors.accent2, decoration: TextDecoration.underline),
+    strong:
+        const TextStyle(color: TalonColors.text, fontWeight: FontWeight.w700),
+    em: const TextStyle(color: TalonColors.text, fontStyle: FontStyle.italic),
+    listBullet: const TextStyle(color: TalonColors.textDim, fontSize: 14.5),
+    h1: const TextStyle(
+        color: TalonColors.text, fontSize: 21, fontWeight: FontWeight.w700),
+    h2: const TextStyle(
+        color: TalonColors.text, fontSize: 18, fontWeight: FontWeight.w700),
+    h3: const TextStyle(
+        color: TalonColors.text, fontSize: 16, fontWeight: FontWeight.w700),
+    code: const TextStyle(
+      color: TalonColors.accent2,
+      backgroundColor: Color(0x22000000),
+      fontFamily: 'monospace',
+      fontSize: 13.2,
+    ),
+    codeblockDecoration: BoxDecoration(
+      color: TalonColors.void0.withValues(alpha: 0.72),
+      borderRadius: BorderRadius.circular(12),
+      border: Border.all(color: TalonColors.glassStroke),
+    ),
+    codeblockPadding: const EdgeInsets.all(14),
+    blockquoteDecoration: BoxDecoration(
+      color: TalonColors.glassFill,
+      borderRadius: BorderRadius.circular(8),
+      border: const Border(
+        left: BorderSide(color: TalonColors.accent, width: 3),
+      ),
+    ),
+    blockquotePadding: const EdgeInsets.fromLTRB(12, 6, 12, 6),
+    tableBorder: TableBorder.all(color: TalonColors.glassStroke),
+    tableHead: const TextStyle(fontWeight: FontWeight.w700),
+    horizontalRuleDecoration: const BoxDecoration(
+      border: Border(top: BorderSide(color: TalonColors.glassStroke)),
+    ),
+  );
+}

--- a/apps/companion/lib/src/ui/message_bubble.dart
+++ b/apps/companion/lib/src/ui/message_bubble.dart
@@ -5,6 +5,7 @@ import 'package:url_launcher/url_launcher.dart' show launchUrl, LaunchMode;
 
 import '../models/bridge_models.dart';
 import '../theme.dart';
+import 'activity_card.dart';
 import 'brand.dart';
 import 'markdown.dart';
 
@@ -111,6 +112,11 @@ class MessageBubble extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: 4),
+                  if (message.tools.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: _ToolHistory(tools: message.tools),
+                    ),
                   MarkdownBody(
                     data: message.text.isEmpty ? '…' : message.text,
                     selectable: true,
@@ -182,6 +188,103 @@ class MessageBubble extends StatelessWidget {
           ],
         ),
       );
+}
+
+/// Collapsed summary of the tools the model ran for an assistant message.
+/// Tap to expand and see the chip for each call.
+class _ToolHistory extends StatefulWidget {
+  final List<ToolActivity> tools;
+  const _ToolHistory({required this.tools});
+
+  @override
+  State<_ToolHistory> createState() => _ToolHistoryState();
+}
+
+class _ToolHistoryState extends State<_ToolHistory> {
+  bool _open = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final tools = widget.tools;
+    final failed = tools.where((t) => t.error != null).length;
+    final total = Duration(
+      milliseconds:
+          tools.fold<int>(0, (a, t) => a + t.elapsed.inMilliseconds),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        InkWell(
+          onTap: () => setState(() => _open = !_open),
+          borderRadius: BorderRadius.circular(10),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AnimatedRotation(
+                  duration: const Duration(milliseconds: 160),
+                  turns: _open ? 0.25 : 0,
+                  child: const Icon(
+                    Icons.chevron_right,
+                    size: 16,
+                    color: TalonColors.textFaint,
+                  ),
+                ),
+                const SizedBox(width: 4),
+                Icon(
+                  failed > 0 ? Icons.error_outline : Icons.handyman_outlined,
+                  size: 13,
+                  color: failed > 0 ? TalonColors.bad : TalonColors.textFaint,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  _summary(tools.length, failed, total),
+                  style: const TextStyle(
+                    color: TalonColors.textFaint,
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        AnimatedSize(
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOut,
+          alignment: Alignment.topLeft,
+          child: _open
+              ? Padding(
+                  padding: const EdgeInsets.only(top: 6),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      for (final t in tools) ToolChip(key: ValueKey(t.id), tool: t),
+                    ],
+                  ),
+                )
+              : const SizedBox(width: double.infinity),
+        ),
+      ],
+    );
+  }
+
+  String _summary(int n, int failed, Duration total) {
+    final base = '$n ${n == 1 ? 'tool' : 'tools'} · ${_fmt(total)}';
+    if (failed == 0) return base;
+    return '$base · $failed failed';
+  }
+
+  String _fmt(Duration d) {
+    final ms = d.inMilliseconds;
+    if (ms < 1000) return '${ms}ms';
+    final s = ms / 1000;
+    if (s < 10) return '${s.toStringAsFixed(1)}s';
+    if (s < 60) return '${s.toStringAsFixed(0)}s';
+    final m = (s / 60).floor();
+    return '${m}m${(s - m * 60).toStringAsFixed(0)}s';
+  }
 }
 
 class _CopyButton extends StatefulWidget {

--- a/apps/companion/lib/src/ui/message_bubble.dart
+++ b/apps/companion/lib/src/ui/message_bubble.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:url_launcher/url_launcher.dart' show launchUrl, LaunchMode;
+
+import '../models/bridge_models.dart';
+import '../theme.dart';
+import 'brand.dart';
+import 'markdown.dart';
+
+/// A single conversation row, ChatGPT-style:
+///   - user: a compact rounded bubble aligned right
+///   - assistant: a full-width row with the Talon avatar + markdown + actions
+///   - system: a quiet centered note
+class MessageBubble extends StatelessWidget {
+  final ClientMessage message;
+  final String botName;
+  const MessageBubble({super.key, required this.message, required this.botName});
+
+  @override
+  Widget build(BuildContext context) {
+    switch (message.role) {
+      case Role.system:
+        return _system();
+      case Role.user:
+        return _userRow();
+      case Role.assistant:
+        return _assistantRow();
+    }
+  }
+
+  Widget _system() => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 12),
+        child: Center(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            decoration: BoxDecoration(
+              color: TalonColors.glassFill,
+              borderRadius: BorderRadius.circular(999),
+              border: Border.all(color: TalonColors.glassStroke),
+            ),
+            child: Text(
+              message.text,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: TalonColors.textFaint,
+                fontSize: 12,
+              ),
+            ),
+          ),
+        ),
+      );
+
+  Widget _userRow() => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Spacer(flex: 2),
+            Flexible(
+              flex: 9,
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 11),
+                  decoration: BoxDecoration(
+                    color: TalonColors.surfaceHi,
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(18),
+                      topRight: Radius.circular(18),
+                      bottomLeft: Radius.circular(18),
+                      bottomRight: Radius.circular(6),
+                    ),
+                    border: Border.all(color: TalonColors.glassStroke),
+                  ),
+                  child: SelectableText(
+                    message.text,
+                    style: const TextStyle(
+                      color: TalonColors.text,
+                      fontSize: 14.5,
+                      height: 1.5,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+
+  Widget _assistantRow() => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 10),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Padding(
+              padding: EdgeInsets.only(top: 2),
+              child: BrandMark(size: 28),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    botName,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 13.5,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  MarkdownBody(
+                    data: message.text.isEmpty ? '…' : message.text,
+                    selectable: true,
+                    onTapLink: (_, href, __) {
+                      if (href != null) {
+                        launchUrl(Uri.parse(href),
+                            mode: LaunchMode.externalApplication);
+                      }
+                    },
+                    styleSheet: talonMarkdownStyle(),
+                  ),
+                  if (message.buttons.isNotEmpty) _buttons(),
+                  if (message.reactions.isNotEmpty) _reactions(),
+                  _actions(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      );
+
+  Widget _actions() => Padding(
+        padding: const EdgeInsets.only(top: 6),
+        child: _CopyButton(text: message.text),
+      );
+
+  Widget _buttons() => Padding(
+        padding: const EdgeInsets.only(top: 10),
+        child: Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final row in message.buttons)
+              for (final b in row)
+                OutlinedButton(
+                  onPressed: b.url == null
+                      ? null
+                      : () => launchUrl(Uri.parse(b.url!),
+                          mode: LaunchMode.externalApplication),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: TalonColors.accent,
+                    side: BorderSide(
+                        color: TalonColors.accent.withValues(alpha: 0.5)),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10)),
+                  ),
+                  child: Text(b.text),
+                ),
+          ],
+        ),
+      );
+
+  Widget _reactions() => Padding(
+        padding: const EdgeInsets.only(top: 8),
+        child: Wrap(
+          spacing: 4,
+          children: [
+            for (final r in message.reactions)
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                decoration: BoxDecoration(
+                  color: TalonColors.glassFill,
+                  borderRadius: BorderRadius.circular(999),
+                  border: Border.all(color: TalonColors.glassStroke),
+                ),
+                child: Text(r, style: const TextStyle(fontSize: 13)),
+              ),
+          ],
+        ),
+      );
+}
+
+class _CopyButton extends StatefulWidget {
+  final String text;
+  const _CopyButton({required this.text});
+
+  @override
+  State<_CopyButton> createState() => _CopyButtonState();
+}
+
+class _CopyButtonState extends State<_CopyButton> {
+  bool _copied = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () async {
+        await Clipboard.setData(ClipboardData(text: widget.text));
+        if (!mounted) return;
+        setState(() => _copied = true);
+        Future.delayed(const Duration(milliseconds: 1400), () {
+          if (mounted) setState(() => _copied = false);
+        });
+      },
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(_copied ? Icons.check : Icons.copy_rounded,
+                size: 14, color: TalonColors.textFaint),
+            const SizedBox(width: 5),
+            Text(
+              _copied ? 'Copied' : 'Copy',
+              style: const TextStyle(
+                  fontSize: 11.5, color: TalonColors.textFaint),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/model_sheet.dart
+++ b/apps/companion/lib/src/ui/model_sheet.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+
+import '../models/bridge_models.dart';
+import '../state/app_state.dart';
+import '../theme.dart';
+
+Future<void> openModelSheet(
+  BuildContext context,
+  AppState state,
+  ClientChat chat,
+) {
+  return showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    builder: (_) => _ModelSheet(state: state, chat: chat),
+  );
+}
+
+class _ModelSheet extends StatefulWidget {
+  final AppState state;
+  final ClientChat chat;
+  const _ModelSheet({required this.state, required this.chat});
+
+  @override
+  State<_ModelSheet> createState() => _ModelSheetState();
+}
+
+class _ModelSheetState extends State<_ModelSheet> {
+  String _query = '';
+  List<String> _effortLevels = const [];
+  String _activeEffort = 'adaptive';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadEffort();
+  }
+
+  Future<void> _loadEffort() async {
+    final (active, levels) = await widget.state.effortLevels(widget.chat.id);
+    if (mounted) {
+      setState(() {
+        _effortLevels = levels;
+        _activeEffort = widget.chat.effort ?? active;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final models = widget.state.models
+        .where((m) =>
+            _query.isEmpty ||
+            m.displayName.toLowerCase().contains(_query.toLowerCase()) ||
+            m.provider.toLowerCase().contains(_query.toLowerCase()))
+        .toList();
+    final activeModel = widget.chat.model ?? widget.state.status.model;
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.7,
+      minChildSize: 0.4,
+      maxChildSize: 0.92,
+      builder: (context, scroll) {
+        return Container(
+          decoration: const BoxDecoration(
+            color: TalonColors.void1,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+            border: Border(top: BorderSide(color: TalonColors.glassStroke)),
+          ),
+          child: Column(
+            children: [
+              const SizedBox(height: 10),
+              Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: TalonColors.textFaint,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+                child: Row(
+                  children: [
+                    const Icon(Icons.tune, size: 18, color: TalonColors.accent),
+                    const SizedBox(width: 8),
+                    Text(
+                      widget.chat.title,
+                      style: const TextStyle(
+                          fontSize: 16, fontWeight: FontWeight.w700),
+                    ),
+                  ],
+                ),
+              ),
+              if (_effortLevels.isNotEmpty) _effortRow(),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                child: TextField(
+                  onChanged: (v) => setState(() => _query = v),
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.search, size: 18),
+                    hintText: 'Search models',
+                    filled: true,
+                    fillColor: TalonColors.surface,
+                    contentPadding: const EdgeInsets.symmetric(vertical: 0),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: models.isEmpty
+                    ? const Center(
+                        child: Text('No models reported',
+                            style: TextStyle(color: TalonColors.textFaint)))
+                    : ListView.builder(
+                        controller: scroll,
+                        padding: const EdgeInsets.fromLTRB(12, 0, 12, 20),
+                        itemCount: models.length,
+                        itemBuilder: (context, i) {
+                          final m = models[i];
+                          final selected = m.id == activeModel;
+                          return _ModelRow(
+                            model: m,
+                            selected: selected,
+                            onTap: () {
+                              widget.state.setModel(widget.chat.id, m.id);
+                              Navigator.pop(context);
+                            },
+                          );
+                        },
+                      ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _effortRow() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Wrap(
+          spacing: 8,
+          children: [
+            for (final level in ['adaptive', ..._effortLevels])
+              ChoiceChip(
+                label: Text(level),
+                selected: _activeEffort == level,
+                showCheckmark: false,
+                backgroundColor: TalonColors.surface,
+                selectedColor: TalonColors.accent.withValues(alpha: 0.3),
+                side: BorderSide(
+                  color: _activeEffort == level
+                      ? TalonColors.accent
+                      : TalonColors.glassStroke,
+                ),
+                labelStyle: TextStyle(
+                  color: _activeEffort == level
+                      ? TalonColors.text
+                      : TalonColors.textDim,
+                  fontSize: 12.5,
+                ),
+                onSelected: (_) {
+                  setState(() => _activeEffort = level);
+                  widget.state.setEffort(
+                      widget.chat.id, level == 'adaptive' ? 'adaptive' : level);
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ModelRow extends StatelessWidget {
+  final ModelOption model;
+  final bool selected;
+  final VoidCallback onTap;
+  const _ModelRow(
+      {required this.model, required this.selected, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 3),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: selected
+              ? TalonColors.accent.withValues(alpha: 0.16)
+              : TalonColors.surface,
+          border: Border.all(
+            color: selected ? TalonColors.accent : Colors.transparent,
+          ),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    model.displayName,
+                    style: const TextStyle(
+                        fontSize: 14, fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    model.provider,
+                    style: const TextStyle(
+                        fontSize: 11.5, color: TalonColors.textFaint),
+                  ),
+                ],
+              ),
+            ),
+            if (model.reasoning)
+              const Padding(
+                padding: EdgeInsets.only(right: 8),
+                child: Icon(Icons.psychology_outlined,
+                    size: 16, color: TalonColors.textFaint),
+              ),
+            if (selected)
+              const Icon(Icons.check_circle, color: TalonColors.accent, size: 18),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/root_view.dart
+++ b/apps/companion/lib/src/ui/root_view.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import '../state/app_state.dart';
+import '../theme.dart';
+import 'app_shell.dart';
+import 'connect_screen.dart';
+import 'glass.dart';
+
+/// Decides between the first-run connect screen and the main app shell, and
+/// paints the global backdrop + ambient glow behind everything.
+class RootView extends StatelessWidget {
+  final AppState state;
+  const RootView({super.key, required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: const BoxDecoration(gradient: TalonColors.backdrop),
+      child: Stack(
+        children: [
+          const Positioned.fill(child: AmbientGlow()),
+          Positioned.fill(
+            child: ListenableBuilder(
+              listenable: state,
+              builder: (context, _) {
+                if (!state.prefs.onboarded) {
+                  return ConnectScreen(state: state, firstRun: true);
+                }
+                return AppShell(state: state);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/root_view.dart
+++ b/apps/companion/lib/src/ui/root_view.dart
@@ -16,21 +16,24 @@ class RootView extends StatelessWidget {
   Widget build(BuildContext context) {
     return DecoratedBox(
       decoration: const BoxDecoration(gradient: TalonColors.backdrop),
-      child: Stack(
-        children: [
-          const Positioned.fill(child: AmbientGlow()),
-          Positioned.fill(
-            child: ListenableBuilder(
-              listenable: state,
-              builder: (context, _) {
-                if (!state.prefs.onboarded) {
-                  return ConnectScreen(state: state, firstRun: true);
-                }
-                return AppShell(state: state);
-              },
+      child: Material(
+        type: MaterialType.transparency,
+        child: Stack(
+          children: [
+            const Positioned.fill(child: AmbientGlow()),
+            Positioned.fill(
+              child: ListenableBuilder(
+                listenable: state,
+                builder: (context, _) {
+                  if (!state.prefs.onboarded) {
+                    return ConnectScreen(state: state, firstRun: true);
+                  }
+                  return AppShell(state: state);
+                },
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/apps/companion/lib/src/ui/settings_screen.dart
+++ b/apps/companion/lib/src/ui/settings_screen.dart
@@ -1,0 +1,496 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/bridge_models.dart';
+import '../state/app_state.dart';
+import '../theme.dart';
+import 'connect_screen.dart';
+import 'glass.dart';
+
+/// Talon control panel: live daemon status, the daemon's own settings (synced
+/// and editable), connection profile, and a restart action. This is the parity
+/// surface — everything Telegram's `/settings` exposes, plus the global config
+/// the chat frontends can't touch.
+class SettingsScreen extends StatefulWidget {
+  final AppState state;
+  const SettingsScreen({super.key, required this.state});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  ConfigSnapshot? _cfg;
+  bool _loading = true;
+  String? _error;
+
+  final _name = TextEditingController();
+  final _tz = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _tz.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final c = await widget.state.loadConfig();
+      if (!mounted) return;
+      setState(() {
+        _cfg = c;
+        _loading = false;
+        if (c != null) {
+          _name.text = c.botDisplayName;
+          _tz.text = c.timezone;
+        }
+      });
+    } catch (e) {
+      if (mounted) setState(() {
+        _loading = false;
+        _error = e.toString();
+      });
+    }
+  }
+
+  Future<void> _apply(Map<String, dynamic> update) async {
+    final c = await widget.state.updateConfig(update);
+    if (mounted && c != null) setState(() => _cfg = c);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        title: const Text('Talon settings'),
+        actions: [
+          IconButton(
+            onPressed: _load,
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+          ),
+        ],
+      ),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: _loading
+                ? const Padding(
+                    padding: EdgeInsets.all(40),
+                    child: CircularProgressIndicator(),
+                  )
+                : _body(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _body() {
+    final cfg = _cfg;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _statusCard(cfg),
+        const SizedBox(height: 16),
+        if (cfg == null)
+          _Section(
+            title: 'Settings unavailable',
+            child: Text(
+              _error ?? 'Could not read settings from the daemon.',
+              style: const TextStyle(color: TalonColors.textFaint),
+            ),
+          )
+        else ...[
+          _Section(
+            title: 'General',
+            child: Column(
+              children: [
+                _ModelRow(state: widget.state, cfg: cfg, onPick: (id) =>
+                    _apply({'model': id})),
+                const SizedBox(height: 14),
+                _textRow('Display name', _name,
+                    onSubmit: (v) => _apply({'botDisplayName': v})),
+                const SizedBox(height: 14),
+                _textRow('Timezone', _tz,
+                    hint: 'e.g. Europe/London',
+                    onSubmit: (v) => _apply({'timezone': v})),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          _Section(
+            title: 'Background agents',
+            child: Column(
+              children: [
+                _switchRow(
+                  'Pulse',
+                  'Proactive check-ins when something matters',
+                  cfg.pulse,
+                  (v) => _apply({'pulse': v}),
+                ),
+                if (cfg.pulse)
+                  _intervalRow(
+                    'Pulse interval',
+                    '${(cfg.pulseIntervalMs / 60000).round()} min',
+                    (cfg.pulseIntervalMs / 60000).round(),
+                    min: 1,
+                    onChange: (m) => _apply({'pulseIntervalMs': m * 60000}),
+                  ),
+                const Divider(height: 22),
+                _switchRow(
+                  'Heartbeat',
+                  'Periodic goal advancement',
+                  cfg.heartbeat,
+                  (v) => _apply({'heartbeat': v}),
+                ),
+                if (cfg.heartbeat)
+                  _intervalRow(
+                    'Heartbeat interval',
+                    '${cfg.heartbeatIntervalMinutes} min',
+                    cfg.heartbeatIntervalMinutes,
+                    min: 5,
+                    onChange: (m) => _apply({'heartbeatIntervalMinutes': m}),
+                  ),
+                const Divider(height: 22),
+                _switchRow(
+                  'Dream',
+                  'Memory consolidation + diary',
+                  cfg.dream,
+                  (v) => _apply({'dream': v}),
+                ),
+              ],
+            ),
+          ),
+        ],
+        const SizedBox(height: 16),
+        _connectionCard(),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+
+  Widget _statusCard(ConfigSnapshot? cfg) {
+    final s = widget.state;
+    final connected = s.conn == ConnState.connected;
+    final up = cfg == null ? '' : _fmtUptime(cfg.uptimeMs);
+    return Glass(
+      radius: 18,
+      padding: const EdgeInsets.all(18),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 10,
+                height: 10,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: connected ? TalonColors.ok : TalonColors.bad,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                connected ? 'Connected' : 'Disconnected',
+                style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15),
+              ),
+              const Spacer(),
+              if (s.config.canManageDaemon)
+                TextButton.icon(
+                  onPressed: () async {
+                    final r = await s.restartDaemon();
+                    if (mounted && !r.ok && r.detail != null) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text(r.detail!)));
+                    }
+                  },
+                  icon: const Icon(Icons.restart_alt, size: 18),
+                  label: const Text('Restart'),
+                ),
+            ],
+          ),
+          if (cfg != null) ...[
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 18,
+              runSpacing: 10,
+              children: [
+                _stat('Backend', cfg.backend),
+                _stat('Sessions', '${cfg.sessions}'),
+                _stat('Messages', '${cfg.messages}'),
+                _stat('Memory', '${cfg.memoryMb} MB'),
+                if (up.isNotEmpty) _stat('Uptime', up),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _connectionCard() {
+    final c = widget.state.config;
+    final where = c.isLoopback
+        ? 'This computer${c.canManageDaemon ? ' (managed)' : ''}'
+        : '${c.host}:${c.port}';
+    return _Section(
+      title: 'Connection',
+      child: Column(
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.lan_outlined, size: 18, color: TalonColors.textDim),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(where, style: const TextStyle(fontSize: 14)),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) =>
+                        ConnectScreen(state: widget.state, firstRun: false),
+                  ),
+                ),
+                child: const Text('Change'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Row builders ──────────────────────────────────────────────────────────
+
+  Widget _stat(String label, String value) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label.toUpperCase(),
+              style: const TextStyle(
+                  fontSize: 10,
+                  color: TalonColors.textFaint,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.8)),
+          const SizedBox(height: 2),
+          Text(value, style: const TextStyle(fontSize: 14)),
+        ],
+      );
+
+  Widget _textRow(String label, TextEditingController c,
+      {String? hint, required ValueChanged<String> onSubmit}) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 120,
+          child: Text(label, style: const TextStyle(fontSize: 13.5)),
+        ),
+        Expanded(
+          child: TextField(
+            controller: c,
+            style: const TextStyle(fontSize: 14),
+            onSubmitted: onSubmit,
+            decoration: InputDecoration(
+              isDense: true,
+              hintText: hint,
+              suffixIcon: IconButton(
+                icon: const Icon(Icons.check, size: 16),
+                onPressed: () => onSubmit(c.text),
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+                borderSide: const BorderSide(color: TalonColors.glassStroke),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _switchRow(
+      String title, String subtitle, bool value, ValueChanged<bool> onChanged) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title,
+                    style: const TextStyle(
+                        fontSize: 14, fontWeight: FontWeight.w600)),
+                Text(subtitle,
+                    style: const TextStyle(
+                        fontSize: 12, color: TalonColors.textFaint)),
+              ],
+            ),
+          ),
+          Switch.adaptive(
+            value: value,
+            activeColor: TalonColors.accent,
+            onChanged: onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _intervalRow(String label, String current, int value,
+      {required int min, required ValueChanged<int> onChange}) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8, left: 6),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(label,
+                style: const TextStyle(
+                    fontSize: 13, color: TalonColors.textDim)),
+          ),
+          IconButton(
+            iconSize: 18,
+            onPressed: value > min ? () => onChange(value - 1) : null,
+            icon: const Icon(Icons.remove_circle_outline),
+          ),
+          Text(current, style: const TextStyle(fontSize: 13.5)),
+          IconButton(
+            iconSize: 18,
+            onPressed: () => onChange(value + 1),
+            icon: const Icon(Icons.add_circle_outline),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _fmtUptime(int ms) {
+    final s = ms ~/ 1000;
+    if (s < 60) return '${s}s';
+    final m = s ~/ 60;
+    if (m < 60) return '${m}m';
+    final h = m ~/ 60;
+    if (h < 24) return '${h}h ${m % 60}m';
+    return '${h ~/ 24}d ${h % 24}h';
+  }
+}
+
+class _Section extends StatelessWidget {
+  final String title;
+  final Widget child;
+  const _Section({required this.title, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Glass(
+      radius: 18,
+      padding: const EdgeInsets.all(18),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title.toUpperCase(),
+              style: const TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 1.1,
+                  color: TalonColors.textFaint)),
+          const SizedBox(height: 14),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _ModelRow extends StatelessWidget {
+  final AppState state;
+  final ConfigSnapshot cfg;
+  final ValueChanged<String> onPick;
+  const _ModelRow(
+      {required this.state, required this.cfg, required this.onPick});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const SizedBox(
+          width: 120,
+          child: Text('Default model', style: TextStyle(fontSize: 13.5)),
+        ),
+        Expanded(
+          child: InkWell(
+            onTap: () => _pick(context),
+            borderRadius: BorderRadius.circular(10),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 11),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(color: TalonColors.glassStroke),
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      cfg.modelDisplay.isEmpty ? cfg.model : cfg.modelDisplay,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(fontSize: 14),
+                    ),
+                  ),
+                  const Icon(Icons.unfold_more,
+                      size: 16, color: TalonColors.textFaint),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _pick(BuildContext context) async {
+    HapticFeedback.selectionClick();
+    final picked = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: TalonColors.void1,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (ctx) => SizedBox(
+        height: MediaQuery.of(ctx).size.height * 0.7,
+        child: ListView(
+          padding: const EdgeInsets.all(12),
+          children: [
+            for (final m in state.models)
+              ListTile(
+                title: Text(m.displayName),
+                subtitle: Text(m.provider,
+                    style: const TextStyle(color: TalonColors.textFaint)),
+                trailing: m.id == cfg.model
+                    ? const Icon(Icons.check, color: TalonColors.accent)
+                    : null,
+                onTap: () => Navigator.pop(ctx, m.id),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (picked != null) onPick(picked);
+  }
+}

--- a/apps/companion/lib/src/ui/sidebar.dart
+++ b/apps/companion/lib/src/ui/sidebar.dart
@@ -1,0 +1,341 @@
+import 'package:flutter/material.dart';
+
+import '../models/bridge_models.dart';
+import '../state/app_state.dart';
+import '../theme.dart';
+import 'brand.dart';
+import 'glass.dart';
+import 'settings_screen.dart';
+import 'status_pill.dart';
+
+/// ChatGPT-style left rail: new chat, search, time-grouped history, and a
+/// footer with live status + settings.
+class Sidebar extends StatefulWidget {
+  final AppState state;
+
+  /// When set (narrow layout) tapping a chat routes through this.
+  final void Function(String chatId)? onSelect;
+
+  const Sidebar({super.key, required this.state, required this.onSelect});
+
+  @override
+  State<Sidebar> createState() => _SidebarState();
+}
+
+class _SidebarState extends State<Sidebar> {
+  String _query = '';
+
+  @override
+  Widget build(BuildContext context) {
+    return Glass(
+      radius: 22,
+      blur: 24,
+      padding: const EdgeInsets.fromLTRB(12, 14, 12, 10),
+      child: ListenableBuilder(
+        listenable: widget.state,
+        builder: (context, _) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  const BrandMark(size: 30),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      widget.state.status.botName,
+                      style: const TextStyle(
+                          fontSize: 16, fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 14),
+              _NewChatButton(onTap: widget.state.newChat),
+              const SizedBox(height: 10),
+              _SearchBox(onChanged: (v) => setState(() => _query = v)),
+              const SizedBox(height: 8),
+              Expanded(child: _groupedList(context)),
+              const Divider(height: 14),
+              Row(
+                children: [
+                  Expanded(child: StatusPill(state: widget.state)),
+                  IconButton(
+                    tooltip: 'Settings',
+                    onPressed: () => Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => SettingsScreen(state: widget.state),
+                      ),
+                    ),
+                    icon: const Icon(Icons.settings_outlined,
+                        size: 20, color: TalonColors.textDim),
+                  ),
+                ],
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _groupedList(BuildContext context) {
+    final chats = widget.state.chats.where((c) {
+      if (_query.isEmpty) return true;
+      final q = _query.toLowerCase();
+      return c.title.toLowerCase().contains(q) ||
+          c.preview.toLowerCase().contains(q);
+    }).toList();
+
+    if (chats.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(18),
+          child: Text(
+            widget.state.conn == ConnState.connected
+                ? (_query.isEmpty ? 'No chats yet.' : 'No matches.')
+                : 'Connecting…',
+            textAlign: TextAlign.center,
+            style: const TextStyle(color: TalonColors.textFaint, height: 1.5),
+          ),
+        ),
+      );
+    }
+
+    final groups = _groupByTime(chats);
+    return ListView(
+      padding: EdgeInsets.zero,
+      children: [
+        for (final group in groups) ...[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(8, 10, 8, 6),
+            child: Text(
+              group.label.toUpperCase(),
+              style: const TextStyle(
+                color: TalonColors.textFaint,
+                fontSize: 10.5,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 1.1,
+              ),
+            ),
+          ),
+          for (final chat in group.chats)
+            _ChatTile(
+              chat: chat,
+              selected: chat.id == widget.state.selectedChatId,
+              onTap: () =>
+                  (widget.onSelect ?? widget.state.selectChat)(chat.id),
+              onDelete: () => _confirmDelete(context, chat),
+            ),
+        ],
+      ],
+    );
+  }
+
+  List<_Group> _groupByTime(List<ClientChat> chats) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = today.subtract(const Duration(days: 1));
+    final week = today.subtract(const Duration(days: 7));
+    final month = today.subtract(const Duration(days: 30));
+
+    final buckets = <String, List<ClientChat>>{
+      'Today': [],
+      'Yesterday': [],
+      'Previous 7 days': [],
+      'Previous 30 days': [],
+      'Older': [],
+    };
+    for (final c in chats) {
+      final d = c.lastActiveTime;
+      if (!d.isBefore(today)) {
+        buckets['Today']!.add(c);
+      } else if (!d.isBefore(yesterday)) {
+        buckets['Yesterday']!.add(c);
+      } else if (!d.isBefore(week)) {
+        buckets['Previous 7 days']!.add(c);
+      } else if (!d.isBefore(month)) {
+        buckets['Previous 30 days']!.add(c);
+      } else {
+        buckets['Older']!.add(c);
+      }
+    }
+    return [
+      for (final entry in buckets.entries)
+        if (entry.value.isNotEmpty) _Group(entry.key, entry.value),
+    ];
+  }
+
+  Future<void> _confirmDelete(BuildContext context, ClientChat chat) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: TalonColors.surface,
+        title: const Text('Delete chat?'),
+        content: Text('"${chat.title}" and its history will be removed.'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          FilledButton(
+            style: FilledButton.styleFrom(backgroundColor: TalonColors.bad),
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (ok == true) await widget.state.deleteChat(chat.id);
+  }
+}
+
+class _Group {
+  final String label;
+  final List<ClientChat> chats;
+  _Group(this.label, this.chats);
+}
+
+class _ChatTile extends StatefulWidget {
+  final ClientChat chat;
+  final bool selected;
+  final VoidCallback onTap;
+  final VoidCallback onDelete;
+
+  const _ChatTile({
+    required this.chat,
+    required this.selected,
+    required this.onTap,
+    required this.onDelete,
+  });
+
+  @override
+  State<_ChatTile> createState() => _ChatTileState();
+}
+
+class _ChatTileState extends State<_ChatTile> {
+  bool _hover = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = widget.selected;
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hover = true),
+      onExit: (_) => setState(() => _hover = false),
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 130),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(10),
+            color: selected
+                ? TalonColors.surfaceHi
+                : (_hover ? TalonColors.surface : Colors.transparent),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  widget.chat.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 13.5,
+                    fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                    color: selected ? TalonColors.text : TalonColors.textDim,
+                  ),
+                ),
+              ),
+              if (_hover || selected)
+                InkWell(
+                  onTap: widget.onDelete,
+                  borderRadius: BorderRadius.circular(6),
+                  child: const Padding(
+                    padding: EdgeInsets.all(2),
+                    child: Icon(Icons.close,
+                        size: 15, color: TalonColors.textFaint),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NewChatButton extends StatelessWidget {
+  final VoidCallback onTap;
+  const _NewChatButton({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 11, horizontal: 12),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          gradient: TalonColors.accentGradient,
+          boxShadow: [
+            BoxShadow(
+              color: TalonColors.accent.withValues(alpha: 0.30),
+              blurRadius: 16,
+              offset: const Offset(0, 5),
+            ),
+          ],
+        ),
+        child: const Row(
+          children: [
+            Icon(Icons.add_rounded, color: Colors.white, size: 19),
+            SizedBox(width: 8),
+            Text(
+              'New chat',
+              style: TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w700,
+                  fontSize: 13.5),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SearchBox extends StatelessWidget {
+  final ValueChanged<String> onChanged;
+  const _SearchBox({required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      onChanged: onChanged,
+      style: const TextStyle(fontSize: 13.5),
+      decoration: InputDecoration(
+        isDense: true,
+        prefixIcon: const Icon(Icons.search, size: 17),
+        prefixIconConstraints:
+            const BoxConstraints(minWidth: 36, minHeight: 36),
+        hintText: 'Search chats',
+        hintStyle: const TextStyle(color: TalonColors.textFaint, fontSize: 13),
+        filled: true,
+        fillColor: TalonColors.void0.withValues(alpha: 0.5),
+        contentPadding: const EdgeInsets.symmetric(vertical: 10),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(11),
+          borderSide: const BorderSide(color: TalonColors.glassStroke),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(11),
+          borderSide: const BorderSide(color: TalonColors.glassStroke),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(11),
+          borderSide: const BorderSide(color: TalonColors.accent),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/status_pill.dart
+++ b/apps/companion/lib/src/ui/status_pill.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+import '../state/app_state.dart';
+import '../theme.dart';
+
+/// Compact "Talon running / connecting / offline" indicator with a live dot.
+class StatusPill extends StatelessWidget {
+  final AppState state;
+  const StatusPill({super.key, required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final (color, label) = switch (state.conn) {
+      ConnState.connected => (TalonColors.ok, 'Talon online'),
+      ConnState.connecting => (TalonColors.warn, _connectingLabel()),
+      ConnState.error => (TalonColors.bad, 'Offline'),
+      ConnState.idle => (TalonColors.textFaint, 'Idle'),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 7),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color.withValues(alpha: 0.32)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _Dot(color: color, pulse: state.conn == ConnState.connecting),
+          const SizedBox(width: 7),
+          Text(
+            label,
+            style: TextStyle(
+              color: color,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _connectingLabel() {
+    final d = state.daemon;
+    return d.detail ?? 'Connecting…';
+  }
+}
+
+class _Dot extends StatefulWidget {
+  final Color color;
+  final bool pulse;
+  const _Dot({required this.color, required this.pulse});
+
+  @override
+  State<_Dot> createState() => _DotState();
+}
+
+class _DotState extends State<_Dot> with SingleTickerProviderStateMixin {
+  late final AnimationController _c =
+      AnimationController(vsync: this, duration: const Duration(milliseconds: 1100))
+        ..repeat(reverse: true);
+
+  @override
+  void dispose() {
+    _c.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _c,
+      builder: (context, _) {
+        final t = widget.pulse ? _c.value : 1.0;
+        return Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: widget.color,
+            boxShadow: [
+              BoxShadow(
+                color: widget.color.withValues(alpha: 0.55 * t),
+                blurRadius: 8 * t,
+                spreadRadius: 1.5 * t,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/apps/companion/pubspec.yaml
+++ b/apps/companion/pubspec.yaml
@@ -1,0 +1,32 @@
+name: talon_companion
+description: >
+  Talon Companion — a beautiful cross-platform client for the Talon agent.
+  One Flutter codebase for Windows, macOS, Linux, and Android. On desktop it
+  launches/attaches a local Talon daemon; on mobile it connects to a remote
+  bridge over the network.
+publish_to: "none"
+version: 1.0.0+1
+
+environment:
+  # Uses the Color.withValues / WidgetStateProperty APIs (Flutter 3.27+).
+  sdk: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  # REST + Server-Sent Events transport to the Talon bridge.
+  http: ^1.2.2
+  # Persist the connection profile (host/port/token, local vs remote).
+  shared_preferences: ^2.3.2
+  # Markdown rendering for assistant replies (code blocks, tables, lists).
+  flutter_markdown: ^0.7.4
+  # Open links from assistant messages / buttons in the OS browser.
+  url_launcher: ^6.3.0
+  cupertino_icons: ^1.0.8
+
+dev_dependencies:
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: true

--- a/apps/companion/test/bridge_models_test.dart
+++ b/apps/companion/test/bridge_models_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:talon_companion/src/models/bridge_models.dart';
+import 'package:talon_companion/src/models/connection.dart';
+
+void main() {
+  group('ConnectionConfig', () {
+    test('builds base + events URLs, with token on the SSE query', () {
+      const c = ConnectionConfig(host: '10.0.0.5', port: 1234, token: 'sk e/t');
+      expect(c.baseUrl, 'http://10.0.0.5:1234');
+      expect(c.eventsUrl(), startsWith('http://10.0.0.5:1234/events?token='));
+      // token is URL-encoded
+      expect(c.eventsUrl(), contains('sk%20e%2Ft'));
+      expect(c.authHeaders()['Authorization'], 'Bearer sk e/t');
+    });
+
+    test('loopback detection + no token => no auth header', () {
+      const c = ConnectionConfig();
+      expect(c.isLoopback, isTrue);
+      expect(c.eventsUrl(), 'http://127.0.0.1:19880/events');
+      expect(c.authHeaders().containsKey('Authorization'), isFalse);
+    });
+
+    test('round-trips through json', () {
+      const c = ConnectionConfig(
+        host: 'host',
+        port: 42,
+        token: 't',
+        manageLocalDaemon: false,
+        launchCommand: 'talon',
+        launchArgs: ['start'],
+      );
+      final back = ConnectionConfig.fromJson(c.toJson());
+      expect(back.host, 'host');
+      expect(back.port, 42);
+      expect(back.token, 't');
+      expect(back.manageLocalDaemon, isFalse);
+    });
+  });
+
+  group('wire model parsing', () {
+    test('ClientMessage roles + buttons', () {
+      final m = ClientMessage.fromJson({
+        'id': 7,
+        'chatId': 'd_1',
+        'role': 'assistant',
+        'text': 'hi',
+        'ts': 1000,
+        'buttons': [
+          [
+            {'text': 'Docs', 'url': 'https://x'},
+          ],
+        ],
+        'reactions': ['👍'],
+      });
+      expect(m.id, '7');
+      expect(m.role, Role.assistant);
+      expect(m.buttons.first.first.text, 'Docs');
+      expect(m.reactions, ['👍']);
+    });
+
+    test('defaults are tolerant of missing fields', () {
+      final m = ClientMessage.fromJson({'id': 'x', 'role': 'user'});
+      expect(m.role, Role.user);
+      expect(m.text, '');
+      expect(m.buttons, isEmpty);
+    });
+
+    test('ClientChat + ConfigSnapshot', () {
+      final chat = ClientChat.fromJson({
+        'id': 'd_1',
+        'title': 'General',
+        'createdAt': 1,
+        'lastActive': 2,
+        'preview': 'hey',
+        'pulse': true,
+      });
+      expect(chat.title, 'General');
+      expect(chat.pulse, isTrue);
+
+      final cfg = ConfigSnapshot.fromJson({
+        'backend': 'claude',
+        'model': 'default',
+        'modelDisplay': 'Opus',
+        'botDisplayName': 'Talon',
+        'pulse': true,
+        'pulseIntervalMs': 300000,
+        'heartbeat': false,
+        'heartbeatIntervalMinutes': 60,
+        'dream': true,
+        'editable': ['model'],
+        'health': {'healthy': true, 'sessions': 3, 'memoryMb': 120},
+      });
+      expect(cfg.modelDisplay, 'Opus');
+      expect(cfg.sessions, 3);
+      expect(cfg.healthy, isTrue);
+      expect(cfg.editable, contains('model'));
+    });
+  });
+}

--- a/prompts/desktop.md
+++ b/prompts/desktop.md
@@ -1,0 +1,33 @@
+## Desktop Mode
+
+You are running in the Talon companion app — a native client (Windows, macOS, Linux, Android) connected to you over the local bridge. One human is on the other end, usually in a one-to-one conversation, and they can keep several separate chats open at once.
+
+How replies are delivered (end_turn / send_message and what counts as a valid turn) is defined in the **Response flow** section at the end of these instructions — that contract wins over anything here.
+
+### Messaging tools
+
+- `end_turn(text="…")` — your final reply; this is the normal way to respond
+- `end_turn(text="…", buttons=[[{"text":"Open","url":"https://…"}]])` — reply with link buttons
+- `send_message(text="…")` — send an extra message mid-turn (before a later `end_turn`)
+- `react(message_id=…, emoji="👍")` — react to the user's message (a reaction can stand in for a short acknowledgement)
+- `edit_message(message_id=…, text="…")` / `delete_message(message_id=…)` — revise or remove a message you already sent
+
+### Other tools
+
+- `web_search(query)` — search the web
+- `fetch_url(url)` — fetch & parse a URL
+- `get_chat_info()` — info about the current chat
+
+### Choosing not to respond
+
+You don't have to respond to every message. If nothing is needed, close the turn silently with `end_turn()`.
+
+### Formatting
+
+The client renders standard **Markdown**: headings, **bold**, _italic_, `inline code`, fenced code blocks, links, tables, and bullet/numbered lists all work. Use fenced code blocks for code and commands.
+
+Style:
+
+- Concise. No filler.
+- Reach for code blocks for anything code-like; tables for structured data.
+- A single, well-formed `end_turn` is better than several fragmented sends.

--- a/src/__tests__/desktop-frontend.test.ts
+++ b/src/__tests__/desktop-frontend.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for the `desktop` frontend's pure pieces — the bits that don't
+ * need a live daemon or DB:
+ *   - protocol mappers (previewOf, historyToClientMessage)
+ *   - the in-memory chat registry (ensure/get/byNumeric/list ordering)
+ *   - the gateway action handler (delivery tools → bridge events)
+ *   - the settings snapshot + allowlist enforcement
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  previewOf,
+  historyToClientMessage,
+  BOT_SENDER_ID,
+  USER_SENDER_ID,
+} from "../frontend/desktop/protocol.js";
+import { DesktopChats } from "../frontend/desktop/chats.js";
+import { createDesktopActionHandler } from "../frontend/desktop/actions.js";
+import {
+  configSnapshot,
+  applyConfigUpdate,
+  EDITABLE,
+} from "../frontend/desktop/settings.js";
+import type { Gateway } from "../core/engine/gateway.js";
+import type { TalonConfig } from "../util/config.js";
+
+describe("desktop protocol mappers", () => {
+  it("previewOf collapses whitespace and clips long text", () => {
+    expect(previewOf("  hello   world \n there ")).toBe("hello world there");
+    const long = "x".repeat(200);
+    const out = previewOf(long, 50);
+    expect(out.length).toBe(50);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("historyToClientMessage maps sender ids to roles", () => {
+    const assistant = historyToClientMessage(
+      {
+        msgId: 5,
+        senderId: BOT_SENDER_ID,
+        senderName: "Talon",
+        text: "hi",
+        timestamp: 10,
+      },
+      "d_1",
+    );
+    expect(assistant).toMatchObject({
+      id: "5",
+      role: "assistant",
+      text: "hi",
+      ts: 10,
+    });
+
+    const user = historyToClientMessage(
+      {
+        msgId: 6,
+        senderId: USER_SENDER_ID,
+        senderName: "User",
+        text: "yo",
+        timestamp: 11,
+      },
+      "d_1",
+    );
+    expect(user.role).toBe("user");
+  });
+});
+
+describe("DesktopChats registry", () => {
+  it("creates, indexes by string + numeric id, and lists newest-first", () => {
+    const chats = new DesktopChats();
+    const a = chats.create();
+    const b = chats.create();
+    expect(chats.get(a.id)).toBe(a);
+    expect(chats.byNumeric(a.numericId)).toBe(a);
+    expect(chats.count()).toBe(2);
+
+    // Touch `a` so it becomes most-recent; list() is newest-first.
+    chats.touch(a.id, "latest message");
+    const list = chats.list();
+    expect(list[0].id).toBe(a.id);
+    expect(list[0].preview).toBe("latest message");
+    expect(list).toContain(b);
+  });
+
+  it("ensure() adopts a client-supplied id without duplicating", () => {
+    const chats = new DesktopChats();
+    const first = chats.ensure("d_supplied");
+    const again = chats.ensure("d_supplied");
+    expect(first).toBe(again);
+    expect(chats.count()).toBe(1);
+  });
+});
+
+describe("desktop action handler", () => {
+  function setup() {
+    const chats = new DesktopChats();
+    const entry = chats.ensure("d_action");
+    const incrementMessages = vi.fn();
+    const gateway = { incrementMessages } as unknown as Gateway;
+    const emitAssistant = vi.fn().mockReturnValue(4242);
+    const broadcast = vi.fn();
+    const handler = createDesktopActionHandler({
+      chats,
+      gateway,
+      emitAssistant,
+      broadcast,
+    });
+    return { entry, handler, incrementMessages, emitAssistant, broadcast };
+  }
+
+  it("delivers send_message as an assistant message and counts it", async () => {
+    const { entry, handler, incrementMessages, emitAssistant } = setup();
+    const res = await handler(
+      { action: "send_message", text: "hello" },
+      entry.numericId,
+    );
+    expect(emitAssistant).toHaveBeenCalledWith(entry, "hello");
+    expect(incrementMessages).toHaveBeenCalledWith(entry.numericId);
+    expect(res).toMatchObject({ ok: true, message_id: 4242 });
+  });
+
+  it("maps button rows on send_message_with_buttons", async () => {
+    const { entry, handler, emitAssistant } = setup();
+    await handler(
+      {
+        action: "send_message_with_buttons",
+        text: "pick",
+        rows: [[{ text: "Docs", url: "https://x" }]],
+      },
+      entry.numericId,
+    );
+    expect(emitAssistant).toHaveBeenCalledWith(entry, "pick", [
+      [{ text: "Docs", url: "https://x", data: undefined }],
+    ]);
+  });
+
+  it("broadcasts a reaction event", async () => {
+    const { entry, handler, broadcast } = setup();
+    const res = await handler(
+      { action: "react", message_id: 7, emoji: "🔥" },
+      entry.numericId,
+    );
+    expect(res).toMatchObject({ ok: true });
+    expect(broadcast).toHaveBeenCalledWith({
+      kind: "reaction",
+      chatId: entry.id,
+      messageId: "7",
+      emoji: "🔥",
+    });
+  });
+
+  it("answers get_chat_info and returns null for unknown actions", async () => {
+    const { entry, handler } = setup();
+    const info = await handler({ action: "get_chat_info" }, entry.numericId);
+    expect(info).toMatchObject({
+      ok: true,
+      id: entry.numericId,
+      type: "private",
+    });
+
+    const unknown = await handler(
+      { action: "totally_made_up" },
+      entry.numericId,
+    );
+    expect(unknown).toBeNull();
+  });
+
+  it("rejects actions for an unknown chat", async () => {
+    const { handler } = setup();
+    const res = await handler({ action: "send_message", text: "x" }, 999999);
+    expect(res).toMatchObject({ ok: false });
+  });
+});
+
+describe("desktop settings", () => {
+  function fakeConfig(): TalonConfig {
+    return {
+      backend: "claude",
+      frontend: "desktop",
+      model: "default",
+      botDisplayName: "Talon",
+      timezone: "UTC",
+      pulse: true,
+      pulseIntervalMs: 300000,
+      heartbeat: true,
+      heartbeatIntervalMinutes: 60,
+      dream: true,
+    } as unknown as TalonConfig;
+  }
+
+  it("snapshot exposes the editable keys and curated fields", () => {
+    const snap = configSnapshot(fakeConfig());
+    expect(snap.backend).toBe("claude");
+    expect(snap.botDisplayName).toBe("Talon");
+    expect(snap.editable).toEqual([...EDITABLE]);
+    expect(typeof snap.health.uptimeMs).toBe("number");
+  });
+
+  it("ignores non-editable keys (no mutation, no write)", () => {
+    const config = fakeConfig();
+    // `backend` is intentionally NOT editable through the bridge.
+    const snap = applyConfigUpdate(config, { backend: "codex" });
+    expect(config.backend).toBe("claude");
+    expect(snap.backend).toBe("claude");
+  });
+});

--- a/src/__tests__/end-turn.test.ts
+++ b/src/__tests__/end-turn.test.ts
@@ -267,7 +267,12 @@ describe("end_turn tool definition", () => {
   it("is registered in messagingTools", () => {
     expect(endTurn).toBeDefined();
     expect(endTurn?.tag).toBe("messaging");
-    expect(endTurn?.frontends).toEqual(["telegram", "teams", "discord"]);
+    expect(endTurn?.frontends).toEqual([
+      "telegram",
+      "teams",
+      "discord",
+      "desktop",
+    ]);
   });
 
   it("has text, reply_to, and buttons schema fields", () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -71,6 +71,10 @@ if (selectedFrontend === "terminal") {
   const { createDiscordFrontend } = await import("./frontend/discord/index.js");
   frontend = createDiscordFrontend(config, gateway);
   log("bot", "Frontend: Discord");
+} else if (selectedFrontend === "desktop") {
+  const { createDesktopFrontend } = await import("./frontend/desktop/index.js");
+  frontend = createDesktopFrontend(config, gateway);
+  log("bot", "Frontend: Desktop");
 } else {
   const { createTelegramFrontend } =
     await import("./frontend/telegram/index.js");

--- a/src/backend/shared/delivery-contract.ts
+++ b/src/backend/shared/delivery-contract.ts
@@ -65,6 +65,7 @@ const FRONTEND_TOOLS: Record<string, DeliveryToolNames> = {
   telegram: { endTurn: "end_turn", send: "send", react: "react" },
   discord: { endTurn: "end_turn", send: "send", react: "react" },
   teams: { endTurn: "end_turn", send: "send_message" },
+  desktop: { endTurn: "end_turn", send: "send_message", react: "react" },
 };
 
 const DEFAULT_TOOLS: DeliveryToolNames = {

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -38,7 +38,7 @@ import type { Backend } from "./core/agent-runtime/capabilities.js";
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export type Frontend = {
-  name: "telegram" | "terminal" | "teams" | "discord";
+  name: "telegram" | "terminal" | "teams" | "discord" | "desktop";
   context: ContextManager;
   sendTyping: (chatId: number) => Promise<void>;
   sendMessage: (chatId: number, text: string) => Promise<void>;

--- a/src/core/agent-runtime/backend-registry.ts
+++ b/src/core/agent-runtime/backend-registry.ts
@@ -35,7 +35,12 @@ import type { TalonConfig } from "../../util/config.js";
 // ── Types ───────────────────────────────────────────────────────────────────
 
 /** Frontend identifiers that can be passed to a backend's init step. */
-export type FrontendName = "telegram" | "terminal" | "teams" | "discord";
+export type FrontendName =
+  | "telegram"
+  | "terminal"
+  | "teams"
+  | "discord"
+  | "desktop";
 
 /** Per-init context — runtime dependencies the backend may need at startup. */
 export interface BackendInitContext {

--- a/src/core/tools/mcp-server.ts
+++ b/src/core/tools/mcp-server.ts
@@ -42,6 +42,7 @@ const VALID_FRONTENDS = new Set<ToolFrontend>([
   "teams",
   "terminal",
   "discord",
+  "desktop",
 ]);
 const BRIDGE_URL = process.env.TALON_BRIDGE_URL || "http://127.0.0.1:19876";
 const CHAT_ID = process.env.TALON_CHAT_ID || "";

--- a/src/core/tools/messaging.ts
+++ b/src/core/tools/messaging.ts
@@ -110,7 +110,7 @@ Notes:
       // src/backend/claude-sdk/options.ts:turnTerminatorHook.
       return throwIfFailed(result, "end_turn");
     },
-    frontends: ["telegram", "teams", "discord"],
+    frontends: ["telegram", "teams", "discord", "desktop"],
     tag: "messaging",
     endsTurn: true,
   },
@@ -332,7 +332,7 @@ Examples:
       text: z.string().describe("Message text. Supports Markdown."),
     },
     execute: (params, bridge) => bridge("send_message", params),
-    frontends: ["teams"],
+    frontends: ["teams", "desktop"],
     tag: "messaging",
   },
 
@@ -356,7 +356,7 @@ Example: send_message_with_buttons(text="Choose:", rows=[[{"text":"Docs","url":"
         .describe("Button rows"),
     },
     execute: (params, bridge) => bridge("send_message_with_buttons", params),
-    frontends: ["teams"],
+    frontends: ["teams", "desktop"],
     tag: "messaging",
   },
 
@@ -412,7 +412,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
       const result = await bridge("react", rest);
       return throwIfFailed(result, "react");
     },
-    frontends: ["telegram", "discord"],
+    frontends: ["telegram", "discord", "desktop"],
     tag: "messaging",
     endsTurn: true,
   },
@@ -423,7 +423,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
     description: "Edit a previously sent message.",
     schema: { message_id: snowflakeOrIdSchema, text: z.string() },
     execute: (params, bridge) => bridge("edit_message", params),
-    frontends: ["telegram", "discord"],
+    frontends: ["telegram", "discord", "desktop"],
     tag: "messaging",
   },
 
@@ -433,7 +433,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
     description: "Delete a message.",
     schema: { message_id: snowflakeOrIdSchema },
     execute: (params, bridge) => bridge("delete_message", params),
-    frontends: ["telegram", "discord"],
+    frontends: ["telegram", "discord", "desktop"],
     tag: "messaging",
   },
 

--- a/src/core/tools/types.ts
+++ b/src/core/tools/types.ts
@@ -13,6 +13,7 @@ export type ToolFrontend =
   | "teams"
   | "terminal"
   | "discord"
+  | "desktop"
   | "all";
 
 /** Domain tags for runtime filtering and grouping. */

--- a/src/frontend/desktop/actions.ts
+++ b/src/frontend/desktop/actions.ts
@@ -1,0 +1,121 @@
+/**
+ * Desktop action handler — the gateway-side bridge for the agent's delivery
+ * tools. When the model calls `end_turn` / `send_message` / `react` / edit /
+ * delete, the MCP tool POSTs an action to the gateway, which routes it here
+ * by the active chat's numeric id. We translate each action into a Bridge
+ * event the connected clients render, persist assistant messages to history,
+ * and count deliveries on the gateway (so the dispatcher's trailing-prose
+ * fallback knows the turn already produced output).
+ */
+
+import type { FrontendActionHandler, ActionResult } from "../../core/types.js";
+import type { Gateway } from "../../core/engine/gateway.js";
+import type { DesktopChats, ChatEntry } from "./chats.js";
+import type { BridgeEvent, ClientButton } from "./protocol.js";
+
+export type DesktopActionDeps = {
+  chats: DesktopChats;
+  gateway: Gateway;
+  /** Persist + broadcast an assistant message; returns its numeric id. */
+  emitAssistant: (
+    entry: ChatEntry,
+    text: string,
+    buttons?: ClientButton[][],
+  ) => number;
+  broadcast: (event: BridgeEvent) => void;
+};
+
+/** Coerce gateway button rows (`[[{text,url,callback_data}]]`) to wire buttons. */
+function toButtons(rows: unknown): ClientButton[][] | undefined {
+  if (!Array.isArray(rows)) return undefined;
+  const mapped: ClientButton[][] = [];
+  for (const row of rows) {
+    if (!Array.isArray(row)) continue;
+    const cells: ClientButton[] = [];
+    for (const cell of row) {
+      if (cell && typeof cell === "object") {
+        const c = cell as Record<string, unknown>;
+        const text = typeof c.text === "string" ? c.text : "";
+        if (!text) continue;
+        cells.push({
+          text,
+          url: typeof c.url === "string" ? c.url : undefined,
+          data:
+            typeof c.callback_data === "string" ? c.callback_data : undefined,
+        });
+      }
+    }
+    if (cells.length) mapped.push(cells);
+  }
+  return mapped.length ? mapped : undefined;
+}
+
+export function createDesktopActionHandler(
+  deps: DesktopActionDeps,
+): FrontendActionHandler {
+  const { chats, gateway, emitAssistant, broadcast } = deps;
+
+  return async (body, chatId): Promise<ActionResult | null> => {
+    const action = typeof body.action === "string" ? body.action : "";
+    const entry = chats.byNumeric(chatId);
+    if (!entry) return { ok: false, error: "No active desktop chat" };
+
+    switch (action) {
+      case "send_message": {
+        const text = String(body.text ?? "");
+        const id = emitAssistant(entry, text);
+        gateway.incrementMessages(chatId);
+        return { ok: true, message_id: id };
+      }
+
+      case "send_message_with_buttons": {
+        const text = String(body.text ?? "");
+        const id = emitAssistant(entry, text, toButtons(body.rows));
+        gateway.incrementMessages(chatId);
+        return { ok: true, message_id: id };
+      }
+
+      case "react": {
+        const messageId = String(body.message_id ?? "");
+        const emoji = String(body.emoji ?? "👍");
+        broadcast({ kind: "reaction", chatId: entry.id, messageId, emoji });
+        gateway.incrementMessages(chatId);
+        return { ok: true };
+      }
+
+      case "edit_message": {
+        const messageId = String(body.message_id ?? "");
+        const text = String(body.text ?? "");
+        broadcast({
+          kind: "message_edited",
+          chatId: entry.id,
+          messageId,
+          text,
+        });
+        return { ok: true };
+      }
+
+      case "delete_message": {
+        const messageId = String(body.message_id ?? "");
+        broadcast({ kind: "message_deleted", chatId: entry.id, messageId });
+        return { ok: true };
+      }
+
+      case "get_chat_info":
+        return {
+          ok: true,
+          id: entry.numericId,
+          type: "private",
+          title: entry.title,
+        };
+
+      // Typing is driven by the dispatcher via sendTyping → no-op ack here.
+      case "send_chat_action":
+        return { ok: true };
+
+      default:
+        // Let the gateway try plugin + shared actions (history, web, cron…).
+        return null;
+    }
+  };
+}

--- a/src/frontend/desktop/chats.ts
+++ b/src/frontend/desktop/chats.ts
@@ -1,0 +1,143 @@
+/**
+ * Desktop chat registry — the set of conversations the bridge exposes.
+ *
+ * Each chat maps a string id (`d_…`) to the stable 32-bit numeric id the
+ * engine routes on. Chats with a persisted session survive a daemon restart
+ * (restored from the session/history stores); brand-new empty chats live only
+ * in memory until their first message persists them.
+ */
+
+import {
+  generateDesktopChatId,
+  deriveNumericChatId,
+  isDesktopChatId,
+} from "../../util/chat-id.js";
+import {
+  getAllSessions,
+  setSessionName,
+  resetSession,
+} from "../../storage/sessions.js";
+import { getRecentHistory, clearHistory } from "../../storage/history.js";
+import { previewOf } from "./protocol.js";
+
+export type ChatEntry = {
+  id: string;
+  numericId: number;
+  title: string;
+  createdAt: number;
+  lastActive: number;
+  preview: string;
+};
+
+function defaultTitle(): string {
+  return "New chat";
+}
+
+export class DesktopChats {
+  private byId = new Map<string, ChatEntry>();
+  private byNum = new Map<number, ChatEntry>();
+
+  /**
+   * Re-hydrate chats that have a persisted session (i.e. at least one prior
+   * turn). Called once at startup so the sidebar isn't empty after a restart.
+   */
+  restore(): void {
+    for (const { chatId, info } of getAllSessions()) {
+      if (!isDesktopChatId(chatId)) continue;
+      const recent = getRecentHistory(chatId, 1);
+      const entry: ChatEntry = {
+        id: chatId,
+        numericId: deriveNumericChatId(chatId),
+        title: info.sessionName || defaultTitle(),
+        createdAt: info.createdAt || Date.now(),
+        lastActive: info.lastActive || Date.now(),
+        preview: recent.length ? previewOf(recent[recent.length - 1].text) : "",
+      };
+      this.index(entry);
+    }
+  }
+
+  create(title?: string): ChatEntry {
+    const id = generateDesktopChatId();
+    const trimmed = title?.trim();
+    const entry: ChatEntry = {
+      id,
+      numericId: deriveNumericChatId(id),
+      title: trimmed || defaultTitle(),
+      createdAt: Date.now(),
+      lastActive: Date.now(),
+      preview: "",
+    };
+    this.index(entry);
+    if (trimmed) setSessionName(id, trimmed);
+    return entry;
+  }
+
+  /** Return an existing chat, or adopt a client-supplied id (deep link / sync). */
+  ensure(id: string): ChatEntry {
+    const existing = this.byId.get(id);
+    if (existing) return existing;
+    const entry: ChatEntry = {
+      id,
+      numericId: deriveNumericChatId(id),
+      title: defaultTitle(),
+      createdAt: Date.now(),
+      lastActive: Date.now(),
+      preview: "",
+    };
+    this.index(entry);
+    return entry;
+  }
+
+  get(id: string): ChatEntry | undefined {
+    return this.byId.get(id);
+  }
+
+  byNumeric(numericId: number): ChatEntry | undefined {
+    return this.byNum.get(numericId);
+  }
+
+  /** Most-recently-active first. */
+  list(): ChatEntry[] {
+    return [...this.byId.values()].sort((a, b) => b.lastActive - a.lastActive);
+  }
+
+  count(): number {
+    return this.byId.size;
+  }
+
+  rename(id: string, title: string): ChatEntry | undefined {
+    const entry = this.byId.get(id);
+    if (!entry) return undefined;
+    const trimmed = title.trim();
+    if (trimmed) {
+      entry.title = trimmed;
+      setSessionName(id, trimmed);
+    }
+    return entry;
+  }
+
+  remove(id: string): boolean {
+    const entry = this.byId.get(id);
+    if (!entry) return false;
+    this.byId.delete(id);
+    this.byNum.delete(entry.numericId);
+    resetSession(id);
+    clearHistory(id);
+    return true;
+  }
+
+  /** Bump activity + refresh the preview when a message lands. */
+  touch(id: string, preview?: string): ChatEntry | undefined {
+    const entry = this.byId.get(id);
+    if (!entry) return undefined;
+    entry.lastActive = Date.now();
+    if (preview !== undefined) entry.preview = previewOf(preview);
+    return entry;
+  }
+
+  private index(entry: ChatEntry): void {
+    this.byId.set(entry.id, entry);
+    this.byNum.set(entry.numericId, entry);
+  }
+}

--- a/src/frontend/desktop/index.ts
+++ b/src/frontend/desktop/index.ts
@@ -1,0 +1,453 @@
+/**
+ * Desktop frontend factory.
+ *
+ * A client-agnostic bridge: it runs the same gateway every messaging frontend
+ * uses (so the agent's tools work) PLUS a Bridge server (server.ts) that GUI
+ * clients connect to over the v1 protocol. The Electron-replacement Flutter
+ * companion app is the reference client, but anything speaking the protocol —
+ * a remote Android app over a token-authed LAN connection, a web client —
+ * works identically.
+ *
+ * Per turn it drives `dispatcher.execute()` and forwards the canonical
+ * `AgentEvent` stream to clients as Bridge events: reasoning + tool activity
+ * stream live, while the persisted reply arrives via the gateway action
+ * handler (tool-only backends) or the trailing-prose fallback (text-mode
+ * backends) — mirroring the terminal renderer's delivery semantics.
+ */
+
+import type { TalonConfig } from "../../util/config.js";
+import type { ContextManager } from "../../core/types.js";
+import type { Gateway } from "../../core/engine/gateway.js";
+import { log } from "../../util/log.js";
+import { execute } from "../../core/engine/dispatcher.js";
+import { toolInputToRecord } from "../../core/agent-runtime/events.js";
+import { pushMessage, getRecentHistory } from "../../storage/history.js";
+import {
+  getChatSettings,
+  setChatEffort,
+  setChatModelForBackend,
+  getChatModelForBackend,
+  setChatPulse,
+  EFFORT_LEVELS,
+  type EffortLevel,
+} from "../../storage/chat-settings.js";
+import { resetSession } from "../../storage/sessions.js";
+import { configSnapshot, applyConfigUpdate } from "./settings.js";
+import { getModels, resolveModel } from "../../core/models/catalog.js";
+import {
+  getBackendForChat,
+  getBackendIdForChat,
+} from "../../core/engine/backend-controller/index.js";
+import { getActiveReasoningLevels } from "../shared/reasoning-levels.js";
+import { DesktopChats, type ChatEntry } from "./chats.js";
+import { BridgeServer, type BridgeServerHandlers } from "./server.js";
+import { createDesktopActionHandler } from "./actions.js";
+import {
+  BRIDGE_PROTOCOL_VERSION,
+  BOT_SENDER_ID,
+  USER_SENDER_ID,
+  historyToClientMessage,
+  type BridgeEvent,
+  type BridgeStatus,
+  type ClientButton,
+  type ClientChat,
+  type ClientMessage,
+  type ModelOption,
+} from "./protocol.js";
+
+export type DesktopFrontend = {
+  name: "desktop";
+  context: ContextManager;
+  sendTyping: (chatId: number) => Promise<void>;
+  sendMessage: (chatId: number, text: string) => Promise<void>;
+  getBridgePort: () => number;
+  init: () => Promise<void>;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+};
+
+export function createDesktopFrontend(
+  config: TalonConfig,
+  gateway: Gateway,
+): DesktopFrontend {
+  const startedAt = new Date().toISOString();
+  const botName = config.botDisplayName || "Talon";
+  const chats = new DesktopChats();
+
+  // Monotonic message-id minter. Seeded from the wall clock so ids stay
+  // unique and ascending across restarts (history rows persist their ids).
+  let seq = Date.now();
+  const nextId = (): number => ++seq;
+
+  // ── Per-chat wire projection ─────────────────────────────────────────────
+
+  function toClientChat(entry: ChatEntry): ClientChat {
+    const settings = getChatSettings(entry.id);
+    let model: string | undefined;
+    try {
+      const backendId = getBackendIdForChat(entry.id);
+      model = getChatModelForBackend(entry.id, backendId);
+    } catch {
+      /* backend pool not ready (early boot) — omit model */
+    }
+    return {
+      id: entry.id,
+      title: entry.title,
+      createdAt: entry.createdAt,
+      lastActive: entry.lastActive,
+      preview: entry.preview,
+      model,
+      effort: settings.effort,
+      pulse: settings.pulse,
+    };
+  }
+
+  const broadcast = (event: BridgeEvent): void => server.broadcast(event);
+
+  const broadcastChatUpdated = (entry: ChatEntry): void =>
+    broadcast({ kind: "chat_updated", chat: toClientChat(entry) });
+
+  // ── Outbound message helpers (persist + broadcast) ───────────────────────
+
+  function emitAssistant(
+    entry: ChatEntry,
+    text: string,
+    buttons?: ClientButton[][],
+  ): number {
+    const id = nextId();
+    const ts = Date.now();
+    const message: ClientMessage = {
+      id: String(id),
+      chatId: entry.id,
+      role: "assistant",
+      text,
+      ts,
+      ...(buttons ? { buttons } : {}),
+    };
+    pushMessage(entry.id, {
+      msgId: id,
+      senderId: BOT_SENDER_ID,
+      senderName: botName,
+      text,
+      timestamp: ts,
+    });
+    chats.touch(entry.id, text);
+    broadcast({ kind: "message", chatId: entry.id, message });
+    broadcastChatUpdated(entry);
+    return id;
+  }
+
+  function emitUser(entry: ChatEntry, text: string): void {
+    const id = nextId();
+    const ts = Date.now();
+    const message: ClientMessage = {
+      id: String(id),
+      chatId: entry.id,
+      role: "user",
+      text,
+      ts,
+    };
+    pushMessage(entry.id, {
+      msgId: id,
+      senderId: USER_SENDER_ID,
+      senderName: "User",
+      text,
+      timestamp: ts,
+    });
+    chats.touch(entry.id, text);
+    broadcast({ kind: "message", chatId: entry.id, message });
+    broadcastChatUpdated(entry);
+  }
+
+  /** Transient, non-persisted notice (e.g. "session reset"). */
+  function emitSystem(entry: ChatEntry, text: string): void {
+    broadcast({
+      kind: "message",
+      chatId: entry.id,
+      message: {
+        id: `sys-${nextId()}`,
+        chatId: entry.id,
+        role: "system",
+        text,
+        ts: Date.now(),
+      },
+    });
+  }
+
+  // ── A user turn ──────────────────────────────────────────────────────────
+
+  async function runTurn(entry: ChatEntry, text: string): Promise<void> {
+    const start = Date.now();
+    try {
+      const result = await execute({
+        chatId: entry.id,
+        numericChatId: entry.numericId,
+        prompt: text,
+        senderName: "User",
+        isGroup: false,
+        source: "message",
+        onEvent: async (event) => {
+          switch (event.type) {
+            case "reasoning":
+              if (event.text)
+                broadcast({
+                  kind: "reasoning",
+                  chatId: entry.id,
+                  text: event.text,
+                });
+              break;
+            case "text_delta":
+              broadcast({ kind: "delta", chatId: entry.id, text: event.text });
+              break;
+            case "tool_call":
+              broadcast({
+                kind: "tool",
+                chatId: entry.id,
+                id: event.id,
+                name: event.name,
+                phase: "call",
+                input: toolInputToRecord(event.name, event.input),
+              });
+              break;
+            case "tool_result":
+              broadcast({
+                kind: "tool",
+                chatId: entry.id,
+                id: event.id,
+                name: event.name,
+                phase: "result",
+                ...(event.error ? { error: event.error } : {}),
+              });
+              break;
+            case "error":
+              broadcast({
+                kind: "error",
+                chatId: entry.id,
+                message: event.error.message,
+              });
+              break;
+          }
+        },
+      });
+
+      // Trailing-prose fallback: text-mode backends (kilo/opencode/codex)
+      // deliver the reply as plain text rather than a bridge send. When no
+      // delivery tool fired this turn, surface result.text as the message —
+      // exactly what the terminal renderer does.
+      let delivered = result.bridgeMessageCount;
+      if (delivered === 0 && result.text.trim()) {
+        emitAssistant(entry, result.text.trim());
+        delivered = 1;
+      }
+
+      broadcast({ kind: "typing", chatId: entry.id, on: false });
+      broadcast({
+        kind: "turn_end",
+        chatId: entry.id,
+        delivered,
+        durationMs: result.durationMs,
+        usage: { input: result.inputTokens, output: result.outputTokens },
+      });
+    } catch (err) {
+      broadcast({ kind: "typing", chatId: entry.id, on: false });
+      broadcast({
+        kind: "error",
+        chatId: entry.id,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      broadcast({
+        kind: "turn_end",
+        chatId: entry.id,
+        delivered: 0,
+        durationMs: Date.now() - start,
+      });
+    }
+  }
+
+  // ── Status + model helpers ───────────────────────────────────────────────
+
+  function status(): BridgeStatus {
+    return {
+      app: "talon-bridge",
+      protocol: BRIDGE_PROTOCOL_VERSION,
+      botName,
+      backend: config.backend,
+      model: resolveModel(config.model)?.displayName ?? config.model,
+      activeChats: chats.count(),
+      startedAt,
+    };
+  }
+
+  function listModels(): { active: string; models: ModelOption[] } {
+    const models: ModelOption[] = getModels().map((m) => ({
+      id: m.id,
+      displayName: m.displayName,
+      provider: m.provider,
+      reasoning: Boolean(m.supportedReasoningLevels?.length),
+    }));
+    return { active: config.model, models };
+  }
+
+  function setModel(chatId: string, model: string): void {
+    const entry = chats.get(chatId);
+    if (!entry) return;
+    const backendId = getBackendIdForChat(chatId);
+    setChatModelForBackend(chatId, backendId, model.trim() || undefined);
+    broadcastChatUpdated(entry);
+  }
+
+  function setEffort(chatId: string, effort: string): void {
+    const entry = chats.get(chatId);
+    if (!entry) return;
+    const level = EFFORT_LEVELS.includes(effort as EffortLevel)
+      ? (effort as EffortLevel)
+      : undefined;
+    setChatEffort(chatId, level);
+    broadcastChatUpdated(entry);
+  }
+
+  async function effortLevels(
+    chatId: string,
+  ): Promise<{ active: string; levels: string[] }> {
+    try {
+      const backend = getBackendForChat(chatId);
+      const backendId = getBackendIdForChat(chatId);
+      const { levels } = await getActiveReasoningLevels({
+        chatId,
+        backend,
+        backendId,
+        config,
+      });
+      const active = getChatSettings(chatId).effort ?? "adaptive";
+      return { active, levels };
+    } catch {
+      return { active: "adaptive", levels: [] };
+    }
+  }
+
+  // ── Bridge server wiring ─────────────────────────────────────────────────
+
+  const handlers: BridgeServerHandlers = {
+    status,
+    listChats: () => chats.list().map(toClientChat),
+    createChat: (title) => {
+      const entry = chats.create(title);
+      const chat = toClientChat(entry);
+      broadcast({ kind: "chat_created", chat });
+      return chat;
+    },
+    renameChat: (id, title) => {
+      const entry = chats.rename(id, title);
+      if (!entry) return null;
+      const chat = toClientChat(entry);
+      broadcast({ kind: "chat_updated", chat });
+      return chat;
+    },
+    deleteChat: (id) => {
+      const ok = chats.remove(id);
+      if (ok) broadcast({ kind: "chat_deleted", chatId: id });
+      return ok;
+    },
+    history: (id) =>
+      getRecentHistory(id, 200)
+        .map((m) => historyToClientMessage(m, id))
+        .sort((a, b) => Number(a.id) - Number(b.id)),
+    send: (id, text) => {
+      const entry = chats.get(id) ?? chats.ensure(id);
+      emitUser(entry, text);
+      broadcast({ kind: "turn_start", chatId: entry.id });
+      broadcast({ kind: "typing", chatId: entry.id, on: true });
+      void runTurn(entry, text);
+    },
+    listModels,
+    setModel,
+    setEffort,
+    effortLevels,
+    resetChat: (id) => {
+      const entry = chats.get(id);
+      if (!entry) return false;
+      resetSession(id);
+      emitSystem(entry, "Session reset — starting a fresh conversation.");
+      broadcastChatUpdated(entry);
+      return true;
+    },
+    setPulse: (id, on) => {
+      const entry = chats.get(id);
+      if (!entry) return;
+      setChatPulse(id, on);
+      broadcastChatUpdated(entry);
+    },
+    getConfig: () => configSnapshot(config),
+    setConfig: (update) => {
+      const snap = applyConfigUpdate(config, update);
+      broadcast({ kind: "status", status: status() });
+      return snap;
+    },
+  };
+
+  const desktopCfg = config.desktop ?? { port: 19880, host: "127.0.0.1" };
+  const server = new BridgeServer(
+    {
+      host: desktopCfg.host ?? "127.0.0.1",
+      port: desktopCfg.port ?? 19880,
+      token: desktopCfg.token,
+      startedAt,
+    },
+    handlers,
+  );
+
+  // ── Frontend interface ─────────────────────────────────────────────────--
+
+  const context: ContextManager = {
+    acquire: (chatId: number, stringId?: string) =>
+      gateway.setContext(chatId, stringId),
+    release: (chatId: number) => gateway.clearContext(chatId),
+    getMessageCount: (chatId: number) => gateway.getMessageCount(chatId),
+  };
+
+  return {
+    name: "desktop",
+    context,
+
+    sendTyping: async (chatId: number) => {
+      const entry = chats.byNumeric(chatId);
+      if (entry) broadcast({ kind: "typing", chatId: entry.id, on: true });
+    },
+
+    // Used by cron / pulse / heartbeat to reach a chat outside a user turn.
+    sendMessage: async (chatId: number, text: string) => {
+      if (!text.trim()) return;
+      const entry = chats.byNumeric(chatId);
+      if (entry) emitAssistant(entry, text);
+    },
+
+    getBridgePort: () => gateway.getPort(),
+
+    async init() {
+      gateway.setFrontendHandler(
+        createDesktopActionHandler({
+          chats,
+          gateway,
+          emitAssistant,
+          broadcast,
+        }),
+      );
+      const gatewayPort = await gateway.start(19876);
+      log("desktop", `Gateway on :${gatewayPort}`);
+      chats.restore();
+      await server.start();
+    },
+
+    async start() {
+      log(
+        "desktop",
+        `Desktop bridge ready (${chats.count()} chat(s)) — connect a client to :${server.getPort()}`,
+      );
+    },
+
+    async stop() {
+      await server.stop();
+      await gateway.stop();
+    },
+  };
+}

--- a/src/frontend/desktop/protocol.ts
+++ b/src/frontend/desktop/protocol.ts
@@ -1,0 +1,140 @@
+/**
+ * Talon Client Bridge Protocol (v1).
+ *
+ * The stable, client-agnostic contract between a Talon daemon running the
+ * `desktop` frontend and ANY GUI client: the bundled Electron companion app
+ * (apps/desktop), and future clients (Android, iOS, web). Transport is plain
+ * HTTP + Server-Sent Events with JSON bodies, so a client written in any
+ * language can speak it against `http://<host>:<port>` (plus a bearer token
+ * when one is configured).
+ *
+ * This module is the TRANSLATION LAYER. It defines the wire types and the
+ * pure mappers from Talon's internal shapes (`HistoryMessage`, sessions,
+ * `AgentEvent`) into them. Nothing Talon-internal crosses the wire — clients
+ * depend only on the types here, never on Talon's engine. Bump
+ * `BRIDGE_PROTOCOL_VERSION` on a breaking change so clients can refuse a
+ * mismatch instead of misrendering.
+ */
+
+import type { HistoryMessage } from "../../storage/history.js";
+
+/** Wire-format version. Surfaced in `/health` and the `hello` event. */
+export const BRIDGE_PROTOCOL_VERSION = 1;
+
+/** History sender id reserved for Talon's own (assistant) messages. */
+export const BOT_SENDER_ID = 0;
+/** History sender id used for the human on the other end of a desktop chat. */
+export const USER_SENDER_ID = 1;
+
+export type ClientRole = "user" | "assistant" | "system";
+
+/** An inline button. `url` opens a link; `data` is an opaque callback token. */
+export type ClientButton = { text: string; url?: string; data?: string };
+
+/** A single rendered message in a conversation. */
+export type ClientMessage = {
+  id: string;
+  chatId: string;
+  role: ClientRole;
+  text: string;
+  /** Epoch milliseconds. */
+  ts: number;
+  buttons?: ClientButton[][];
+  reactions?: string[];
+};
+
+/** A conversation in the sidebar. */
+export type ClientChat = {
+  id: string;
+  title: string;
+  createdAt: number;
+  lastActive: number;
+  /** Truncated last-message text for the list preview. */
+  preview: string;
+  /** Resolved model id for this chat, when known. */
+  model?: string;
+  /** Reasoning effort for this chat, when known. */
+  effort?: string;
+  /** Whether proactive pulse check-ins are enabled for this chat. */
+  pulse?: boolean;
+};
+
+/** Daemon-level status shown in the client's header / status pill. */
+export type BridgeStatus = {
+  app: "talon-bridge";
+  protocol: number;
+  botName: string;
+  backend: string;
+  /** Display name of the global default model. */
+  model: string;
+  activeChats: number;
+  startedAt: string;
+};
+
+/** A selectable model for the picker. */
+export type ModelOption = {
+  id: string;
+  displayName: string;
+  provider: string;
+  reasoning: boolean;
+};
+
+/**
+ * Server → client events, delivered as SSE `data:` lines (one JSON object
+ * each). The client switches on `kind`. Streaming text arrives as ephemeral
+ * `delta` events; the canonical, persisted reply always arrives as a
+ * `message` event (possibly several per turn).
+ */
+export type BridgeEvent =
+  | { kind: "hello"; status: BridgeStatus; chats: ClientChat[] }
+  | { kind: "status"; status: BridgeStatus }
+  | { kind: "chat_created"; chat: ClientChat }
+  | { kind: "chat_updated"; chat: ClientChat }
+  | { kind: "chat_deleted"; chatId: string }
+  | { kind: "message"; chatId: string; message: ClientMessage }
+  | { kind: "message_edited"; chatId: string; messageId: string; text: string }
+  | { kind: "message_deleted"; chatId: string; messageId: string }
+  | { kind: "reaction"; chatId: string; messageId: string; emoji: string }
+  | { kind: "turn_start"; chatId: string }
+  | { kind: "reasoning"; chatId: string; text: string }
+  | { kind: "delta"; chatId: string; text: string }
+  | {
+      kind: "tool";
+      chatId: string;
+      id: string;
+      name: string;
+      phase: "call" | "result";
+      input?: Record<string, unknown>;
+      error?: string;
+    }
+  | { kind: "typing"; chatId: string; on: boolean }
+  | {
+      kind: "turn_end";
+      chatId: string;
+      delivered: number;
+      durationMs?: number;
+      usage?: { input: number; output: number };
+    }
+  | { kind: "error"; chatId?: string; message: string };
+
+// ── Mappers (Talon internals → wire types) ───────────────────────────────────
+
+/** Collapse whitespace and clip a string for list previews. */
+export function previewOf(text: string, max = 90): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
+}
+
+/** Map a persisted history row to a wire message. */
+export function historyToClientMessage(
+  m: HistoryMessage,
+  chatId: string,
+): ClientMessage {
+  return {
+    id: String(m.msgId),
+    chatId,
+    role: m.senderId === BOT_SENDER_ID ? "assistant" : "user",
+    text: m.text,
+    ts: m.timestamp,
+  };
+}

--- a/src/frontend/desktop/server.ts
+++ b/src/frontend/desktop/server.ts
@@ -1,0 +1,388 @@
+/**
+ * Bridge server — the HTTP + Server-Sent Events transport for the Talon
+ * Client Bridge Protocol (see protocol.ts).
+ *
+ * Pure transport: it parses requests, enforces the optional bearer token,
+ * fans SSE events out to every connected client, and delegates all logic to
+ * the injected `BridgeServerHandlers`. No engine imports live here, so the
+ * same server serves the Electron desktop app, a remote Android client, or a
+ * curl one-liner identically.
+ *
+ * Binds `host` (loopback by default) with the gateway's EADDRINUSE +1..+5
+ * fallback so two daemons on one machine don't collide.
+ */
+
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import { log, logError, logDebug } from "../../util/log.js";
+import {
+  BRIDGE_PROTOCOL_VERSION,
+  type BridgeEvent,
+  type BridgeStatus,
+  type ClientChat,
+  type ClientMessage,
+  type ModelOption,
+} from "./protocol.js";
+import type { ConfigSnapshot } from "./settings.js";
+
+/** Everything the transport needs the frontend to implement. */
+export type BridgeServerHandlers = {
+  status(): BridgeStatus;
+  listChats(): ClientChat[];
+  createChat(title?: string): ClientChat;
+  renameChat(id: string, title: string): ClientChat | null;
+  deleteChat(id: string): boolean;
+  history(id: string): ClientMessage[];
+  /** Fire-and-forget: streams its results back through `broadcast`. */
+  send(id: string, text: string): void;
+  listModels(): { active: string; models: ModelOption[] };
+  setModel(id: string, model: string): void;
+  setEffort(id: string, effort: string): void;
+  effortLevels(id: string): Promise<{ active: string; levels: string[] }>;
+  resetChat(id: string): boolean;
+  setPulse(id: string, on: boolean): void;
+  /** Read the daemon's own (allowlisted) settings + health. */
+  getConfig(): ConfigSnapshot;
+  /** Change daemon settings; returns the fresh snapshot. */
+  setConfig(update: Record<string, unknown>): ConfigSnapshot;
+};
+
+const SSE_PING_MS = 25_000;
+const MAX_BODY_BYTES = 256 * 1024;
+const PORT_FALLBACKS = 5;
+
+export class BridgeServer {
+  private server: Server | null = null;
+  private clients = new Set<ServerResponse>();
+  private pingTimer: ReturnType<typeof setInterval> | undefined;
+  private port = 0;
+
+  constructor(
+    private readonly opts: {
+      host: string;
+      port: number;
+      token?: string;
+      startedAt: string;
+    },
+    private readonly handlers: BridgeServerHandlers,
+  ) {}
+
+  getPort(): number {
+    return this.port;
+  }
+
+  /** Push an event to every connected SSE client. */
+  broadcast(event: BridgeEvent): void {
+    if (this.clients.size === 0) return;
+    const payload = `data: ${JSON.stringify(event)}\n\n`;
+    for (const res of this.clients) {
+      try {
+        res.write(payload);
+      } catch {
+        // Write on a half-closed socket — the 'close' handler will evict it.
+      }
+    }
+  }
+
+  async start(): Promise<number> {
+    if (this.server) return this.port;
+    const server = createServer((req, res) => {
+      this.handle(req, res).catch((err) => {
+        logError("desktop", "Bridge request handler threw", err);
+        if (!res.headersSent) {
+          res.writeHead(500, this.jsonHeaders());
+          res.end(JSON.stringify({ ok: false, error: "Internal error" }));
+        }
+      });
+    });
+
+    this.pingTimer = setInterval(() => {
+      for (const res of this.clients) {
+        try {
+          res.write(": ping\n\n");
+        } catch {
+          /* evicted on close */
+        }
+      }
+    }, SSE_PING_MS);
+    this.pingTimer.unref?.();
+
+    return new Promise<number>((resolve, reject) => {
+      let attempt = 0;
+      const tryPort = (p: number): void => {
+        server.once("error", (err: NodeJS.ErrnoException) => {
+          if (err.code === "EADDRINUSE" && attempt < PORT_FALLBACKS) {
+            attempt++;
+            server.removeAllListeners("error");
+            server.removeAllListeners("listening");
+            tryPort(p + 1);
+          } else {
+            reject(err);
+          }
+        });
+        server.listen(p, this.opts.host, () => {
+          this.server = server;
+          const addr = server.address();
+          this.port =
+            typeof addr === "object" && addr !== null
+              ? (addr as { port: number }).port
+              : p;
+          server.removeAllListeners("error");
+          server.on("error", (err) =>
+            logError("desktop", "Bridge server error", err),
+          );
+          log(
+            "desktop",
+            `Bridge listening on ${this.opts.host}:${this.port}` +
+              (this.opts.token ? " (token required)" : ""),
+          );
+          resolve(this.port);
+        });
+      };
+      tryPort(this.opts.port);
+    });
+  }
+
+  async stop(): Promise<void> {
+    clearInterval(this.pingTimer);
+    for (const res of this.clients) {
+      try {
+        res.end();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.clients.clear();
+    return new Promise((resolve) => {
+      if (!this.server) return resolve();
+      this.server.close(() => {
+        this.server = null;
+        this.port = 0;
+        resolve();
+      });
+    });
+  }
+
+  // ── Routing ────────────────────────────────────────────────────────────────
+
+  private async handle(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<void> {
+    const url = new URL(req.url ?? "/", "http://bridge");
+    const path = url.pathname;
+    const method = req.method ?? "GET";
+
+    if (method === "OPTIONS") {
+      res.writeHead(204, this.corsHeaders());
+      res.end();
+      return;
+    }
+
+    // /health is unauthenticated so clients can discover/ping the bridge
+    // before they hold a token. It exposes no chat content.
+    if (method === "GET" && path === "/health") {
+      const s = this.handlers.status();
+      return this.json(res, 200, {
+        app: "talon-bridge",
+        ok: true,
+        protocol: BRIDGE_PROTOCOL_VERSION,
+        host: this.opts.host,
+        port: this.port,
+        authRequired: Boolean(this.opts.token),
+        startedAt: this.opts.startedAt,
+        botName: s.botName,
+        backend: s.backend,
+        model: s.model,
+        activeChats: s.activeChats,
+      });
+    }
+
+    if (!this.authOk(req, url)) {
+      return this.json(res, 401, { ok: false, error: "Unauthorized" });
+    }
+
+    try {
+      if (method === "GET" && path === "/events") return this.openStream(res);
+
+      if (method === "GET" && path === "/chats")
+        return this.json(res, 200, { chats: this.handlers.listChats() });
+
+      if (method === "POST" && path === "/chats") {
+        const body = await this.readJson(req);
+        const chat = this.handlers.createChat(asString(body.title));
+        return this.json(res, 200, { chat });
+      }
+
+      if (method === "POST" && path === "/chats/rename") {
+        const body = await this.readJson(req);
+        const chat = this.handlers.renameChat(
+          asString(body.chatId) ?? "",
+          asString(body.title) ?? "",
+        );
+        return chat
+          ? this.json(res, 200, { chat })
+          : this.json(res, 404, { ok: false, error: "No such chat" });
+      }
+
+      if (method === "POST" && path === "/chats/delete") {
+        const body = await this.readJson(req);
+        const ok = this.handlers.deleteChat(asString(body.chatId) ?? "");
+        return this.json(res, 200, { ok });
+      }
+
+      if (method === "POST" && path === "/chats/reset") {
+        const body = await this.readJson(req);
+        const ok = this.handlers.resetChat(asString(body.chatId) ?? "");
+        return this.json(res, 200, { ok });
+      }
+
+      if (method === "POST" && path === "/chats/pulse") {
+        const body = await this.readJson(req);
+        this.handlers.setPulse(asString(body.chatId) ?? "", body.on === true);
+        return this.json(res, 200, { ok: true });
+      }
+
+      if (method === "GET" && path === "/history") {
+        const id = url.searchParams.get("chatId") ?? "";
+        return this.json(res, 200, {
+          chatId: id,
+          messages: this.handlers.history(id),
+        });
+      }
+
+      if (method === "POST" && path === "/send") {
+        const body = await this.readJson(req);
+        const id = asString(body.chatId) ?? "";
+        const text = asString(body.text) ?? "";
+        if (!id || !text.trim())
+          return this.json(res, 400, {
+            ok: false,
+            error: "chatId and text required",
+          });
+        this.handlers.send(id, text);
+        return this.json(res, 202, { ok: true });
+      }
+
+      if (method === "GET" && path === "/models")
+        return this.json(res, 200, this.handlers.listModels());
+
+      if (method === "POST" && path === "/model") {
+        const body = await this.readJson(req);
+        this.handlers.setModel(
+          asString(body.chatId) ?? "",
+          asString(body.model) ?? "",
+        );
+        return this.json(res, 200, { ok: true });
+      }
+
+      if (method === "GET" && path === "/effort") {
+        const id = url.searchParams.get("chatId") ?? "";
+        return this.json(res, 200, await this.handlers.effortLevels(id));
+      }
+
+      if (method === "POST" && path === "/effort") {
+        const body = await this.readJson(req);
+        this.handlers.setEffort(
+          asString(body.chatId) ?? "",
+          asString(body.effort) ?? "",
+        );
+        return this.json(res, 200, { ok: true });
+      }
+
+      if (method === "GET" && path === "/config")
+        return this.json(res, 200, this.handlers.getConfig());
+
+      if (method === "POST" && path === "/config") {
+        const body = await this.readJson(req);
+        return this.json(res, 200, this.handlers.setConfig(body));
+      }
+
+      return this.json(res, 404, { ok: false, error: "Not found" });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return this.json(res, 400, { ok: false, error: msg });
+    }
+  }
+
+  private openStream(res: ServerResponse): void {
+    res.writeHead(200, {
+      ...this.corsHeaders(),
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    });
+    res.write(`retry: 3000\n\n`);
+    // Opening snapshot so a freshly-connected client renders immediately.
+    res.write(
+      `data: ${JSON.stringify({
+        kind: "hello",
+        status: this.handlers.status(),
+        chats: this.handlers.listChats(),
+      })}\n\n`,
+    );
+    this.clients.add(res);
+    logDebug("desktop", `SSE client connected (${this.clients.size} total)`);
+    res.on("close", () => {
+      this.clients.delete(res);
+      logDebug("desktop", `SSE client left (${this.clients.size} total)`);
+    });
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private authOk(req: IncomingMessage, url: URL): boolean {
+    if (!this.opts.token) return true;
+    const header = req.headers["authorization"];
+    if (typeof header === "string" && header === `Bearer ${this.opts.token}`)
+      return true;
+    // EventSource can't set headers, so SSE clients pass ?token=… instead.
+    return url.searchParams.get("token") === this.opts.token;
+  }
+
+  private corsHeaders(): Record<string, string> {
+    return {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Authorization, Content-Type",
+      "Access-Control-Max-Age": "86400",
+    };
+  }
+
+  private jsonHeaders(): Record<string, string> {
+    return { ...this.corsHeaders(), "Content-Type": "application/json" };
+  }
+
+  private json(res: ServerResponse, code: number, body: unknown): void {
+    res.writeHead(code, this.jsonHeaders());
+    res.end(JSON.stringify(body));
+  }
+
+  private async readJson(
+    req: IncomingMessage,
+  ): Promise<Record<string, unknown>> {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for await (const chunk of req) {
+      total += (chunk as Buffer).length;
+      if (total > MAX_BODY_BYTES) throw new Error("Request body too large");
+      chunks.push(chunk as Buffer);
+    }
+    if (chunks.length === 0) return {};
+    const raw = Buffer.concat(chunks).toString("utf-8").trim();
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
+      throw new Error("Body must be a JSON object");
+    return parsed as Record<string, unknown>;
+  }
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}

--- a/src/frontend/desktop/settings.ts
+++ b/src/frontend/desktop/settings.ts
@@ -1,0 +1,205 @@
+/**
+ * Settings sync — lets a connected client read and change Talon's own
+ * configuration, not just per-chat options. This is what pushes the companion
+ * past read-only parity with the chat frontends: the app surfaces the daemon's
+ * config and writes an allowlisted, safe subset back to `talon.json`, applying
+ * the runtime-meaningful ones live (timezone, pulse/heartbeat timers, default
+ * model).
+ *
+ * Only the keys in {@link EDITABLE} are accepted; anything else in an update is
+ * ignored. Credentials and structural choices (tokens, backend, frontend) are
+ * deliberately NOT editable here — those belong in a deliberate restart.
+ */
+
+import { existsSync, readFileSync, mkdirSync } from "node:fs";
+import writeFileAtomic from "write-file-atomic";
+import { dirname } from "node:path";
+import type { TalonConfig } from "../../util/config.js";
+import { files as pathFiles } from "../../util/paths.js";
+import { setTimezone } from "../../util/time.js";
+import { resolveModel } from "../../core/models/catalog.js";
+import { getHealthStatus } from "../../util/watchdog.js";
+import { getActiveSessionCount } from "../../storage/sessions.js";
+import {
+  startPulseTimer,
+  stopPulseTimer,
+} from "../../core/background/pulse.js";
+import {
+  startHeartbeatTimer,
+  stopHeartbeatTimer,
+} from "../../core/background/heartbeat/index.js";
+import { log } from "../../util/log.js";
+
+/** Config keys a client may change through the bridge. */
+export const EDITABLE = [
+  "model",
+  "botDisplayName",
+  "timezone",
+  "pulse",
+  "pulseIntervalMs",
+  "heartbeat",
+  "heartbeatIntervalMinutes",
+  "dream",
+] as const;
+
+export type ConfigSnapshot = {
+  backend: string;
+  frontend: string;
+  model: string;
+  modelDisplay: string;
+  botDisplayName: string;
+  timezone: string;
+  pulse: boolean;
+  pulseIntervalMs: number;
+  heartbeat: boolean;
+  heartbeatIntervalMinutes: number;
+  dream: boolean;
+  editable: string[];
+  health: {
+    healthy: boolean;
+    uptimeMs: number;
+    sessions: number;
+    messages: number;
+    memoryMb: number;
+  };
+};
+
+export function configSnapshot(config: TalonConfig): ConfigSnapshot {
+  const h = getHealthStatus();
+  return {
+    backend: config.backend,
+    frontend: Array.isArray(config.frontend)
+      ? config.frontend[0]
+      : config.frontend,
+    model: config.model,
+    modelDisplay: resolveModel(config.model)?.displayName ?? config.model,
+    botDisplayName: config.botDisplayName,
+    timezone: config.timezone ?? "",
+    pulse: config.pulse,
+    pulseIntervalMs: config.pulseIntervalMs,
+    heartbeat: config.heartbeat,
+    heartbeatIntervalMinutes: config.heartbeatIntervalMinutes,
+    dream: config.dream,
+    editable: [...EDITABLE],
+    health: {
+      healthy: h.healthy,
+      uptimeMs: h.uptimeMs,
+      sessions: getActiveSessionCount(),
+      messages: h.totalMessagesProcessed,
+      memoryMb: Math.round(process.memoryUsage().heapUsed / 1024 / 1024),
+    },
+  };
+}
+
+/**
+ * Apply an allowlisted config update: validate, mutate the live config object,
+ * persist to talon.json, and re-arm runtime timers as needed. Returns the fresh
+ * snapshot. Unknown / non-editable keys are ignored.
+ */
+export function applyConfigUpdate(
+  config: TalonConfig,
+  update: Record<string, unknown>,
+): ConfigSnapshot {
+  const allowed = new Set<string>(EDITABLE);
+  const persist: Record<string, unknown> = {};
+  let pulseChanged = false;
+  let heartbeatChanged = false;
+
+  for (const [key, value] of Object.entries(update)) {
+    if (!allowed.has(key)) continue;
+    switch (key) {
+      case "model":
+        if (typeof value === "string" && value.trim()) {
+          config.model = value.trim();
+          persist.model = config.model;
+        }
+        break;
+      case "botDisplayName":
+        if (typeof value === "string" && value.trim()) {
+          config.botDisplayName = value.trim();
+          persist.botDisplayName = config.botDisplayName;
+        }
+        break;
+      case "timezone":
+        if (typeof value === "string") {
+          config.timezone = value.trim() || undefined;
+          setTimezone(config.timezone);
+          persist.timezone = config.timezone;
+        }
+        break;
+      case "pulse":
+        if (typeof value === "boolean") {
+          config.pulse = value;
+          persist.pulse = value;
+          pulseChanged = true;
+        }
+        break;
+      case "pulseIntervalMs":
+        if (typeof value === "number" && value >= 60_000) {
+          config.pulseIntervalMs = Math.round(value);
+          persist.pulseIntervalMs = config.pulseIntervalMs;
+          pulseChanged = true;
+        }
+        break;
+      case "heartbeat":
+        if (typeof value === "boolean") {
+          config.heartbeat = value;
+          persist.heartbeat = value;
+          heartbeatChanged = true;
+        }
+        break;
+      case "heartbeatIntervalMinutes":
+        if (typeof value === "number" && value >= 5) {
+          config.heartbeatIntervalMinutes = Math.round(value);
+          persist.heartbeatIntervalMinutes = config.heartbeatIntervalMinutes;
+          heartbeatChanged = true;
+        }
+        break;
+      case "dream":
+        if (typeof value === "boolean") {
+          config.dream = value;
+          persist.dream = value;
+        }
+        break;
+    }
+  }
+
+  // Re-arm timers so toggles/intervals take effect now, not just next boot.
+  if (pulseChanged) {
+    stopPulseTimer();
+    if (config.pulse) startPulseTimer(config.pulseIntervalMs);
+  }
+  if (heartbeatChanged) {
+    stopHeartbeatTimer();
+    if (config.heartbeat) startHeartbeatTimer(config.heartbeatIntervalMinutes);
+  }
+
+  if (Object.keys(persist).length > 0) {
+    persistToFile(persist);
+    log("desktop", `Config updated: ${Object.keys(persist).join(", ")}`);
+  }
+
+  return configSnapshot(config);
+}
+
+/** Merge a partial update into talon.json on disk, preserving everything else. */
+function persistToFile(update: Record<string, unknown>): void {
+  const file = pathFiles.config;
+  let current: Record<string, unknown> = {};
+  try {
+    if (existsSync(file)) {
+      current = JSON.parse(readFileSync(file, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+    }
+  } catch {
+    /* corrupt/absent — start from empty */
+  }
+  for (const [k, v] of Object.entries(update)) {
+    if (v === undefined) delete current[k];
+    else current[k] = v;
+  }
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileAtomic.sync(file, JSON.stringify(current, null, 2) + "\n");
+}

--- a/src/util/chat-id.ts
+++ b/src/util/chat-id.ts
@@ -19,3 +19,18 @@ export function generateTerminalChatId(): string {
 export function isTerminalChatId(chatId: string): boolean {
   return chatId.startsWith("t_") || chatId === "1";
 }
+
+/**
+ * Generate a unique desktop chat ID. A short random suffix is appended so
+ * two chats created within the same millisecond don't collide (the desktop
+ * UI lets you spin up several conversations quickly).
+ */
+export function generateDesktopChatId(): string {
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `d_${Date.now()}_${rand}`;
+}
+
+/** Check if a chat ID belongs to a desktop session. */
+export function isDesktopChatId(chatId: string): boolean {
+  return chatId.startsWith("d_");
+}

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -113,7 +113,42 @@ const pluginEntrySchema = z
   })
   .pipe(z.union([pluginPathSchema, pluginMcpSchema]));
 
-const frontendEnum = z.enum(["telegram", "terminal", "teams", "discord"]);
+const frontendEnum = z.enum([
+  "telegram",
+  "terminal",
+  "teams",
+  "discord",
+  "desktop",
+]);
+
+/**
+ * Desktop frontend — a client-agnostic bridge (HTTP + Server-Sent Events,
+ * JSON) that GUI clients connect to: the bundled Electron companion app
+ * (apps/desktop), and any future client (Android, web, …) speaking the
+ * same versioned protocol against `host:port`.
+ *
+ * Defaults are loopback-only and unauthenticated (single-machine use). To
+ * reach Talon remotely, set `host: "0.0.0.0"` and a `token` — the bridge
+ * then requires `Authorization: Bearer <token>` (or `?token=` for SSE).
+ */
+const desktopConfigSchema = z
+  .object({
+    /** Port the bridge binds. Falls back +1..+5 on EADDRINUSE. */
+    port: z.number().int().min(1024).max(65535).default(19880),
+    /**
+     * Interface to bind. `127.0.0.1` (default) is local-only; `0.0.0.0`
+     * exposes the bridge on the LAN for remote clients — only do this with
+     * a `token` set.
+     */
+    host: z.string().default("127.0.0.1"),
+    /**
+     * Optional shared secret. When set, every request must present it as a
+     * bearer token (header) or `?token=` query param (SSE). Required in
+     * practice whenever `host` is not loopback.
+     */
+    token: z.string().optional(),
+  })
+  .strict();
 
 const discordConfigSchema = z
   .object({
@@ -365,6 +400,9 @@ const configSchema = z.object({
   // Discord — discord.js v14-based frontend
   discord: discordConfigSchema.optional(),
 
+  // Desktop — local bridge for the Electron companion app (apps/desktop)
+  desktop: desktopConfigSchema.optional(),
+
   // Display name shown in terminal UI (defaults to "Talon")
   botDisplayName: z.string().default("Talon"),
 
@@ -454,6 +492,15 @@ function ensureConfigFile(): boolean {
 export function loadConfig(): TalonConfig {
   ensureConfigFile();
   const fileConfig = loadConfigFile();
+
+  // Runtime frontend override (TALON_FRONTEND_OVERRIDE). Lets the desktop
+  // companion app spawn a daemon on the `desktop` frontend without rewriting
+  // the user's saved config (which may target Telegram/Discord). Validated
+  // against the same enum, so a bogus value fails fast like any other.
+  const frontendOverride = process.env.TALON_FRONTEND_OVERRIDE?.trim();
+  if (frontendOverride) {
+    fileConfig.frontend = frontendOverride;
+  }
 
   const parsed = configSchema.parse(fileConfig);
 

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -45,6 +45,7 @@ export type LogComponent =
   | "plugin"
   | "teams"
   | "discord"
+  | "desktop"
   | "config"
   | "access"
   | "github"


### PR DESCRIPTION
## Summary

Adds a **`desktop` frontend** that turns the Talon daemon into a client bridge — a versioned **HTTP + Server-Sent-Events JSON protocol** (the _Talon Client Bridge Protocol_) — plus a **cross-platform Flutter companion app** (`apps/companion/`) as the reference client. One Flutter codebase runs on **Windows, macOS, Linux, and Android**.

The bridge is deliberately client-agnostic (the "translation layer"): the app is just one client, and a future Android/web/other client speaks the same protocol against `host:port` (+ token). The app reaches 1:1-and-then-some parity with the chat frontends — multi-chat, live streaming with tool/reasoning visibility, per-chat model/effort/pulse/reset, **and syncing/editing Talon's own settings**.

## Talon side — `src/frontend/desktop/`

| File | Role |
| ---- | ---- |
| `protocol.ts` | Client-agnostic wire types + pure mappers (the translation layer) |
| `server.ts` | HTTP + SSE transport — host/port/token configurable, CORS, EADDRINUSE fallback, optional bearer auth |
| `chats.ts` | Multi-chat registry over the session/history stores |
| `actions.ts` | Gateway action handler: `end_turn`/`send`/`react`/`edit`/`delete` → bridge events |
| `index.ts` | `Frontend` impl — drives `dispatcher.execute`, streams reasoning + tool calls live, mirrors the terminal delivery semantics |
| `settings.ts` | Read/change the daemon's own config, persisted to `talon.json` |

`desktop` is registered across the frontend enum sites (config schema, `FrontendName`, `ToolFrontend`, `VALID_FRONTENDS`, `delivery-contract`, messaging tools, `app.ts`). A new `TALON_FRONTEND_OVERRIDE` env lets the app launch a desktop daemon **without rewriting the user's saved config**. `prompts/desktop.md` documents the frontend's capabilities to the model.

### Connection / auth

```jsonc
// ~/.talon/config.json
{ "frontend": "desktop", "desktop": { "host": "127.0.0.1", "port": 19880 } }
// remote: "host": "0.0.0.0", "token": "your-secret"
```

`/health` is unauthenticated (discovery, no chat content); every other route requires `Authorization: Bearer …` (or `?token=` on the SSE stream) when a token is configured.

## Companion app — `apps/companion/` (Flutter, vanilla Dart)

- **Two connection modes:** desktop launches/attaches a local daemon (`Process.start` + `TALON_FRONTEND_OVERRIDE=desktop`); mobile connects to a remote bridge.
- **ChatGPT-style UI:** time-grouped, searchable chat-history sidebar + a centered conversation column with avatar message rows; modern dark, glassy theme.
- **Live streaming** with reasoning + tool-call cards, full Markdown (code/tables/lists/links).
- **Per-chat:** model, reasoning effort, pulse toggle, session reset, rename, delete.
- **Settings sync:** read & change default model, display name, timezone, pulse/heartbeat/dream; live daemon status (uptime/sessions/memory) + restart.

## Testing

- `src/__tests__/desktop-frontend.test.ts` — protocol mappers, chat registry, action handler, settings snapshot/allowlist (11 tests).
- `apps/companion/test/bridge_models_test.dart` — wire parsing + connection config.
- Full suite green: **3567 passed**, typecheck / lint / format / tarball all clean.

## Running the app

The per-OS runner folders are generated, not committed:

```bash
cd apps/companion
flutter create --platforms=windows,macos,linux,android .   # one-time scaffold
flutter pub get
flutter run -d windows      # or macos / linux / <android-device>
```

## Notes

- `apps/` is outside the npm package `files[]`, so the tarball is unchanged (verified by `tarball:check`).
- Flutter SDK isn't available in CI here, so the Dart app was reviewed by hand (imports resolve, APIs match the documented package versions); `flutter analyze`/`flutter test` should be run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
