### PR TITLE
feat(companion): minimal, modern UI polish with flutter_animate

### DIFF
--- a/apps/companion/lib/src/models/bridge_models.dart
+++ b/apps/companion/lib/src/models/bridge_models.dart
@@ -72,6 +72,13 @@ class ClientMessage {
   /// True while assistant text is still streaming into this bubble (client-only).
   bool streaming;
 
+  /// Turn metadata attached when the turn ends (client-only): wall-clock
+  /// duration and token usage, surfaced as a quiet footer under the reply.
+  /// Null until the matching `turn_end` lands (and always null for user rows).
+  int? durationMs;
+  int? tokensIn;
+  int? tokensOut;
+
   ClientMessage({
     required this.id,
     required this.chatId,
@@ -83,8 +90,17 @@ class ClientMessage {
     this.imagePath,
     List<ToolActivity>? tools,
     this.streaming = false,
+    this.durationMs,
+    this.tokensIn,
+    this.tokensOut,
   })  : reactions = reactions ?? <String>[],
         tools = tools ?? <ToolActivity>[];
+
+  /// Whether this row has any turn stats worth showing.
+  bool get hasStats =>
+      (durationMs != null && durationMs! > 0) ||
+      (tokensIn != null && tokensIn! > 0) ||
+      (tokensOut != null && tokensOut! > 0);
 
   factory ClientMessage.fromJson(Map<String, dynamic> j) {
     final rawButtons = _list(j['buttons']);

--- a/apps/companion/lib/src/state/app_state.dart
+++ b/apps/companion/lib/src/state/app_state.dart
@@ -443,7 +443,11 @@ class AppState extends ChangeNotifier {
         final t = turnFor(chatId);
         // Guarantee all tools in the most recent assistant message are done.
         // Tool result events can race against the message snapshot — this is
-        // the definitive point where the turn is finished.
+        // the definitive point where the turn is finished. Also attach the
+        // turn's stats (duration + token usage) to that message so the bubble
+        // can show a quiet footer.
+        final usage = _map(e['usage']);
+        final durationMs = e['durationMs'];
         final msgs = _messages[chatId];
         if (msgs != null) {
           for (final msg in msgs.reversed) {
@@ -453,6 +457,13 @@ class AppState extends ChangeNotifier {
                   tool.done = true;
                   tool.finishedAt ??= DateTime.now();
                 }
+              }
+              if (durationMs is num) msg.durationMs = durationMs.toInt();
+              if (usage != null) {
+                final inTok = usage['input'];
+                final outTok = usage['output'];
+                if (inTok is num) msg.tokensIn = inTok.toInt();
+                if (outTok is num) msg.tokensOut = outTok.toInt();
               }
               break;
             }

--- a/apps/companion/lib/src/theme.dart
+++ b/apps/companion/lib/src/theme.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 
-/// The Talon visual language: a deep, near-black canvas under a soft indigo→cyan
-/// glow, frosted glass panels, and a single vivid accent. Tuned for the "modern
-/// dark, glassy" look — gradients, translucency, rounded geometry.
+/// The Talon visual language: a deep, near-black canvas with restrained, mostly
+/// monochrome surfaces and a single vivid accent used sparingly. The old build
+/// leaned on gradients + colored glows on nearly every control, which read as
+/// "consumer / flashy"; the design now favours calm, flat surfaces and lets
+/// motion (see [TalonMotion] + flutter_animate) carry the delight instead.
 class TalonColors {
   TalonColors._();
 
@@ -16,7 +18,8 @@ class TalonColors {
   static const Color glassFill = Color(0x14FFFFFF);
   static const Color glassStroke = Color(0x1FFFFFFF);
 
-  // Accent — electric indigo with a cyan partner for gradients/glow
+  // Accent — electric indigo with a cyan partner reserved for the gradient
+  // brand mark and the rare hero moment (never every button).
   static const Color accent = Color(0xFF7C8CFF);
   static const Color accent2 = Color(0xFF54E6FF);
   static const Color accentDeep = Color(0xFF5B6BF0);
@@ -50,6 +53,99 @@ class TalonColors {
   );
 }
 
+/// Spacing scale — an 8pt grid (with a 2/4 half-step for tight insets). Snap
+/// every padding/gap to one of these so the layout reads as a system rather
+/// than a pile of hand-tuned magic numbers.
+class TalonSpace {
+  TalonSpace._();
+
+  static const double xxs = 2;
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 12;
+  static const double lg = 16;
+  static const double xl = 24;
+  static const double xxl = 32;
+}
+
+/// Corner-radius tokens. Three steps + a full pill; everything rounds to one of
+/// these so panels, cards, and controls feel related.
+class TalonRadius {
+  TalonRadius._();
+
+  static const double sm = 8; // chips, small controls
+  static const double md = 14; // cards, inputs, buttons
+  static const double lg = 22; // panels, sheets
+  static const double pill = 999;
+
+  static const BorderRadius rSm = BorderRadius.all(Radius.circular(sm));
+  static const BorderRadius rMd = BorderRadius.all(Radius.circular(md));
+  static const BorderRadius rLg = BorderRadius.all(Radius.circular(lg));
+  static const BorderRadius rPill = BorderRadius.all(Radius.circular(pill));
+}
+
+/// Type scale. Named, deliberate sizes replace the scattered 15.5/14.5/13.5/…
+/// literals so the whole app can be re-tuned in one place and stays consistent.
+class TalonType {
+  TalonType._();
+
+  static const TextStyle display = TextStyle(
+    fontSize: 22,
+    height: 1.2,
+    fontWeight: FontWeight.w700,
+    color: TalonColors.text,
+  );
+
+  static const TextStyle title = TextStyle(
+    fontSize: 16,
+    height: 1.3,
+    fontWeight: FontWeight.w700,
+    color: TalonColors.text,
+  );
+
+  static const TextStyle subtitle = TextStyle(
+    fontSize: 14,
+    height: 1.3,
+    fontWeight: FontWeight.w600,
+    color: TalonColors.text,
+  );
+
+  static const TextStyle body = TextStyle(
+    fontSize: 14,
+    height: 1.5,
+    color: TalonColors.text,
+  );
+
+  static const TextStyle label = TextStyle(
+    fontSize: 13,
+    height: 1.3,
+    color: TalonColors.textDim,
+  );
+
+  static const TextStyle caption = TextStyle(
+    fontSize: 12,
+    height: 1.4,
+    color: TalonColors.textFaint,
+  );
+
+  /// All-caps section eyebrow (sidebar groups, settings section headers).
+  static const TextStyle eyebrow = TextStyle(
+    fontSize: 11,
+    height: 1.2,
+    fontWeight: FontWeight.w700,
+    letterSpacing: 1.1,
+    color: TalonColors.textFaint,
+  );
+
+  /// Monospace for tool names, code, tabular readouts.
+  static const TextStyle mono = TextStyle(
+    fontFamily: 'monospace',
+    fontSize: 13,
+    height: 1.4,
+    color: TalonColors.text,
+  );
+}
+
 /// Shared motion vocabulary so every surface animates with the same rhythm.
 /// Durations climb in a consistent scale; curves favour a soft, "emphasized"
 /// deceleration (fast out, gentle settle) that reads as calm rather than
@@ -65,6 +161,9 @@ class TalonMotion {
 
   /// Larger, more deliberate moves (expanding panels, first paint).
   static const Duration slow = Duration(milliseconds: 360);
+
+  /// Per-item offset for staggered list entrances (sidebar, model list).
+  static const Duration stagger = Duration(milliseconds: 45);
 
   /// Standard deceleration — fast to start, easing gently into place.
   static const Curve emphasized = Curves.easeOutCubic;
@@ -94,7 +193,7 @@ ThemeData buildTalonTheme() {
           fontFamily: _fontFamily,
         )
         .copyWith(
-          bodyMedium: const TextStyle(fontSize: 14.5, height: 1.5),
+          bodyMedium: TalonType.body,
           titleMedium: const TextStyle(fontWeight: FontWeight.w600),
         ),
     splashFactory: InkSparkle.splashFactory,
@@ -103,7 +202,7 @@ ThemeData buildTalonTheme() {
     tooltipTheme: const TooltipThemeData(
       decoration: BoxDecoration(
         color: TalonColors.surfaceHi,
-        borderRadius: BorderRadius.all(Radius.circular(8)),
+        borderRadius: TalonRadius.rSm,
       ),
       textStyle: TextStyle(color: TalonColors.text, fontSize: 12),
     ),

--- a/apps/companion/lib/src/ui/activity_card.dart
+++ b/apps/companion/lib/src/ui/activity_card.dart
@@ -1,16 +1,16 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
-import '../models/bridge_models.dart';
 import '../state/app_state.dart';
 import '../theme.dart';
 import 'brand.dart';
 import 'markdown.dart';
+import 'tool_timeline.dart';
 
 /// The in-progress turn, rendered in the assistant-row layout: the Talon
-/// avatar, the model's reasoning, live tool calls, and the streaming reply.
+/// avatar, the model's reasoning, the live tool timeline, and the streaming
+/// reply (with a blinking caret while text is still arriving).
 class LiveTurn extends StatelessWidget {
   final TurnState turn;
   final String botName;
@@ -19,7 +19,7 @@ class LiveTurn extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 10),
+      padding: const EdgeInsets.symmetric(vertical: TalonSpace.md),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -27,40 +27,26 @@ class LiveTurn extends StatelessWidget {
             padding: EdgeInsets.only(top: 2),
             child: BrandMark(size: 28),
           ),
-          const SizedBox(width: 14),
+          const SizedBox(width: TalonSpace.md),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  botName,
-                  style: const TextStyle(
-                      fontWeight: FontWeight.w700, fontSize: 13.5),
-                ),
+                Text(botName, style: TalonType.subtitle),
                 const SizedBox(height: 6),
                 if (turn.reasoning.isNotEmpty)
                   _ReasoningStrip(text: turn.reasoning.join('')),
-                AnimatedSize(
-                  duration: const Duration(milliseconds: 160),
-                  curve: Curves.easeOut,
-                  alignment: Alignment.topLeft,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      for (final t in turn.tools)
-                        ToolChip(key: ValueKey(t.id), tool: t),
-                    ],
+                if (turn.tools.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: TalonSpace.sm),
+                    child: ToolTimeline(tools: turn.tools),
                   ),
-                ),
                 AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 140),
-                  switchInCurve: Curves.easeOut,
+                  duration: TalonMotion.fast,
+                  switchInCurve: TalonMotion.emphasized,
                   switchOutCurve: Curves.easeIn,
                   child: turn.draft.isNotEmpty
-                      ? MarkdownBody(
-                          key: const ValueKey('draft'),
-                          data: turn.draft,
-                          styleSheet: talonMarkdownStyle())
+                      ? _StreamingText(text: turn.draft)
                       : turn.typing
                           ? const Padding(
                               key: ValueKey('typing'),
@@ -78,214 +64,61 @@ class LiveTurn extends StatelessWidget {
   }
 }
 
-/// One row per tool call. Pulses while running, animates to a calm "done"
-/// state when finished, shows live elapsed time.
-class ToolChip extends StatefulWidget {
-  final ToolActivity tool;
-  const ToolChip({super.key, required this.tool});
-
-  @override
-  State<ToolChip> createState() => _ToolChipState();
-}
-
-class _ToolChipState extends State<ToolChip>
-    with SingleTickerProviderStateMixin {
-  late final AnimationController _pulse = AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 1400),
-  )..repeat(reverse: true);
-  Timer? _ticker;
-
-  @override
-  void initState() {
-    super.initState();
-    _ticker = Timer.periodic(const Duration(milliseconds: 100), (_) {
-      if (!mounted) return;
-      if (!widget.tool.done) setState(() {});
-    });
-  }
-
-  @override
-  void didUpdateWidget(covariant ToolChip old) {
-    super.didUpdateWidget(old);
-    if (widget.tool.done && _pulse.isAnimating) _pulse.stop();
-  }
-
-  @override
-  void dispose() {
-    _ticker?.cancel();
-    _pulse.dispose();
-    super.dispose();
-  }
+/// The streaming draft with a blinking caret pinned to its end — the expected
+/// "still generating" signal. The caret sits inline after the markdown so it
+/// tracks the last line of text.
+class _StreamingText extends StatelessWidget {
+  final String text;
+  const _StreamingText({required this.text});
 
   @override
   Widget build(BuildContext context) {
-    final tool = widget.tool;
-    final failed = tool.error != null;
-    final color = failed
-        ? TalonColors.bad
-        : (tool.done ? TalonColors.ok : TalonColors.accent2);
-    final running = !tool.done && !failed;
-
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
-      child: AnimatedBuilder(
-        animation: _pulse,
-        builder: (context, child) {
-          final glow = running
-              ? 0.18 + 0.18 * _pulse.value
-              : 0.0;
-          return Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
-            decoration: BoxDecoration(
-              color: TalonColors.glassFill,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: color.withValues(alpha: running ? 0.55 : 0.30),
-              ),
-              boxShadow: running
-                  ? [
-                      BoxShadow(
-                        color: color.withValues(alpha: glow),
-                        blurRadius: 14,
-                        spreadRadius: 0.5,
-                      ),
-                    ]
-                  : null,
-            ),
-            child: child,
-          );
-        },
-        // The name + arg share the flexible middle and ellipsize when long,
-        // so the elapsed-time readout on the right is pinned and never clips.
-        child: Row(
-          children: [
-            SizedBox(
-              width: 14,
-              height: 14,
-              child: AnimatedSwitcher(
-                duration: const Duration(milliseconds: 220),
-                transitionBuilder: (c, a) =>
-                    ScaleTransition(scale: a, child: FadeTransition(opacity: a, child: c)),
-                child: running
-                    ? CircularProgressIndicator(
-                        key: const ValueKey('run'),
-                        strokeWidth: 2,
-                        valueColor: AlwaysStoppedAnimation(color),
-                      )
-                    : Icon(
-                        failed ? Icons.error_outline : Icons.check_circle,
-                        key: ValueKey(failed ? 'err' : 'ok'),
-                        size: 14,
-                        color: color,
-                      ),
-              ),
-            ),
-            const SizedBox(width: 9),
-            Expanded(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Flexible(
-                    child: Text(
-                      _displayName(tool.name),
-                      maxLines: 1,
-                      softWrap: false,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        color: TalonColors.text,
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                        fontFamily: 'monospace',
-                      ),
-                    ),
-                  ),
-                  if (_arg(tool) != null) ...[
-                    const SizedBox(width: 8),
-                    Flexible(
-                      child: Text(
-                        _arg(tool)!,
-                        maxLines: 1,
-                        softWrap: false,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          color: TalonColors.textFaint,
-                          fontSize: 12,
-                          fontFamily: 'monospace',
-                        ),
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-            const SizedBox(width: 10),
-            Text(
-              _fmt(tool.elapsed),
-              maxLines: 1,
-              softWrap: false,
-              style: const TextStyle(
-                color: TalonColors.textFaint,
-                fontSize: 11.5,
-                fontFeatures: [FontFeature.tabularFigures()],
-              ),
-            ),
-          ],
-        ),
+    final caret = Container(
+      width: 8,
+      height: 15,
+      margin: const EdgeInsets.only(left: 3, bottom: 1),
+      decoration: BoxDecoration(
+        color: TalonColors.accent2,
+        borderRadius: BorderRadius.circular(2),
       ),
     );
-  }
-
-  /// De-noise MCP tool names for display:
-  /// `mcp__email-tools__search_emails` → `email · search_emails`.
-  /// Non-MCP names (e.g. `Bash`, `Read`) are shown as-is.
-  String _displayName(String raw) {
-    if (!raw.startsWith('mcp__')) return raw;
-    final parts = raw.substring(5).split('__');
-    if (parts.length < 2) return raw;
-    var server = parts.first;
-    if (server.endsWith('-tools')) {
-      server = server.substring(0, server.length - '-tools'.length);
-    }
-    final tool = parts.sublist(1).join('__');
-    return '$server · $tool';
-  }
-
-  String? _arg(ToolActivity t) {
-    if (t.input.isEmpty) return null;
-    for (final key in const ['query', 'url', 'path', 'text', 'name', 'command']) {
-      final v = t.input[key];
-      if (v is String && v.isNotEmpty) {
-        return v.length > 64 ? '${v.substring(0, 63)}…' : v;
-      }
-    }
-    return null;
-  }
-
-  String _fmt(Duration d) {
-    final ms = d.inMilliseconds;
-    if (ms < 1000) return '${ms}ms';
-    final s = ms / 1000;
-    if (s < 10) return '${s.toStringAsFixed(1)}s';
-    if (s < 60) return '${s.toStringAsFixed(0)}s';
-    final m = (s / 60).floor();
-    return '${m}m${(s - m * 60).toStringAsFixed(0)}s';
+    return Row(
+      key: const ValueKey('draft'),
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Flexible(
+          child: MarkdownBody(
+            data: text,
+            styleSheet: talonMarkdownStyle(),
+          ),
+        ),
+        if (MediaQuery.of(context).disableAnimations)
+          caret
+        else
+          caret
+              .animate(onPlay: (c) => c.repeat(reverse: true))
+              .fadeOut(duration: 650.ms, curve: Curves.easeInOut),
+      ],
+    );
   }
 }
 
+/// The model's live reasoning, in a quiet accent-edged strip. Fades/blurs in
+/// so it doesn't pop when the model starts thinking.
 class _ReasoningStrip extends StatelessWidget {
   final String text;
   const _ReasoningStrip({required this.text});
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
+    final strip = Padding(
+      padding: const EdgeInsets.only(bottom: TalonSpace.sm),
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(12),
-          border: const Border(
+        padding:
+            const EdgeInsets.symmetric(horizontal: TalonSpace.md, vertical: 9),
+        decoration: const BoxDecoration(
+          borderRadius: TalonRadius.rMd,
+          border: Border(
             left: BorderSide(color: TalonColors.accent, width: 2.5),
           ),
           color: TalonColors.glassFill,
@@ -295,11 +128,11 @@ class _ReasoningStrip extends StatelessWidget {
           children: [
             const Icon(Icons.bubble_chart_outlined,
                 size: 15, color: TalonColors.textFaint),
-            const SizedBox(width: 8),
+            const SizedBox(width: TalonSpace.sm),
             Expanded(
               child: AnimatedSize(
-                duration: const Duration(milliseconds: 180),
-                curve: Curves.easeOut,
+                duration: TalonMotion.base,
+                curve: TalonMotion.emphasized,
                 alignment: Alignment.topLeft,
                 child: Text(
                   text.trim(),
@@ -318,54 +151,45 @@ class _ReasoningStrip extends StatelessWidget {
         ),
       ),
     );
+    if (MediaQuery.of(context).disableAnimations) return strip;
+    return strip.animate().fadeIn(duration: TalonMotion.base).blurX(
+          begin: 3,
+          end: 0,
+          duration: TalonMotion.base,
+          curve: TalonMotion.emphasized,
+        );
   }
 }
 
-class _TypingDots extends StatefulWidget {
+/// Three dots that ripple while the model is thinking but hasn't produced text
+/// yet. A staggered fade/scale loop via flutter_animate — no manual controller.
+class _TypingDots extends StatelessWidget {
   const _TypingDots();
 
   @override
-  State<_TypingDots> createState() => _TypingDotsState();
-}
-
-class _TypingDotsState extends State<_TypingDots>
-    with SingleTickerProviderStateMixin {
-  late final AnimationController _c =
-      AnimationController(vsync: this, duration: const Duration(milliseconds: 1100))
-        ..repeat();
-
-  @override
-  void dispose() {
-    _c.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    Widget dot(int i) {
+      final base = Container(
+        width: 7,
+        height: 7,
+        margin: const EdgeInsets.symmetric(horizontal: 3),
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          color: TalonColors.textDim,
+        ),
+      );
+      if (MediaQuery.of(context).disableAnimations) return base;
+      return base
+          .animate(onPlay: (c) => c.repeat(reverse: true))
+          .fadeIn(delay: (i * 160).ms, duration: 500.ms, begin: 0.3)
+          .scaleXY(begin: 0.7, end: 1, curve: Curves.easeOut);
+    }
+
     return SizedBox(
       height: 20,
-      child: AnimatedBuilder(
-        animation: _c,
-        builder: (context, _) {
-          return Row(
-            mainAxisSize: MainAxisSize.min,
-            children: List.generate(3, (i) {
-              final phase = (_c.value + i * 0.2) % 1.0;
-              final o = 0.3 + 0.7 * (0.5 - (phase - 0.5).abs()) * 2;
-              return Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 3),
-                child: Container(
-                  width: 7,
-                  height: 7,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: TalonColors.textDim.withValues(alpha: o.clamp(0, 1)),
-                  ),
-                ),
-              );
-            }),
-          );
-        },
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [dot(0), dot(1), dot(2)],
       ),
     );
   }

--- a/apps/companion/lib/src/ui/brand.dart
+++ b/apps/companion/lib/src/ui/brand.dart
@@ -18,9 +18,9 @@ class BrandMark extends StatelessWidget {
         gradient: TalonColors.accentGradient,
         boxShadow: [
           BoxShadow(
-            color: TalonColors.accent.withValues(alpha: 0.45),
-            blurRadius: size * 0.5,
-            offset: Offset(0, size * 0.14),
+            color: TalonColors.accent.withValues(alpha: 0.22),
+            blurRadius: size * 0.28,
+            offset: Offset(0, size * 0.1),
           ),
         ],
       ),

--- a/apps/companion/lib/src/ui/chat_view.dart
+++ b/apps/companion/lib/src/ui/chat_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 
 import '../models/bridge_models.dart';
 import '../state/app_state.dart';
@@ -133,7 +134,13 @@ class _ChatViewState extends State<ChatView> {
             turn.tools.isNotEmpty ||
             turn.typing);
 
-    if (msgs.isEmpty && !showActivity) return const _ConversationEmpty();
+    if (msgs.isEmpty && !showActivity) {
+      return _ConversationEmpty(
+        onPrompt: widget.state.conn == ConnState.connected
+            ? (p) => widget.state.sendMessage(p)
+            : null,
+      );
+    }
 
     final itemCount = msgs.length + (showActivity ? 1 : 0);
     return Align(
@@ -389,16 +396,22 @@ class _EmptyState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+    const mark = BrandMark(size: 64);
+    return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          BrandMark(size: 64),
-          SizedBox(height: 18),
-          Text('Talon',
-              style: TextStyle(fontSize: 22, fontWeight: FontWeight.w700)),
-          SizedBox(height: 6),
-          Text('Select a chat, or start a new one.',
+          reduceMotion
+              ? mark
+              : mark
+                  .animate()
+                  .fadeIn(duration: TalonMotion.slow)
+                  .scaleXY(begin: 0.85, end: 1, curve: TalonMotion.emphasized),
+          const SizedBox(height: TalonSpace.lg),
+          const Text('Talon', style: TalonType.display),
+          const SizedBox(height: 6),
+          const Text('Select a chat, or start a new one.',
               style: TextStyle(color: TalonColors.textFaint)),
         ],
       ),
@@ -406,35 +419,130 @@ class _EmptyState extends StatelessWidget {
   }
 }
 
+/// Suggested prompts shown in a fresh conversation, à la ChatGPT/Claude — a few
+/// tappable starters so an empty chat feels intentional rather than blank.
+const List<({IconData icon, String label, String prompt})> _starters = [
+  (
+    icon: Icons.summarize_outlined,
+    label: 'Summarize my day',
+    prompt: 'Summarize what happened today and what needs my attention.',
+  ),
+  (
+    icon: Icons.checklist_rounded,
+    label: 'Plan a task',
+    prompt: 'Help me break down a task into clear, actionable steps.',
+  ),
+  (
+    icon: Icons.lightbulb_outline,
+    label: 'Brainstorm ideas',
+    prompt: 'Brainstorm a few creative ideas with me.',
+  ),
+];
+
 class _ConversationEmpty extends StatelessWidget {
-  const _ConversationEmpty();
+  /// Sends a suggested prompt; null while disconnected (chips disabled).
+  final void Function(String prompt)? onPrompt;
+  const _ConversationEmpty({required this.onPrompt});
 
   @override
   Widget build(BuildContext context) {
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+    final header = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const BrandMark(size: 52),
+        const SizedBox(height: TalonSpace.lg),
+        Text(
+          'How can I help?',
+          style: TalonType.title.copyWith(fontSize: 19),
+        ),
+        const SizedBox(height: 6),
+        const Text('Send a message to begin.',
+            style: TextStyle(color: TalonColors.textFaint)),
+      ],
+    );
+
     return Center(
       child: Padding(
-        padding: const EdgeInsets.all(28),
+        padding: const EdgeInsets.all(TalonSpace.xl),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const BrandMark(size: 52),
-            const SizedBox(height: 18),
-            Text(
-              'How can I help?',
-              style: TextStyle(
-                fontSize: 19,
-                fontWeight: FontWeight.w600,
-                color: TalonColors.text.withValues(alpha: 0.92),
-              ),
-            ),
-            const SizedBox(height: 6),
-            const Text(
-              'Send a message to begin.',
-              style: TextStyle(color: TalonColors.textFaint),
+            reduceMotion
+                ? header
+                : header
+                    .animate()
+                    .fadeIn(duration: TalonMotion.slow)
+                    .slideY(begin: 0.1, end: 0, curve: TalonMotion.emphasized),
+            const SizedBox(height: TalonSpace.xl),
+            Wrap(
+              alignment: WrapAlignment.center,
+              spacing: TalonSpace.sm,
+              runSpacing: TalonSpace.sm,
+              children: [
+                for (var i = 0; i < _starters.length; i++)
+                  _StarterChip(
+                    starter: _starters[i],
+                    index: i,
+                    reduceMotion: reduceMotion,
+                    onTap: onPrompt == null
+                        ? null
+                        : () => onPrompt!(_starters[i].prompt),
+                  ),
+              ],
             ),
           ],
         ),
       ),
     );
+  }
+}
+
+class _StarterChip extends StatelessWidget {
+  final ({IconData icon, String label, String prompt}) starter;
+  final int index;
+  final bool reduceMotion;
+  final VoidCallback? onTap;
+
+  const _StarterChip({
+    required this.starter,
+    required this.index,
+    required this.reduceMotion,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final chip = Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: TalonRadius.rMd,
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+              horizontal: TalonSpace.md, vertical: TalonSpace.sm),
+          decoration: BoxDecoration(
+            color: TalonColors.glassFill,
+            borderRadius: TalonRadius.rMd,
+            border: Border.all(color: TalonColors.glassStroke),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(starter.icon, size: 15, color: TalonColors.accent),
+              const SizedBox(width: 7),
+              Text(starter.label, style: TalonType.label),
+            ],
+          ),
+        ),
+      ),
+    );
+    if (reduceMotion) return chip;
+    final delay = (120 + index * 70).ms;
+    return chip
+        .animate()
+        .fadeIn(delay: delay, duration: TalonMotion.base)
+        .slideY(
+            begin: 0.3, end: 0, delay: delay, curve: TalonMotion.emphasized);
   }
 }

--- a/apps/companion/lib/src/ui/composer.dart
+++ b/apps/companion/lib/src/ui/composer.dart
@@ -304,19 +304,8 @@ class _SendButtonState extends State<_SendButton> {
           width: 40,
           height: 40,
           decoration: BoxDecoration(
-            gradient: colored ? TalonColors.accentGradient : null,
-            color: colored ? null : TalonColors.surfaceHi,
+            color: colored ? TalonColors.accent : TalonColors.surfaceHi,
             borderRadius: BorderRadius.circular(13),
-            boxShadow: colored
-                ? [
-                    BoxShadow(
-                      color: TalonColors.accent.withValues(alpha: 0.35),
-                      blurRadius: 14,
-                      spreadRadius: -2,
-                      offset: const Offset(0, 3),
-                    ),
-                  ]
-                : null,
           ),
           child: busy
               ? const Padding(

--- a/apps/companion/lib/src/ui/connect_screen.dart
+++ b/apps/companion/lib/src/ui/connect_screen.dart
@@ -341,16 +341,9 @@ class _ConnectButton extends StatelessWidget {
       borderRadius: BorderRadius.circular(14),
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 14),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(14),
+        decoration: const BoxDecoration(
+          borderRadius: TalonRadius.rMd,
           gradient: TalonColors.accentGradient,
-          boxShadow: [
-            BoxShadow(
-              color: TalonColors.accent.withValues(alpha: 0.4),
-              blurRadius: 20,
-              offset: const Offset(0, 8),
-            ),
-          ],
         ),
         child: const Row(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/apps/companion/lib/src/ui/glass.dart
+++ b/apps/companion/lib/src/ui/glass.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 
 import '../theme.dart';
 
@@ -51,28 +52,52 @@ class Glass extends StatelessWidget {
   }
 }
 
-/// A soft radial glow used behind the backdrop to give the dark canvas depth.
+/// A whisper of radial colour behind the backdrop, giving the near-black canvas
+/// depth without tinting the whole surface. The two blobs drift on a slow,
+/// offset loop so the background feels alive rather than static — the effect is
+/// deliberately barely-perceptible, and it holds still under reduce-motion.
 class AmbientGlow extends StatelessWidget {
   const AmbientGlow({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
     return IgnorePointer(
       child: Stack(
         children: [
           Positioned(
-            top: -160,
-            left: -120,
-            child: _blob(TalonColors.accent.withValues(alpha: 0.20), 420),
+            top: -180,
+            left: -140,
+            child: _drift(
+              _blob(TalonColors.accent.withValues(alpha: 0.10), 440),
+              reduceMotion,
+              const Offset(24, 18),
+              18000,
+            ),
           ),
           Positioned(
-            bottom: -180,
-            right: -120,
-            child: _blob(TalonColors.accent2.withValues(alpha: 0.12), 460),
+            bottom: -200,
+            right: -140,
+            child: _drift(
+              _blob(TalonColors.accent2.withValues(alpha: 0.07), 480),
+              reduceMotion,
+              const Offset(-20, -22),
+              24000,
+            ),
           ),
         ],
       ),
     );
+  }
+
+  Widget _drift(Widget child, bool reduceMotion, Offset to, int ms) {
+    if (reduceMotion) return child;
+    return child.animate(onPlay: (c) => c.repeat(reverse: true)).move(
+          begin: Offset.zero,
+          end: to,
+          duration: ms.ms,
+          curve: Curves.easeInOut,
+        );
   }
 
   Widget _blob(Color color, double size) => Container(

--- a/apps/companion/lib/src/ui/message_bubble.dart
+++ b/apps/companion/lib/src/ui/message_bubble.dart
@@ -5,9 +5,10 @@ import 'package:url_launcher/url_launcher.dart' show launchUrl, LaunchMode;
 
 import '../models/bridge_models.dart';
 import '../theme.dart';
-import 'activity_card.dart';
 import 'brand.dart';
 import 'markdown.dart';
+import 'motion.dart';
+import 'tool_timeline.dart';
 
 /// A single conversation row, ChatGPT-style:
 ///   - user: a compact rounded bubble aligned right
@@ -44,39 +45,42 @@ class MessageBubble extends StatelessWidget {
       case Role.assistant:
         row = _assistantRow();
     }
-    // Respect the platform "reduce motion" setting.
-    if (!animateIn || MediaQuery.of(context).disableAnimations) return row;
-    return _MessageEntrance(
-      // A user message rises from its side; the assistant fades in place.
-      fromRight: message.role == Role.user,
+    // A user message rises from its side; the assistant fades in place with a
+    // whisper of upward drift so it settles rather than snaps. EntranceFx
+    // latches the play decision at mount so the frequent streaming rebuilds
+    // (which flip `animateIn` back to false) can't tear the entrance down
+    // mid-flight. Reduce-motion is honoured inside EntranceFx via `enabled`.
+    final fromRight = message.role == Role.user;
+    return EntranceFx(
+      enabled: animateIn && !reduceMotion(context),
+      from: Offset(fromRight ? 0.04 : -0.01, 0.12),
       child: row,
     );
   }
 
   Widget _system() => Padding(
-        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 12),
+        padding: const EdgeInsets.symmetric(
+            vertical: TalonSpace.sm, horizontal: TalonSpace.md),
         child: Center(
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            padding: const EdgeInsets.symmetric(
+                horizontal: TalonSpace.md, vertical: 6),
             decoration: BoxDecoration(
               color: TalonColors.glassFill,
-              borderRadius: BorderRadius.circular(999),
+              borderRadius: TalonRadius.rPill,
               border: Border.all(color: TalonColors.glassStroke),
             ),
             child: Text(
               message.text,
               textAlign: TextAlign.center,
-              style: const TextStyle(
-                color: TalonColors.textFaint,
-                fontSize: 12,
-              ),
+              style: TalonType.caption,
             ),
           ),
         ),
       );
 
   Widget _userRow() => Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8),
+        padding: const EdgeInsets.symmetric(vertical: TalonSpace.sm),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -86,8 +90,8 @@ class MessageBubble extends StatelessWidget {
               child: Align(
                 alignment: Alignment.centerRight,
                 child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 11),
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: TalonSpace.lg, vertical: 11),
                   decoration: BoxDecoration(
                     color: TalonColors.surfaceHi,
                     borderRadius: const BorderRadius.only(
@@ -100,11 +104,7 @@ class MessageBubble extends StatelessWidget {
                   ),
                   child: SelectableText(
                     message.text,
-                    style: const TextStyle(
-                      color: TalonColors.text,
-                      fontSize: 14.5,
-                      height: 1.5,
-                    ),
+                    style: TalonType.body,
                   ),
                 ),
               ),
@@ -114,7 +114,7 @@ class MessageBubble extends StatelessWidget {
       );
 
   Widget _assistantRow() => Padding(
-        padding: const EdgeInsets.symmetric(vertical: 10),
+        padding: const EdgeInsets.symmetric(vertical: TalonSpace.md),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -122,28 +122,22 @@ class MessageBubble extends StatelessWidget {
               padding: EdgeInsets.only(top: 2),
               child: BrandMark(size: 28),
             ),
-            const SizedBox(width: 14),
+            const SizedBox(width: TalonSpace.md),
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    botName,
-                    style: const TextStyle(
-                      fontWeight: FontWeight.w700,
-                      fontSize: 13.5,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
+                  Text(botName, style: TalonType.subtitle),
+                  const SizedBox(height: TalonSpace.xs),
                   if (message.tools.isNotEmpty)
                     Padding(
-                      padding: const EdgeInsets.only(bottom: 8),
-                      child: _ToolHistory(tools: message.tools),
+                      padding: const EdgeInsets.only(bottom: TalonSpace.sm),
+                      child: ToolTrace(tools: message.tools),
                     ),
                   if (imageUrl != null)
                     Padding(
-                      padding:
-                          EdgeInsets.only(bottom: message.text.isEmpty ? 0 : 8),
+                      padding: EdgeInsets.only(
+                          bottom: message.text.isEmpty ? 0 : TalonSpace.sm),
                       child: _InlineImage(url: imageUrl!),
                     ),
                   // Suppress the "…" placeholder for an image-only message.
@@ -161,7 +155,7 @@ class MessageBubble extends StatelessWidget {
                     ),
                   if (message.buttons.isNotEmpty) _buttons(),
                   if (message.reactions.isNotEmpty) _reactions(),
-                  _actions(),
+                  _MessageActions(message: message),
                 ],
               ),
             ),
@@ -169,16 +163,11 @@ class MessageBubble extends StatelessWidget {
         ),
       );
 
-  Widget _actions() => Padding(
-        padding: const EdgeInsets.only(top: 6),
-        child: _CopyButton(text: message.text),
-      );
-
   Widget _buttons() => Padding(
-        padding: const EdgeInsets.only(top: 10),
+        padding: const EdgeInsets.only(top: TalonSpace.sm),
         child: Wrap(
-          spacing: 8,
-          runSpacing: 8,
+          spacing: TalonSpace.sm,
+          runSpacing: TalonSpace.sm,
           children: [
             for (final row in message.buttons)
               for (final b in row)
@@ -191,8 +180,8 @@ class MessageBubble extends StatelessWidget {
                     foregroundColor: TalonColors.accent,
                     side: BorderSide(
                         color: TalonColors.accent.withValues(alpha: 0.5)),
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10)),
+                    shape: const RoundedRectangleBorder(
+                        borderRadius: TalonRadius.rSm),
                   ),
                   child: Text(b.text),
                 ),
@@ -201,16 +190,17 @@ class MessageBubble extends StatelessWidget {
       );
 
   Widget _reactions() => Padding(
-        padding: const EdgeInsets.only(top: 8),
+        padding: const EdgeInsets.only(top: TalonSpace.sm),
         child: Wrap(
-          spacing: 4,
+          spacing: TalonSpace.xs,
           children: [
             for (final r in message.reactions)
               Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                padding: const EdgeInsets.symmetric(
+                    horizontal: TalonSpace.sm, vertical: 3),
                 decoration: BoxDecoration(
                   color: TalonColors.glassFill,
-                  borderRadius: BorderRadius.circular(999),
+                  borderRadius: TalonRadius.rPill,
                   border: Border.all(color: TalonColors.glassStroke),
                 ),
                 child: Text(r, style: const TextStyle(fontSize: 13)),
@@ -218,62 +208,6 @@ class MessageBubble extends StatelessWidget {
           ],
         ),
       );
-}
-
-/// One-shot entrance for a freshly-arrived message row: a gentle rise + fade,
-/// with a whisper of scale so it settles rather than snaps. Plays exactly once
-/// (on first mount); recycled rows never wrap this, so scrolling stays still.
-class _MessageEntrance extends StatefulWidget {
-  final Widget child;
-  final bool fromRight;
-  const _MessageEntrance({required this.child, required this.fromRight});
-
-  @override
-  State<_MessageEntrance> createState() => _MessageEntranceState();
-}
-
-class _MessageEntranceState extends State<_MessageEntrance>
-    with SingleTickerProviderStateMixin {
-  late final AnimationController _c = AnimationController(
-    vsync: this,
-    duration: TalonMotion.base,
-  )..forward();
-
-  late final Animation<double> _eased = CurvedAnimation(
-    parent: _c,
-    curve: TalonMotion.emphasized,
-  );
-
-  @override
-  void dispose() {
-    _c.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final dx = widget.fromRight ? 0.06 : -0.02;
-    return FadeTransition(
-      opacity: _eased,
-      child: AnimatedBuilder(
-        animation: _eased,
-        builder: (context, child) {
-          final t = _eased.value;
-          return Transform.translate(
-            offset: Offset(dx * 40 * (1 - t), 10 * (1 - t)),
-            child: Transform.scale(
-              scale: 0.985 + 0.015 * t,
-              alignment: widget.fromRight
-                  ? Alignment.centerRight
-                  : Alignment.centerLeft,
-              child: child,
-            ),
-          );
-        },
-        child: widget.child,
-      ),
-    );
-  }
 }
 
 /// An inline attached image: rounded, width-capped, tap to open full-screen,
@@ -288,7 +222,7 @@ class _InlineImage extends StatelessWidget {
     return GestureDetector(
       onTap: () => _openFull(context),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(14),
+        borderRadius: TalonRadius.rMd,
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 320, maxHeight: 320),
           child: Image.network(
@@ -318,7 +252,7 @@ class _InlineImage extends StatelessWidget {
                 children: [
                   Icon(Icons.broken_image_outlined,
                       size: 18, color: TalonColors.textFaint),
-                  SizedBox(width: 8),
+                  SizedBox(width: TalonSpace.sm),
                   Text('Image unavailable',
                       style: TextStyle(
                           color: TalonColors.textFaint, fontSize: 12.5)),
@@ -348,7 +282,7 @@ class _InlineImage extends StatelessWidget {
               ),
               Positioned(
                 top: 40,
-                right: 16,
+                right: TalonSpace.lg,
                 child: IconButton(
                   onPressed: () => Navigator.of(context).pop(),
                   icon: const Icon(Icons.close, color: Colors.white),
@@ -362,142 +296,86 @@ class _InlineImage extends StatelessWidget {
   }
 }
 
-/// Collapsed summary of the tools the model ran for an assistant message.
-/// Tap to expand and see the chip for each call.
-class _ToolHistory extends StatefulWidget {
-  final List<ToolActivity> tools;
-  const _ToolHistory({required this.tools});
+/// The assistant row's footer: a Copy button plus a quiet stats readout
+/// (duration + token usage) once the turn has ended.
+class _MessageActions extends StatefulWidget {
+  final ClientMessage message;
+  const _MessageActions({required this.message});
 
   @override
-  State<_ToolHistory> createState() => _ToolHistoryState();
+  State<_MessageActions> createState() => _MessageActionsState();
 }
 
-class _ToolHistoryState extends State<_ToolHistory> {
-  bool _open = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final tools = widget.tools;
-    final failed = tools.where((t) => t.error != null).length;
-    final total = Duration(
-      milliseconds: tools.fold<int>(0, (a, t) => a + t.elapsed.inMilliseconds),
-    );
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        InkWell(
-          onTap: () => setState(() => _open = !_open),
-          borderRadius: BorderRadius.circular(10),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                AnimatedRotation(
-                  duration: const Duration(milliseconds: 160),
-                  turns: _open ? 0.25 : 0,
-                  child: const Icon(
-                    Icons.chevron_right,
-                    size: 16,
-                    color: TalonColors.textFaint,
-                  ),
-                ),
-                const SizedBox(width: 4),
-                Icon(
-                  failed > 0 ? Icons.error_outline : Icons.handyman_outlined,
-                  size: 13,
-                  color: failed > 0 ? TalonColors.bad : TalonColors.textFaint,
-                ),
-                const SizedBox(width: 6),
-                Text(
-                  _summary(tools.length, failed, total),
-                  style: const TextStyle(
-                    color: TalonColors.textFaint,
-                    fontSize: 12,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-        AnimatedSize(
-          duration: const Duration(milliseconds: 180),
-          curve: Curves.easeOut,
-          alignment: Alignment.topLeft,
-          child: _open
-              ? Padding(
-                  padding: const EdgeInsets.only(top: 6),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      for (final t in tools)
-                        ToolChip(key: ValueKey(t.id), tool: t),
-                    ],
-                  ),
-                )
-              : const SizedBox(width: double.infinity),
-        ),
-      ],
-    );
-  }
-
-  String _summary(int n, int failed, Duration total) {
-    final base = '$n ${n == 1 ? 'tool' : 'tools'} · ${_fmt(total)}';
-    if (failed == 0) return base;
-    return '$base · $failed failed';
-  }
-
-  String _fmt(Duration d) {
-    final ms = d.inMilliseconds;
-    if (ms < 1000) return '${ms}ms';
-    final s = ms / 1000;
-    if (s < 10) return '${s.toStringAsFixed(1)}s';
-    if (s < 60) return '${s.toStringAsFixed(0)}s';
-    final m = (s / 60).floor();
-    return '${m}m${(s - m * 60).toStringAsFixed(0)}s';
-  }
-}
-
-class _CopyButton extends StatefulWidget {
-  final String text;
-  const _CopyButton({required this.text});
-
-  @override
-  State<_CopyButton> createState() => _CopyButtonState();
-}
-
-class _CopyButtonState extends State<_CopyButton> {
+class _MessageActionsState extends State<_MessageActions> {
   bool _copied = false;
 
+  Future<void> _copy() async {
+    await Clipboard.setData(ClipboardData(text: widget.message.text));
+    if (!mounted) return;
+    setState(() => _copied = true);
+    Future.delayed(const Duration(milliseconds: 1400), () {
+      if (mounted) setState(() => _copied = false);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: () async {
-        await Clipboard.setData(ClipboardData(text: widget.text));
-        if (!mounted) return;
-        setState(() => _copied = true);
-        Future.delayed(const Duration(milliseconds: 1400), () {
-          if (mounted) setState(() => _copied = false);
-        });
-      },
-      borderRadius: BorderRadius.circular(8),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(_copied ? Icons.check : Icons.copy_rounded,
-                size: 14, color: TalonColors.textFaint),
-            const SizedBox(width: 5),
-            Text(
-              _copied ? 'Copied' : 'Copy',
-              style:
-                  const TextStyle(fontSize: 11.5, color: TalonColors.textFaint),
+    final m = widget.message;
+    if (m.text.isEmpty && !m.hasStats) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: Row(
+        children: [
+          if (m.text.isNotEmpty)
+            InkWell(
+              onTap: _copy,
+              borderRadius: TalonRadius.rSm,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(_copied ? Icons.check : Icons.copy_rounded,
+                        size: 14, color: TalonColors.textFaint),
+                    const SizedBox(width: 5),
+                    Text(
+                      _copied ? 'Copied' : 'Copy',
+                      style: const TextStyle(
+                          fontSize: 11.5, color: TalonColors.textFaint),
+                    ),
+                  ],
+                ),
+              ),
             ),
+          if (m.hasStats) ...[
+            const SizedBox(width: TalonSpace.sm),
+            Text(_stats(m), style: TalonType.caption.copyWith(fontSize: 11)),
           ],
-        ),
+        ],
       ),
     );
+  }
+
+  String _stats(ClientMessage m) {
+    final parts = <String>[];
+    if (m.tokensIn != null && m.tokensIn! > 0) {
+      parts.add('${_compact(m.tokensIn!)} in');
+    }
+    if (m.tokensOut != null && m.tokensOut! > 0) {
+      parts.add('${_compact(m.tokensOut!)} out');
+    }
+    if (m.durationMs != null && m.durationMs! > 0) {
+      // Reuse the same formatter the tool trace uses, so the duration here and
+      // in the ToolTrace summary on the same row read identically.
+      parts.add(fmtToolDuration(Duration(milliseconds: m.durationMs!)));
+    }
+    return parts.join(' · ');
+  }
+
+  static String _compact(int n) {
+    if (n < 1000) return '$n';
+    final k = n / 1000;
+    // Round first so 9950 → "10k", not "10.0k".
+    return k < 9.95 ? '${k.toStringAsFixed(1)}k' : '${k.round()}k';
   }
 }

--- a/apps/companion/lib/src/ui/model_sheet.dart
+++ b/apps/companion/lib/src/ui/model_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 
 import '../models/bridge_models.dart';
 import '../state/app_state.dart';
@@ -159,7 +160,7 @@ class _ModelSheetState extends State<_ModelSheet> {
                         itemBuilder: (context, i) {
                           final m = models[i];
                           final selected = m.id == activeModel;
-                          return _ModelRow(
+                          final row = _ModelRow(
                             model: m,
                             selected: selected,
                             onTap: () {
@@ -167,6 +168,20 @@ class _ModelSheetState extends State<_ModelSheet> {
                               Navigator.pop(context);
                             },
                           );
+                          if (MediaQuery.of(context).disableAnimations) {
+                            return row;
+                          }
+                          // Cascade the first screenful in; later rows (revealed
+                          // by scrolling) shouldn't wait on a growing delay.
+                          final delay = (i.clamp(0, 8) * 35).ms;
+                          return row
+                              .animate()
+                              .fadeIn(delay: delay, duration: TalonMotion.base)
+                              .slideY(
+                                  begin: 0.15,
+                                  end: 0,
+                                  delay: delay,
+                                  curve: TalonMotion.emphasized);
                         },
                       ),
               ),

--- a/apps/companion/lib/src/ui/motion.dart
+++ b/apps/companion/lib/src/ui/motion.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+
+import '../theme.dart';
+
+/// True when the platform asks us to minimise motion.
+bool reduceMotion(BuildContext context) =>
+    MediaQuery.of(context).disableAnimations;
+
+/// A one-shot entrance (fade + slide) that plays exactly once and then holds —
+/// crucially, it survives parent rebuilds that flip [enabled] back to false.
+///
+/// This matters because the chat list and sidebar rebuild on every streaming
+/// token (AppState is a ChangeNotifier). The freshness gates that decide
+/// whether a row is "new" (`_seen` sets) return true on first sight and false
+/// forever after — so a naive `enabled ? child.animate() : child` swaps the
+/// Animate widget for a plain one on the very next rebuild, tearing the
+/// entrance down a few frames in and making the row visibly snap into place.
+///
+/// [EntranceFx] captures the decision in [initState] and always returns the
+/// same subtree shape afterwards, so flutter_animate reuses the element and
+/// plays the entrance through to completion regardless of later rebuilds.
+class EntranceFx extends StatefulWidget {
+  /// Whether to animate. Read once, at mount; later changes are ignored.
+  final bool enabled;
+
+  /// Fractional (relative to the child's size) offset the child slides from.
+  final Offset from;
+  final Duration delay;
+  final Duration duration;
+  final Widget child;
+
+  const EntranceFx({
+    super.key,
+    required this.enabled,
+    required this.child,
+    this.from = const Offset(0, 0.12),
+    this.delay = Duration.zero,
+    this.duration = TalonMotion.base,
+  });
+
+  @override
+  State<EntranceFx> createState() => _EntranceFxState();
+}
+
+class _EntranceFxState extends State<EntranceFx> {
+  // Fixed at mount so a rebuild that flips widget.enabled can't restart or
+  // cancel the entrance mid-flight.
+  late final bool _play = widget.enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_play) return widget.child;
+    return widget.child
+        .animate()
+        .fadeIn(delay: widget.delay, duration: widget.duration)
+        .slide(
+          begin: widget.from,
+          end: Offset.zero,
+          delay: widget.delay,
+          duration: widget.duration,
+          curve: TalonMotion.emphasized,
+        );
+  }
+}

--- a/apps/companion/lib/src/ui/settings_screen.dart
+++ b/apps/companion/lib/src/ui/settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 
 import '../models/bridge_models.dart';
 import '../services/log.dart';
@@ -96,12 +97,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           padding: const EdgeInsets.all(20),
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 560),
-            child: _loading
-                ? const Padding(
-                    padding: EdgeInsets.all(40),
-                    child: CircularProgressIndicator(),
-                  )
-                : _body(),
+            child: _loading ? const _SettingsSkeleton() : _body(),
           ),
         ),
       ),
@@ -655,6 +651,58 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final h = m ~/ 60;
     if (h < 24) return '${h}h ${m % 60}m';
     return '${h ~/ 24}d ${h % 24}h';
+  }
+}
+
+/// Shimmering placeholder cards shown while the daemon config loads — reads as
+/// "loading this specific layout" rather than a lonely spinner.
+class _SettingsSkeleton extends StatelessWidget {
+  const _SettingsSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+    Widget bar(double w, double h) {
+      final box = Container(
+        width: w,
+        height: h,
+        decoration: BoxDecoration(
+          color: TalonColors.surfaceHi,
+          borderRadius: BorderRadius.circular(6),
+        ),
+      );
+      if (reduceMotion) return box;
+      return box.animate(onPlay: (c) => c.repeat()).shimmer(
+            duration: 1200.ms,
+            color: Colors.white.withValues(alpha: 0.08),
+          );
+    }
+
+    Widget card(int rows) => Glass(
+          radius: TalonRadius.md,
+          padding: const EdgeInsets.all(TalonSpace.lg),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              bar(120, 12),
+              const SizedBox(height: TalonSpace.lg),
+              for (var i = 0; i < rows; i++) ...[
+                if (i > 0) const SizedBox(height: TalonSpace.md),
+                bar(double.infinity, 16),
+              ],
+            ],
+          ),
+        );
+
+    return Column(
+      children: [
+        card(3),
+        const SizedBox(height: TalonSpace.lg),
+        card(2),
+        const SizedBox(height: TalonSpace.lg),
+        card(4),
+      ],
+    );
   }
 }
 

--- a/apps/companion/lib/src/ui/sidebar.dart
+++ b/apps/companion/lib/src/ui/sidebar.dart
@@ -5,6 +5,7 @@ import '../state/app_state.dart';
 import '../theme.dart';
 import 'brand.dart';
 import 'glass.dart';
+import 'motion.dart';
 import 'settings_screen.dart';
 import 'status_pill.dart';
 
@@ -25,12 +26,17 @@ class Sidebar extends StatefulWidget {
 class _SidebarState extends State<Sidebar> {
   String _query = '';
 
+  /// Chat ids we've already shown, so the entrance cascade plays once per tile
+  /// and never re-fires on the frequent rebuilds driven by live streaming.
+  final Set<String> _seen = <String>{};
+
   @override
   Widget build(BuildContext context) {
     return Glass(
-      radius: 22,
+      radius: TalonRadius.lg,
       blur: 24,
-      padding: const EdgeInsets.fromLTRB(12, 14, 12, 10),
+      padding: const EdgeInsets.fromLTRB(
+          TalonSpace.md, TalonSpace.lg, TalonSpace.md, TalonSpace.sm),
       child: ListenableBuilder(
         listenable: widget.state,
         builder: (context, _) {
@@ -40,23 +46,22 @@ class _SidebarState extends State<Sidebar> {
               Row(
                 children: [
                   const BrandMark(size: 30),
-                  const SizedBox(width: 10),
+                  const SizedBox(width: TalonSpace.sm),
                   Expanded(
                     child: Text(
                       widget.state.status.botName,
-                      style: const TextStyle(
-                          fontSize: 16, fontWeight: FontWeight.w700),
+                      style: TalonType.title,
                     ),
                   ),
                 ],
               ),
-              const SizedBox(height: 14),
+              const SizedBox(height: TalonSpace.md),
               _NewChatButton(onTap: widget.state.newChat),
-              const SizedBox(height: 10),
+              const SizedBox(height: TalonSpace.sm),
               _SearchBox(onChanged: (v) => setState(() => _query = v)),
-              const SizedBox(height: 8),
+              const SizedBox(height: TalonSpace.sm),
               Expanded(child: _groupedList(context)),
-              const Divider(height: 14),
+              const Divider(height: TalonSpace.md),
               Row(
                 children: [
                   Expanded(child: StatusPill(state: widget.state)),
@@ -90,7 +95,7 @@ class _SidebarState extends State<Sidebar> {
     if (chats.isEmpty) {
       return Center(
         child: Padding(
-          padding: const EdgeInsets.all(18),
+          padding: const EdgeInsets.all(TalonSpace.lg),
           child: Text(
             widget.state.conn == ConnState.connected
                 ? (_query.isEmpty ? 'No chats yet.' : 'No matches.')
@@ -103,30 +108,44 @@ class _SidebarState extends State<Sidebar> {
     }
 
     final groups = _groupByTime(chats);
+    // Stagger only tiles the sidebar hasn't shown before, cascading by their
+    // ordinal among the fresh ones so the first paint ripples in without
+    // re-animating on every streaming-driven rebuild.
+    var freshOrdinal = 0;
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+
     return ListView(
       padding: EdgeInsets.zero,
       children: [
         for (final group in groups) ...[
           Padding(
-            padding: const EdgeInsets.fromLTRB(8, 10, 8, 6),
-            child: Text(
-              group.label.toUpperCase(),
-              style: const TextStyle(
-                color: TalonColors.textFaint,
-                fontSize: 10.5,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 1.1,
-              ),
-            ),
+            padding: const EdgeInsets.fromLTRB(
+                TalonSpace.sm, TalonSpace.sm, TalonSpace.sm, 6),
+            child: Text(group.label.toUpperCase(), style: TalonType.eyebrow),
           ),
           for (final chat in group.chats)
-            _ChatTile(
-              chat: chat,
-              selected: chat.id == widget.state.selectedChatId,
-              onTap: () =>
-                  (widget.onSelect ?? widget.state.selectChat)(chat.id),
-              onDelete: () => _confirmDelete(context, chat),
-            ),
+            Builder(builder: (context) {
+              final isFresh = _seen.add(chat.id);
+              // Stagger only the fresh tiles; the delay is fixed at the tile's
+              // first appearance and latched inside EntranceFx, so later
+              // streaming rebuilds never restart or truncate the cascade.
+              final delay = isFresh
+                  ? TalonMotion.stagger * (freshOrdinal++).clamp(0, 12)
+                  : Duration.zero;
+              return EntranceFx(
+                key: ValueKey('tile-${chat.id}'),
+                enabled: isFresh && !reduceMotion,
+                from: const Offset(-0.12, 0),
+                delay: delay,
+                child: _ChatTile(
+                  chat: chat,
+                  selected: chat.id == widget.state.selectedChatId,
+                  onTap: () =>
+                      (widget.onSelect ?? widget.state.selectChat)(chat.id),
+                  onDelete: () => _confirmDelete(context, chat),
+                ),
+              );
+            }),
         ],
       ],
     );
@@ -234,9 +253,10 @@ class _ChatTileState extends State<_ChatTile> {
           child: AnimatedContainer(
             duration: TalonMotion.fast,
             curve: TalonMotion.standard,
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
+            padding: const EdgeInsets.symmetric(
+                horizontal: TalonSpace.sm, vertical: 9),
             decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(10),
+              borderRadius: TalonRadius.rSm,
               color: selected
                   ? TalonColors.surfaceHi
                   : (_hover ? TalonColors.surface : Colors.transparent),
@@ -250,9 +270,9 @@ class _ChatTileState extends State<_ChatTile> {
                   width: selected ? 3 : 0,
                   height: 15,
                   margin: EdgeInsets.only(right: selected ? 9 : 0),
-                  decoration: BoxDecoration(
+                  decoration: const BoxDecoration(
                     gradient: TalonColors.accentGradient,
-                    borderRadius: BorderRadius.circular(2),
+                    borderRadius: BorderRadius.all(Radius.circular(2)),
                   ),
                 ),
                 Expanded(
@@ -292,40 +312,54 @@ class _ChatTileState extends State<_ChatTile> {
   }
 }
 
-class _NewChatButton extends StatelessWidget {
+class _NewChatButton extends StatefulWidget {
   final VoidCallback onTap;
   const _NewChatButton({required this.onTap});
 
   @override
+  State<_NewChatButton> createState() => _NewChatButtonState();
+}
+
+class _NewChatButtonState extends State<_NewChatButton> {
+  bool _hover = false;
+
+  @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(12),
-      child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 11, horizontal: 12),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(12),
-          gradient: TalonColors.accentGradient,
-          boxShadow: [
-            BoxShadow(
-              color: TalonColors.accent.withValues(alpha: 0.30),
-              blurRadius: 16,
-              offset: const Offset(0, 5),
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hover = true),
+      onExit: (_) => setState(() => _hover = false),
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: AnimatedContainer(
+          duration: TalonMotion.fast,
+          curve: TalonMotion.standard,
+          padding: const EdgeInsets.symmetric(
+              vertical: 11, horizontal: TalonSpace.md),
+          decoration: BoxDecoration(
+            borderRadius: TalonRadius.rMd,
+            color: _hover
+                ? TalonColors.accent.withValues(alpha: 0.18)
+                : TalonColors.glassFill,
+            border: Border.all(
+              color: _hover
+                  ? TalonColors.accent.withValues(alpha: 0.6)
+                  : TalonColors.glassStroke,
             ),
-          ],
-        ),
-        child: const Row(
-          children: [
-            Icon(Icons.add_rounded, color: Colors.white, size: 19),
-            SizedBox(width: 8),
-            Text(
-              'New chat',
-              style: TextStyle(
-                  color: Colors.white,
-                  fontWeight: FontWeight.w700,
-                  fontSize: 13.5),
-            ),
-          ],
+          ),
+          child: const Row(
+            children: [
+              Icon(Icons.add_rounded, color: TalonColors.text, size: 19),
+              SizedBox(width: TalonSpace.sm),
+              Text(
+                'New chat',
+                style: TextStyle(
+                    color: TalonColors.text,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 13.5),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -350,7 +384,7 @@ class _SearchBox extends StatelessWidget {
         hintStyle: const TextStyle(color: TalonColors.textFaint, fontSize: 13),
         filled: true,
         fillColor: TalonColors.void0.withValues(alpha: 0.5),
-        contentPadding: const EdgeInsets.symmetric(vertical: 10),
+        contentPadding: const EdgeInsets.symmetric(vertical: TalonSpace.sm),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(11),
           borderSide: const BorderSide(color: TalonColors.glassStroke),

--- a/apps/companion/lib/src/ui/status_pill.dart
+++ b/apps/companion/lib/src/ui/status_pill.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 
 import '../state/app_state.dart';
 import '../theme.dart';
@@ -21,7 +22,7 @@ class StatusPill extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 7),
       decoration: BoxDecoration(
         color: color.withValues(alpha: 0.10),
-        borderRadius: BorderRadius.circular(999),
+        borderRadius: TalonRadius.rPill,
         border: Border.all(color: color.withValues(alpha: 0.32)),
       ),
       child: Row(
@@ -49,48 +50,44 @@ class StatusPill extends StatelessWidget {
   }
 }
 
-class _Dot extends StatefulWidget {
+/// A live status dot. While connecting it emits a soft expanding ring; once
+/// connected it rests solid. The ripple is a flutter_animate loop, gated on the
+/// platform reduce-motion setting.
+class _Dot extends StatelessWidget {
   final Color color;
   final bool pulse;
   const _Dot({required this.color, required this.pulse});
 
   @override
-  State<_Dot> createState() => _DotState();
-}
-
-class _DotState extends State<_Dot> with SingleTickerProviderStateMixin {
-  late final AnimationController _c =
-      AnimationController(vsync: this, duration: const Duration(milliseconds: 1100))
-        ..repeat(reverse: true);
-
-  @override
-  void dispose() {
-    _c.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: _c,
-      builder: (context, _) {
-        final t = widget.pulse ? _c.value : 1.0;
-        return Container(
-          width: 8,
-          height: 8,
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            color: widget.color,
-            boxShadow: [
-              BoxShadow(
-                color: widget.color.withValues(alpha: 0.55 * t),
-                blurRadius: 8 * t,
-                spreadRadius: 1.5 * t,
-              ),
-            ],
-          ),
-        );
-      },
+    final dot = Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(shape: BoxShape.circle, color: color),
+    );
+
+    if (!pulse || MediaQuery.of(context).disableAnimations) return dot;
+    return SizedBox(
+      width: 8,
+      height: 8,
+      child: Stack(
+        clipBehavior: Clip.none,
+        alignment: Alignment.center,
+        children: [
+          Container(
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: color.withValues(alpha: 0.6),
+            ),
+          )
+              .animate(onPlay: (c) => c.repeat())
+              .fadeOut(duration: 1200.ms, curve: Curves.easeOut)
+              .scaleXY(end: 2.6, curve: Curves.easeOut),
+          dot,
+        ],
+      ),
     );
   }
 }

--- a/apps/companion/lib/src/ui/tool_timeline.dart
+++ b/apps/companion/lib/src/ui/tool_timeline.dart
@@ -1,0 +1,495 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+
+import '../models/bridge_models.dart';
+import '../theme.dart';
+import 'motion.dart';
+
+/// The agent's tool activity, rendered as a connected vertical timeline: one
+/// node per call, linked by a hairline rail, with a live spinner while running
+/// and a calm check / warning when finished. Tapping a step reveals its full
+/// input as formatted JSON (and its error, if any). Errored steps open on
+/// their own so a failure is never hidden behind a tap.
+///
+/// Used in two places with the same visual language:
+///   - live, under the streaming reply ([LiveTurn]);
+///   - in history, tucked inside a collapsible [ToolTrace] summary.
+class ToolTimeline extends StatelessWidget {
+  final List<ToolActivity> tools;
+  const ToolTimeline({super.key, required this.tools});
+
+  @override
+  Widget build(BuildContext context) {
+    if (tools.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (var i = 0; i < tools.length; i++)
+          ToolStep(
+            key: ValueKey(tools[i].id),
+            tool: tools[i],
+            isFirst: i == 0,
+            isLast: i == tools.length - 1,
+          ),
+      ],
+    );
+  }
+}
+
+/// A single node in the [ToolTimeline].
+class ToolStep extends StatefulWidget {
+  final ToolActivity tool;
+  final bool isFirst;
+  final bool isLast;
+
+  const ToolStep({
+    super.key,
+    required this.tool,
+    this.isFirst = true,
+    this.isLast = true,
+  });
+
+  @override
+  State<ToolStep> createState() => _ToolStepState();
+}
+
+class _ToolStepState extends State<ToolStep> {
+  bool _expanded = false;
+  bool _userToggled = false;
+  Timer? _ticker;
+
+  /// The tool's input as pretty JSON, computed once. The input map is set when
+  /// the call is created and never mutated (see AppState._onTool), and this
+  /// State is keyed by tool.id — so caching avoids re-encoding on every 200ms
+  /// ticker rebuild while an expanded step is running.
+  late final String _inputJson =
+      widget.tool.input.isEmpty ? '' : _prettyJson(widget.tool.input);
+
+  bool get _failed => widget.tool.error != null;
+  bool get _running => !widget.tool.done && !_failed;
+  bool get _expandable =>
+      widget.tool.input.isNotEmpty || widget.tool.error != null;
+
+  @override
+  void initState() {
+    super.initState();
+    // Keep the elapsed readout live while the call is in flight.
+    if (_running) {
+      _ticker = Timer.periodic(const Duration(milliseconds: 200), (_) {
+        if (mounted && _running) setState(() {});
+      });
+    }
+    _expanded = _failed; // a failure explains itself without a tap.
+  }
+
+  @override
+  void didUpdateWidget(covariant ToolStep old) {
+    super.didUpdateWidget(old);
+    if (!_running) {
+      _ticker?.cancel();
+      _ticker = null;
+    }
+    // Surface a freshly-arrived error automatically (unless the user has
+    // deliberately collapsed this step).
+    if (_failed && !_userToggled && !_expanded) {
+      _expanded = true;
+    }
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  Color get _statusColor => _failed
+      ? TalonColors.bad
+      : (widget.tool.done ? TalonColors.ok : TalonColors.accent2);
+
+  @override
+  Widget build(BuildContext context) {
+    final row = IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _rail(context),
+          const SizedBox(width: TalonSpace.md),
+          Expanded(child: _content(context)),
+        ],
+      ),
+    );
+
+    if (reduceMotion(context)) return row;
+    return row
+        .animate()
+        .fadeIn(duration: TalonMotion.base, curve: TalonMotion.emphasized)
+        .slideY(begin: 0.18, end: 0, curve: TalonMotion.emphasized);
+  }
+
+  /// The node + the hairline connector that links it to the next step.
+  Widget _rail(BuildContext context) {
+    return SizedBox(
+      width: 20,
+      child: Column(
+        children: [
+          _node(context),
+          if (!widget.isLast)
+            Expanded(
+              child: Container(
+                width: 1.5,
+                margin: const EdgeInsets.only(top: 2, bottom: 2),
+                color: TalonColors.glassStroke,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _node(BuildContext context) {
+    final color = _statusColor;
+    final ring = Container(
+      width: 20,
+      height: 20,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: color.withValues(alpha: 0.14),
+        border: Border.all(color: color.withValues(alpha: 0.55), width: 1.4),
+      ),
+      alignment: Alignment.center,
+      child: _running
+          ? SizedBox(
+              width: 10,
+              height: 10,
+              child: CircularProgressIndicator(
+                strokeWidth: 1.8,
+                valueColor: AlwaysStoppedAnimation(color),
+              ),
+            )
+          : Icon(
+              _failed ? Icons.priority_high_rounded : Icons.check_rounded,
+              size: 12,
+              color: color,
+            ),
+    );
+
+    // A soft breathing halo behind a running node — the one bit of ambient
+    // motion, kept subtle and gated on the platform reduce-motion setting.
+    if (!_running || reduceMotion(context)) return ring;
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        Container(
+          width: 20,
+          height: 20,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: color.withValues(alpha: 0.5),
+          ),
+        )
+            .animate(onPlay: (c) => c.repeat(reverse: true))
+            .fadeOut(duration: 1100.ms, curve: Curves.easeInOut)
+            .scaleXY(end: 1.9, curve: Curves.easeOut),
+        ring,
+      ],
+    );
+  }
+
+  Widget _content(BuildContext context) {
+    final tool = widget.tool;
+    final arg = toolArg(tool);
+    final header = Row(
+      children: [
+        Flexible(
+          child: Text(
+            toolDisplayName(tool.name),
+            maxLines: 1,
+            softWrap: false,
+            overflow: TextOverflow.ellipsis,
+            style: TalonType.mono.copyWith(fontWeight: FontWeight.w600),
+          ),
+        ),
+        if (arg != null) ...[
+          const SizedBox(width: TalonSpace.sm),
+          Flexible(
+            child: Text(
+              arg,
+              maxLines: 1,
+              softWrap: false,
+              overflow: TextOverflow.ellipsis,
+              style: TalonType.mono.copyWith(
+                fontSize: 12,
+                color: TalonColors.textFaint,
+              ),
+            ),
+          ),
+        ],
+        const SizedBox(width: TalonSpace.sm),
+        if (_running) const _StatusBadge('Running', TalonColors.accent2),
+        if (_failed) const _StatusBadge('Failed', TalonColors.bad),
+        const SizedBox(width: TalonSpace.sm),
+        Text(
+          fmtToolDuration(tool.elapsed),
+          maxLines: 1,
+          softWrap: false,
+          style: const TextStyle(
+            color: TalonColors.textFaint,
+            fontSize: 11.5,
+            fontFeatures: [FontFeature.tabularFigures()],
+          ),
+        ),
+        if (_expandable)
+          AnimatedRotation(
+            duration: TalonMotion.fast,
+            turns: _expanded ? 0.25 : 0,
+            child: const Icon(Icons.chevron_right,
+                size: 16, color: TalonColors.textFaint),
+          )
+        else
+          const SizedBox(width: 4),
+      ],
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: TalonSpace.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          InkWell(
+            onTap: _expandable
+                ? () => setState(() {
+                      _expanded = !_expanded;
+                      _userToggled = true;
+                    })
+                : null,
+            borderRadius: TalonRadius.rSm,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: header,
+            ),
+          ),
+          AnimatedSize(
+            duration: TalonMotion.fast,
+            curve: TalonMotion.emphasized,
+            alignment: Alignment.topLeft,
+            child: _expanded && _expandable
+                ? _details(context)
+                : const SizedBox(width: double.infinity),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _details(BuildContext context) {
+    final tool = widget.tool;
+    return Padding(
+      padding: const EdgeInsets.only(top: TalonSpace.sm),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (_inputJson.isNotEmpty) _CodeBlock(text: _inputJson),
+          if (tool.error != null) ...[
+            if (_inputJson.isNotEmpty) const SizedBox(height: TalonSpace.sm),
+            _CodeBlock(text: tool.error!, tone: TalonColors.bad),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// A small pill that names a live state ("Running" / "Failed") so status is
+/// read from text, not colour alone (colour-blind friendly).
+class _StatusBadge extends StatelessWidget {
+  final String label;
+  final Color color;
+  const _StatusBadge(this.label, this.color);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      margin: const EdgeInsets.only(right: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: TalonRadius.rPill,
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 10.5,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.3,
+        ),
+      ),
+    );
+  }
+}
+
+/// A framed, selectable monospace block for tool input / error detail.
+class _CodeBlock extends StatelessWidget {
+  final String text;
+  final Color? tone;
+  const _CodeBlock({required this.text, this.tone});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(TalonSpace.md),
+      decoration: BoxDecoration(
+        color: TalonColors.void0.withValues(alpha: 0.6),
+        borderRadius: TalonRadius.rSm,
+        border: Border.all(
+          color: (tone ?? TalonColors.glassStroke)
+              .withValues(alpha: tone == null ? 1 : 0.4),
+        ),
+      ),
+      child: SelectableText(
+        text,
+        style: TalonType.mono.copyWith(
+          fontSize: 12,
+          height: 1.5,
+          color: tone ?? TalonColors.textDim,
+        ),
+      ),
+    );
+  }
+}
+
+/// A collapsible summary of a finished turn's tool calls, for message history.
+/// Reads "Worked for 4.2s · 3 steps"; expands to the full [ToolTimeline].
+/// Opens itself when a step failed so problems aren't buried.
+class ToolTrace extends StatefulWidget {
+  final List<ToolActivity> tools;
+  const ToolTrace({super.key, required this.tools});
+
+  @override
+  State<ToolTrace> createState() => _ToolTraceState();
+}
+
+class _ToolTraceState extends State<ToolTrace> {
+  late bool _open = widget.tools.any((t) => t.error != null);
+
+  @override
+  Widget build(BuildContext context) {
+    final tools = widget.tools;
+    final failed = tools.where((t) => t.error != null).length;
+    final total = Duration(
+      milliseconds: tools.fold<int>(0, (a, t) => a + t.elapsed.inMilliseconds),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        InkWell(
+          onTap: () => setState(() => _open = !_open),
+          borderRadius: TalonRadius.rSm,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 5),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AnimatedRotation(
+                  duration: TalonMotion.fast,
+                  turns: _open ? 0.25 : 0,
+                  child: const Icon(Icons.chevron_right,
+                      size: 16, color: TalonColors.textFaint),
+                ),
+                const SizedBox(width: TalonSpace.xs),
+                Icon(
+                  failed > 0
+                      ? Icons.error_outline
+                      : Icons.auto_awesome_outlined,
+                  size: 13,
+                  color: failed > 0 ? TalonColors.bad : TalonColors.textFaint,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  _summary(tools.length, failed, total),
+                  style: const TextStyle(
+                    color: TalonColors.textFaint,
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        AnimatedSize(
+          duration: TalonMotion.base,
+          curve: TalonMotion.emphasized,
+          alignment: Alignment.topLeft,
+          child: _open
+              ? Padding(
+                  padding: const EdgeInsets.only(top: 6, left: 4),
+                  child: ToolTimeline(tools: tools),
+                )
+              : const SizedBox(width: double.infinity),
+        ),
+      ],
+    );
+  }
+
+  String _summary(int n, int failed, Duration total) {
+    final base = 'Worked for ${fmtToolDuration(total)} · $n '
+        '${n == 1 ? 'step' : 'steps'}';
+    return failed == 0 ? base : '$base · $failed failed';
+  }
+}
+
+// ── Shared formatting helpers ────────────────────────────────────────────────
+
+/// De-noise MCP tool names for display:
+/// `mcp__email-tools__search_emails` → `email · search_emails`.
+/// Non-MCP names (e.g. `Bash`, `Read`) are shown as-is.
+String toolDisplayName(String raw) {
+  if (!raw.startsWith('mcp__')) return raw;
+  final parts = raw.substring(5).split('__');
+  if (parts.length < 2) return raw;
+  var server = parts.first;
+  if (server.endsWith('-tools')) {
+    server = server.substring(0, server.length - '-tools'.length);
+  }
+  final tool = parts.sublist(1).join('__');
+  return '$server · $tool';
+}
+
+/// Pick the most telling argument to preview inline next to the tool name.
+String? toolArg(ToolActivity t) {
+  if (t.input.isEmpty) return null;
+  for (final key in const ['query', 'url', 'path', 'text', 'name', 'command']) {
+    final v = t.input[key];
+    if (v is String && v.isNotEmpty) {
+      final flat = v.replaceAll(RegExp(r'\s+'), ' ').trim();
+      return flat.length > 64 ? '${flat.substring(0, 63)}…' : flat;
+    }
+  }
+  return null;
+}
+
+/// Compact elapsed-time formatting: `840ms`, `4.2s`, `12s`, `1m30s`.
+String fmtToolDuration(Duration d) {
+  final ms = d.inMilliseconds;
+  if (ms < 1000) return '${ms}ms';
+  final s = ms / 1000;
+  if (s < 10) return '${s.toStringAsFixed(1)}s';
+  if (s < 60) return '${s.toStringAsFixed(0)}s';
+  final m = (s / 60).floor();
+  return '${m}m${(s - m * 60).toStringAsFixed(0)}s';
+}
+
+String _prettyJson(Map<String, dynamic> input) {
+  try {
+    final text = const JsonEncoder.withIndent('  ').convert(input);
+    return text.length > 1400 ? '${text.substring(0, 1399)}…' : text;
+  } catch (_) {
+    return input.toString();
+  }
+}

--- a/apps/companion/pubspec.yaml
+++ b/apps/companion/pubspec.yaml
@@ -21,6 +21,10 @@ dependencies:
   shared_preferences: ^2.3.2
   # Markdown rendering for assistant replies (code blocks, tables, lists).
   flutter_markdown: ^0.7.4
+  # Declarative animation layer (gskinner, a Flutter Favorite). Replaces the
+  # hand-rolled AnimationControllers with a chainable .animate() API and powers
+  # the staggered list entrances, shimmer skeletons, and streaming caret.
+  flutter_animate: ^4.5.0
   # Open links from assistant messages / buttons in the OS browser.
   url_launcher: ^6.3.0
   # Pick an image to attach to a message. Chosen over image_picker because it

--- a/apps/companion/test/ui_smoke_test.dart
+++ b/apps/companion/test/ui_smoke_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:talon_companion/src/models/bridge_models.dart';
+import 'package:talon_companion/src/theme.dart';
+import 'package:talon_companion/src/ui/message_bubble.dart';
+import 'package:talon_companion/src/ui/motion.dart';
+import 'package:talon_companion/src/ui/tool_timeline.dart';
+
+/// Runtime smoke tests: pump the redesigned widgets and assert they build and
+/// surface their key content, catching layout/assertion errors the analyzer
+/// can't. Animations are disabled so the pumps settle deterministically.
+Widget _host(Widget child) => MediaQuery(
+      data: const MediaQueryData(disableAnimations: true),
+      child: MaterialApp(
+        theme: buildTalonTheme(),
+        home: Scaffold(
+          body: SingleChildScrollView(child: child),
+        ),
+      ),
+    );
+
+ToolActivity _tool({
+  required String id,
+  required String name,
+  bool done = true,
+  String? error,
+  Map<String, dynamic>? input,
+}) =>
+    ToolActivity(
+      id: id,
+      name: name,
+      done: done,
+      error: error,
+      input: input,
+      startedAt: DateTime(2020),
+      finishedAt: DateTime(2020, 1, 1, 0, 0, 2),
+    );
+
+void main() {
+  testWidgets('ToolTimeline renders a step per tool with de-noised names',
+      (tester) async {
+    await tester.pumpWidget(_host(ToolTimeline(tools: [
+      _tool(id: 't1', name: 'Bash', input: {'command': 'ls -la'}),
+      _tool(
+        id: 't2',
+        name: 'mcp__email-tools__search_emails',
+        input: {'query': 'invoices'},
+      ),
+    ])));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Bash'), findsOneWidget);
+    // MCP name is de-noised: server · tool.
+    expect(find.text('email · search_emails'), findsOneWidget);
+  });
+
+  testWidgets('a failed tool step auto-expands to show its error',
+      (tester) async {
+    await tester.pumpWidget(_host(ToolTimeline(tools: [
+      _tool(
+        id: 't1',
+        name: 'run_tests',
+        done: true,
+        error: 'exit code 1: 2 failing',
+        input: {'path': 'test/'},
+      ),
+    ])));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Failed'), findsOneWidget);
+    // Error detail is visible without any tap because failures open on arrival.
+    expect(find.textContaining('exit code 1'), findsOneWidget);
+  });
+
+  testWidgets('ToolTrace summarizes a finished turn', (tester) async {
+    await tester.pumpWidget(_host(ToolTrace(tools: [
+      _tool(id: 't1', name: 'Read'),
+      _tool(id: 't2', name: 'Write'),
+    ])));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('2 steps'), findsOneWidget);
+  });
+
+  testWidgets('assistant bubble shows the reply and a token/duration footer',
+      (tester) async {
+    final msg = ClientMessage(
+      id: 'm1',
+      chatId: 'c1',
+      role: Role.assistant,
+      text: 'Here is your answer.',
+      ts: 0,
+      durationMs: 4200,
+      tokensIn: 1500,
+      tokensOut: 320,
+    );
+    await tester.pumpWidget(_host(
+      MessageBubble(message: msg, botName: 'Talon'),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Talon'), findsOneWidget);
+    expect(find.text('Copy'), findsOneWidget);
+    // Compact stats: 1.5k in · 320 out · 4.2s
+    expect(find.textContaining('1.5k in'), findsOneWidget);
+    expect(find.textContaining('4.2s'), findsOneWidget);
+  });
+
+  testWidgets('EntranceFx plays through even when enabled flips to false',
+      (tester) async {
+    // Reproduces the streaming-rebuild bug: a parent rebuild flips the "fresh"
+    // gate to false a few frames in. EntranceFx must keep rendering its child
+    // (never throw / drop it) rather than tearing the animation down.
+    var enabled = true;
+    late StateSetter setOuter;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: StatefulBuilder(builder: (context, setState) {
+          setOuter = setState;
+          return EntranceFx(
+            enabled: enabled,
+            child: const Text('hello', key: Key('fx-child')),
+          );
+        }),
+      ),
+    ));
+    await tester.pump(const Duration(milliseconds: 80));
+    expect(find.byKey(const Key('fx-child')), findsOneWidget);
+
+    // Simulate the streaming rebuild that flips the gate mid-entrance.
+    setOuter(() => enabled = false);
+    await tester.pump();
+    expect(find.byKey(const Key('fx-child')), findsOneWidget);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('fx-child')), findsOneWidget);
+  });
+
+  testWidgets('reduceMotion reflects MediaQuery.disableAnimations',
+      (tester) async {
+    late bool observed;
+    await tester.pumpWidget(MediaQuery(
+      data: const MediaQueryData(disableAnimations: true),
+      child: Builder(builder: (context) {
+        observed = reduceMotion(context);
+        return const SizedBox();
+      }),
+    ));
+    expect(observed, isTrue);
+  });
+}


### PR DESCRIPTION
## What & why

Reworks the companion app's UI toward a **calmer, more professional** look — restrained static surfaces carrying **rich, deliberate motion** (the Linear/Wonderous formula) rather than gradients and colored glows on every control. Focus areas were the two the ask called out: the **tool-call UI** (previously the flashiest, least-informative part) and **overall polish/animation**.

Adds [`flutter_animate`](https://pub.dev/packages/flutter_animate) (gskinner, a Flutter Favorite) as the motion layer.

## Highlights

### Tool UI — a connected timeline (new `tool_timeline.dart`)
Replaces the stack of pulsing, glowing tool chips with a calm **vertical timeline**: one node per call linked by a hairline rail, a spinner while running / check / warning when done, a **text status badge** (not colour alone — colour-blind friendly), live elapsed time, and **tap-to-expand pretty-JSON input**. Failed steps **auto-expand** so an error is never hidden. In history it collapses behind a `Worked for 4.2s · 3 steps` summary that opens itself when a step failed.

### Design system (`theme.dart`)
- New tokens: `TalonSpace` (8pt grid), `TalonRadius` (3 steps + pill), `TalonType` (named type scale), `TalonMotion.stagger` — replacing scattered half-point font sizes and ad-hoc paddings/radii.
- Stripped the colored drop-shadow glows off the send / new-chat / connect buttons and brand mark; tamed the ambient backdrop blobs to a barely-perceptible slow drift. The accent gradient is now reserved for the brand mark + one hero moment.

### Motion (`flutter_animate`)
- Streaming caret, rippling typing dots, reasoning fade/blur-in, status-dot ripple, staggered sidebar + model-list entrances, empty-state reveal.
- New **`EntranceFx`** latches its play decision at mount, so the frequent streaming rebuilds (AppState is a `ChangeNotifier`, notified per token) can't tear a one-shot entrance down mid-flight and make rows snap into place.
- All looping/entrance motion is gated on `MediaQuery.disableAnimations` via a shared `reduceMotion()` helper.

### Polish
- **Per-turn stats footer** (tokens in/out + duration) under assistant replies, plumbed from the `turn_end` event's `usage`/`durationMs` (previously dropped on the floor).
- **Suggested-prompt chips** on an empty conversation; **shimmer skeleton** cards for the settings screen instead of a bare spinner.

## Testing

Verified locally against the **exact CI toolchain (Flutter 3.44.4 / Dart 3.12.2)**:
- `flutter analyze --fatal-infos` → **clean**
- `flutter test` → **40 passed**, including new runtime smoke tests (`test/ui_smoke_test.dart`) for the tool timeline, the failed-step auto-expand, the stats footer, and the `EntranceFx` latching behavior.

A high-effort multi-agent code review ran over the diff; its confirmed findings (entrance animations tearing down on streaming rebuilds, two duration/token formatting inconsistencies, and a per-frame JSON re-encode) are all fixed in this branch.

> Note: Flutter SDK isn't in the dev env by default; the Dart was validated with a locally-bootstrapped 3.44.4 SDK matching CI. The `companion.yml` workflow builds Windows/macOS/Linux/Android on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)