### PR TITLE
feat(companion,native): bug fixes, protocol v1 extensions, offline-first app, UI system upgrade

### DIFF
--- a/apps/companion/lib/src/models/bridge_models.dart
+++ b/apps/companion/lib/src/models/bridge_models.dart
@@ -104,6 +104,14 @@ class ClientMessage {
 
   factory ClientMessage.fromJson(Map<String, dynamic> j) {
     final rawButtons = _list(j['buttons']);
+    // Turn meta hydrated by the daemon (protocol-additive): the tool timeline
+    // and stats footer for this assistant turn, surviving reload/restart.
+    final tools = _list(j['tools'])
+        .map((t) => ToolActivity.fromHistoryJson(_map(t)))
+        .toList();
+    final durationMs = _int(j['durationMs']);
+    final tokensIn = _int(j['tokensIn']);
+    final tokensOut = _int(j['tokensOut']);
     return ClientMessage(
       id: _string(j['id']),
       chatId: _string(j['chatId']),
@@ -118,10 +126,28 @@ class ClientMessage {
           .toList(),
       reactions: _list(j['reactions']).map((e) => e.toString()).toList(),
       imagePath: j['imagePath'] is String ? j['imagePath'] as String : null,
+      tools: tools.isEmpty ? null : tools,
+      durationMs: durationMs > 0 ? durationMs : null,
+      tokensIn: tokensIn > 0 ? tokensIn : null,
+      tokensOut: tokensOut > 0 ? tokensOut : null,
     );
   }
 
   DateTime get time => DateTime.fromMillisecondsSinceEpoch(ts);
+
+  /// Minimal wire-shape encoding for the local offline snapshot (buttons,
+  /// reactions and tool traces are re-fetched from the daemon on connect).
+  Map<String, dynamic> toSnapshotJson() => {
+        'id': id,
+        'chatId': chatId,
+        'role': role.name,
+        'text': text,
+        'ts': ts,
+        if (imagePath != null) 'imagePath': imagePath,
+        if (durationMs != null) 'durationMs': durationMs,
+        if (tokensIn != null) 'tokensIn': tokensIn,
+        if (tokensOut != null) 'tokensOut': tokensOut,
+      };
 }
 
 class ClientChat {
@@ -161,6 +187,18 @@ class ClientChat {
 
   DateTime get lastActiveTime =>
       DateTime.fromMillisecondsSinceEpoch(lastActive);
+
+  Map<String, dynamic> toSnapshotJson() => {
+        'id': id,
+        'title': title,
+        'createdAt': createdAt,
+        'lastActive': lastActive,
+        'preview': preview,
+        if (model != null) 'model': model,
+        if (backend != null) 'backend': backend,
+        if (effort != null) 'effort': effort,
+        if (pulse != null) 'pulse': pulse,
+      };
 }
 
 /// Snapshot of the daemon's own (editable) settings + health — the payload of
@@ -320,5 +358,40 @@ class ToolActivity {
   })  : input = input ?? <String, dynamic>{},
         startedAt = startedAt ?? DateTime.now();
 
+  /// A finished call re-hydrated from persisted history: anchor the window at
+  /// parse time so [elapsed] reproduces the recorded duration.
+  factory ToolActivity.fromHistoryJson(Map<String, dynamic> j) {
+    final started = DateTime.now();
+    final duration = _int(j['durationMs']);
+    return ToolActivity(
+      id: _string(j['id']),
+      name: _string(j['name'], 'tool'),
+      done: true,
+      error: j['error'] is String ? j['error'] as String : null,
+      input: _map(j['input']),
+      startedAt: started,
+      finishedAt: started.add(Duration(milliseconds: duration)),
+    );
+  }
+
   Duration get elapsed => (finishedAt ?? DateTime.now()).difference(startedAt);
+}
+
+/// One full-text search hit from `GET /search`.
+class SearchHit {
+  final String chatId;
+  final String chatTitle;
+  final ClientMessage message;
+
+  const SearchHit({
+    required this.chatId,
+    required this.chatTitle,
+    required this.message,
+  });
+
+  factory SearchHit.fromJson(Map<String, dynamic> j) => SearchHit(
+        chatId: _string(j['chatId']),
+        chatTitle: _string(j['chatTitle']),
+        message: ClientMessage.fromJson(_map(j['message'])),
+      );
 }

--- a/apps/companion/lib/src/services/bridge_client.dart
+++ b/apps/companion/lib/src/services/bridge_client.dart
@@ -165,11 +165,30 @@ class BridgeClient {
   Future<ConfigSnapshot> setConfig(Map<String, dynamic> update) async =>
       ConfigSnapshot.fromJson(await _postJson('/config', update));
 
-  Future<List<ClientMessage>> history(String chatId) async {
-    final j = await _getJson('/history', {'chatId': chatId});
+  /// A page of history: the newest window by default, or — when [before] is
+  /// given — the window of messages strictly older than that message id.
+  Future<List<ClientMessage>> history(
+    String chatId, {
+    int? before,
+    int? limit,
+  }) async {
+    final j = await _getJson('/history', {
+      'chatId': chatId,
+      if (before != null) 'before': '$before',
+      if (limit != null) 'limit': '$limit',
+    });
     return _list(
       j['messages'],
     ).map((m) => ClientMessage.fromJson(_map(m))).toList();
+  }
+
+  /// Full-text search across chats (or one chat when [chatId] is given).
+  Future<List<SearchHit>> search(String query, {String? chatId}) async {
+    final j = await _getJson('/search', {
+      'q': query,
+      if (chatId != null) 'chatId': chatId,
+    });
+    return _list(j['results']).map((r) => SearchHit.fromJson(_map(r))).toList();
   }
 
   Future<void> send(

--- a/apps/companion/lib/src/services/bridge_client.dart
+++ b/apps/companion/lib/src/services/bridge_client.dart
@@ -108,7 +108,9 @@ class BridgeClient {
       },
       onError: (Object e) {
         AppLog.warn('bridge', 'event stream error', e);
-        _events.addError(e);
+        // dispose() closes the controller before the socket subscription is
+        // fully torn down — a late transport error must not throw into it.
+        if (!_closed) _events.addError(e);
       },
       onDone: () {
         if (!_closed) {
@@ -123,7 +125,7 @@ class BridgeClient {
   void _flush(StringBuffer buffer) {
     final raw = buffer.toString().trim();
     buffer.clear();
-    if (raw.isEmpty) return;
+    if (raw.isEmpty || _closed) return;
     try {
       final obj = _decodeObject(raw);
       _events.add(obj);

--- a/apps/companion/lib/src/services/prefs.dart
+++ b/apps/companion/lib/src/services/prefs.dart
@@ -4,13 +4,17 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/connection.dart';
 
-/// Thin wrapper over [SharedPreferences] for the one thing we persist:
-/// the connection profile (local-managed vs remote, host/port/token).
+/// Thin wrapper over [SharedPreferences] for everything we persist locally:
+/// the connection profile, per-chat read markers (unread badges), and a
+/// bounded chat/message snapshot for instant offline cold-start.
 class Prefs {
   static const _kConnection = 'connection.v1';
   static const _kOnboarded = 'onboarded.v1';
+  static const _kLastRead = 'lastRead.v1';
+  static const _kSnapshot = 'snapshot.v1';
 
   final SharedPreferences _sp;
+  late final Map<String, int> _lastRead = _decodeLastRead();
   Prefs(this._sp);
 
   static Future<Prefs> load() async => Prefs(await SharedPreferences.getInstance());
@@ -31,4 +35,48 @@ class Prefs {
 
   bool get onboarded => _sp.getBool(_kOnboarded) ?? false;
   Future<void> setOnboarded(bool v) => _sp.setBool(_kOnboarded, v);
+
+  // ── Read markers ──────────────────────────────────────────────────────────
+
+  Map<String, int> _decodeLastRead() {
+    try {
+      final raw = _sp.getString(_kLastRead);
+      if (raw == null) return {};
+      return (jsonDecode(raw) as Map)
+          .map((k, v) => MapEntry(k.toString(), v is num ? v.toInt() : 0));
+    } catch (_) {
+      return {};
+    }
+  }
+
+  /// Epoch-ms of the newest activity the user has seen in a chat (0 = never).
+  int lastReadOf(String chatId) => _lastRead[chatId] ?? 0;
+
+  Future<void> setLastRead(String chatId, int ts) {
+    if ((_lastRead[chatId] ?? 0) >= ts) return Future.value();
+    _lastRead[chatId] = ts;
+    return _sp.setString(_kLastRead, jsonEncode(_lastRead));
+  }
+
+  Future<void> clearLastRead(String chatId) {
+    _lastRead.remove(chatId);
+    return _sp.setString(_kLastRead, jsonEncode(_lastRead));
+  }
+
+  // ── Offline snapshot ──────────────────────────────────────────────────────
+
+  /// Last-known chats + recent messages, decoded; null when absent/corrupt.
+  Map<String, dynamic>? get snapshot {
+    try {
+      final raw = _sp.getString(_kSnapshot);
+      if (raw == null) return null;
+      final decoded = jsonDecode(raw);
+      return decoded is Map ? decoded.cast<String, dynamic>() : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> saveSnapshot(Map<String, dynamic> snapshot) =>
+      _sp.setString(_kSnapshot, jsonEncode(snapshot));
 }

--- a/apps/companion/lib/src/state/app_state.dart
+++ b/apps/companion/lib/src/state/app_state.dart
@@ -45,6 +45,18 @@ class AppState extends ChangeNotifier {
   int _backoffMs = 800;
   bool _disposed = false;
 
+  /// Monotonic connection-attempt counter. Each [start] bumps it; awaited
+  /// continuations from an older attempt compare against it and bail instead
+  /// of disposing the newer attempt's client or stomping its state (e.g. the
+  /// user taps Reconnect while a backoff-timer attempt is mid-flight).
+  int _epoch = 0;
+
+  /// The connection actually in use. In local auto-discover mode this carries
+  /// the discovered port/token, which the saved [config] doesn't — anything
+  /// that builds URLs (media, diagnostics) must use this, not [config].
+  ConnectionConfig? _activeConfig;
+  ConnectionConfig get activeConfig => _activeConfig ?? config;
+
   // Connection
   ConnState conn = ConnState.idle;
   String? connError;
@@ -81,12 +93,14 @@ class AppState extends ChangeNotifier {
   /// explicitly configured; everywhere, open the event stream and load chats.
   Future<void> start() async {
     _reconnect?.cancel();
+    final epoch = ++_epoch;
     AppLog.info('app_state', 'connect attempt ${config.host}:${config.port}');
     _setConn(ConnState.connecting, null);
 
     if (config.canAutoDiscoverLocal) {
       daemon = const DaemonState(DaemonPhase.unknown);
       final bridge = await readLocalBridge();
+      if (epoch != _epoch) return; // superseded by a newer attempt
       if (bridge == null) {
         _setConn(
           ConnState.error,
@@ -107,13 +121,15 @@ class AppState extends ChangeNotifier {
         'app_state',
         'local discovery ${effective.host}:${effective.port}',
       );
-      await _openStream(effective);
+      await _openStream(effective, epoch);
     } else if (config.canManageDaemon) {
       _supervisor = DaemonSupervisor(config);
       final ok = await _supervisor!.ensureRunning((d) {
+        if (epoch != _epoch) return;
         daemon = d;
         notifyListeners();
       });
+      if (epoch != _epoch) return;
       if (!ok) {
         _setConn(
           ConnState.error,
@@ -123,34 +139,41 @@ class AppState extends ChangeNotifier {
         _scheduleReconnect();
         return;
       }
-      await _openStream();
+      await _openStream(null, epoch);
     } else {
       daemon = const DaemonState(DaemonPhase.unknown);
-      await _openStream();
+      await _openStream(null, epoch);
     }
   }
 
-  Future<void> _openStream([ConnectionConfig? effectiveConfig]) async {
+  Future<void> _openStream(ConnectionConfig? effectiveConfig, int epoch) async {
     await _sub?.cancel();
+    if (epoch != _epoch) return;
     _client?.dispose();
-    final activeConfig = effectiveConfig ?? config;
-    final client = BridgeClient(activeConfig);
+    final cfg = effectiveConfig ?? config;
+    final client = BridgeClient(cfg);
     _client = client;
+    _activeConfig = cfg;
 
     try {
       // Verify identity before committing to the stream — gives a crisp error
       // when the host/token is wrong rather than a silent dead stream.
       final h = await client.health();
+      if (epoch != _epoch) {
+        _disposeStale(client);
+        return;
+      }
       AppLog.info('app_state', 'health ${h == null ? 'failed' : 'ok'}');
       if (h == null) {
         throw BridgeException(
-          'No Talon bridge at ${activeConfig.host}:${activeConfig.port}',
+          'No Talon bridge at ${cfg.host}:${cfg.port}',
         );
       }
 
       _sub = client.events.listen(
         _onEvent,
         onError: (Object e) {
+          if (!identical(_client, client)) return; // stale stream
           if (_isUnauthorized(e)) {
             _stopUnauthorized();
             return;
@@ -160,6 +183,10 @@ class AppState extends ChangeNotifier {
         },
       );
       await client.connect();
+      if (epoch != _epoch) {
+        _disposeStale(client);
+        return;
+      }
 
       AppLog.info('app_state', 'connected');
       _setConn(ConnState.connected, null);
@@ -167,6 +194,10 @@ class AppState extends ChangeNotifier {
       await _refreshChats();
       unawaited(_refreshModels());
     } catch (e) {
+      if (epoch != _epoch) {
+        _disposeStale(client);
+        return;
+      }
       if (_isUnauthorized(e)) {
         _stopUnauthorized();
         return;
@@ -174,6 +205,12 @@ class AppState extends ChangeNotifier {
       _setConn(ConnState.error, e.toString());
       _scheduleReconnect();
     }
+  }
+
+  /// Tear down a client from a superseded connection attempt without touching
+  /// the current one (a newer attempt may already own [_client]).
+  void _disposeStale(BridgeClient client) {
+    if (!identical(_client, client)) client.dispose();
   }
 
   void _scheduleReconnect() {
@@ -200,11 +237,13 @@ class AppState extends ChangeNotifier {
   /// Apply a new connection profile and reconnect from scratch.
   Future<void> applyConfig(ConnectionConfig next) async {
     config = next;
+    _activeConfig = null;
     await prefs.setConnection(next);
     chats.clear();
     _messages.clear();
     _turns.clear();
     _loadedHistory.clear();
+    models = [];
     selectedChatId = null;
     AppLog.info('app_state', 'connection config applied; stores reset');
     await start();
@@ -234,12 +273,41 @@ class AppState extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> renameChat(String chatId, String title) =>
-      _client?.renameChat(chatId, title) ?? Future.value();
+  ClientChat? _chatById(String chatId) {
+    for (final c in chats) {
+      if (c.id == chatId) return c;
+    }
+    return null;
+  }
+
+  /// Run a chat-scoped daemon command, surfacing failure as a system note in
+  /// that chat instead of an unhandled async exception in a UI callback.
+  Future<void> _command(String chatId, String what, Future<void> future) async {
+    try {
+      await future;
+    } catch (e) {
+      AppLog.warn('app_state', '$what failed', e);
+      _appendSystem(chatId, '$what failed: $e');
+    }
+  }
+
+  Future<void> renameChat(String chatId, String title) async {
+    // Optimistic: reflect immediately; the chat_updated event reconciles.
+    final chat = _chatById(chatId);
+    if (chat != null && chat.title != title) {
+      chat.title = title;
+      notifyListeners();
+    }
+    final client = _client;
+    if (client == null) return;
+    await _command(chatId, 'Rename', client.renameChat(chatId, title));
+  }
 
   Future<void> deleteChat(String chatId) async {
-    await _client?.deleteChat(chatId);
+    final client = _client;
+    if (client == null) return;
     // chat_deleted event reconciles state.
+    await _command(chatId, 'Delete', client.deleteChat(chatId));
   }
 
   Future<void> sendMessage(
@@ -283,12 +351,29 @@ class AppState extends ChangeNotifier {
   }
 
   Future<void> setModel(String chatId, String model) async {
-    await _client?.setModel(chatId, model);
+    // Optimistic: the header chip and sheet update instantly instead of
+    // waiting a round-trip for chat_updated.
+    final chat = _chatById(chatId);
+    if (chat != null && chat.model != model) {
+      chat.model = model;
+      notifyListeners();
+    }
+    final client = _client;
+    if (client == null) return;
+    await _command(chatId, 'Model change', client.setModel(chatId, model));
   }
 
-  /// Backends selectable for a chat + the chat's active backend id.
-  Future<(String, List<BackendOption>)> backends(String chatId) async =>
-      await _client?.backends(chatId) ?? ('', const <BackendOption>[]);
+  /// Backends selectable for a chat + the chat's active backend id. Returns
+  /// empty on any failure (e.g. an older daemon without the endpoint) so the
+  /// sheet simply hides the backend row.
+  Future<(String, List<BackendOption>)> backends(String chatId) async {
+    try {
+      return await _client?.backends(chatId) ?? ('', const <BackendOption>[]);
+    } catch (e) {
+      AppLog.warn('app_state', 'backends fetch failed', e);
+      return ('', const <BackendOption>[]);
+    }
+  }
 
   /// Switch a chat's backend. Returns the daemon result so the UI can toast a
   /// failure (e.g. "Backend not available") instead of silently no-op'ing.
@@ -296,27 +381,63 @@ class AppState extends ChangeNotifier {
     String chatId,
     String backend,
   ) async {
-    final r = await _client?.setBackend(chatId, backend);
-    // The new backend exposes a different model catalog, so re-pull the models
-    // for this chat from the gateway. Without this the picker keeps showing the
-    // previous backend's models until the next manual refresh.
-    if (r?.ok == true) await _refreshModels(chatId);
-    return r ?? (ok: false, error: 'Not connected');
+    try {
+      final r = await _client?.setBackend(chatId, backend);
+      if (r?.ok == true) {
+        final chat = _chatById(chatId);
+        if (chat != null && chat.backend != backend) {
+          chat.backend = backend;
+          notifyListeners();
+        }
+        // The new backend exposes a different model catalog, so re-pull the
+        // models for this chat from the gateway. Without this the picker keeps
+        // showing the previous backend's models until the next manual refresh.
+        await _refreshModels(chatId);
+      }
+      return r ?? (ok: false, error: 'Not connected');
+    } catch (e) {
+      AppLog.warn('app_state', 'backend switch failed', e);
+      return (ok: false, error: e.toString());
+    }
   }
 
   Future<void> setEffort(String chatId, String effort) async {
-    await _client?.setEffort(chatId, effort);
+    final chat = _chatById(chatId);
+    if (chat != null && chat.effort != effort) {
+      chat.effort = effort;
+      notifyListeners();
+    }
+    final client = _client;
+    if (client == null) return;
+    await _command(chatId, 'Effort change', client.setEffort(chatId, effort));
   }
 
-  Future<(String, List<String>)> effortLevels(String chatId) async =>
-      await _client?.effortLevels(chatId) ?? ('adaptive', const <String>[]);
+  /// Effort levels for a chat; empty on failure so the row hides.
+  Future<(String, List<String>)> effortLevels(String chatId) async {
+    try {
+      return await _client?.effortLevels(chatId) ??
+          ('adaptive', const <String>[]);
+    } catch (e) {
+      AppLog.warn('app_state', 'effort fetch failed', e);
+      return ('adaptive', const <String>[]);
+    }
+  }
 
   Future<void> resetChat(String chatId) async {
-    await _client?.resetChat(chatId);
+    final client = _client;
+    if (client == null) return;
+    await _command(chatId, 'Reset', client.resetChat(chatId));
   }
 
   Future<void> setPulse(String chatId, bool on) async {
-    await _client?.setPulse(chatId, on);
+    final chat = _chatById(chatId);
+    if (chat != null && chat.pulse != on) {
+      chat.pulse = on;
+      notifyListeners();
+    }
+    final client = _client;
+    if (client == null) return;
+    await _command(chatId, 'Pulse toggle', client.setPulse(chatId, on));
   }
 
   Future<ConfigSnapshot?> loadConfig() async {
@@ -329,12 +450,17 @@ class AppState extends ChangeNotifier {
   }
 
   Future<ConfigSnapshot?> updateConfig(Map<String, dynamic> update) async {
-    final c = await _client?.setConfig(update);
-    if (c != null) {
-      appConfig = c;
-      notifyListeners();
+    try {
+      final c = await _client?.setConfig(update);
+      if (c != null) {
+        appConfig = c;
+        notifyListeners();
+      }
+      return c;
+    } catch (e) {
+      AppLog.warn('app_state', 'config update failed', e);
+      return null;
     }
-    return c;
   }
 
   /// Desktop only: restart the managed daemon, then reconnect.
@@ -557,7 +683,7 @@ class AppState extends ChangeNotifier {
       ..clear()
       ..addAll(list);
     _sortChats();
-    selectedChatId ??= chats.isNotEmpty ? chats.first.id : null;
+    _reconcileSelection();
     // This runs on every (re)connect. History may have advanced while we were
     // disconnected (a heartbeat/cron reply, another client, a network blip or
     // laptop sleep), so drop the "already loaded" marks — otherwise a chat we'd
@@ -580,6 +706,13 @@ class AppState extends ChangeNotifier {
       final r = await _client?.models(chatId);
       if (r != null && !_disposed) {
         models = r.$2;
+        // The gateway also reports the chat's active model — sync it so the
+        // header chip is right immediately after a backend switch, even if
+        // the daemon's chat_updated event is late or missing.
+        if (chatId != null && r.$1.isNotEmpty) {
+          final chat = _chatById(chatId);
+          if (chat != null) chat.model = r.$1;
+        }
         notifyListeners();
       }
     } catch (e) {
@@ -615,6 +748,18 @@ class AppState extends ChangeNotifier {
             .map(ClientChat.fromJson),
       );
     _sortChats();
+    _reconcileSelection();
+  }
+
+  /// Keep the selection valid against the freshly-set chat list: a chat
+  /// deleted while we were away must not stay selected (it would render an
+  /// empty conversation and fetch history for a dead id), and with nothing
+  /// selected we default to the most recent chat.
+  void _reconcileSelection() {
+    if (selectedChatId != null &&
+        !chats.any((c) => c.id == selectedChatId)) {
+      selectedChatId = null;
+    }
     selectedChatId ??= chats.isNotEmpty ? chats.first.id : null;
   }
 
@@ -669,6 +814,9 @@ class AppState extends ChangeNotifier {
             ts: DateTime.now().millisecondsSinceEpoch,
           ),
         );
+    // Callers outside the event loop (send/upload/command failures) rely on
+    // this notify — without it the note only appears on the next repaint.
+    notifyListeners();
   }
 
   void _setConn(ConnState s, String? err) {

--- a/apps/companion/lib/src/state/app_state.dart
+++ b/apps/companion/lib/src/state/app_state.dart
@@ -36,7 +36,9 @@ class AppState extends ChangeNotifier {
   final Prefs prefs;
   ConnectionConfig config;
 
-  AppState(this.prefs) : config = prefs.connection;
+  AppState(this.prefs) : config = prefs.connection {
+    _hydrateFromSnapshot();
+  }
 
   BridgeClient? _client;
   DaemonSupervisor? _supervisor;
@@ -69,6 +71,23 @@ class AppState extends ChangeNotifier {
   final Map<String, List<ClientMessage>> _messages = {};
   final Map<String, TurnState> _turns = {};
   final Set<String> _loadedHistory = {};
+
+  // History pagination: chats whose scrollback is fully loaded, and chats
+  // with an older-page fetch in flight.
+  static const int _historyPageSize = 100;
+  static const int _historyInitialSize = 200;
+  final Set<String> _historyExhausted = {};
+  final Set<String> _loadingOlder = {};
+  final Set<String> _loadingHistory = {};
+
+  // Offline snapshot: debounce handle for persisted cold-start state.
+  Timer? _snapshotTimer;
+
+  bool isLoadingOlder(String chatId) => _loadingOlder.contains(chatId);
+  bool hasMoreHistory(String chatId) => !_historyExhausted.contains(chatId);
+
+  /// True while a chat's first history page is being fetched (skeleton UI).
+  bool isHistoryLoading(String chatId) => _loadingHistory.contains(chatId);
 
   // Models
   List<ModelOption> models = [];
@@ -253,8 +272,81 @@ class AppState extends ChangeNotifier {
 
   Future<void> selectChat(String chatId) async {
     selectedChatId = chatId;
+    markRead(chatId);
     notifyListeners();
     if (!_loadedHistory.contains(chatId)) await _loadHistory(chatId);
+  }
+
+  // ── Unread tracking ────────────────────────────────────────────────────────
+
+  /// A chat is unread when it saw activity newer than the user's last look
+  /// and it isn't the one currently on screen.
+  bool hasUnread(ClientChat chat) =>
+      chat.id != selectedChatId &&
+      chat.lastActive > prefs.lastReadOf(chat.id);
+
+  void markRead(String chatId) {
+    final chat = _chatById(chatId);
+    final ts = chat?.lastActive ?? DateTime.now().millisecondsSinceEpoch;
+    unawaited(prefs.setLastRead(chatId, ts));
+  }
+
+  // ── History pagination + search ───────────────────────────────────────────
+
+  /// Fetch the page of messages older than the oldest one currently loaded.
+  /// Returns how many new messages were prepended (0 when exhausted/offline).
+  Future<int> loadOlderMessages(String chatId) async {
+    if (_loadingOlder.contains(chatId) ||
+        _historyExhausted.contains(chatId) ||
+        conn != ConnState.connected) {
+      return 0;
+    }
+    final msgs = _messages[chatId];
+    if (msgs == null || msgs.isEmpty) return 0;
+    // Oldest server-assigned id (local system notes have non-numeric ids).
+    int? oldest;
+    for (final m in msgs) {
+      final n = int.tryParse(m.id);
+      if (n != null) {
+        oldest = n;
+        break;
+      }
+    }
+    if (oldest == null) return 0;
+
+    _loadingOlder.add(chatId);
+    notifyListeners();
+    try {
+      final page = await _client?.history(
+            chatId,
+            before: oldest,
+            limit: _historyPageSize,
+          ) ??
+          const <ClientMessage>[];
+      if (page.length < _historyPageSize) _historyExhausted.add(chatId);
+      final existing = msgs.map((m) => m.id).toSet();
+      final fresh = page.where((m) => !existing.contains(m.id)).toList();
+      msgs.insertAll(0, fresh);
+      return fresh.length;
+    } catch (e) {
+      AppLog.warn('app_state', 'older-history fetch failed', e);
+      return 0;
+    } finally {
+      _loadingOlder.remove(chatId);
+      notifyListeners();
+    }
+  }
+
+  /// Daemon-side full-text search across all chats. Empty on failure so the
+  /// quick switcher can fall back to local title matches silently.
+  Future<List<SearchHit>> searchMessages(String query) async {
+    if (conn != ConnState.connected || query.trim().isEmpty) return const [];
+    try {
+      return await _client?.search(query.trim()) ?? const [];
+    } catch (e) {
+      AppLog.warn('app_state', 'search failed', e);
+      return const [];
+    }
   }
 
   /// Narrow layout: return to the chat list.
@@ -614,6 +706,8 @@ class AppState extends ChangeNotifier {
     final list = _messages.putIfAbsent(chatId, () => []);
     if (list.any((x) => x.id == m.id)) return; // dedupe re-delivery
     list.add(m);
+    // The visible chat is by definition read up to now.
+    if (chatId == selectedChatId) markRead(chatId);
     // Canonical reply supersedes the live turn. End it now so we don't flash
     // typing dots / orphan tool chips while waiting for the trailing turn_end.
     if (m.role == Role.assistant) {
@@ -690,6 +784,7 @@ class AppState extends ChangeNotifier {
     // viewed before would keep its stale message list forever. Re-fetch the
     // visible chat now; the rest reload lazily when next opened.
     _loadedHistory.clear();
+    _historyExhausted.clear();
     if (selectedChatId != null) {
       await _loadHistory(selectedChatId!);
     }
@@ -721,8 +816,17 @@ class AppState extends ChangeNotifier {
   }
 
   Future<void> _loadHistory(String chatId) async {
+    _loadingHistory.add(chatId);
+    notifyListeners();
     try {
-      final hist = await _client?.history(chatId) ?? const [];
+      final hist =
+          await _client?.history(chatId, limit: _historyInitialSize) ??
+              const <ClientMessage>[];
+      if (hist.length < _historyInitialSize) {
+        _historyExhausted.add(chatId);
+      } else {
+        _historyExhausted.remove(chatId);
+      }
       // Merge rather than overwrite: a live `message` event can land while this
       // fetch is in flight, and a blind assignment would drop it (it isn't in
       // the server snapshot yet). History is authoritative for order; append
@@ -732,9 +836,11 @@ class AppState extends ChangeNotifier {
           .where((m) => !histIds.contains(m.id));
       _messages[chatId] = [...hist, ...extras];
       _loadedHistory.add(chatId);
-      notifyListeners();
     } catch (_) {
       /* leave existing messages; stream will fill in */
+    } finally {
+      _loadingHistory.remove(chatId);
+      notifyListeners();
     }
   }
 
@@ -778,6 +884,8 @@ class AppState extends ChangeNotifier {
     _messages.remove(chatId);
     _turns.remove(chatId);
     _loadedHistory.remove(chatId);
+    _historyExhausted.remove(chatId);
+    unawaited(prefs.clearLastRead(chatId));
     if (selectedChatId == chatId) {
       selectedChatId = chats.isNotEmpty ? chats.first.id : null;
     }
@@ -825,6 +933,95 @@ class AppState extends ChangeNotifier {
     notifyListeners();
   }
 
+  // ── Offline snapshot (instant cold-start) ─────────────────────────────────
+
+  /// Restore last-known chats + recent messages so the app renders content
+  /// immediately on launch, before (or without) a bridge connection. The
+  /// live connect replaces everything with authoritative server state.
+  void _hydrateFromSnapshot() {
+    final snap = prefs.snapshot;
+    if (snap == null) return;
+    try {
+      final rawChats = snap['chats'];
+      if (rawChats is List) {
+        chats.addAll(rawChats
+            .map(_map)
+            .whereType<Map<String, dynamic>>()
+            .map(ClientChat.fromJson));
+      }
+      final rawMessages = snap['messages'];
+      if (rawMessages is Map) {
+        rawMessages.forEach((chatId, list) {
+          if (list is List) {
+            _messages['$chatId'] = list
+                .map(_map)
+                .whereType<Map<String, dynamic>>()
+                .map(ClientMessage.fromJson)
+                .toList();
+          }
+        });
+      }
+      _sortChats();
+      _reconcileSelection();
+      AppLog.info('app_state', 'hydrated ${chats.length} chats from snapshot');
+    } catch (e) {
+      AppLog.warn('app_state', 'snapshot hydration failed', e);
+    }
+  }
+
+  /// Debounced persist of a bounded snapshot (all chats, last 30 messages
+  /// each, system notes excluded — they're transient).
+  void _scheduleSnapshotSave() {
+    if (_disposed || _snapshotTimer != null) return;
+    _snapshotTimer = Timer(const Duration(seconds: 2), () {
+      _snapshotTimer = null;
+      if (_disposed) return;
+      final snapshot = <String, dynamic>{
+        'chats': chats.map((c) => c.toSnapshotJson()).toList(),
+        'messages': {
+          for (final entry in _messages.entries)
+            entry.key: entry.value
+                .where((m) => m.role != Role.system)
+                .toList()
+                .reversed
+                .take(30)
+                .toList()
+                .reversed
+                .map((m) => m.toSnapshotJson())
+                .toList(),
+        },
+      };
+      unawaited(prefs.saveSnapshot(snapshot));
+    });
+  }
+
+  @override
+  void notifyListeners() {
+    super.notifyListeners();
+    // Every state change is a candidate for the offline snapshot; the
+    // 2s debounce keeps this from thrashing during streaming.
+    _scheduleSnapshotSave();
+  }
+
+  // ── Export ────────────────────────────────────────────────────────────────
+
+  /// Render a conversation as portable markdown (for copy/share).
+  String exportMarkdown(String chatId) {
+    final chat = _chatById(chatId);
+    final buf = StringBuffer('# ${chat?.title ?? 'Talon chat'}\n\n');
+    for (final m in messagesFor(chatId)) {
+      if (m.role == Role.system) continue;
+      final who = m.role == Role.user ? 'User' : status.botName;
+      final when = m.time.toLocal().toString().split('.').first;
+      buf
+        ..writeln('**$who** — $when')
+        ..writeln()
+        ..writeln(m.text.trim())
+        ..writeln();
+    }
+    return buf.toString();
+  }
+
   static String? _string(Object? value) {
     if (value == null) return null;
     if (value is String) return value;
@@ -841,6 +1038,7 @@ class AppState extends ChangeNotifier {
   void dispose() {
     _disposed = true;
     _reconnect?.cancel();
+    _snapshotTimer?.cancel();
     _sub?.cancel();
     _client?.dispose();
     super.dispose();

--- a/apps/companion/lib/src/ui/activity_card.dart
+++ b/apps/companion/lib/src/ui/activity_card.dart
@@ -35,7 +35,12 @@ class LiveTurn extends StatelessWidget {
                 Text(botName, style: TalonType.subtitle),
                 const SizedBox(height: 6),
                 if (turn.reasoning.isNotEmpty)
-                  _ReasoningStrip(text: turn.reasoning.join('')),
+                  _ReasoningStrip(
+                    text: turn.reasoning.join(''),
+                    // Once the reply starts streaming, the thinking is done —
+                    // fold the strip into a quiet pill (tap re-expands).
+                    condensed: turn.draft.isNotEmpty,
+                  ),
                 if (turn.tools.isNotEmpty)
                   Padding(
                     padding: const EdgeInsets.only(bottom: TalonSpace.sm),
@@ -104,13 +109,62 @@ class _StreamingText extends StatelessWidget {
 }
 
 /// The model's live reasoning, in a quiet accent-edged strip. Fades/blurs in
-/// so it doesn't pop when the model starts thinking.
-class _ReasoningStrip extends StatelessWidget {
+/// so it doesn't pop when the model starts thinking, and folds into a
+/// one-line pill once the reply starts streaming (tap to re-expand) — the
+/// pattern users know from the Claude/ChatGPT apps.
+class _ReasoningStrip extends StatefulWidget {
   final String text;
-  const _ReasoningStrip({required this.text});
+  final bool condensed;
+  const _ReasoningStrip({required this.text, this.condensed = false});
+
+  @override
+  State<_ReasoningStrip> createState() => _ReasoningStripState();
+}
+
+class _ReasoningStripState extends State<_ReasoningStrip> {
+  /// The user's explicit choice, overriding the automatic fold. Null = auto.
+  bool? _userExpanded;
+
+  bool get _expanded => _userExpanded ?? !widget.condensed;
 
   @override
   Widget build(BuildContext context) {
+    if (!_expanded) {
+      return Padding(
+        padding: const EdgeInsets.only(bottom: TalonSpace.sm),
+        child: InkWell(
+          onTap: () => setState(() => _userExpanded = true),
+          borderRadius: TalonRadius.rPill,
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+                horizontal: TalonSpace.md, vertical: 5),
+            decoration: BoxDecoration(
+              color: TalonColors.glassFill,
+              borderRadius: TalonRadius.rPill,
+              border: Border.all(color: TalonColors.glassStroke),
+            ),
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.bubble_chart_outlined,
+                    size: 13, color: TalonColors.textFaint),
+                SizedBox(width: 6),
+                Text(
+                  'Thought — tap to expand',
+                  style:
+                      TextStyle(fontSize: 11.5, color: TalonColors.textFaint),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+    return _strip(context);
+  }
+
+  Widget _strip(BuildContext context) {
+    final text = widget.text;
     final strip = Padding(
       padding: const EdgeInsets.only(bottom: TalonSpace.sm),
       child: Container(
@@ -151,8 +205,16 @@ class _ReasoningStrip extends StatelessWidget {
         ),
       ),
     );
-    if (MediaQuery.of(context).disableAnimations) return strip;
-    return strip.animate().fadeIn(duration: TalonMotion.base).blurX(
+    // While the reply streams, the expanded strip stays tappable to fold
+    // back down (the pill re-expands it).
+    final Widget body = widget.condensed
+        ? GestureDetector(
+            onTap: () => setState(() => _userExpanded = false),
+            child: strip,
+          )
+        : strip;
+    if (MediaQuery.of(context).disableAnimations) return body;
+    return body.animate().fadeIn(duration: TalonMotion.base).blurX(
           begin: 3,
           end: 0,
           duration: TalonMotion.base,

--- a/apps/companion/lib/src/ui/app_shell.dart
+++ b/apps/companion/lib/src/ui/app_shell.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../state/app_state.dart';
 import 'chat_view.dart';
+import 'quick_switcher.dart';
 import 'sidebar.dart';
 
 /// The main two-pane layout. Side-by-side on desktop/tablet; on a phone it
@@ -24,7 +26,21 @@ class AppShell extends StatelessWidget {
     return Scaffold(
       backgroundColor: Colors.transparent,
       resizeToAvoidBottomInset: true,
-      body: SafeArea(
+      // Global keyboard shortcuts: Cmd/Ctrl+K quick switcher, Cmd/Ctrl+N new
+      // chat, Esc back to the list on the narrow layout. CallbackShortcuts
+      // sees keys bubbling from any focused descendant (composer included).
+      body: CallbackShortcuts(
+        bindings: {
+          const SingleActivator(LogicalKeyboardKey.keyK, meta: true): () =>
+              openQuickSwitcher(context, state),
+          const SingleActivator(LogicalKeyboardKey.keyK, control: true): () =>
+              openQuickSwitcher(context, state),
+          const SingleActivator(LogicalKeyboardKey.keyN, meta: true):
+              state.newChat,
+          const SingleActivator(LogicalKeyboardKey.keyN, control: true):
+              state.newChat,
+        },
+        child: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
             final wide = constraints.maxWidth >= _wideBreakpoint;
@@ -49,41 +65,56 @@ class AppShell extends StatelessWidget {
               listenable: state,
               builder: (context, _) {
                 final showChat = state.selectedChatId != null;
-                return AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 220),
-                  switchInCurve: Curves.easeOutCubic,
-                  transitionBuilder: (child, anim) => FadeTransition(
-                    opacity: anim,
-                    child: SlideTransition(
-                      position: Tween(
-                        begin: const Offset(0.04, 0),
-                        end: Offset.zero,
-                      ).animate(anim),
-                      child: child,
-                    ),
-                  ),
-                  child: showChat
-                      ? Padding(
-                          key: const ValueKey('chat'),
-                          padding: const EdgeInsets.all(8),
-                          child: ChatView(
-                            state: state,
-                            showBack: true,
-                            onBack: state.clearSelection,
-                          ),
-                        )
-                      : Padding(
-                          key: const ValueKey('list'),
-                          padding: const EdgeInsets.all(8),
-                          child: Sidebar(
-                            state: state,
-                            onSelect: (id) => state.selectChat(id),
-                          ),
+                return CallbackShortcuts(
+                  bindings: {
+                    const SingleActivator(LogicalKeyboardKey.escape): () {
+                      if (state.selectedChatId != null) state.clearSelection();
+                    },
+                  },
+                  child: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 240),
+                    switchInCurve: Curves.easeOutCubic,
+                    switchOutCurve: Curves.easeIn,
+                    // Shared-axis feel: the conversation slides in from the
+                    // right, the list from the left, so navigation reads as
+                    // moving through space instead of a flat cross-fade.
+                    transitionBuilder: (child, anim) {
+                      final fromRight = child.key == const ValueKey('chat');
+                      return FadeTransition(
+                        opacity: anim,
+                        child: SlideTransition(
+                          position: Tween(
+                            begin: Offset(fromRight ? 0.10 : -0.10, 0),
+                            end: Offset.zero,
+                          ).animate(anim),
+                          child: child,
                         ),
+                      );
+                    },
+                    child: showChat
+                        ? Padding(
+                            key: const ValueKey('chat'),
+                            padding: const EdgeInsets.all(8),
+                            child: ChatView(
+                              state: state,
+                              showBack: true,
+                              onBack: state.clearSelection,
+                            ),
+                          )
+                        : Padding(
+                            key: const ValueKey('list'),
+                            padding: const EdgeInsets.all(8),
+                            child: Sidebar(
+                              state: state,
+                              onSelect: (id) => state.selectChat(id),
+                            ),
+                          ),
+                  ),
                 );
               },
             );
           },
+        ),
         ),
       ),
     );

--- a/apps/companion/lib/src/ui/chat_view.dart
+++ b/apps/companion/lib/src/ui/chat_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 
 import '../models/bridge_models.dart';
@@ -62,6 +63,29 @@ class _ChatViewState extends State<ChatView> {
     final pos = _scroll.position;
     final away = pos.maxScrollExtent - pos.pixels > 420;
     if (away != _awayFromBottom) setState(() => _awayFromBottom = away);
+    // Nearing the top of loaded scrollback → pull the previous page in.
+    if (pos.pixels < 240 && !_pendingJumpToBottom) _maybeLoadOlder();
+  }
+
+  /// Fetch the page above the current scrollback and keep the viewport
+  /// anchored on the row the user was looking at (prepending grows
+  /// maxScrollExtent; jump by the delta so nothing visibly shifts).
+  Future<void> _maybeLoadOlder() async {
+    final chatId = _anchoredChatId;
+    if (chatId == null) return;
+    final state = widget.state;
+    if (state.isLoadingOlder(chatId) || !state.hasMoreHistory(chatId)) return;
+    final extentBefore =
+        _scroll.hasClients ? _scroll.position.maxScrollExtent : 0.0;
+    final pixelsBefore = _scroll.hasClients ? _scroll.position.pixels : 0.0;
+    final added = await state.loadOlderMessages(chatId);
+    if (added > 0 && mounted) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!_scroll.hasClients) return;
+        final delta = _scroll.position.maxScrollExtent - extentBefore;
+        if (delta > 0) _scroll.jumpTo(pixelsBefore + delta);
+      });
+    }
   }
 
   void _jumpToLatest() {
@@ -162,6 +186,10 @@ class _ChatViewState extends State<ChatView> {
             turn.tools.isNotEmpty ||
             turn.typing);
 
+    if (msgs.isEmpty && widget.state.isHistoryLoading(chatId)) {
+      return const _HistorySkeleton();
+    }
+
     if (msgs.isEmpty && !showActivity) {
       return _ConversationEmpty(
         onPrompt: widget.state.conn == ConnState.connected
@@ -170,7 +198,8 @@ class _ChatViewState extends State<ChatView> {
       );
     }
 
-    final itemCount = msgs.length + (showActivity ? 1 : 0);
+    final topLoader = widget.state.isLoadingOlder(chatId);
+    final itemCount = (topLoader ? 1 : 0) + msgs.length + (showActivity ? 1 : 0);
     return Stack(
       children: [
         Align(
@@ -182,8 +211,21 @@ class _ChatViewState extends State<ChatView> {
               padding: const EdgeInsets.fromLTRB(20, 18, 20, 10),
               itemCount: itemCount,
               itemBuilder: (context, i) {
-                if (i < msgs.length) {
-                  final m = msgs[i];
+                if (topLoader && i == 0) {
+                  return const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 10),
+                    child: Center(
+                      child: SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                  );
+                }
+                final mi = i - (topLoader ? 1 : 0);
+                if (mi < msgs.length) {
+                  final m = msgs[mi];
                   return MessageBubble(
                     message: m,
                     botName: widget.state.status.botName,
@@ -384,6 +426,15 @@ class _ChatMenu extends StatelessWidget {
           case 'pulse':
             await state.setPulse(chat.id, !pulseOn);
             break;
+          case 'export':
+            final messenger = ScaffoldMessenger.of(context);
+            await Clipboard.setData(
+              ClipboardData(text: state.exportMarkdown(chat.id)),
+            );
+            messenger.showSnackBar(
+              const SnackBar(content: Text('Conversation copied as Markdown')),
+            );
+            break;
           case 'rename':
             await _rename(context);
             break;
@@ -396,6 +447,11 @@ class _ChatMenu extends StatelessWidget {
         const PopupMenuItem(
           value: 'reset',
           child: _MenuRow(icon: Icons.refresh, label: 'Reset session'),
+        ),
+        const PopupMenuItem(
+          value: 'export',
+          child: _MenuRow(
+              icon: Icons.ios_share_outlined, label: 'Copy as Markdown'),
         ),
         PopupMenuItem(
           value: 'pulse',
@@ -522,6 +578,53 @@ class _Chip extends StatelessWidget {
                     const TextStyle(fontSize: 12, color: TalonColors.textDim),
               ),
             ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Shimmering placeholder rows while a chat's first history page loads, in
+/// the same silhouette as real messages so the swap doesn't jump.
+class _HistorySkeleton extends StatelessWidget {
+  const _HistorySkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+    Widget bar(double width, {bool right = false}) {
+      final box = Align(
+        alignment: right ? Alignment.centerRight : Alignment.centerLeft,
+        child: Container(
+          width: width,
+          height: 40,
+          margin: const EdgeInsets.symmetric(vertical: 8),
+          decoration: BoxDecoration(
+            color: TalonColors.surfaceHi.withValues(alpha: 0.55),
+            borderRadius: BorderRadius.circular(14),
+          ),
+        ),
+      );
+      if (reduceMotion) return box;
+      return box.animate(onPlay: (c) => c.repeat()).shimmer(
+            duration: 1200.ms,
+            color: Colors.white.withValues(alpha: 0.06),
+          );
+    }
+
+    return Align(
+      alignment: Alignment.topCenter,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: _columnMax),
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 24, 20, 10),
+          children: [
+            bar(220, right: true),
+            bar(320),
+            bar(180, right: true),
+            bar(380),
+            bar(260),
           ],
         ),
       ),

--- a/apps/companion/lib/src/ui/chat_view.dart
+++ b/apps/companion/lib/src/ui/chat_view.dart
@@ -41,10 +41,36 @@ class _ChatViewState extends State<ChatView> {
   String? _anchoredChatId;
   bool _pendingJumpToBottom = false;
 
+  /// Whether the user has scrolled up into history far enough that a
+  /// jump-to-latest affordance is useful.
+  bool _awayFromBottom = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scroll.addListener(_onScrolled);
+  }
+
   @override
   void dispose() {
     _scroll.dispose();
     super.dispose();
+  }
+
+  void _onScrolled() {
+    if (!_scroll.hasClients) return;
+    final pos = _scroll.position;
+    final away = pos.maxScrollExtent - pos.pixels > 420;
+    if (away != _awayFromBottom) setState(() => _awayFromBottom = away);
+  }
+
+  void _jumpToLatest() {
+    if (!_scroll.hasClients) return;
+    _scroll.animateTo(
+      _scroll.position.maxScrollExtent,
+      duration: const Duration(milliseconds: 260),
+      curve: Curves.easeOutCubic,
+    );
   }
 
   /// A row animates in only the first time we see it AND when it's genuinely
@@ -106,6 +132,8 @@ class _ChatViewState extends State<ChatView> {
                   showBack: widget.showBack,
                   onBack: widget.onBack,
                 ),
+                if (widget.state.conn != ConnState.connected)
+                  _ConnBanner(state: widget.state),
                 Expanded(child: _messages(chat.id)),
                 Center(
                   child: ConstrainedBox(
@@ -143,29 +171,139 @@ class _ChatViewState extends State<ChatView> {
     }
 
     final itemCount = msgs.length + (showActivity ? 1 : 0);
-    return Align(
-      alignment: Alignment.topCenter,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: _columnMax),
-        child: ListView.builder(
-          controller: _scroll,
-          padding: const EdgeInsets.fromLTRB(20, 18, 20, 10),
-          itemCount: itemCount,
-          itemBuilder: (context, i) {
-            if (i < msgs.length) {
-              final m = msgs[i];
-              return MessageBubble(
-                message: m,
-                botName: widget.state.status.botName,
-                animateIn: _shouldAnimate(m),
-                imageUrl: m.imagePath == null
-                    ? null
-                    : widget.state.config.mediaUrl(m.imagePath!),
-              );
-            }
-            return LiveTurn(turn: turn, botName: widget.state.status.botName);
-          },
+    return Stack(
+      children: [
+        Align(
+          alignment: Alignment.topCenter,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: _columnMax),
+            child: ListView.builder(
+              controller: _scroll,
+              padding: const EdgeInsets.fromLTRB(20, 18, 20, 10),
+              itemCount: itemCount,
+              itemBuilder: (context, i) {
+                if (i < msgs.length) {
+                  final m = msgs[i];
+                  return MessageBubble(
+                    message: m,
+                    botName: widget.state.status.botName,
+                    animateIn: _shouldAnimate(m),
+                    // activeConfig, not config: in local auto-discover mode the
+                    // saved config lacks the bridge's real port/token, and media
+                    // fetched through it 404s or gets rejected.
+                    imageUrl: m.imagePath == null
+                        ? null
+                        : widget.state.activeConfig.mediaUrl(m.imagePath!),
+                  );
+                }
+                return LiveTurn(
+                    turn: turn, botName: widget.state.status.botName);
+              },
+            ),
+          ),
         ),
+        Positioned(
+          right: 18,
+          bottom: 12,
+          child: AnimatedSlide(
+            duration: TalonMotion.base,
+            curve: TalonMotion.emphasized,
+            offset: _awayFromBottom ? Offset.zero : const Offset(0, 0.4),
+            child: AnimatedOpacity(
+              duration: TalonMotion.fast,
+              opacity: _awayFromBottom ? 1 : 0,
+              child: IgnorePointer(
+                ignoring: !_awayFromBottom,
+                child: _JumpToLatest(onTap: _jumpToLatest),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Round "back to the newest message" button shown once the user scrolls up
+/// into history.
+class _JumpToLatest extends StatelessWidget {
+  final VoidCallback onTap;
+  const _JumpToLatest({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: TalonColors.surfaceHi,
+      shape: const CircleBorder(
+        side: BorderSide(color: TalonColors.glassStroke),
+      ),
+      elevation: 3,
+      child: InkWell(
+        onTap: onTap,
+        customBorder: const CircleBorder(),
+        child: const Padding(
+          padding: EdgeInsets.all(9),
+          child: Icon(Icons.arrow_downward_rounded,
+              size: 18, color: TalonColors.textDim),
+        ),
+      ),
+    );
+  }
+}
+
+/// Slim status strip under the header while the app is reconnecting or the
+/// bridge is unreachable, so a dead connection is visible from the chat
+/// itself (not just the sidebar pill) and recoverable in place.
+class _ConnBanner extends StatelessWidget {
+  final AppState state;
+  const _ConnBanner({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final error = state.conn == ConnState.error;
+    final color = error ? TalonColors.bad : TalonColors.warn;
+    final text = error
+        ? (state.connError ?? 'Connection lost')
+        : 'Connecting to Talon…';
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 7),
+      color: color.withValues(alpha: 0.10),
+      child: Row(
+        children: [
+          if (error)
+            Icon(Icons.cloud_off_rounded, size: 15, color: color)
+          else
+            SizedBox(
+              width: 13,
+              height: 13,
+              child: CircularProgressIndicator(
+                strokeWidth: 1.8,
+                valueColor: AlwaysStoppedAnimation(color),
+              ),
+            ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              text,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(fontSize: 12.5, color: color),
+            ),
+          ),
+          if (error)
+            TextButton(
+              onPressed: state.start,
+              style: TextButton.styleFrom(
+                foregroundColor: color,
+                padding: const EdgeInsets.symmetric(horizontal: 10),
+                minimumSize: const Size(0, 30),
+                textStyle: const TextStyle(
+                    fontSize: 12.5, fontWeight: FontWeight.w700),
+              ),
+              child: const Text('Retry'),
+            ),
+        ],
       ),
     );
   }

--- a/apps/companion/lib/src/ui/code_block.dart
+++ b/apps/companion/lib/src/ui/code_block.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_highlight/flutter_highlight.dart';
+import 'package:flutter_highlight/themes/atom-one-dark.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:markdown/markdown.dart' as md;
+
+import '../theme.dart';
+
+/// Renders fenced code blocks as framed, syntax-highlighted panels with a
+/// language tag and a copy button — inline code falls through to the default
+/// markdown styling (returning null keeps flutter_markdown's own rendering).
+class CodeElementBuilder extends MarkdownElementBuilder {
+  @override
+  Widget? visitElementAfter(md.Element element, TextStyle? preferredStyle) {
+    var language = '';
+    final className = element.attributes['class'];
+    if (className != null && className.startsWith('language-')) {
+      language = className.substring('language-'.length);
+    }
+    final code = element.textContent;
+    // Fenced blocks carry a language class or contain newlines; single-line
+    // `inline code` gets the default pill styling from the stylesheet.
+    final isBlock = language.isNotEmpty || code.contains('\n');
+    if (!isBlock) return null;
+    return CodeBlock(code: code.trimRight(), language: language);
+  }
+}
+
+class CodeBlock extends StatefulWidget {
+  final String code;
+  final String language;
+  const CodeBlock({super.key, required this.code, this.language = ''});
+
+  @override
+  State<CodeBlock> createState() => _CodeBlockState();
+}
+
+class _CodeBlockState extends State<CodeBlock> {
+  bool _copied = false;
+
+  Future<void> _copy() async {
+    await Clipboard.setData(ClipboardData(text: widget.code));
+    if (!mounted) return;
+    setState(() => _copied = true);
+    Future.delayed(const Duration(milliseconds: 1400), () {
+      if (mounted) setState(() => _copied = false);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.symmetric(vertical: 6),
+      decoration: BoxDecoration(
+        color: TalonColors.void0.withValues(alpha: 0.65),
+        borderRadius: TalonRadius.rMd,
+        border: Border.all(color: TalonColors.glassStroke),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Header strip: language tag + copy affordance.
+          Container(
+            padding: const EdgeInsets.fromLTRB(12, 6, 6, 6),
+            decoration: const BoxDecoration(
+              border: Border(
+                bottom: BorderSide(color: TalonColors.glassStroke),
+              ),
+            ),
+            child: Row(
+              children: [
+                Text(
+                  widget.language.isEmpty ? 'code' : widget.language,
+                  style: TalonType.mono.copyWith(
+                    fontSize: 11,
+                    color: TalonColors.textFaint,
+                    letterSpacing: 0.4,
+                  ),
+                ),
+                const Spacer(),
+                InkWell(
+                  onTap: _copy,
+                  borderRadius: TalonRadius.rSm,
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          _copied ? Icons.check : Icons.copy_rounded,
+                          size: 13,
+                          color: _copied
+                              ? TalonColors.ok
+                              : TalonColors.textFaint,
+                        ),
+                        const SizedBox(width: 5),
+                        Text(
+                          _copied ? 'Copied' : 'Copy',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: _copied
+                                ? TalonColors.ok
+                                : TalonColors.textFaint,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.all(12),
+            child: widget.language.isEmpty
+                ? SelectableText(
+                    widget.code,
+                    style: TalonType.mono.copyWith(fontSize: 12.5, height: 1.5),
+                  )
+                : HighlightView(
+                    widget.code,
+                    language: widget.language,
+                    theme: {
+                      ...atomOneDarkTheme,
+                      'root': (atomOneDarkTheme['root'] ?? const TextStyle())
+                          .copyWith(backgroundColor: Colors.transparent),
+                    },
+                    textStyle:
+                        TalonType.mono.copyWith(fontSize: 12.5, height: 1.5),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/composer.dart
+++ b/apps/companion/lib/src/ui/composer.dart
@@ -112,7 +112,20 @@ class _ComposerState extends State<Composer> {
       setState(() => _uploading = true);
       final up = await widget.onUpload(bytes, name, _contentTypeFor(name));
       if (mounted) setState(() => _uploading = false);
-      if (up == null) return; // failure already surfaced as a system note
+      if (up == null) {
+        // Upload failed (a system note explains why). Hand the draft back so
+        // the user's message and attachment aren't silently thrown away —
+        // unless they already started typing a new one.
+        if (mounted) {
+          setState(() {
+            _pendingBytes = bytes;
+            _pendingName = name;
+          });
+          if (_controller.text.trim().isEmpty) _controller.text = text;
+          _recomputeCanSend();
+        }
+        return;
+      }
       imagePath = up.imagePath;
       attachmentPath = up.path;
     }
@@ -125,7 +138,8 @@ class _ComposerState extends State<Composer> {
 
   KeyEventResult _onKey(FocusNode node, KeyEvent event) {
     if (event is KeyDownEvent &&
-        event.logicalKey == LogicalKeyboardKey.enter &&
+        (event.logicalKey == LogicalKeyboardKey.enter ||
+            event.logicalKey == LogicalKeyboardKey.numpadEnter) &&
         !HardwareKeyboard.instance.isShiftPressed) {
       _send();
       return KeyEventResult.handled;

--- a/apps/companion/lib/src/ui/connect_screen.dart
+++ b/apps/companion/lib/src/ui/connect_screen.dart
@@ -137,16 +137,30 @@ class _ConnectScreenState extends State<ConnectScreen> {
                 const SizedBox(height: 18),
                 if (_remote) ..._remoteFields() else ..._localFields(),
                 const SizedBox(height: 22),
-                _ConnectButton(onTap: _connect),
-                if (widget.state.conn == ConnState.error &&
-                    widget.state.connError != null) ...[
-                  const SizedBox(height: 14),
-                  Text(
-                    widget.state.connError!,
-                    style:
-                        const TextStyle(color: TalonColors.bad, fontSize: 12.5),
+                // Listen to AppState here: when pushed from Settings this
+                // screen sits outside RootView's ListenableBuilder, so without
+                // its own listener the error text and busy state never update.
+                ListenableBuilder(
+                  listenable: widget.state,
+                  builder: (context, _) => Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      _ConnectButton(
+                        onTap: _connect,
+                        busy: widget.state.conn == ConnState.connecting,
+                      ),
+                      if (widget.state.conn == ConnState.error &&
+                          widget.state.connError != null) ...[
+                        const SizedBox(height: 14),
+                        Text(
+                          widget.state.connError!,
+                          style: const TextStyle(
+                              color: TalonColors.bad, fontSize: 12.5),
+                        ),
+                      ],
+                    ],
                   ),
-                ],
+                ),
               ],
             ),
           ),
@@ -332,12 +346,13 @@ class _Hint extends StatelessWidget {
 
 class _ConnectButton extends StatelessWidget {
   final VoidCallback onTap;
-  const _ConnectButton({required this.onTap});
+  final bool busy;
+  const _ConnectButton({required this.onTap, this.busy = false});
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: onTap,
+      onTap: busy ? null : onTap,
       borderRadius: BorderRadius.circular(14),
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 14),
@@ -345,14 +360,24 @@ class _ConnectButton extends StatelessWidget {
           borderRadius: TalonRadius.rMd,
           gradient: TalonColors.accentGradient,
         ),
-        child: const Row(
+        child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.bolt, color: Colors.white, size: 19),
-            SizedBox(width: 8),
+            if (busy)
+              const SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation(Colors.white),
+                ),
+              )
+            else
+              const Icon(Icons.bolt, color: Colors.white, size: 19),
+            const SizedBox(width: 8),
             Text(
-              'Connect',
-              style: TextStyle(
+              busy ? 'Connecting…' : 'Connect',
+              style: const TextStyle(
                 color: Colors.white,
                 fontWeight: FontWeight.w700,
                 fontSize: 15,

--- a/apps/companion/lib/src/ui/message_bubble.dart
+++ b/apps/companion/lib/src/ui/message_bubble.dart
@@ -6,9 +6,17 @@ import 'package:url_launcher/url_launcher.dart' show launchUrl, LaunchMode;
 import '../models/bridge_models.dart';
 import '../theme.dart';
 import 'brand.dart';
+import 'code_block.dart';
 import 'markdown.dart';
 import 'motion.dart';
 import 'tool_timeline.dart';
+
+/// Compact clock stamp for message rows ("14:32").
+String _clock(DateTime t) {
+  final local = t.toLocal();
+  String two(int n) => n < 10 ? '0$n' : '$n';
+  return '${two(local.hour)}:${two(local.minute)}';
+}
 
 /// A single conversation row, ChatGPT-style:
 ///   - user: a compact rounded bubble aligned right
@@ -89,22 +97,26 @@ class MessageBubble extends StatelessWidget {
               flex: 9,
               child: Align(
                 alignment: Alignment.centerRight,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: TalonSpace.lg, vertical: 11),
-                  decoration: BoxDecoration(
-                    color: TalonColors.surfaceHi,
-                    borderRadius: const BorderRadius.only(
-                      topLeft: Radius.circular(18),
-                      topRight: Radius.circular(18),
-                      bottomLeft: Radius.circular(18),
-                      bottomRight: Radius.circular(6),
+                child: Tooltip(
+                  message: message.time.toLocal().toString().split('.').first,
+                  waitDuration: const Duration(milliseconds: 600),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: TalonSpace.lg, vertical: 11),
+                    decoration: BoxDecoration(
+                      color: TalonColors.surfaceHi,
+                      borderRadius: const BorderRadius.only(
+                        topLeft: Radius.circular(18),
+                        topRight: Radius.circular(18),
+                        bottomLeft: Radius.circular(18),
+                        bottomRight: Radius.circular(6),
+                      ),
+                      border: Border.all(color: TalonColors.glassStroke),
                     ),
-                    border: Border.all(color: TalonColors.glassStroke),
-                  ),
-                  child: SelectableText(
-                    message.text,
-                    style: TalonType.body,
+                    child: SelectableText(
+                      message.text,
+                      style: TalonType.body,
+                    ),
                   ),
                 ),
               ),
@@ -127,7 +139,18 @@ class MessageBubble extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(botName, style: TalonType.subtitle),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.baseline,
+                    textBaseline: TextBaseline.alphabetic,
+                    children: [
+                      Text(botName, style: TalonType.subtitle),
+                      const SizedBox(width: TalonSpace.sm),
+                      Text(
+                        _clock(message.time),
+                        style: TalonType.caption.copyWith(fontSize: 10.5),
+                      ),
+                    ],
+                  ),
                   const SizedBox(height: TalonSpace.xs),
                   if (message.tools.isNotEmpty)
                     Padding(
@@ -145,6 +168,7 @@ class MessageBubble extends StatelessWidget {
                     MarkdownBody(
                       data: message.text.isEmpty ? '…' : message.text,
                       selectable: true,
+                      builders: {'code': CodeElementBuilder()},
                       onTapLink: (_, href, __) {
                         if (href != null) {
                           launchUrl(Uri.parse(href),

--- a/apps/companion/lib/src/ui/model_sheet.dart
+++ b/apps/companion/lib/src/ui/model_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 
@@ -35,6 +37,16 @@ class _ModelSheetState extends State<_ModelSheet> {
   String _activeBackend = '';
   bool _switchingBackend = false;
 
+  /// The live chat from AppState, so `chat_updated` events (model, effort or
+  /// backend changed here or from another client) are reflected while the
+  /// sheet is open. [widget.chat] is only a fallback if the chat vanished.
+  ClientChat get _chat {
+    for (final c in widget.state.chats) {
+      if (c.id == widget.chat.id) return c;
+    }
+    return widget.chat;
+  }
+
   @override
   void initState() {
     super.initState();
@@ -46,8 +58,10 @@ class _ModelSheetState extends State<_ModelSheet> {
     final (active, levels) = await widget.state.effortLevels(widget.chat.id);
     if (mounted) {
       setState(() {
-        _effortLevels = levels;
-        _activeEffort = widget.chat.effort ?? active;
+        // 'adaptive' is rendered as a fixed first chip; some daemons also
+        // include it in the level list, which would draw it twice.
+        _effortLevels = levels.where((l) => l != 'adaptive').toList();
+        _activeEffort = _chat.effort ?? active;
       });
     }
   }
@@ -57,7 +71,7 @@ class _ModelSheetState extends State<_ModelSheet> {
     if (mounted) {
       setState(() {
         _backends = backends;
-        _activeBackend = widget.chat.backend ?? active;
+        _activeBackend = _chat.backend ?? active;
       });
     }
   }
@@ -68,13 +82,14 @@ class _ModelSheetState extends State<_ModelSheet> {
     final result = await widget.state.setBackend(widget.chat.id, id);
     if (!mounted) return;
     if (result.ok) {
+      // setBackend already re-pulled the new backend's model catalog; the
+      // ListenableBuilder in build picks it up. Effort levels are per-backend
+      // too, so re-fetch them for the new backend.
       setState(() {
         _activeBackend = id;
         _switchingBackend = false;
       });
-      // The new backend exposes its own models — refresh the daemon's list.
-      await widget.state.refreshModels(widget.chat.id);
-      if (mounted) setState(() {});
+      unawaited(_loadEffort());
     } else {
       setState(() => _switchingBackend = false);
       ScaffoldMessenger.of(context).showSnackBar(
@@ -85,13 +100,22 @@ class _ModelSheetState extends State<_ModelSheet> {
 
   @override
   Widget build(BuildContext context) {
+    // Listen to AppState so the list repopulates when the catalog lands after
+    // the sheet opened (first open, or the refresh after a backend switch).
+    return ListenableBuilder(
+      listenable: widget.state,
+      builder: (context, _) => _sheet(context),
+    );
+  }
+
+  Widget _sheet(BuildContext context) {
     final models = widget.state.models
         .where((m) =>
             _query.isEmpty ||
             m.displayName.toLowerCase().contains(_query.toLowerCase()) ||
             m.provider.toLowerCase().contains(_query.toLowerCase()))
         .toList();
-    final activeModel = widget.chat.model ?? widget.state.status.model;
+    final activeModel = _chat.model ?? widget.state.status.model;
 
     return DraggableScrollableSheet(
       initialChildSize: 0.7,
@@ -122,7 +146,7 @@ class _ModelSheetState extends State<_ModelSheet> {
                     const Icon(Icons.tune, size: 18, color: TalonColors.accent),
                     const SizedBox(width: 8),
                     Text(
-                      widget.chat.title,
+                      _chat.title,
                       style: const TextStyle(
                           fontSize: 16, fontWeight: FontWeight.w700),
                     ),

--- a/apps/companion/lib/src/ui/quick_switcher.dart
+++ b/apps/companion/lib/src/ui/quick_switcher.dart
@@ -1,0 +1,258 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/bridge_models.dart';
+import '../state/app_state.dart';
+import '../theme.dart';
+
+/// Cmd/Ctrl+K quick switcher: fuzzy chat jump + daemon-side full-text search
+/// over message content, keyboard-first (↑↓ to move, Enter to open, Esc to
+/// dismiss). Chats match locally and instantly; message hits stream in from
+/// `GET /search` after a short debounce.
+Future<void> openQuickSwitcher(BuildContext context, AppState state) {
+  return showDialog<void>(
+    context: context,
+    barrierColor: Colors.black.withValues(alpha: 0.55),
+    builder: (_) => _QuickSwitcher(state: state),
+  );
+}
+
+/// One selectable row: either a chat (jump to it) or a message hit
+/// (jump to its chat).
+class _Entry {
+  final String chatId;
+  final String title;
+  final String? subtitle;
+  final IconData icon;
+  const _Entry({
+    required this.chatId,
+    required this.title,
+    this.subtitle,
+    required this.icon,
+  });
+}
+
+class _QuickSwitcher extends StatefulWidget {
+  final AppState state;
+  const _QuickSwitcher({required this.state});
+
+  @override
+  State<_QuickSwitcher> createState() => _QuickSwitcherState();
+}
+
+class _QuickSwitcherState extends State<_QuickSwitcher> {
+  final _controller = TextEditingController();
+  Timer? _debounce;
+  List<SearchHit> _hits = const [];
+  bool _searching = false;
+  int _highlighted = 0;
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onQuery(String q) {
+    setState(() => _highlighted = 0);
+    _debounce?.cancel();
+    if (q.trim().length < 2) {
+      setState(() {
+        _hits = const [];
+        _searching = false;
+      });
+      return;
+    }
+    setState(() => _searching = true);
+    _debounce = Timer(const Duration(milliseconds: 300), () async {
+      final hits = await widget.state.searchMessages(q);
+      if (mounted) {
+        setState(() {
+          _hits = hits;
+          _searching = false;
+        });
+      }
+    });
+  }
+
+  List<_Entry> _entries() {
+    final q = _controller.text.trim().toLowerCase();
+    final chats = widget.state.chats
+        .where((c) => q.isEmpty || c.title.toLowerCase().contains(q))
+        .take(6)
+        .map((c) => _Entry(
+              chatId: c.id,
+              title: c.title,
+              subtitle: c.preview.isEmpty ? null : c.preview,
+              icon: Icons.chat_bubble_outline,
+            ));
+    final hits = _hits.take(12).map((h) => _Entry(
+          chatId: h.chatId,
+          title: h.chatTitle,
+          subtitle: h.message.text.replaceAll('\n', ' '),
+          icon: Icons.manage_search,
+        ));
+    return [...chats, ...hits];
+  }
+
+  void _open(_Entry entry) {
+    Navigator.of(context).pop();
+    widget.state.selectChat(entry.chatId);
+  }
+
+  KeyEventResult _onKey(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    final entries = _entries();
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+      setState(() =>
+          _highlighted = entries.isEmpty ? 0 : (_highlighted + 1) % entries.length);
+      return KeyEventResult.handled;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+      setState(() => _highlighted = entries.isEmpty
+          ? 0
+          : (_highlighted - 1 + entries.length) % entries.length);
+      return KeyEventResult.handled;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.enter) {
+      if (entries.isNotEmpty) {
+        _open(entries[_highlighted.clamp(0, entries.length - 1)]);
+      }
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = _entries();
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      alignment: const Alignment(0, -0.5),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 560, maxHeight: 460),
+        child: Container(
+          decoration: BoxDecoration(
+            color: TalonColors.void1,
+            borderRadius: TalonRadius.rLg,
+            border: Border.all(color: TalonColors.glassStroke),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(10),
+                child: Focus(
+                  onKeyEvent: _onKey,
+                  child: TextField(
+                    controller: _controller,
+                    autofocus: true,
+                    onChanged: _onQuery,
+                    style: const TextStyle(fontSize: 15),
+                    decoration: InputDecoration(
+                      prefixIcon: const Icon(Icons.search, size: 19),
+                      suffixIcon: _searching
+                          ? const Padding(
+                              padding: EdgeInsets.all(12),
+                              child: SizedBox(
+                                width: 14,
+                                height: 14,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2),
+                              ),
+                            )
+                          : null,
+                      hintText: 'Jump to a chat or search messages…',
+                      filled: true,
+                      fillColor: TalonColors.void0.withValues(alpha: 0.6),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide.none,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Flexible(
+                child: entries.isEmpty
+                    ? Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 6, 16, 18),
+                        child: Text(
+                          _controller.text.trim().length >= 2 && !_searching
+                              ? 'No matches.'
+                              : 'Type to search chats and messages.',
+                          style:
+                              const TextStyle(color: TalonColors.textFaint),
+                        ),
+                      )
+                    : ListView.builder(
+                        shrinkWrap: true,
+                        padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+                        itemCount: entries.length,
+                        itemBuilder: (context, i) {
+                          final e = entries[i];
+                          final selected = i == _highlighted;
+                          return InkWell(
+                            onTap: () => _open(e),
+                            borderRadius: TalonRadius.rSm,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 10, vertical: 8),
+                              decoration: BoxDecoration(
+                                borderRadius: TalonRadius.rSm,
+                                color: selected
+                                    ? TalonColors.surfaceHi
+                                    : Colors.transparent,
+                              ),
+                              child: Row(
+                                children: [
+                                  Icon(e.icon,
+                                      size: 15,
+                                      color: selected
+                                          ? TalonColors.accent
+                                          : TalonColors.textFaint),
+                                  const SizedBox(width: 10),
+                                  Expanded(
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          e.title,
+                                          maxLines: 1,
+                                          overflow: TextOverflow.ellipsis,
+                                          style: const TextStyle(
+                                              fontSize: 13.5,
+                                              fontWeight: FontWeight.w600),
+                                        ),
+                                        if (e.subtitle != null)
+                                          Text(
+                                            e.subtitle!,
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                            style: const TextStyle(
+                                                fontSize: 12,
+                                                color: TalonColors.textFaint),
+                                          ),
+                                      ],
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/settings_screen.dart
+++ b/apps/companion/lib/src/ui/settings_screen.dart
@@ -247,7 +247,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Widget _diagnosticsCard(ConfigSnapshot? cfg) {
     final s = widget.state;
-    final c = s.config;
+    // The effective connection (with any auto-discovered port/token), not the
+    // saved profile — diagnostics should describe what's actually in use.
+    final c = s.activeConfig;
     final protoOk = s.status.protocol == kBridgeProtocolVersion;
     final connected = s.conn == ConnState.connected;
 
@@ -337,7 +339,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final buf = StringBuffer()
       ..writeln('Talon diagnostics')
       ..writeln('connection: ${s.conn.name}')
-      ..writeln('endpoint: ${s.config.baseUrl}')
+      ..writeln('endpoint: ${s.activeConfig.baseUrl}')
       ..writeln(
           'protocol: app v$kBridgeProtocolVersion / daemon v${s.status.protocol}')
       ..writeln('backend: ${s.status.backend}')

--- a/apps/companion/lib/src/ui/sidebar.dart
+++ b/apps/companion/lib/src/ui/sidebar.dart
@@ -214,6 +214,21 @@ class _Group {
   _Group(this.label, this.chats);
 }
 
+/// Compact "how long ago" stamp for chat tiles: `now`, `12m`, `3h`, `2d`,
+/// then a short date once it's over a week old.
+String _relTime(DateTime t) {
+  final diff = DateTime.now().difference(t);
+  if (diff.inMinutes < 1) return 'now';
+  if (diff.inMinutes < 60) return '${diff.inMinutes}m';
+  if (diff.inHours < 24) return '${diff.inHours}h';
+  if (diff.inDays < 7) return '${diff.inDays}d';
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  return '${t.day} ${months[t.month - 1]}';
+}
+
 class _ChatTile extends StatefulWidget {
   final ClientChat chat;
   final bool selected;
@@ -262,13 +277,14 @@ class _ChatTileState extends State<_ChatTile> {
                   : (_hover ? TalonColors.surface : Colors.transparent),
             ),
             child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 // A slim accent bar slides in on the selected tile.
                 AnimatedContainer(
                   duration: TalonMotion.base,
                   curve: TalonMotion.emphasized,
                   width: selected ? 3 : 0,
-                  height: 15,
+                  height: 28,
                   margin: EdgeInsets.only(right: selected ? 9 : 0),
                   decoration: const BoxDecoration(
                     gradient: TalonColors.accentGradient,
@@ -276,15 +292,55 @@ class _ChatTileState extends State<_ChatTile> {
                   ),
                 ),
                 Expanded(
-                  child: Text(
-                    widget.chat.title,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 13.5,
-                      fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
-                      color: selected ? TalonColors.text : TalonColors.textDim,
-                    ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              widget.chat.title,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontSize: 13.5,
+                                fontWeight: selected
+                                    ? FontWeight.w600
+                                    : FontWeight.w500,
+                                color: selected
+                                    ? TalonColors.text
+                                    : TalonColors.textDim,
+                              ),
+                            ),
+                          ),
+                          if (widget.chat.pulse == true)
+                            const Padding(
+                              padding: EdgeInsets.only(left: 4),
+                              child: Icon(Icons.notifications_active_outlined,
+                                  size: 11, color: TalonColors.textFaint),
+                            ),
+                          const SizedBox(width: 6),
+                          Text(
+                            _relTime(widget.chat.lastActiveTime),
+                            style: const TextStyle(
+                                fontSize: 10.5, color: TalonColors.textFaint),
+                          ),
+                        ],
+                      ),
+                      if (widget.chat.preview.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 1),
+                          child: Text(
+                            widget.chat.preview.replaceAll('\n', ' '),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                                fontSize: 11.5,
+                                color: TalonColors.textFaint,
+                                height: 1.3),
+                          ),
+                        ),
+                    ],
                   ),
                 ),
                 AnimatedOpacity(

--- a/apps/companion/lib/src/ui/sidebar.dart
+++ b/apps/companion/lib/src/ui/sidebar.dart
@@ -140,6 +140,7 @@ class _SidebarState extends State<Sidebar> {
                 child: _ChatTile(
                   chat: chat,
                   selected: chat.id == widget.state.selectedChatId,
+                  unread: widget.state.hasUnread(chat),
                   onTap: () =>
                       (widget.onSelect ?? widget.state.selectChat)(chat.id),
                   onDelete: () => _confirmDelete(context, chat),
@@ -232,12 +233,14 @@ String _relTime(DateTime t) {
 class _ChatTile extends StatefulWidget {
   final ClientChat chat;
   final bool selected;
+  final bool unread;
   final VoidCallback onTap;
   final VoidCallback onDelete;
 
   const _ChatTile({
     required this.chat,
     required this.selected,
+    required this.unread,
     required this.onTap,
     required this.onDelete,
   });
@@ -304,10 +307,10 @@ class _ChatTileState extends State<_ChatTile> {
                               overflow: TextOverflow.ellipsis,
                               style: TextStyle(
                                 fontSize: 13.5,
-                                fontWeight: selected
+                                fontWeight: selected || widget.unread
                                     ? FontWeight.w600
                                     : FontWeight.w500,
-                                color: selected
+                                color: selected || widget.unread
                                     ? TalonColors.text
                                     : TalonColors.textDim,
                               ),
@@ -325,6 +328,17 @@ class _ChatTileState extends State<_ChatTile> {
                             style: const TextStyle(
                                 fontSize: 10.5, color: TalonColors.textFaint),
                           ),
+                          // Unread: activity newer than the user's last look.
+                          if (widget.unread)
+                            Container(
+                              width: 7,
+                              height: 7,
+                              margin: const EdgeInsets.only(left: 6),
+                              decoration: const BoxDecoration(
+                                shape: BoxShape.circle,
+                                gradient: TalonColors.accentGradient,
+                              ),
+                            ),
                         ],
                       ),
                       if (widget.chat.preview.isNotEmpty)

--- a/apps/companion/pubspec.yaml
+++ b/apps/companion/pubspec.yaml
@@ -21,6 +21,11 @@ dependencies:
   shared_preferences: ^2.3.2
   # Markdown rendering for assistant replies (code blocks, tables, lists).
   flutter_markdown: ^0.7.4
+  # AST access for the custom fenced-code-block builder (copy button +
+  # syntax highlighting). Same package flutter_markdown parses with.
+  markdown: ^7.2.2
+  # Syntax highlighting inside fenced code blocks.
+  flutter_highlight: ^0.7.0
   # Declarative animation layer (gskinner, a Flutter Favorite). Replaces the
   # hand-rolled AnimationControllers with a chainable .animate() API and powers
   # the staggered list entrances, shimmer skeletons, and streaming caret.

--- a/apps/companion/test/app_state_test.dart
+++ b/apps/companion/test/app_state_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:talon_companion/src/models/bridge_models.dart';
 import 'package:talon_companion/src/models/connection.dart';
 import 'package:talon_companion/src/state/app_state.dart';
 import 'package:talon_companion/src/services/prefs.dart';
@@ -219,6 +220,91 @@ void main() {
         expect(bridge.streamCount, 0);
       },
     );
+
+    test('reconnect drops selection of a chat deleted while away', () async {
+      final bridge = await MockBridge.start();
+      addTearDown(bridge.close);
+      final state = await stateFor(configFor(bridge));
+      addTearDown(state.dispose);
+
+      await state.start();
+      await _waitFor(() => state.conn == ConnState.connected);
+      expect(state.selectedChatId, 'c1');
+
+      // The chat is deleted server-side while the client is away.
+      bridge.chats
+        ..clear()
+        ..add({
+          'id': 'c2',
+          'title': 'Fresh',
+          'createdAt': 3,
+          'lastActive': 4,
+          'preview': '',
+        });
+      bridge.messages
+        ..clear()
+        ..['c2'] = [];
+
+      await state.start();
+      await _waitFor(() => state.selectedChatId == 'c2');
+      expect(state.selectedChat, isNotNull);
+    });
+
+    test('setModel/setEffort/renameChat apply optimistically', () async {
+      final bridge = await MockBridge.start();
+      addTearDown(bridge.close);
+      final state = await stateFor(configFor(bridge));
+      addTearDown(state.dispose);
+      await state.start();
+      await _waitFor(() => state.conn == ConnState.connected);
+
+      final modelDone = state.setModel('c1', 'm2');
+      expect(state.chats.single.model, 'm2');
+      await modelDone;
+
+      final effortDone = state.setEffort('c1', 'high');
+      expect(state.chats.single.effort, 'high');
+      await effortDone;
+
+      final renameDone = state.renameChat('c1', 'Renamed locally');
+      expect(state.chats.single.title, 'Renamed locally');
+      await renameDone;
+    });
+
+    test('failed chat command surfaces a system note, not a throw', () async {
+      final bridge = await MockBridge.start();
+      addTearDown(bridge.close);
+      final state = await stateFor(configFor(bridge));
+      addTearDown(state.dispose);
+      await state.start();
+      await _waitFor(() => state.conn == ConnState.connected);
+
+      // The mock bridge has no /chats/rename endpoint → the POST 404s. That
+      // must land as a visible system note in the chat, not an unhandled
+      // async exception out of a UI callback.
+      await state.renameChat('c1', 'nope');
+      final note = state.messagesFor('c1').last;
+      expect(note.role, Role.system);
+      expect(note.text, contains('Rename failed'));
+    });
+
+    test('missing backend/effort endpoints degrade gracefully', () async {
+      final bridge = await MockBridge.start();
+      addTearDown(bridge.close);
+      final state = await stateFor(configFor(bridge));
+      addTearDown(state.dispose);
+      await state.start();
+      await _waitFor(() => state.conn == ConnState.connected);
+
+      // No /backends or /backend on the mock bridge: fetch returns empty and
+      // a switch reports failure instead of throwing.
+      final (active, backends) = await state.backends('c1');
+      expect(active, '');
+      expect(backends, isEmpty);
+      final r = await state.setBackend('c1', 'other');
+      expect(r.ok, isFalse);
+      expect(r.error, isNotNull);
+    });
 
     test('applyConfig resets stores before loading the new bridge', () async {
       final first = await MockBridge.start();

--- a/apps/companion/test/app_state_test.dart
+++ b/apps/companion/test/app_state_test.dart
@@ -306,6 +306,159 @@ void main() {
       expect(r.error, isNotNull);
     });
 
+    test('loadOlderMessages pages scrollback and reports exhaustion',
+        () async {
+      final bridge = await MockBridge.start();
+      addTearDown(bridge.close);
+      // 250 messages: initial load caps at 200, one older page remains.
+      bridge.messages['c1'] = [
+        for (var i = 1; i <= 250; i++)
+          {
+            'id': '$i',
+            'chatId': 'c1',
+            'role': i.isEven ? 'assistant' : 'user',
+            'text': 'msg $i',
+            'ts': i,
+          },
+      ];
+      final state = await stateFor(configFor(bridge));
+      addTearDown(state.dispose);
+      await state.start();
+      await _waitFor(() => state.conn == ConnState.connected);
+      await _waitFor(() => state.messagesFor('c1').length == 200);
+      expect(state.messagesFor('c1').first.text, 'msg 51');
+      expect(state.hasMoreHistory('c1'), isTrue);
+
+      final added = await state.loadOlderMessages('c1');
+      expect(added, 50);
+      expect(state.messagesFor('c1').length, 250);
+      expect(state.messagesFor('c1').first.text, 'msg 1');
+      // A 50-row page (< page size) marks the scrollback exhausted.
+      expect(state.hasMoreHistory('c1'), isFalse);
+      expect(await state.loadOlderMessages('c1'), 0);
+    });
+
+    test('searchMessages returns daemon hits', () async {
+      final bridge = await MockBridge.start();
+      addTearDown(bridge.close);
+      final state = await stateFor(configFor(bridge));
+      addTearDown(state.dispose);
+      await state.start();
+      await _waitFor(() => state.conn == ConnState.connected);
+
+      final hits = await state.searchMessages('Hello');
+      expect(hits, hasLength(1));
+      expect(hits.single.chatId, 'c1');
+      expect(hits.single.chatTitle, 'General');
+      expect(hits.single.message.text, 'Hello');
+      expect(await state.searchMessages('zzz-no-match'), isEmpty);
+    });
+
+    test('history hydrates persisted tool traces and turn stats', () async {
+      final bridge = await MockBridge.start();
+      addTearDown(bridge.close);
+      bridge.messages['c1']!.add({
+        'id': 'm2',
+        'chatId': 'c1',
+        'role': 'assistant',
+        'text': 'done',
+        'ts': 20,
+        'durationMs': 4200,
+        'tokensIn': 1200,
+        'tokensOut': 340,
+        'tools': [
+          {
+            'id': 't1',
+            'name': 'search',
+            'input': {'q': 'talon'},
+            'durationMs': 800,
+          },
+          {'id': 't2', 'name': 'bash', 'error': 'exit 1', 'durationMs': 100},
+        ],
+      });
+      final state = await stateFor(configFor(bridge));
+      addTearDown(state.dispose);
+      await state.start();
+      await _waitFor(() => state.messagesFor('c1').length == 2);
+
+      final m = state.messagesFor('c1').last;
+      expect(m.durationMs, 4200);
+      expect(m.tokensIn, 1200);
+      expect(m.tokensOut, 340);
+      expect(m.tools, hasLength(2));
+      expect(m.tools.first.done, isTrue);
+      expect(m.tools.first.elapsed.inMilliseconds, 800);
+      expect(m.tools.last.error, 'exit 1');
+      expect(m.hasStats, isTrue);
+    });
+
+    test('unread tracks lastActive vs local read marker', () async {
+      final bridge = await MockBridge.start();
+      addTearDown(bridge.close);
+      final state = await stateFor(configFor(bridge));
+      addTearDown(state.dispose);
+      await state.start();
+      await _waitFor(() => state.conn == ConnState.connected);
+
+      // c1 is auto-selected on connect → read.
+      expect(state.selectedChatId, 'c1');
+      await state.selectChat('c1');
+      expect(state.hasUnread(state.chats.single), isFalse);
+
+      // A second chat sees newer activity the user hasn't looked at.
+      await bridge.emit({
+        'kind': 'chat_created',
+        'chat': {
+          'id': 'c2',
+          'title': 'Other',
+          'createdAt': 5,
+          'lastActive': DateTime.now().millisecondsSinceEpoch,
+          'preview': 'ping',
+        },
+      });
+      await _waitFor(() => state.chats.length == 2);
+      final other = state.chats.firstWhere((c) => c.id == 'c2');
+      expect(state.hasUnread(other), isTrue);
+
+      await state.selectChat('c2');
+      expect(state.hasUnread(other), isFalse);
+    });
+
+    test('offline snapshot hydrates chats and messages at construction',
+        () async {
+      final bridge = await MockBridge.start();
+      addTearDown(bridge.close);
+      final state = await stateFor(configFor(bridge));
+      await state.start();
+      await _waitFor(() => state.messagesFor('c1').isNotEmpty);
+      // Let the debounced snapshot land.
+      await Future<void>.delayed(const Duration(milliseconds: 2300));
+      final prefs = state.prefs;
+      state.dispose();
+
+      // A brand-new AppState (fresh launch) renders from the snapshot
+      // without any connection.
+      final cold = AppState(prefs);
+      addTearDown(cold.dispose);
+      expect(cold.chats.single.id, 'c1');
+      expect(cold.messagesFor('c1').single.text, 'Hello');
+      expect(cold.selectedChatId, 'c1');
+    });
+
+    test('exportMarkdown renders the conversation', () async {
+      final bridge = await MockBridge.start();
+      addTearDown(bridge.close);
+      final state = await stateFor(configFor(bridge));
+      addTearDown(state.dispose);
+      await state.start();
+      await _waitFor(() => state.messagesFor('c1').isNotEmpty);
+
+      final md = state.exportMarkdown('c1');
+      expect(md, contains('# General'));
+      expect(md, contains('**User**'));
+      expect(md, contains('Hello'));
+    });
+
     test('applyConfig resets stores before loading the new bridge', () async {
       final first = await MockBridge.start();
       final second = await MockBridge.start();

--- a/apps/companion/test/fixtures/protocol_v1.json
+++ b/apps/companion/test/fixtures/protocol_v1.json
@@ -1,0 +1,63 @@
+{
+  "_comment": "Canonical Bridge Protocol v1 wire samples. Asserted byte-for-byte-compatible by BOTH sides: src/__tests__/native-protocol-fixture.test.ts (daemon) and test/protocol_fixture_test.dart (companion). If a field changes shape or name, one of those suites fails — that is the point. Keep additive.",
+  "protocol": 1,
+  "message": {
+    "id": "1024",
+    "chatId": "d_abc123",
+    "role": "assistant",
+    "text": "Here is **markdown** with `code`.",
+    "ts": 1767225600000,
+    "buttons": [[{ "text": "Open", "url": "https://example.com" }]],
+    "reactions": ["👍"],
+    "imagePath": "/media?id=m42",
+    "durationMs": 4200,
+    "tokensIn": 1200,
+    "tokensOut": 340,
+    "tools": [
+      {
+        "id": "toolu_01",
+        "name": "mcp__search__web",
+        "input": { "query": "talon agent" },
+        "durationMs": 800
+      },
+      {
+        "id": "toolu_02",
+        "name": "Bash",
+        "input": { "command": "ls" },
+        "error": "exit 1",
+        "durationMs": 120
+      }
+    ]
+  },
+  "chat": {
+    "id": "d_abc123",
+    "title": "Protocol design",
+    "createdAt": 1767225500000,
+    "lastActive": 1767225600000,
+    "preview": "Here is markdown with code.",
+    "model": "claude-sonnet-5",
+    "backend": "claude",
+    "effort": "high",
+    "pulse": true
+  },
+  "status": {
+    "app": "talon-bridge",
+    "protocol": 1,
+    "botName": "Talon",
+    "backend": "claude",
+    "model": "Claude Sonnet 5",
+    "activeChats": 3,
+    "startedAt": "2026-01-01T00:00:00.000Z"
+  },
+  "searchResult": {
+    "chatId": "d_abc123",
+    "chatTitle": "Protocol design",
+    "message": {
+      "id": "900",
+      "chatId": "d_abc123",
+      "role": "user",
+      "text": "find the fox",
+      "ts": 1767225000000
+    }
+  }
+}

--- a/apps/companion/test/mock_bridge.dart
+++ b/apps/companion/test/mock_bridge.dart
@@ -149,10 +149,38 @@ class MockBridge {
     }
     if (req.method == 'GET' && path == '/history') {
       final chatId = req.uri.queryParameters['chatId'] ?? '';
+      final before = int.tryParse(req.uri.queryParameters['before'] ?? '');
+      final limit = int.tryParse(req.uri.queryParameters['limit'] ?? '') ?? 200;
+      var list = messages[chatId] ?? const <Map<String, dynamic>>[];
+      if (before != null) {
+        list = list
+            .where((m) => (int.tryParse('${m['id']}') ?? 0) < before)
+            .toList();
+      }
+      if (list.length > limit) list = list.sublist(list.length - limit);
       return _json(req.response, 200, {
         'chatId': chatId,
-        'messages': messages[chatId] ?? const [],
+        'messages': list,
       });
+    }
+    if (req.method == 'GET' && path == '/search') {
+      final q = (req.uri.queryParameters['q'] ?? '').toLowerCase();
+      final results = <Map<String, dynamic>>[];
+      messages.forEach((chatId, list) {
+        for (final m in list) {
+          if ('${m['text']}'.toLowerCase().contains(q)) {
+            results.add({
+              'chatId': chatId,
+              'chatTitle': chats.firstWhere(
+                (c) => c['id'] == chatId,
+                orElse: () => {'title': ''},
+              )['title'],
+              'message': m,
+            });
+          }
+        }
+      });
+      return _json(req.response, 200, {'results': results});
     }
     if (req.method == 'POST' && path == '/send') {
       final body = await _readJson(req);

--- a/apps/companion/test/protocol_fixture_test.dart
+++ b/apps/companion/test/protocol_fixture_test.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:talon_companion/src/models/bridge_models.dart';
+
+/// Contract test against the shared protocol fixture. The daemon asserts the
+/// same file from TypeScript (src/__tests__/native-protocol-fixture.test.ts),
+/// so a wire-shape drift on either side fails one of the two suites instead
+/// of shipping a silent misrender.
+void main() {
+  final fixture = jsonDecode(
+    File('test/fixtures/protocol_v1.json').readAsStringSync(),
+  ) as Map<String, dynamic>;
+
+  test('fixture protocol version matches the client', () {
+    expect(fixture['protocol'], kBridgeProtocolVersion);
+  });
+
+  test('canonical message parses with turn meta intact', () {
+    final m = ClientMessage.fromJson(
+        (fixture['message'] as Map).cast<String, dynamic>());
+    expect(m.id, '1024');
+    expect(m.chatId, 'd_abc123');
+    expect(m.role, Role.assistant);
+    expect(m.text, contains('markdown'));
+    expect(m.ts, 1767225600000);
+    expect(m.buttons.single.single.text, 'Open');
+    expect(m.buttons.single.single.url, 'https://example.com');
+    expect(m.reactions, ['👍']);
+    expect(m.imagePath, '/media?id=m42');
+    expect(m.durationMs, 4200);
+    expect(m.tokensIn, 1200);
+    expect(m.tokensOut, 340);
+    expect(m.hasStats, isTrue);
+    expect(m.tools, hasLength(2));
+    expect(m.tools.first.name, 'mcp__search__web');
+    expect(m.tools.first.input['query'], 'talon agent');
+    expect(m.tools.first.done, isTrue);
+    expect(m.tools.first.elapsed.inMilliseconds, 800);
+    expect(m.tools.last.error, 'exit 1');
+  });
+
+  test('canonical chat parses', () {
+    final c =
+        ClientChat.fromJson((fixture['chat'] as Map).cast<String, dynamic>());
+    expect(c.id, 'd_abc123');
+    expect(c.title, 'Protocol design');
+    expect(c.createdAt, 1767225500000);
+    expect(c.lastActive, 1767225600000);
+    expect(c.model, 'claude-sonnet-5');
+    expect(c.backend, 'claude');
+    expect(c.effort, 'high');
+    expect(c.pulse, isTrue);
+  });
+
+  test('canonical status parses', () {
+    final s = BridgeStatus.fromJson(
+        (fixture['status'] as Map).cast<String, dynamic>());
+    expect(s.protocol, 1);
+    expect(s.botName, 'Talon');
+    expect(s.backend, 'claude');
+    expect(s.model, 'Claude Sonnet 5');
+    expect(s.activeChats, 3);
+    expect(s.startedAt, '2026-01-01T00:00:00.000Z');
+  });
+
+  test('canonical search result parses', () {
+    final r = SearchHit.fromJson(
+        (fixture['searchResult'] as Map).cast<String, dynamic>());
+    expect(r.chatId, 'd_abc123');
+    expect(r.chatTitle, 'Protocol design');
+    expect(r.message.role, Role.user);
+    expect(r.message.text, 'find the fox');
+  });
+}

--- a/src/__tests__/native-bridge-extensions.test.ts
+++ b/src/__tests__/native-bridge-extensions.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the bridge protocol extensions backing the companion app's
+ * next-level features: history scroll-back pagination, wire-level full-text
+ * search, and the turn-meta sidecar that lets tool timelines + turn stats
+ * survive a history reload.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  pushMessage,
+  getRecentHistory,
+  getHistoryBefore,
+  searchHistoryMessages,
+  type HistoryMessage,
+} from "../storage/history.js";
+
+function makeMsg(
+  overrides: Partial<HistoryMessage> & { msgId: number },
+): HistoryMessage {
+  return {
+    senderId: 1,
+    senderName: "TestUser",
+    text: `Message ${overrides.msgId}`,
+    timestamp: overrides.msgId,
+    ...overrides,
+  };
+}
+
+describe("getHistoryBefore (scroll-back pagination)", () => {
+  const chatId = () => `page-${Math.random().toString(36).slice(2)}`;
+
+  it("returns the window strictly older than the anchor, chronological", () => {
+    const id = chatId();
+    for (let i = 1; i <= 30; i++) pushMessage(id, makeMsg({ msgId: i }));
+
+    const newest = getRecentHistory(id, 10);
+    expect(newest[0].msgId).toBe(21);
+
+    const page = getHistoryBefore(id, 21, 10);
+    expect(page).toHaveLength(10);
+    expect(page[0].msgId).toBe(11);
+    expect(page[9].msgId).toBe(20);
+  });
+
+  it("returns a short page at the top and empty past it", () => {
+    const id = chatId();
+    for (let i = 1; i <= 5; i++) pushMessage(id, makeMsg({ msgId: i }));
+
+    expect(getHistoryBefore(id, 3, 10).map((m) => m.msgId)).toEqual([1, 2]);
+    expect(getHistoryBefore(id, 1, 10)).toEqual([]);
+  });
+
+  it("is empty for an unknown chat", () => {
+    expect(getHistoryBefore("nope", 100, 10)).toEqual([]);
+  });
+});
+
+describe("searchHistoryMessages (wire-level FTS)", () => {
+  const chatId = () => `search-${Math.random().toString(36).slice(2)}`;
+
+  it("returns matching rows, not formatted text", () => {
+    const id = chatId();
+    pushMessage(id, makeMsg({ msgId: 1, text: "the quick brown fox" }));
+    pushMessage(id, makeMsg({ msgId: 2, text: "lazy dog sleeps" }));
+    pushMessage(id, makeMsg({ msgId: 3, text: "fox again, quicker" }));
+
+    const hits = searchHistoryMessages(id, "fox");
+    expect(hits.map((m) => m.msgId)).toEqual([1, 3]);
+    expect(hits[0].text).toBe("the quick brown fox");
+  });
+
+  it("is empty on no match or empty query", () => {
+    const id = chatId();
+    pushMessage(id, makeMsg({ msgId: 1, text: "hello world" }));
+    expect(searchHistoryMessages(id, "zebra")).toEqual([]);
+    expect(searchHistoryMessages(id, "")).toEqual([]);
+  });
+
+  it("treats FTS operators as literals (no syntax injection)", () => {
+    const id = chatId();
+    pushMessage(id, makeMsg({ msgId: 1, text: "a AND b" }));
+    expect(() => searchHistoryMessages(id, 'AND OR NEAR( " *')).not.toThrow();
+  });
+});
+
+describe("turn-meta sidecar", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "talon-turnmeta-"));
+    vi.resetModules();
+    // turn-meta pulls in util/log.js, which reads files.log from paths at
+    // import time — the mock must provide both surfaces.
+    vi.doMock("../util/paths.js", () => ({
+      dirs: { data: workDir, root: workDir },
+      files: { log: join(workDir, "talon.log") },
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../util/paths.js");
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  async function loadModule() {
+    return await import("../frontend/native/turn-meta.js");
+  }
+
+  it("records, reads back, and persists meta across a reload", async () => {
+    const m1 = await loadModule();
+    m1.recordTurnMeta("c1", "100", {
+      durationMs: 4200,
+      tokensIn: 10,
+      tokensOut: 20,
+      tools: [{ id: "t1", name: "search", durationMs: 800 }],
+    });
+    expect(m1.getTurnMeta("c1", "100")).toMatchObject({ durationMs: 4200 });
+    m1.flushTurnMeta();
+
+    const file = join(workDir, "native-turn-meta.json");
+    expect(existsSync(file)).toBe(true);
+    expect(JSON.parse(readFileSync(file, "utf-8")).c1["100"].tokensOut).toBe(
+      20,
+    );
+
+    // Fresh module instance (daemon restart) reads the same sidecar.
+    vi.resetModules();
+    vi.doMock("../util/paths.js", () => ({
+      dirs: { data: workDir, root: workDir },
+      files: { log: join(workDir, "talon.log") },
+    }));
+    const m2 = await loadModule();
+    expect(m2.getTurnMeta("c1", "100")?.tools?.[0].name).toBe("search");
+  });
+
+  it("merges repeated records for the same message", async () => {
+    const m = await loadModule();
+    m.recordTurnMeta("c1", "1", { durationMs: 100 });
+    m.recordTurnMeta("c1", "1", { tokensIn: 5 });
+    expect(m.getTurnMeta("c1", "1")).toMatchObject({
+      durationMs: 100,
+      tokensIn: 5,
+    });
+  });
+
+  it("bounds the per-chat window and clears whole chats", async () => {
+    const m = await loadModule();
+    for (let i = 1; i <= 520; i++) {
+      m.recordTurnMeta("c1", String(i), { durationMs: i });
+    }
+    // Oldest ids evicted past the 500 cap.
+    expect(m.getTurnMeta("c1", "1")).toBeNull();
+    expect(m.getTurnMeta("c1", "520")).not.toBeNull();
+
+    m.clearTurnMeta("c1");
+    expect(m.getTurnMeta("c1", "520")).toBeNull();
+  });
+
+  it("is null for unknown chat/message", async () => {
+    const m = await loadModule();
+    expect(m.getTurnMeta("nope", "1")).toBeNull();
+  });
+});

--- a/src/__tests__/native-protocol-fixture.test.ts
+++ b/src/__tests__/native-protocol-fixture.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Contract test against the shared protocol fixture in
+ * apps/companion/test/fixtures/protocol_v1.json. The companion app asserts
+ * the same file from Dart (test/protocol_fixture_test.dart), so a wire-shape
+ * drift on either side fails one of the two suites instead of shipping a
+ * silent misrender. Assignments to the protocol types make renames a
+ * compile-time failure here.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  BRIDGE_PROTOCOL_VERSION,
+  type BridgeStatus,
+  type ClientChat,
+  type ClientMessage,
+  type SearchResult,
+} from "../frontend/native/protocol.js";
+
+const fixture = JSON.parse(
+  readFileSync(
+    join(__dirname, "../../apps/companion/test/fixtures/protocol_v1.json"),
+    "utf-8",
+  ),
+) as {
+  protocol: number;
+  message: ClientMessage;
+  chat: ClientChat;
+  status: BridgeStatus;
+  searchResult: SearchResult;
+};
+
+describe("bridge protocol fixture (shared with the companion app)", () => {
+  it("carries the daemon's protocol version", () => {
+    expect(fixture.protocol).toBe(BRIDGE_PROTOCOL_VERSION);
+  });
+
+  it("message shape matches ClientMessage", () => {
+    const m: ClientMessage = fixture.message;
+    expect(m.id).toBe("1024");
+    expect(m.role).toBe("assistant");
+    expect(m.ts).toBe(1767225600000);
+    expect(m.buttons?.[0][0].url).toBe("https://example.com");
+    expect(m.imagePath).toBe("/media?id=m42");
+    expect(m.durationMs).toBe(4200);
+    expect(m.tokensIn).toBe(1200);
+    expect(m.tokensOut).toBe(340);
+    expect(m.tools).toHaveLength(2);
+    expect(m.tools?.[0].name).toBe("mcp__search__web");
+    expect(m.tools?.[1].error).toBe("exit 1");
+  });
+
+  it("chat shape matches ClientChat", () => {
+    const c: ClientChat = fixture.chat;
+    expect(c.id).toBe("d_abc123");
+    expect(c.model).toBe("claude-sonnet-5");
+    expect(c.backend).toBe("claude");
+    expect(c.effort).toBe("high");
+    expect(c.pulse).toBe(true);
+  });
+
+  it("status shape matches BridgeStatus", () => {
+    const s: BridgeStatus = fixture.status;
+    expect(s.app).toBe("talon-bridge");
+    expect(s.protocol).toBe(1);
+    expect(s.activeChats).toBe(3);
+  });
+
+  it("search result shape matches SearchResult", () => {
+    const r: SearchResult = fixture.searchResult;
+    expect(r.chatTitle).toBe("Protocol design");
+    expect(r.message.role).toBe("user");
+  });
+});

--- a/src/frontend/native/index.ts
+++ b/src/frontend/native/index.ts
@@ -27,8 +27,16 @@ import { toolInputToRecord } from "../../core/agent-runtime/events.js";
 import {
   pushMessage,
   getRecentHistory,
+  getHistoryBefore,
+  searchHistoryMessages,
   clearHistory,
 } from "../../storage/history.js";
+import {
+  recordTurnMeta,
+  getTurnMeta,
+  clearTurnMeta,
+  flushTurnMeta,
+} from "./turn-meta.js";
 import {
   getChatSettings,
   setChatEffort,
@@ -69,7 +77,9 @@ import {
   type ClientButton,
   type ClientChat,
   type ClientMessage,
+  type ClientToolCall,
   type ModelOption,
+  type SearchResult,
 } from "./protocol.js";
 
 export type NativeFrontend = {
@@ -150,6 +160,11 @@ export function createNativeFrontend(
 
   const broadcast = (event: BridgeEvent): void => server.broadcast(event);
 
+  // The most recent assistant message id per chat — turn_end attaches the
+  // turn's meta (tools/stats) to this message so history hydration can show
+  // what the model did after a reload.
+  const lastAssistantId = new Map<string, string>();
+
   const broadcastChatUpdated = (entry: ChatEntry): void =>
     broadcast({ kind: "chat_updated", chat: toClientChat(entry) });
 
@@ -194,6 +209,7 @@ export function createNativeFrontend(
       timestamp: ts,
     });
     chats.touch(entry.id, text);
+    lastAssistantId.set(entry.id, String(id));
     broadcast({ kind: "message", chatId: entry.id, message });
     broadcastChatUpdated(entry);
     return id;
@@ -230,6 +246,7 @@ export function createNativeFrontend(
       filePath,
     });
     chats.touch(entry.id, text || "[photo]");
+    lastAssistantId.set(entry.id, String(id));
     broadcast({ kind: "message", chatId: entry.id, message });
     broadcastChatUpdated(entry);
     return id;
@@ -301,6 +318,12 @@ export function createNativeFrontend(
     attachmentPath?: string,
   ): Promise<void> {
     const start = Date.now();
+    // Tool calls observed during this turn, in call order — recorded into the
+    // turn-meta sidecar at turn_end so history can replay the timeline.
+    const turnTools = new Map<
+      string,
+      { call: ClientToolCall; startedAt: number }
+    >();
     // Point the model at an attached image so it can read the file itself.
     const prompt = attachmentPath
       ? `${text ? `${text}\n\n` : ""}[Attached image: ${attachmentPath}]`
@@ -329,17 +352,28 @@ export function createNativeFrontend(
             case "text_delta":
               broadcast({ kind: "delta", chatId: entry.id, text: event.text });
               break;
-            case "tool_call":
+            case "tool_call": {
+              const input = toolInputToRecord(event.name, event.input);
+              turnTools.set(event.id, {
+                call: { id: event.id, name: event.name, input },
+                startedAt: Date.now(),
+              });
               broadcast({
                 kind: "tool",
                 chatId: entry.id,
                 id: event.id,
                 name: event.name,
                 phase: "call",
-                input: toolInputToRecord(event.name, event.input),
+                input,
               });
               break;
-            case "tool_result":
+            }
+            case "tool_result": {
+              const live = turnTools.get(event.id);
+              if (live) {
+                live.call.durationMs = Date.now() - live.startedAt;
+                if (event.error) live.call.error = event.error;
+              }
               broadcast({
                 kind: "tool",
                 chatId: entry.id,
@@ -349,6 +383,7 @@ export function createNativeFrontend(
                 ...(event.error ? { error: event.error } : {}),
               });
               break;
+            }
             case "error":
               broadcast({
                 kind: "error",
@@ -368,6 +403,23 @@ export function createNativeFrontend(
       if (delivered === 0 && result.text.trim()) {
         emitAssistant(entry, result.text.trim());
         delivered = 1;
+      }
+
+      // Persist what this turn did against its final assistant message, so
+      // reloaded history keeps the tool timeline + stats footer. Only when
+      // the turn actually delivered — otherwise the "last assistant id"
+      // belongs to a previous turn and the meta would land on the wrong row.
+      if (delivered > 0) {
+        const msgId = lastAssistantId.get(entry.id);
+        if (msgId) {
+          const tools = [...turnTools.values()].map((t) => t.call);
+          recordTurnMeta(entry.id, msgId, {
+            durationMs: result.durationMs,
+            tokensIn: result.inputTokens,
+            tokensOut: result.outputTokens,
+            ...(tools.length ? { tools } : {}),
+          });
+        }
       }
 
       broadcast({ kind: "typing", chatId: entry.id, on: false });
@@ -523,6 +575,7 @@ export function createNativeFrontend(
     setChatBackend(chatId, target);
     resetSession(chatId);
     clearHistory(chatId);
+    clearTurnMeta(chatId);
     resetPulseCheckpoint(chatId);
     emitSystem(entry, `Switched to ${target} — starting a fresh conversation.`);
     broadcastChatUpdated(entry);
@@ -579,11 +632,19 @@ export function createNativeFrontend(
     },
     deleteChat: (id) => {
       const ok = chats.remove(id);
-      if (ok) broadcast({ kind: "chat_deleted", chatId: id });
+      if (ok) {
+        clearTurnMeta(id);
+        broadcast({ kind: "chat_deleted", chatId: id });
+      }
       return ok;
     },
-    history: (id) =>
-      getRecentHistory(id, 200)
+    history: (id, opts) => {
+      const limit = Math.min(Math.max(opts?.limit ?? 200, 1), 500);
+      const rows =
+        opts?.before !== undefined
+          ? getHistoryBefore(id, opts.before, limit)
+          : getRecentHistory(id, limit);
+      return rows
         .map((m) => {
           const msg = historyToClientMessage(m, id);
           // Re-hydrate an attached image: re-register its on-disk path into
@@ -593,9 +654,38 @@ export function createNativeFrontend(
             const mediaId = registerMedia(m.filePath);
             msg.imagePath = `/media?id=${encodeURIComponent(mediaId)}`;
           }
+          // Re-hydrate turn meta (tool timeline + stats) for assistant rows.
+          if (msg.role === "assistant") {
+            const meta = getTurnMeta(id, msg.id);
+            if (meta) {
+              if (meta.tools?.length) msg.tools = meta.tools;
+              if (meta.durationMs) msg.durationMs = meta.durationMs;
+              if (meta.tokensIn) msg.tokensIn = meta.tokensIn;
+              if (meta.tokensOut) msg.tokensOut = meta.tokensOut;
+            }
+          }
           return msg;
         })
-        .sort((a, b) => Number(a.id) - Number(b.id)),
+        .sort((a, b) => Number(a.id) - Number(b.id));
+    },
+    search: (query, chatId) => {
+      const targets = chatId
+        ? [chats.get(chatId)].filter((e): e is ChatEntry => e != null)
+        : chats.list();
+      const results: SearchResult[] = [];
+      for (const entry of targets) {
+        for (const m of searchHistoryMessages(entry.id, query, 10)) {
+          results.push({
+            chatId: entry.id,
+            chatTitle: entry.title,
+            message: historyToClientMessage(m, entry.id),
+          });
+        }
+      }
+      // Newest hits first, bounded across all chats.
+      results.sort((a, b) => b.message.ts - a.message.ts);
+      return results.slice(0, 50);
+    },
     send: (id, text, opts) => {
       const entry = chats.get(id) ?? chats.ensure(id);
       const messageId = emitUser(
@@ -710,6 +800,7 @@ export function createNativeFrontend(
     },
 
     async stop() {
+      flushTurnMeta();
       await removeBridgeDiscovery();
       await server.stop();
       await gateway.stop();

--- a/src/frontend/native/protocol.ts
+++ b/src/frontend/native/protocol.ts
@@ -31,6 +31,20 @@ export type ClientRole = "user" | "assistant" | "system";
 /** An inline button. `url` opens a link; `data` is an opaque callback token. */
 export type ClientButton = { text: string; url?: string; data?: string };
 
+/**
+ * A tool invocation that ran during an assistant turn, persisted so history
+ * shows what the model did even after a reload/restart (additive in v1 —
+ * older clients simply ignore the field).
+ */
+export type ClientToolCall = {
+  id: string;
+  name: string;
+  input?: Record<string, unknown>;
+  error?: string;
+  /** Wall-clock duration of this call, when known. */
+  durationMs?: number;
+};
+
 /** A single rendered message in a conversation. */
 export type ClientMessage = {
   id: string;
@@ -47,6 +61,19 @@ export type ClientMessage = {
    * Present on photo messages the bot sends; `text` carries any caption.
    */
   imagePath?: string;
+  /** Tools that ran during this assistant turn (history hydration). */
+  tools?: ClientToolCall[];
+  /** Turn stats attached once the turn ended (history hydration). */
+  durationMs?: number;
+  tokensIn?: number;
+  tokensOut?: number;
+};
+
+/** One full-text search hit: the message plus the chat it lives in. */
+export type SearchResult = {
+  chatId: string;
+  chatTitle: string;
+  message: ClientMessage;
 };
 
 /** A conversation in the sidebar. */

--- a/src/frontend/native/server.ts
+++ b/src/frontend/native/server.ts
@@ -30,6 +30,7 @@ import {
   type ClientChat,
   type ClientMessage,
   type ModelOption,
+  type SearchResult,
 } from "./protocol.js";
 import type { ConfigSnapshot } from "./settings.js";
 
@@ -48,7 +49,13 @@ export type BridgeServerHandlers = {
   createChat(title?: string): ClientChat;
   renameChat(id: string, title: string): ClientChat | null;
   deleteChat(id: string): boolean;
-  history(id: string): ClientMessage[];
+  /** A page of history: newest window, or the window before `before`. */
+  history(
+    id: string,
+    opts?: { before?: number; limit?: number },
+  ): ClientMessage[];
+  /** Full-text search across chats (or one chat when `chatId` is given). */
+  search(query: string, chatId?: string): SearchResult[];
   /** Fire-and-forget: streams its results back through `broadcast`. */
   send(id: string, text: string, opts?: SendOptions): void;
   /** Persist an uploaded image and return its render path + on-disk path. */
@@ -281,9 +288,20 @@ export class BridgeServer {
 
       if (method === "GET" && path === "/history") {
         const id = url.searchParams.get("chatId") ?? "";
+        const before = asPositiveInt(url.searchParams.get("before"));
+        const limit = asPositiveInt(url.searchParams.get("limit"));
         return this.json(res, 200, {
           chatId: id,
-          messages: this.handlers.history(id),
+          messages: this.handlers.history(id, { before, limit }),
+        });
+      }
+
+      if (method === "GET" && path === "/search") {
+        const q = (url.searchParams.get("q") ?? "").trim();
+        if (!q) return this.json(res, 400, { ok: false, error: "q required" });
+        const chatId = url.searchParams.get("chatId") ?? undefined;
+        return this.json(res, 200, {
+          results: this.handlers.search(q, chatId),
         });
       }
 
@@ -494,6 +512,13 @@ export class BridgeServer {
 
 function asString(v: unknown): string | undefined {
   return typeof v === "string" ? v : undefined;
+}
+
+/** Parse a positive-integer query param; undefined when absent/invalid. */
+function asPositiveInt(v: string | null): number | undefined {
+  if (!v) return undefined;
+  const n = Number(v);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
 }
 
 /** Minimal image content-type map for the media endpoint. */

--- a/src/frontend/native/turn-meta.ts
+++ b/src/frontend/native/turn-meta.ts
@@ -1,0 +1,104 @@
+/**
+ * Turn-meta sidecar — persists what each assistant turn *did* (tool calls,
+ * duration, token usage) keyed by chat + message id, so the companion app's
+ * tool timeline and stats footer survive a history reload or daemon restart.
+ *
+ * History rows live in SQLite with a fixed schema shared by every frontend;
+ * this data is native-frontend-only presentation metadata, so it lives in a
+ * small JSON sidecar under the data dir instead of a schema migration.
+ * Writes are debounced; each chat keeps a bounded window of recent turns.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { join } from "node:path";
+import { dirs } from "../../util/paths.js";
+import { logError } from "../../util/log.js";
+import type { ClientToolCall } from "./protocol.js";
+
+export type TurnMeta = {
+  durationMs?: number;
+  tokensIn?: number;
+  tokensOut?: number;
+  tools?: ClientToolCall[];
+};
+
+const FILE = () => join(dirs.data, "native-turn-meta.json");
+/** Per-chat cap — matches the /history page ceiling, so hydration covers
+ *  everything a client can actually fetch. */
+const MAX_PER_CHAT = 500;
+const FLUSH_MS = 1_500;
+
+type Store = Record<string, Record<string, TurnMeta>>;
+
+let store: Store | null = null;
+let flushTimer: ReturnType<typeof setTimeout> | undefined;
+
+function load(): Store {
+  if (store) return store;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(FILE(), "utf-8"));
+    store =
+      typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+        ? (parsed as Store)
+        : {};
+  } catch {
+    store = {}; // first run / unreadable — start fresh
+  }
+  return store;
+}
+
+function scheduleFlush(): void {
+  if (flushTimer) return;
+  flushTimer = setTimeout(() => {
+    flushTimer = undefined;
+    flushTurnMeta();
+  }, FLUSH_MS);
+  flushTimer.unref?.();
+}
+
+/** Write-through for shutdown; atomic via rename so a crash can't torch it. */
+export function flushTurnMeta(): void {
+  if (!store) return;
+  try {
+    mkdirSync(dirs.data, { recursive: true });
+    const tmp = `${FILE()}.tmp`;
+    writeFileSync(tmp, JSON.stringify(store));
+    renameSync(tmp, FILE());
+  } catch (err) {
+    logError("native", "Failed to persist turn meta", err);
+  }
+}
+
+/** Record (or extend) the meta for one assistant message. */
+export function recordTurnMeta(
+  chatId: string,
+  msgId: string,
+  meta: TurnMeta,
+): void {
+  const s = load();
+  const chat = (s[chatId] ??= {});
+  chat[msgId] = { ...chat[msgId], ...meta };
+  // Bounded window: drop the oldest entries (numeric-ascending ids).
+  const ids = Object.keys(chat);
+  if (ids.length > MAX_PER_CHAT) {
+    ids
+      .sort((a, b) => Number(a) - Number(b))
+      .slice(0, ids.length - MAX_PER_CHAT)
+      .forEach((id) => delete chat[id]);
+  }
+  scheduleFlush();
+}
+
+/** Look up the meta for one message, or null. */
+export function getTurnMeta(chatId: string, msgId: string): TurnMeta | null {
+  return load()[chatId]?.[msgId] ?? null;
+}
+
+/** Forget a chat entirely (chat deleted / history cleared). */
+export function clearTurnMeta(chatId: string): void {
+  const s = load();
+  if (s[chatId]) {
+    delete s[chatId];
+    scheduleFlush();
+  }
+}

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -121,6 +121,40 @@ export function getRecentHistory(chatId: string, limit = 50): HistoryMessage[] {
   return repo.recent(chatId, limit);
 }
 
+/**
+ * Scroll-back pagination: the `limit` messages strictly older than
+ * `beforeMsgId`, chronological. Used by the bridge's /history endpoint so
+ * clients can walk long histories page by page instead of one giant fetch.
+ */
+export function getHistoryBefore(
+  chatId: string,
+  beforeMsgId: number,
+  limit = 50,
+): HistoryMessage[] {
+  return repo.recentBefore(chatId, beforeMsgId, limit);
+}
+
+/**
+ * Raw (wire-friendly) full-text search over a chat's history. Unlike
+ * [searchHistory] — which formats a string for the agent's tool — this
+ * returns the matching rows for the bridge's /search endpoint to map into
+ * protocol messages. Empty on FTS failure rather than throwing.
+ */
+export function searchHistoryMessages(
+  chatId: string,
+  query: string,
+  limit = 20,
+): HistoryMessage[] {
+  const match = ftsQuery(query);
+  if (!match) return [];
+  try {
+    return repo.searchFts(chatId, match, limit);
+  } catch (err) {
+    logError("history", `FTS search failed for ${JSON.stringify(query)}`, err);
+    return [];
+  }
+}
+
 /** Update a message's file path after media download. */
 export function setMessageFilePath(
   chatId: string,

--- a/src/storage/repositories/history-repo.ts
+++ b/src/storage/repositories/history-repo.ts
@@ -71,6 +71,21 @@ export function recent(chatId: string, limit: number): HistoryMessage[] {
   return rows.reverse().map(rowToMessage);
 }
 
+/**
+ * Scroll-back pagination: the `limit` messages strictly older than
+ * `beforeMsgId`, in chronological order.
+ */
+export function recentBefore(
+  chatId: string,
+  beforeMsgId: number,
+  limit: number,
+): HistoryMessage[] {
+  const rows = getDatabase()
+    .prepare(historySql.recentBefore)
+    .all(chatId, beforeMsgId, limit) as Row[];
+  return rows.reverse().map(rowToMessage);
+}
+
 export function setFilePath(
   chatId: string,
   msgId: number,

--- a/src/storage/sql/history.sql
+++ b/src/storage/sql/history.sql
@@ -13,6 +13,14 @@ SELECT msg_id, sender_id, sender_name, text, reply_to_msg_id,
 FROM history_messages
 WHERE chat_id = ? ORDER BY id DESC LIMIT ?
 
+-- name: recentBefore
+-- Scroll-back pagination: the window of messages strictly older than a
+-- given msg_id, newest-first (the repository reverses to chronological).
+SELECT msg_id, sender_id, sender_name, text, reply_to_msg_id,
+       timestamp, media_type, sticker_file_id, file_path
+FROM history_messages
+WHERE chat_id = ? AND msg_id < ? ORDER BY id DESC LIMIT ?
+
 -- name: setFilePath
 UPDATE history_messages SET file_path = ? WHERE chat_id = ? AND msg_id = ?
 

--- a/src/storage/sql/statements.generated.ts
+++ b/src/storage/sql/statements.generated.ts
@@ -201,6 +201,12 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
        timestamp, media_type, sticker_file_id, file_path
 FROM history_messages
 WHERE chat_id = ? ORDER BY id DESC LIMIT ?`,
+  recentBefore: `-- Scroll-back pagination: the window of messages strictly older than a
+-- given msg_id, newest-first (the repository reverses to chronological).
+SELECT msg_id, sender_id, sender_name, text, reply_to_msg_id,
+       timestamp, media_type, sticker_file_id, file_path
+FROM history_messages
+WHERE chat_id = ? AND msg_id < ? ORDER BY id DESC LIMIT ?`,
   setFilePath: `UPDATE history_messages SET file_path = ? WHERE chat_id = ? AND msg_id = ?`,
   deleteChat: `DELETE FROM history_messages WHERE chat_id = ?`,
   searchFts: `-- The match param must already be a valid FTS5 expression


### PR DESCRIPTION
## Summary

Two-part upgrade of the companion app and its daemon bridge, in one PR.

**Commit 1 — bug fixes & real-time correctness** (`815778a`): media URLs from the discovered bridge config; epoch-guarded reconnects; upload-failure draft restore; live model list after backend switches; optimistic model/effort/pulse/rename updates; graceful degradation on older daemons; connection banner + retry; sidebar previews/timestamps; connect-screen live state.

**Commit 2 — all four "next level" phases** (`d1a5078`):

### Phase 1 — Protocol extensions (daemon, additive → stays v1)
- `/history?before=&limit=` scroll-back pagination (new `recentBefore` SQL)
- `GET /search?q=` — FTS5 full-text search across chats
- Turn-meta sidecar: tool calls, duration, token usage persisted per assistant message and hydrated into `/history`, so tool timelines + stats survive reload/restart

### Phase 2 — App functionality
- Infinite scroll-back with anchored viewport + top loader + first-load skeleton
- Offline-first cold start from a bounded local snapshot (renders instantly before any connection)
- Unread tracking with per-chat read markers and sidebar badges
- Cmd/Ctrl+K quick switcher (chat jump + full-text message search, keyboard-first), Cmd/Ctrl+N new chat, Esc back
- Copy conversation as Markdown

### Phase 3 — UI, design, motion
- Syntax-highlighted fenced code blocks with language tag + copy button
- Reasoning strip folds into a "Thought" pill once the reply streams (tap toggles)
- Direction-aware shared-axis list⇄chat transition on narrow layouts
- Message timestamps (clock on assistant rows, tooltip on user bubbles)

### Phase 4 — Guardrails
- Shared protocol fixture asserted from **both** sides (vitest + flutter test) so wire-shape drift fails a suite instead of misrendering
- Daemon tests for pagination/search/turn-meta; app tests for pagination, search, hydration, unread, snapshot, export
- Release artifact pipeline already existed in `companion.yml` (verified)

**Scoped out**: true turn interrupt needs an abort path through the weaver for interactive turns — engine work, tracked for a follow-up.

## Test plan
- Daemon: `tsc --noEmit` clean; new + adjacent vitest suites pass (full suite: only the network-gated kilo live-bootstrap integration test fails locally, environmental — its CI job passed)
- App: `flutter analyze` clean; `flutter test` — **55 tests pass** (15 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)