### PR TITLE
fix(companion,native): image rendering, phantom backend reset, light/dark/auto theming

### DIFF
--- a/apps/companion/lib/main.dart
+++ b/apps/companion/lib/main.dart
@@ -8,6 +8,14 @@ import 'src/ui/root_view.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final prefs = await Prefs.load();
+  TalonTheme.mode.value = switch (prefs.themeMode) {
+    'light' => ThemeMode.light,
+    'dark' => ThemeMode.dark,
+    _ => ThemeMode.system,
+  };
+  TalonTheme.apply(
+    WidgetsBinding.instance.platformDispatcher.platformBrightness,
+  );
   final state = AppState(prefs);
   runApp(TalonApp(state: state));
 }
@@ -20,18 +28,35 @@ class TalonApp extends StatefulWidget {
   State<TalonApp> createState() => _TalonAppState();
 }
 
-class _TalonAppState extends State<TalonApp> {
+class _TalonAppState extends State<TalonApp> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    // Theme-mode changes (Settings) re-resolve the palette and rebuild.
+    TalonTheme.mode.addListener(_onThemeChanged);
     // Connect on launch using the saved profile (or platform default).
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (widget.state.prefs.onboarded) widget.state.start();
     });
   }
 
+  /// The OS flipped light/dark — matters in auto mode.
+  @override
+  void didChangePlatformBrightness() => _onThemeChanged();
+
+  void _onThemeChanged() {
+    setState(() {
+      TalonTheme.apply(
+        WidgetsBinding.instance.platformDispatcher.platformBrightness,
+      );
+    });
+  }
+
   @override
   void dispose() {
+    TalonTheme.mode.removeListener(_onThemeChanged);
+    WidgetsBinding.instance.removeObserver(this);
     widget.state.dispose();
     super.dispose();
   }

--- a/apps/companion/lib/src/services/prefs.dart
+++ b/apps/companion/lib/src/services/prefs.dart
@@ -36,6 +36,14 @@ class Prefs {
   bool get onboarded => _sp.getBool(_kOnboarded) ?? false;
   Future<void> setOnboarded(bool v) => _sp.setBool(_kOnboarded, v);
 
+  // ── Appearance ────────────────────────────────────────────────────────────
+
+  static const _kThemeMode = 'themeMode.v1';
+
+  /// Persisted theme selection: 'system' (default), 'light', or 'dark'.
+  String get themeMode => _sp.getString(_kThemeMode) ?? 'system';
+  Future<void> setThemeMode(String v) => _sp.setString(_kThemeMode, v);
+
   // ── Read markers ──────────────────────────────────────────────────────────
 
   Map<String, int> _decodeLastRead() {

--- a/apps/companion/lib/src/theme.dart
+++ b/apps/companion/lib/src/theme.dart
@@ -1,56 +1,173 @@
 import 'package:flutter/material.dart';
 
-/// The Talon visual language: a deep, near-black canvas with restrained, mostly
-/// monochrome surfaces and a single vivid accent used sparingly. The old build
-/// leaned on gradients + colored glows on nearly every control, which read as
-/// "consumer / flashy"; the design now favours calm, flat surfaces and lets
-/// motion (see [TalonMotion] + flutter_animate) carry the delight instead.
-class TalonColors {
-  TalonColors._();
+/// The Talon visual language: a calm canvas with restrained, mostly
+/// monochrome surfaces and a single vivid accent used sparingly. Ships in two
+/// palettes — the original near-black dark theme and a soft paper-white light
+/// theme — selected by [TalonTheme] (auto / light / dark).
+class TalonPalette {
+  final Brightness brightness;
 
   // Base canvas
-  static const Color void0 = Color(0xFF07070C); // deepest background
-  static const Color void1 = Color(0xFF0C0D16); // panels base
-  static const Color surface = Color(0xFF13141F); // raised surface
-  static const Color surfaceHi = Color(0xFF1B1D2B); // hover / selected
+  final Color void0; // deepest background
+  final Color void1; // panels base
+  final Color surface; // raised surface
+  final Color surfaceHi; // hover / selected
 
   // Glass strokes & fills (used with opacity over the gradient backdrop)
-  static const Color glassFill = Color(0x14FFFFFF);
-  static const Color glassStroke = Color(0x1FFFFFFF);
+  final Color glassFill;
+  final Color glassStroke;
 
   // Accent — electric indigo with a cyan partner reserved for the gradient
   // brand mark and the rare hero moment (never every button).
-  static const Color accent = Color(0xFF7C8CFF);
-  static const Color accent2 = Color(0xFF54E6FF);
-  static const Color accentDeep = Color(0xFF5B6BF0);
+  final Color accent;
+  final Color accent2;
+  final Color accentDeep;
 
   // Text
-  static const Color text = Color(0xFFEDEEF7);
-  static const Color textDim = Color(0xFFA6A9C2);
-  static const Color textFaint = Color(0xFF6F7392);
+  final Color text;
+  final Color textDim;
+  final Color textFaint;
 
   // Status
-  static const Color ok = Color(0xFF49E2A0);
-  static const Color warn = Color(0xFFFFC56B);
-  static const Color bad = Color(0xFFFF6B81);
-
-  // Bubbles
-  static const Color userBubbleA = Color(0xFF6B79F5);
-  static const Color userBubbleB = Color(0xFF7C8CFF);
-  static const Color assistantBubble = Color(0xFF161826);
+  final Color ok;
+  final Color warn;
+  final Color bad;
 
   /// Backdrop gradient painted behind everything.
-  static const LinearGradient backdrop = LinearGradient(
+  final LinearGradient backdrop;
+
+  const TalonPalette({
+    required this.brightness,
+    required this.void0,
+    required this.void1,
+    required this.surface,
+    required this.surfaceHi,
+    required this.glassFill,
+    required this.glassStroke,
+    required this.accent,
+    required this.accent2,
+    required this.accentDeep,
+    required this.text,
+    required this.textDim,
+    required this.textFaint,
+    required this.ok,
+    required this.warn,
+    required this.bad,
+    required this.backdrop,
+  });
+
+  LinearGradient get accentGradient => LinearGradient(
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+        colors: [accent, accent2],
+      );
+}
+
+const TalonPalette kTalonDark = TalonPalette(
+  brightness: Brightness.dark,
+  void0: Color(0xFF07070C),
+  void1: Color(0xFF0C0D16),
+  surface: Color(0xFF13141F),
+  surfaceHi: Color(0xFF1B1D2B),
+  glassFill: Color(0x14FFFFFF),
+  glassStroke: Color(0x1FFFFFFF),
+  accent: Color(0xFF7C8CFF),
+  accent2: Color(0xFF54E6FF),
+  accentDeep: Color(0xFF5B6BF0),
+  text: Color(0xFFEDEEF7),
+  textDim: Color(0xFFA6A9C2),
+  textFaint: Color(0xFF6F7392),
+  ok: Color(0xFF49E2A0),
+  warn: Color(0xFFFFC56B),
+  bad: Color(0xFFFF6B81),
+  backdrop: LinearGradient(
     begin: Alignment.topLeft,
     end: Alignment.bottomRight,
     colors: [Color(0xFF0A0B13), Color(0xFF07070C), Color(0xFF0B0A12)],
-  );
+  ),
+);
 
-  static const LinearGradient accentGradient = LinearGradient(
+/// Paper-white counterpart: same hues, deepened for contrast on light
+/// surfaces (the dark theme's pastel accent and faint grays wash out on
+/// white). Glass becomes ink-tinted instead of white-tinted.
+const TalonPalette kTalonLight = TalonPalette(
+  brightness: Brightness.light,
+  void0: Color(0xFFF2F3F9),
+  void1: Color(0xFFF9FAFD),
+  surface: Color(0xFFFFFFFF),
+  surfaceHi: Color(0xFFE9EBF6),
+  glassFill: Color(0x0A10123B),
+  glassStroke: Color(0x2210123B),
+  accent: Color(0xFF5B6BF0),
+  accent2: Color(0xFF0E9CC7),
+  accentDeep: Color(0xFF4553D6),
+  text: Color(0xFF191B2A),
+  textDim: Color(0xFF4C5069),
+  textFaint: Color(0xFF83879F),
+  ok: Color(0xFF178F62),
+  warn: Color(0xFFA9720A),
+  bad: Color(0xFFDB3B52),
+  backdrop: LinearGradient(
     begin: Alignment.topLeft,
     end: Alignment.bottomRight,
-    colors: [accent, accent2],
-  );
+    colors: [Color(0xFFF0F1F8), Color(0xFFF7F8FC), Color(0xFFEDEFF7)],
+  ),
+);
+
+/// Global theme selection: a persisted [mode] (auto/light/dark) resolved
+/// against the platform brightness into the active [palette]. [revision]
+/// bumps whenever the palette actually changes, so pushed routes (Settings,
+/// Connect) can subscribe and repaint in place — the root app rebuilds via
+/// its own listener in main.dart.
+class TalonTheme {
+  TalonTheme._();
+
+  static final ValueNotifier<ThemeMode> mode = ValueNotifier(ThemeMode.system);
+  static final ValueNotifier<int> revision = ValueNotifier(0);
+
+  static TalonPalette _palette = kTalonDark;
+  static TalonPalette get palette => _palette;
+  static bool get isDark => _palette.brightness == Brightness.dark;
+
+  /// Resolve [mode] against the platform brightness and swap the palette.
+  static void apply(Brightness platformBrightness) {
+    final dark = switch (mode.value) {
+      ThemeMode.dark => true,
+      ThemeMode.light => false,
+      ThemeMode.system => platformBrightness == Brightness.dark,
+    };
+    final next = dark ? kTalonDark : kTalonLight;
+    if (!identical(next, _palette)) {
+      _palette = next;
+      revision.value++;
+    }
+  }
+}
+
+/// Color tokens. Same call sites as the original constants, now resolving
+/// through the active [TalonTheme.palette] — which is why these can no longer
+/// appear in `const` expressions.
+class TalonColors {
+  TalonColors._();
+
+  static Color get void0 => TalonTheme.palette.void0;
+  static Color get void1 => TalonTheme.palette.void1;
+  static Color get surface => TalonTheme.palette.surface;
+  static Color get surfaceHi => TalonTheme.palette.surfaceHi;
+  static Color get glassFill => TalonTheme.palette.glassFill;
+  static Color get glassStroke => TalonTheme.palette.glassStroke;
+  static Color get accent => TalonTheme.palette.accent;
+  static Color get accent2 => TalonTheme.palette.accent2;
+  static Color get accentDeep => TalonTheme.palette.accentDeep;
+  static Color get text => TalonTheme.palette.text;
+  static Color get textDim => TalonTheme.palette.textDim;
+  static Color get textFaint => TalonTheme.palette.textFaint;
+  static Color get ok => TalonTheme.palette.ok;
+  static Color get warn => TalonTheme.palette.warn;
+  static Color get bad => TalonTheme.palette.bad;
+  static LinearGradient get backdrop => TalonTheme.palette.backdrop;
+  static LinearGradient get accentGradient =>
+      TalonTheme.palette.accentGradient;
 }
 
 /// Spacing scale — an 8pt grid (with a 2/4 half-step for tight insets). Snap
@@ -84,66 +201,67 @@ class TalonRadius {
   static const BorderRadius rPill = BorderRadius.all(Radius.circular(pill));
 }
 
-/// Type scale. Named, deliberate sizes replace the scattered 15.5/14.5/13.5/…
-/// literals so the whole app can be re-tuned in one place and stays consistent.
+/// Type scale. Named, deliberate sizes replace scattered literals so the whole
+/// app can be re-tuned in one place. Getters, not consts: they carry the
+/// active palette's text colors.
 class TalonType {
   TalonType._();
 
-  static const TextStyle display = TextStyle(
-    fontSize: 22,
-    height: 1.2,
-    fontWeight: FontWeight.w700,
-    color: TalonColors.text,
-  );
+  static TextStyle get display => TextStyle(
+        fontSize: 22,
+        height: 1.2,
+        fontWeight: FontWeight.w700,
+        color: TalonColors.text,
+      );
 
-  static const TextStyle title = TextStyle(
-    fontSize: 16,
-    height: 1.3,
-    fontWeight: FontWeight.w700,
-    color: TalonColors.text,
-  );
+  static TextStyle get title => TextStyle(
+        fontSize: 16,
+        height: 1.3,
+        fontWeight: FontWeight.w700,
+        color: TalonColors.text,
+      );
 
-  static const TextStyle subtitle = TextStyle(
-    fontSize: 14,
-    height: 1.3,
-    fontWeight: FontWeight.w600,
-    color: TalonColors.text,
-  );
+  static TextStyle get subtitle => TextStyle(
+        fontSize: 14,
+        height: 1.3,
+        fontWeight: FontWeight.w600,
+        color: TalonColors.text,
+      );
 
-  static const TextStyle body = TextStyle(
-    fontSize: 14,
-    height: 1.5,
-    color: TalonColors.text,
-  );
+  static TextStyle get body => TextStyle(
+        fontSize: 14,
+        height: 1.5,
+        color: TalonColors.text,
+      );
 
-  static const TextStyle label = TextStyle(
-    fontSize: 13,
-    height: 1.3,
-    color: TalonColors.textDim,
-  );
+  static TextStyle get label => TextStyle(
+        fontSize: 13,
+        height: 1.3,
+        color: TalonColors.textDim,
+      );
 
-  static const TextStyle caption = TextStyle(
-    fontSize: 12,
-    height: 1.4,
-    color: TalonColors.textFaint,
-  );
+  static TextStyle get caption => TextStyle(
+        fontSize: 12,
+        height: 1.4,
+        color: TalonColors.textFaint,
+      );
 
   /// All-caps section eyebrow (sidebar groups, settings section headers).
-  static const TextStyle eyebrow = TextStyle(
-    fontSize: 11,
-    height: 1.2,
-    fontWeight: FontWeight.w700,
-    letterSpacing: 1.1,
-    color: TalonColors.textFaint,
-  );
+  static TextStyle get eyebrow => TextStyle(
+        fontSize: 11,
+        height: 1.2,
+        fontWeight: FontWeight.w700,
+        letterSpacing: 1.1,
+        color: TalonColors.textFaint,
+      );
 
   /// Monospace for tool names, code, tabular readouts.
-  static const TextStyle mono = TextStyle(
-    fontFamily: 'monospace',
-    fontSize: 13,
-    height: 1.4,
-    color: TalonColors.text,
-  );
+  static TextStyle get mono => TextStyle(
+        fontFamily: 'monospace',
+        fontSize: 13,
+        height: 1.4,
+        color: TalonColors.text,
+      );
 }
 
 /// Shared motion vocabulary so every surface animates with the same rhythm.
@@ -173,13 +291,16 @@ class TalonMotion {
 }
 
 ThemeData buildTalonTheme() {
-  final base = ThemeData.dark(useMaterial3: true);
-  const accent = TalonColors.accent;
+  final dark = TalonTheme.isDark;
+  final base = dark
+      ? ThemeData.dark(useMaterial3: true)
+      : ThemeData.light(useMaterial3: true);
+  final accent = TalonColors.accent;
 
   return base.copyWith(
     scaffoldBackgroundColor: TalonColors.void0,
     colorScheme: base.colorScheme.copyWith(
-      brightness: Brightness.dark,
+      brightness: dark ? Brightness.dark : Brightness.light,
       primary: accent,
       secondary: TalonColors.accent2,
       surface: TalonColors.surface,
@@ -198,8 +319,8 @@ ThemeData buildTalonTheme() {
         ),
     splashFactory: InkSparkle.splashFactory,
     dividerColor: TalonColors.glassStroke,
-    iconTheme: const IconThemeData(color: TalonColors.textDim, size: 20),
-    tooltipTheme: const TooltipThemeData(
+    iconTheme: IconThemeData(color: TalonColors.textDim, size: 20),
+    tooltipTheme: TooltipThemeData(
       decoration: BoxDecoration(
         color: TalonColors.surfaceHi,
         borderRadius: TalonRadius.rSm,
@@ -207,14 +328,15 @@ ThemeData buildTalonTheme() {
       textStyle: TextStyle(color: TalonColors.text, fontSize: 12),
     ),
     scrollbarTheme: ScrollbarThemeData(
-      thumbColor: WidgetStatePropertyAll(Colors.white.withValues(alpha: 0.12)),
+      thumbColor:
+          WidgetStatePropertyAll(TalonColors.text.withValues(alpha: 0.12)),
       thickness: const WidgetStatePropertyAll(6),
       radius: const Radius.circular(8),
     ),
     // Material 3's default selected-track has no outline and a thumb that
     // can end up the same color as the track (see settings_screen.dart's
     // _switchRow), reading as a solid undifferentiated pill against this
-    // theme's dark glass surfaces. Give both states an explicit border and
+    // theme's glass surfaces. Give both states an explicit border and
     // a thumb that always contrasts against its track.
     switchTheme: SwitchThemeData(
       trackColor: WidgetStateProperty.resolveWith((states) =>

--- a/apps/companion/lib/src/ui/activity_card.dart
+++ b/apps/companion/lib/src/ui/activity_card.dart
@@ -143,12 +143,12 @@ class _ReasoningStripState extends State<_ReasoningStrip> {
               borderRadius: TalonRadius.rPill,
               border: Border.all(color: TalonColors.glassStroke),
             ),
-            child: const Row(
+            child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
                 Icon(Icons.bubble_chart_outlined,
                     size: 13, color: TalonColors.textFaint),
-                SizedBox(width: 6),
+                const SizedBox(width: 6),
                 Text(
                   'Thought — tap to expand',
                   style:
@@ -170,7 +170,7 @@ class _ReasoningStripState extends State<_ReasoningStrip> {
       child: Container(
         padding:
             const EdgeInsets.symmetric(horizontal: TalonSpace.md, vertical: 9),
-        decoration: const BoxDecoration(
+        decoration: BoxDecoration(
           borderRadius: TalonRadius.rMd,
           border: Border(
             left: BorderSide(color: TalonColors.accent, width: 2.5),
@@ -180,7 +180,7 @@ class _ReasoningStripState extends State<_ReasoningStrip> {
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Icon(Icons.bubble_chart_outlined,
+            Icon(Icons.bubble_chart_outlined,
                 size: 15, color: TalonColors.textFaint),
             const SizedBox(width: TalonSpace.sm),
             Expanded(
@@ -192,7 +192,7 @@ class _ReasoningStripState extends State<_ReasoningStrip> {
                   text.trim(),
                   maxLines: 5,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: TalonColors.textDim,
                     fontSize: 12.5,
                     height: 1.45,
@@ -235,7 +235,7 @@ class _TypingDots extends StatelessWidget {
         width: 7,
         height: 7,
         margin: const EdgeInsets.symmetric(horizontal: 3),
-        decoration: const BoxDecoration(
+        decoration: BoxDecoration(
           shape: BoxShape.circle,
           color: TalonColors.textDim,
         ),

--- a/apps/companion/lib/src/ui/chat_view.dart
+++ b/apps/companion/lib/src/ui/chat_view.dart
@@ -276,15 +276,15 @@ class _JumpToLatest extends StatelessWidget {
   Widget build(BuildContext context) {
     return Material(
       color: TalonColors.surfaceHi,
-      shape: const CircleBorder(
+      shape: CircleBorder(
         side: BorderSide(color: TalonColors.glassStroke),
       ),
       elevation: 3,
       child: InkWell(
         onTap: onTap,
         customBorder: const CircleBorder(),
-        child: const Padding(
-          padding: EdgeInsets.all(9),
+        child: Padding(
+          padding: const EdgeInsets.all(9),
           child: Icon(Icons.arrow_downward_rounded,
               size: 18, color: TalonColors.textDim),
         ),
@@ -370,7 +370,7 @@ class _Header extends StatelessWidget {
     final effort = chat.effort ?? 'adaptive';
     return Container(
       padding: const EdgeInsets.fromLTRB(12, 10, 8, 10),
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         border: Border(bottom: BorderSide(color: TalonColors.glassStroke)),
       ),
       child: Row(
@@ -416,7 +416,7 @@ class _ChatMenu extends StatelessWidget {
   Widget build(BuildContext context) {
     final pulseOn = chat.pulse ?? false;
     return PopupMenuButton<String>(
-      icon: const Icon(Icons.more_vert, size: 20, color: TalonColors.textDim),
+      icon: Icon(Icons.more_vert, size: 20, color: TalonColors.textDim),
       color: TalonColors.surfaceHi,
       onSelected: (v) async {
         switch (v) {
@@ -575,7 +575,7 @@ class _Chip extends StatelessWidget {
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style:
-                    const TextStyle(fontSize: 12, color: TalonColors.textDim),
+                    TextStyle(fontSize: 12, color: TalonColors.textDim),
               ),
             ),
           ],
@@ -650,9 +650,9 @@ class _EmptyState extends StatelessWidget {
                   .fadeIn(duration: TalonMotion.slow)
                   .scaleXY(begin: 0.85, end: 1, curve: TalonMotion.emphasized),
           const SizedBox(height: TalonSpace.lg),
-          const Text('Talon', style: TalonType.display),
+          Text('Talon', style: TalonType.display),
           const SizedBox(height: 6),
-          const Text('Select a chat, or start a new one.',
+          Text('Select a chat, or start a new one.',
               style: TextStyle(color: TalonColors.textFaint)),
         ],
       ),
@@ -698,7 +698,7 @@ class _ConversationEmpty extends StatelessWidget {
           style: TalonType.title.copyWith(fontSize: 19),
         ),
         const SizedBox(height: 6),
-        const Text('Send a message to begin.',
+        Text('Send a message to begin.',
             style: TextStyle(color: TalonColors.textFaint)),
       ],
     );

--- a/apps/companion/lib/src/ui/code_block.dart
+++ b/apps/companion/lib/src/ui/code_block.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_highlight/flutter_highlight.dart';
 import 'package:flutter_highlight/themes/atom-one-dark.dart';
+import 'package:flutter_highlight/themes/atom-one-light.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:markdown/markdown.dart' as md;
 
@@ -64,7 +65,7 @@ class _CodeBlockState extends State<CodeBlock> {
           // Header strip: language tag + copy affordance.
           Container(
             padding: const EdgeInsets.fromLTRB(12, 6, 6, 6),
-            decoration: const BoxDecoration(
+            decoration: BoxDecoration(
               border: Border(
                 bottom: BorderSide(color: TalonColors.glassStroke),
               ),
@@ -121,17 +122,22 @@ class _CodeBlockState extends State<CodeBlock> {
                     widget.code,
                     style: TalonType.mono.copyWith(fontSize: 12.5, height: 1.5),
                   )
-                : HighlightView(
-                    widget.code,
-                    language: widget.language,
-                    theme: {
-                      ...atomOneDarkTheme,
-                      'root': (atomOneDarkTheme['root'] ?? const TextStyle())
-                          .copyWith(backgroundColor: Colors.transparent),
-                    },
-                    textStyle:
-                        TalonType.mono.copyWith(fontSize: 12.5, height: 1.5),
-                  ),
+                : Builder(builder: (context) {
+                    final base = TalonTheme.isDark
+                        ? atomOneDarkTheme
+                        : atomOneLightTheme;
+                    return HighlightView(
+                      widget.code,
+                      language: widget.language,
+                      theme: {
+                        ...base,
+                        'root': (base['root'] ?? const TextStyle())
+                            .copyWith(backgroundColor: Colors.transparent),
+                      },
+                      textStyle:
+                          TalonType.mono.copyWith(fontSize: 12.5, height: 1.5),
+                    );
+                  }),
           ),
         ],
       ),

--- a/apps/companion/lib/src/ui/composer.dart
+++ b/apps/companion/lib/src/ui/composer.dart
@@ -190,7 +190,7 @@ class _ComposerState extends State<Composer> {
                         hintText:
                             widget.enabled ? 'Message Talon…' : 'Connecting…',
                         hintStyle:
-                            const TextStyle(color: TalonColors.textFaint),
+                            TextStyle(color: TalonColors.textFaint),
                       ),
                     ),
                   ),
@@ -232,7 +232,7 @@ class _ComposerState extends State<Composer> {
               child: GestureDetector(
                 onTap: _clearAttachment,
                 child: Container(
-                  decoration: const BoxDecoration(
+                  decoration: BoxDecoration(
                     color: TalonColors.surfaceHi,
                     shape: BoxShape.circle,
                   ),

--- a/apps/companion/lib/src/ui/connect_screen.dart
+++ b/apps/companion/lib/src/ui/connect_screen.dart
@@ -123,7 +123,7 @@ class _ConnectScreenState extends State<ConnectScreen> {
                           style: const TextStyle(
                               fontSize: 20, fontWeight: FontWeight.w700),
                         ),
-                        const Text(
+                        Text(
                           'Connect your companion',
                           style: TextStyle(
                               color: TalonColors.textFaint, fontSize: 12.5),
@@ -154,7 +154,7 @@ class _ConnectScreenState extends State<ConnectScreen> {
                         const SizedBox(height: 14),
                         Text(
                           widget.state.connError!,
-                          style: const TextStyle(
+                          style: TextStyle(
                               color: TalonColors.bad, fontSize: 12.5),
                         ),
                       ],
@@ -169,13 +169,18 @@ class _ConnectScreenState extends State<ConnectScreen> {
     );
 
     if (widget.firstRun) return body;
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      appBar: AppBar(
+    // Pushed route — repaint in place when the palette changes (see
+    // SettingsScreen for the same pattern).
+    return ValueListenableBuilder<int>(
+      valueListenable: TalonTheme.revision,
+      builder: (context, _, __) => Scaffold(
         backgroundColor: Colors.transparent,
-        title: const Text('Settings'),
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          title: const Text('Settings'),
+        ),
+        body: body,
       ),
-      body: body,
     );
   }
 
@@ -276,7 +281,7 @@ class _ConnectScreenState extends State<ConnectScreen> {
           thumbColor: WidgetStateProperty.resolveWith((s) =>
               s.contains(WidgetState.selected) ? TalonColors.accent : null),
           title: const Text('Use HTTPS / TLS', style: TextStyle(fontSize: 14)),
-          subtitle: const Text(
+          subtitle: Text(
               'Turn on if the bridge is behind a TLS reverse proxy (Caddy, '
               'nginx, Tailscale Serve). Auto-detected from an https:// host.',
               style: TextStyle(fontSize: 12, color: TalonColors.textFaint)),
@@ -295,7 +300,7 @@ class _ConnectScreenState extends State<ConnectScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(label,
-            style: const TextStyle(
+            style: TextStyle(
                 fontSize: 12,
                 color: TalonColors.textDim,
                 fontWeight: FontWeight.w600)),
@@ -315,15 +320,15 @@ class _ConnectScreenState extends State<ConnectScreen> {
                 const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: const BorderSide(color: TalonColors.glassStroke),
+              borderSide: BorderSide(color: TalonColors.glassStroke),
             ),
             enabledBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: const BorderSide(color: TalonColors.glassStroke),
+              borderSide: BorderSide(color: TalonColors.glassStroke),
             ),
             focusedBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: const BorderSide(color: TalonColors.accent),
+              borderSide: BorderSide(color: TalonColors.accent),
             ),
           ),
         ),
@@ -339,7 +344,7 @@ class _Hint extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Text(
         text,
-        style: const TextStyle(
+        style: TextStyle(
             fontSize: 12.5, color: TalonColors.textFaint, height: 1.5),
       );
 }
@@ -356,7 +361,7 @@ class _ConnectButton extends StatelessWidget {
       borderRadius: BorderRadius.circular(14),
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 14),
-        decoration: const BoxDecoration(
+        decoration: BoxDecoration(
           borderRadius: TalonRadius.rMd,
           gradient: TalonColors.accentGradient,
         ),

--- a/apps/companion/lib/src/ui/markdown.dart
+++ b/apps/companion/lib/src/ui/markdown.dart
@@ -7,22 +7,22 @@ import '../theme.dart';
 /// code blocks and accent links. Used by finalized messages and the live draft.
 MarkdownStyleSheet talonMarkdownStyle() {
   return MarkdownStyleSheet(
-    p: const TextStyle(color: TalonColors.text, fontSize: 14.5, height: 1.6),
-    a: const TextStyle(
+    p: TextStyle(color: TalonColors.text, fontSize: 14.5, height: 1.6),
+    a: TextStyle(
         color: TalonColors.accent2, decoration: TextDecoration.underline),
     strong:
-        const TextStyle(color: TalonColors.text, fontWeight: FontWeight.w700),
-    em: const TextStyle(color: TalonColors.text, fontStyle: FontStyle.italic),
-    listBullet: const TextStyle(color: TalonColors.textDim, fontSize: 14.5),
-    h1: const TextStyle(
+        TextStyle(color: TalonColors.text, fontWeight: FontWeight.w700),
+    em: TextStyle(color: TalonColors.text, fontStyle: FontStyle.italic),
+    listBullet: TextStyle(color: TalonColors.textDim, fontSize: 14.5),
+    h1: TextStyle(
         color: TalonColors.text, fontSize: 21, fontWeight: FontWeight.w700),
-    h2: const TextStyle(
+    h2: TextStyle(
         color: TalonColors.text, fontSize: 18, fontWeight: FontWeight.w700),
-    h3: const TextStyle(
+    h3: TextStyle(
         color: TalonColors.text, fontSize: 16, fontWeight: FontWeight.w700),
-    code: const TextStyle(
+    code: TextStyle(
       color: TalonColors.accent2,
-      backgroundColor: Color(0x22000000),
+      backgroundColor: const Color(0x22000000),
       fontFamily: 'monospace',
       fontSize: 13.2,
     ),
@@ -35,14 +35,14 @@ MarkdownStyleSheet talonMarkdownStyle() {
     blockquoteDecoration: BoxDecoration(
       color: TalonColors.glassFill,
       borderRadius: BorderRadius.circular(8),
-      border: const Border(
+      border: Border(
         left: BorderSide(color: TalonColors.accent, width: 3),
       ),
     ),
     blockquotePadding: const EdgeInsets.fromLTRB(12, 6, 12, 6),
     tableBorder: TableBorder.all(color: TalonColors.glassStroke),
     tableHead: const TextStyle(fontWeight: FontWeight.w700),
-    horizontalRuleDecoration: const BoxDecoration(
+    horizontalRuleDecoration: BoxDecoration(
       border: Border(top: BorderSide(color: TalonColors.glassStroke)),
     ),
   );

--- a/apps/companion/lib/src/ui/message_bubble.dart
+++ b/apps/companion/lib/src/ui/message_bubble.dart
@@ -101,8 +101,13 @@ class MessageBubble extends StatelessWidget {
                   message: message.time.toLocal().toString().split('.').first,
                   waitDuration: const Duration(milliseconds: 600),
                   child: Container(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: TalonSpace.lg, vertical: 11),
+                    padding: EdgeInsets.symmetric(
+                        horizontal: imageUrl != null && message.text.isEmpty
+                            ? TalonSpace.sm
+                            : TalonSpace.lg,
+                        vertical: imageUrl != null && message.text.isEmpty
+                            ? TalonSpace.sm
+                            : 11),
                     decoration: BoxDecoration(
                       color: TalonColors.surfaceHi,
                       borderRadius: const BorderRadius.only(
@@ -113,9 +118,26 @@ class MessageBubble extends StatelessWidget {
                       ),
                       border: Border.all(color: TalonColors.glassStroke),
                     ),
-                    child: SelectableText(
-                      message.text,
-                      style: TalonType.body,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        // Attached image — user rows previously dropped it
+                        // entirely, so an uploaded photo vanished from the
+                        // conversation and its history.
+                        if (imageUrl != null)
+                          Padding(
+                            padding: EdgeInsets.only(
+                                bottom:
+                                    message.text.isEmpty ? 0 : TalonSpace.sm),
+                            child: _InlineImage(url: imageUrl!),
+                          ),
+                        if (message.text.isNotEmpty)
+                          SelectableText(
+                            message.text,
+                            style: TalonType.body,
+                          ),
+                      ],
                     ),
                   ),
                 ),
@@ -248,15 +270,18 @@ class _InlineImage extends StatelessWidget {
       child: ClipRRect(
         borderRadius: TalonRadius.rMd,
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 320, maxHeight: 320),
+          constraints: const BoxConstraints(maxWidth: 340, maxHeight: 420),
           child: Image.network(
             url,
-            fit: BoxFit.cover,
+            // contain, not cover: cover cropped anything non-square into an
+            // arbitrary window, which is what made history images look wrong.
+            // contain keeps the full frame at its natural aspect ratio.
+            fit: BoxFit.contain,
             loadingBuilder: (context, child, progress) {
               if (progress == null) return child;
               return Container(
-                width: 200,
-                height: 150,
+                width: 220,
+                height: 160,
                 alignment: Alignment.center,
                 color: TalonColors.surface,
                 child: const SizedBox(
@@ -271,12 +296,12 @@ class _InlineImage extends StatelessWidget {
               height: 110,
               alignment: Alignment.center,
               color: TalonColors.surface,
-              child: const Row(
+              child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Icon(Icons.broken_image_outlined,
                       size: 18, color: TalonColors.textFaint),
-                  SizedBox(width: TalonSpace.sm),
+                  const SizedBox(width: TalonSpace.sm),
                   Text('Image unavailable',
                       style: TextStyle(
                           color: TalonColors.textFaint, fontSize: 12.5)),
@@ -364,7 +389,7 @@ class _MessageActionsState extends State<_MessageActions> {
                     const SizedBox(width: 5),
                     Text(
                       _copied ? 'Copied' : 'Copy',
-                      style: const TextStyle(
+                      style: TextStyle(
                           fontSize: 11.5, color: TalonColors.textFaint),
                     ),
                   ],

--- a/apps/companion/lib/src/ui/model_sheet.dart
+++ b/apps/companion/lib/src/ui/model_sheet.dart
@@ -123,9 +123,9 @@ class _ModelSheetState extends State<_ModelSheet> {
       maxChildSize: 0.92,
       builder: (context, scroll) {
         return Container(
-          decoration: const BoxDecoration(
+          decoration: BoxDecoration(
             color: TalonColors.void1,
-            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
             border: Border(top: BorderSide(color: TalonColors.glassStroke)),
           ),
           child: Column(
@@ -143,7 +143,7 @@ class _ModelSheetState extends State<_ModelSheet> {
                 padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
                 child: Row(
                   children: [
-                    const Icon(Icons.tune, size: 18, color: TalonColors.accent),
+                    Icon(Icons.tune, size: 18, color: TalonColors.accent),
                     const SizedBox(width: 8),
                     Text(
                       _chat.title,
@@ -174,7 +174,7 @@ class _ModelSheetState extends State<_ModelSheet> {
               ),
               Expanded(
                 child: models.isEmpty
-                    ? const Center(
+                    ? Center(
                         child: Text('No models reported',
                             style: TextStyle(color: TalonColors.textFaint)))
                     : ListView.builder(
@@ -224,7 +224,7 @@ class _ModelSheetState extends State<_ModelSheet> {
         children: [
           Row(
             children: [
-              const Text(
+              Text(
                 'BACKEND',
                 style: TextStyle(
                   color: TalonColors.textFaint,
@@ -272,7 +272,7 @@ class _ModelSheetState extends State<_ModelSheet> {
             ],
           ),
           const SizedBox(height: 4),
-          const Text(
+          Text(
             'Switching backend starts a fresh conversation.',
             style: TextStyle(color: TalonColors.textFaint, fontSize: 11),
           ),
@@ -358,20 +358,20 @@ class _ModelRow extends StatelessWidget {
                   const SizedBox(height: 2),
                   Text(
                     model.provider,
-                    style: const TextStyle(
+                    style: TextStyle(
                         fontSize: 11.5, color: TalonColors.textFaint),
                   ),
                 ],
               ),
             ),
             if (model.reasoning)
-              const Padding(
-                padding: EdgeInsets.only(right: 8),
+              Padding(
+                padding: const EdgeInsets.only(right: 8),
                 child: Icon(Icons.psychology_outlined,
                     size: 16, color: TalonColors.textFaint),
               ),
             if (selected)
-              const Icon(Icons.check_circle,
+              Icon(Icons.check_circle,
                   color: TalonColors.accent, size: 18),
           ],
         ),

--- a/apps/companion/lib/src/ui/quick_switcher.dart
+++ b/apps/companion/lib/src/ui/quick_switcher.dart
@@ -187,7 +187,7 @@ class _QuickSwitcherState extends State<_QuickSwitcher> {
                               ? 'No matches.'
                               : 'Type to search chats and messages.',
                           style:
-                              const TextStyle(color: TalonColors.textFaint),
+                              TextStyle(color: TalonColors.textFaint),
                         ),
                       )
                     : ListView.builder(
@@ -235,7 +235,7 @@ class _QuickSwitcherState extends State<_QuickSwitcher> {
                                             e.subtitle!,
                                             maxLines: 1,
                                             overflow: TextOverflow.ellipsis,
-                                            style: const TextStyle(
+                                            style: TextStyle(
                                                 fontSize: 12,
                                                 color: TalonColors.textFaint),
                                           ),

--- a/apps/companion/lib/src/ui/root_view.dart
+++ b/apps/companion/lib/src/ui/root_view.dart
@@ -15,7 +15,7 @@ class RootView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DecoratedBox(
-      decoration: const BoxDecoration(gradient: TalonColors.backdrop),
+      decoration: BoxDecoration(gradient: TalonColors.backdrop),
       child: Material(
         type: MaterialType.transparency,
         child: Stack(

--- a/apps/companion/lib/src/ui/settings_screen.dart
+++ b/apps/companion/lib/src/ui/settings_screen.dart
@@ -79,25 +79,30 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      appBar: AppBar(
+    // This screen is a pushed route, outside the root's theme rebuild chain —
+    // subscribe to palette changes so toggling Appearance repaints in place.
+    return ValueListenableBuilder<int>(
+      valueListenable: TalonTheme.revision,
+      builder: (context, _, __) => Scaffold(
         backgroundColor: Colors.transparent,
-        title: const Text('Talon settings'),
-        actions: [
-          IconButton(
-            onPressed: _load,
-            icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
-          ),
-        ],
-      ),
-      body: Center(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(20),
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 560),
-            child: _loading ? const _SettingsSkeleton() : _body(),
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          title: const Text('Talon settings'),
+          actions: [
+            IconButton(
+              onPressed: _load,
+              icon: const Icon(Icons.refresh),
+              tooltip: 'Refresh',
+            ),
+          ],
+        ),
+        body: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 560),
+              child: _loading ? const _SettingsSkeleton() : _body(),
+            ),
           ),
         ),
       ),
@@ -111,6 +116,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       children: [
         _statusCard(cfg),
         const SizedBox(height: 16),
+        _appearanceCard(),
+        const SizedBox(height: 16),
         if (cfg == null)
           _Section(
             title: 'Settings unavailable',
@@ -119,7 +126,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               children: [
                 Text(
                   _error ?? 'Could not read settings from the daemon.',
-                  style: const TextStyle(color: TalonColors.textFaint),
+                  style: TextStyle(color: TalonColors.textFaint),
                 ),
                 if (_error != null && AppLog.diagnose(_error!) != null) ...[
                   const SizedBox(height: 10),
@@ -132,13 +139,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     child: Row(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const Icon(Icons.lightbulb_outline,
+                        Icon(Icons.lightbulb_outline,
                             size: 16, color: TalonColors.accent),
                         const SizedBox(width: 8),
                         Expanded(
                           child: Text(
                             AppLog.diagnose(_error!)!,
-                            style: const TextStyle(
+                            style: TextStyle(
                                 fontSize: 12.5, color: TalonColors.textDim),
                           ),
                         ),
@@ -240,6 +247,59 @@ class _SettingsScreenState extends State<SettingsScreen> {
         _connectionCard(),
         const SizedBox(height: 24),
       ],
+    );
+  }
+
+  // ── Appearance ────────────────────────────────────────────────────────────
+
+  Widget _appearanceCard() {
+    final current = TalonTheme.mode.value;
+    const options = [
+      (ThemeMode.system, 'Auto', Icons.brightness_auto_outlined),
+      (ThemeMode.light, 'Light', Icons.light_mode_outlined),
+      (ThemeMode.dark, 'Dark', Icons.dark_mode_outlined),
+    ];
+    return _Section(
+      title: 'Appearance',
+      child: Wrap(
+        spacing: 8,
+        children: [
+          for (final (mode, label, icon) in options)
+            ChoiceChip(
+              avatar: Icon(
+                icon,
+                size: 15,
+                color: current == mode
+                    ? TalonColors.accent
+                    : TalonColors.textFaint,
+              ),
+              label: Text(label),
+              selected: current == mode,
+              showCheckmark: false,
+              backgroundColor: TalonColors.surface,
+              selectedColor: TalonColors.accent.withValues(alpha: 0.22),
+              side: BorderSide(
+                color: current == mode
+                    ? TalonColors.accent
+                    : TalonColors.glassStroke,
+              ),
+              labelStyle: TextStyle(
+                color: current == mode
+                    ? TalonColors.text
+                    : TalonColors.textDim,
+                fontSize: 13,
+              ),
+              onSelected: (_) {
+                TalonTheme.mode.value = mode;
+                widget.state.prefs.setThemeMode(switch (mode) {
+                  ThemeMode.light => 'light',
+                  ThemeMode.dark => 'dark',
+                  ThemeMode.system => 'system',
+                });
+              },
+            ),
+        ],
+      ),
     );
   }
 
@@ -413,7 +473,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             child: Text(
               detail,
               style:
-                  const TextStyle(fontSize: 12.5, color: TalonColors.textDim),
+                  TextStyle(fontSize: 12.5, color: TalonColors.textDim),
             ),
           ),
         ],
@@ -429,7 +489,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             SizedBox(
               width: 128,
               child: Text(label,
-                  style: const TextStyle(
+                  style: TextStyle(
                       fontSize: 13, color: TalonColors.textDim)),
             ),
             Expanded(
@@ -513,7 +573,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         children: [
           Row(
             children: [
-              const Icon(Icons.lan_outlined,
+              Icon(Icons.lan_outlined,
                   size: 18, color: TalonColors.textDim),
               const SizedBox(width: 10),
               Expanded(
@@ -541,7 +601,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(label.toUpperCase(),
-              style: const TextStyle(
+              style: TextStyle(
                   fontSize: 10,
                   color: TalonColors.textFaint,
                   fontWeight: FontWeight.w700,
@@ -573,7 +633,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(10),
-                borderSide: const BorderSide(color: TalonColors.glassStroke),
+                borderSide: BorderSide(color: TalonColors.glassStroke),
               ),
             ),
           ),
@@ -596,7 +656,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     style: const TextStyle(
                         fontSize: 14, fontWeight: FontWeight.w600)),
                 Text(subtitle,
-                    style: const TextStyle(
+                    style: TextStyle(
                         fontSize: 12, color: TalonColors.textFaint)),
               ],
             ),
@@ -627,7 +687,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           Expanded(
             child: Text(label,
                 style:
-                    const TextStyle(fontSize: 13, color: TalonColors.textDim)),
+                    TextStyle(fontSize: 13, color: TalonColors.textDim)),
           ),
           IconButton(
             iconSize: 18,
@@ -722,7 +782,7 @@ class _Section extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(title.toUpperCase(),
-              style: const TextStyle(
+              style: TextStyle(
                   fontSize: 11,
                   fontWeight: FontWeight.w700,
                   letterSpacing: 1.1,
@@ -770,7 +830,7 @@ class _ModelRow extends StatelessWidget {
                       style: const TextStyle(fontSize: 14),
                     ),
                   ),
-                  const Icon(Icons.unfold_more,
+                  Icon(Icons.unfold_more,
                       size: 16, color: TalonColors.textFaint),
                 ],
               ),
@@ -799,9 +859,9 @@ class _ModelRow extends StatelessWidget {
               ListTile(
                 title: Text(m.displayName),
                 subtitle: Text(m.provider,
-                    style: const TextStyle(color: TalonColors.textFaint)),
+                    style: TextStyle(color: TalonColors.textFaint)),
                 trailing: m.id == cfg.model
-                    ? const Icon(Icons.check, color: TalonColors.accent)
+                    ? Icon(Icons.check, color: TalonColors.accent)
                     : null,
                 onTap: () => Navigator.pop(ctx, m.id),
               ),

--- a/apps/companion/lib/src/ui/sidebar.dart
+++ b/apps/companion/lib/src/ui/sidebar.dart
@@ -72,7 +72,7 @@ class _SidebarState extends State<Sidebar> {
                         builder: (_) => SettingsScreen(state: widget.state),
                       ),
                     ),
-                    icon: const Icon(Icons.settings_outlined,
+                    icon: Icon(Icons.settings_outlined,
                         size: 20, color: TalonColors.textDim),
                   ),
                 ],
@@ -101,7 +101,7 @@ class _SidebarState extends State<Sidebar> {
                 ? (_query.isEmpty ? 'No chats yet.' : 'No matches.')
                 : 'Connecting…',
             textAlign: TextAlign.center,
-            style: const TextStyle(color: TalonColors.textFaint, height: 1.5),
+            style: TextStyle(color: TalonColors.textFaint, height: 1.5),
           ),
         ),
       );
@@ -289,9 +289,9 @@ class _ChatTileState extends State<_ChatTile> {
                   width: selected ? 3 : 0,
                   height: 28,
                   margin: EdgeInsets.only(right: selected ? 9 : 0),
-                  decoration: const BoxDecoration(
+                  decoration: BoxDecoration(
                     gradient: TalonColors.accentGradient,
-                    borderRadius: BorderRadius.all(Radius.circular(2)),
+                    borderRadius: const BorderRadius.all(Radius.circular(2)),
                   ),
                 ),
                 Expanded(
@@ -317,15 +317,15 @@ class _ChatTileState extends State<_ChatTile> {
                             ),
                           ),
                           if (widget.chat.pulse == true)
-                            const Padding(
-                              padding: EdgeInsets.only(left: 4),
+                            Padding(
+                              padding: const EdgeInsets.only(left: 4),
                               child: Icon(Icons.notifications_active_outlined,
                                   size: 11, color: TalonColors.textFaint),
                             ),
                           const SizedBox(width: 6),
                           Text(
                             _relTime(widget.chat.lastActiveTime),
-                            style: const TextStyle(
+                            style: TextStyle(
                                 fontSize: 10.5, color: TalonColors.textFaint),
                           ),
                           // Unread: activity newer than the user's last look.
@@ -334,7 +334,7 @@ class _ChatTileState extends State<_ChatTile> {
                               width: 7,
                               height: 7,
                               margin: const EdgeInsets.only(left: 6),
-                              decoration: const BoxDecoration(
+                              decoration: BoxDecoration(
                                 shape: BoxShape.circle,
                                 gradient: TalonColors.accentGradient,
                               ),
@@ -348,7 +348,7 @@ class _ChatTileState extends State<_ChatTile> {
                             widget.chat.preview.replaceAll('\n', ' '),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
+                            style: TextStyle(
                                 fontSize: 11.5,
                                 color: TalonColors.textFaint,
                                 height: 1.3),
@@ -365,8 +365,8 @@ class _ChatTileState extends State<_ChatTile> {
                     child: InkWell(
                       onTap: widget.onDelete,
                       borderRadius: BorderRadius.circular(6),
-                      child: const Padding(
-                        padding: EdgeInsets.all(2),
+                      child: Padding(
+                        padding: const EdgeInsets.all(2),
                         child: Icon(Icons.close,
                             size: 15, color: TalonColors.textFaint),
                       ),
@@ -417,10 +417,10 @@ class _NewChatButtonState extends State<_NewChatButton> {
                   : TalonColors.glassStroke,
             ),
           ),
-          child: const Row(
+          child: Row(
             children: [
               Icon(Icons.add_rounded, color: TalonColors.text, size: 19),
-              SizedBox(width: TalonSpace.sm),
+              const SizedBox(width: TalonSpace.sm),
               Text(
                 'New chat',
                 style: TextStyle(
@@ -451,21 +451,21 @@ class _SearchBox extends StatelessWidget {
         prefixIconConstraints:
             const BoxConstraints(minWidth: 36, minHeight: 36),
         hintText: 'Search chats',
-        hintStyle: const TextStyle(color: TalonColors.textFaint, fontSize: 13),
+        hintStyle: TextStyle(color: TalonColors.textFaint, fontSize: 13),
         filled: true,
         fillColor: TalonColors.void0.withValues(alpha: 0.5),
         contentPadding: const EdgeInsets.symmetric(vertical: TalonSpace.sm),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(11),
-          borderSide: const BorderSide(color: TalonColors.glassStroke),
+          borderSide: BorderSide(color: TalonColors.glassStroke),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(11),
-          borderSide: const BorderSide(color: TalonColors.glassStroke),
+          borderSide: BorderSide(color: TalonColors.glassStroke),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(11),
-          borderSide: const BorderSide(color: TalonColors.accent),
+          borderSide: BorderSide(color: TalonColors.accent),
         ),
       ),
     );

--- a/apps/companion/lib/src/ui/tool_timeline.dart
+++ b/apps/companion/lib/src/ui/tool_timeline.dart
@@ -228,24 +228,24 @@ class _ToolStepState extends State<ToolStep> {
           ),
         ],
         const SizedBox(width: TalonSpace.sm),
-        if (_running) const _StatusBadge('Running', TalonColors.accent2),
-        if (_failed) const _StatusBadge('Failed', TalonColors.bad),
+        if (_running) _StatusBadge('Running', TalonColors.accent2),
+        if (_failed) _StatusBadge('Failed', TalonColors.bad),
         const SizedBox(width: TalonSpace.sm),
         Text(
           fmtToolDuration(tool.elapsed),
           maxLines: 1,
           softWrap: false,
-          style: const TextStyle(
+          style: TextStyle(
             color: TalonColors.textFaint,
             fontSize: 11.5,
-            fontFeatures: [FontFeature.tabularFigures()],
+            fontFeatures: const [FontFeature.tabularFigures()],
           ),
         ),
         if (_expandable)
           AnimatedRotation(
             duration: TalonMotion.fast,
             turns: _expanded ? 0.25 : 0,
-            child: const Icon(Icons.chevron_right,
+            child: Icon(Icons.chevron_right,
                 size: 16, color: TalonColors.textFaint),
           )
         else
@@ -399,7 +399,7 @@ class _ToolTraceState extends State<ToolTrace> {
                 AnimatedRotation(
                   duration: TalonMotion.fast,
                   turns: _open ? 0.25 : 0,
-                  child: const Icon(Icons.chevron_right,
+                  child: Icon(Icons.chevron_right,
                       size: 16, color: TalonColors.textFaint),
                 ),
                 const SizedBox(width: TalonSpace.xs),
@@ -413,7 +413,7 @@ class _ToolTraceState extends State<ToolTrace> {
                 const SizedBox(width: 6),
                 Text(
                   _summary(tools.length, failed, total),
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: TalonColors.textFaint,
                     fontSize: 12,
                   ),

--- a/apps/companion/test/theme_test.dart
+++ b/apps/companion/test/theme_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:talon_companion/src/theme.dart';
+
+void main() {
+  tearDown(() {
+    // Restore the default so other suites see the dark palette.
+    TalonTheme.mode.value = ThemeMode.system;
+    TalonTheme.apply(Brightness.dark);
+  });
+
+  test('explicit modes override the platform brightness', () {
+    TalonTheme.mode.value = ThemeMode.dark;
+    TalonTheme.apply(Brightness.light);
+    expect(TalonTheme.isDark, isTrue);
+
+    TalonTheme.mode.value = ThemeMode.light;
+    TalonTheme.apply(Brightness.dark);
+    expect(TalonTheme.isDark, isFalse);
+    expect(TalonColors.text, kTalonLight.text);
+  });
+
+  test('auto follows the platform brightness', () {
+    TalonTheme.mode.value = ThemeMode.system;
+    TalonTheme.apply(Brightness.dark);
+    expect(TalonTheme.isDark, isTrue);
+    expect(TalonColors.void0, kTalonDark.void0);
+
+    TalonTheme.apply(Brightness.light);
+    expect(TalonTheme.isDark, isFalse);
+    expect(TalonColors.void0, kTalonLight.void0);
+  });
+
+  test('revision bumps only on an actual palette change', () {
+    TalonTheme.mode.value = ThemeMode.dark;
+    TalonTheme.apply(Brightness.dark);
+    final before = TalonTheme.revision.value;
+    TalonTheme.apply(Brightness.light); // still dark — forced mode
+    expect(TalonTheme.revision.value, before);
+    TalonTheme.mode.value = ThemeMode.light;
+    TalonTheme.apply(Brightness.dark);
+    expect(TalonTheme.revision.value, before + 1);
+  });
+
+  test('light palette keeps status colors distinguishable from text', () {
+    // Guard against a light palette regression where faint text or status
+    // colors collapse into the background.
+    expect(kTalonLight.text.computeLuminance(),
+        lessThan(kTalonLight.void0.computeLuminance()));
+    expect(kTalonLight.ok, isNot(kTalonLight.text));
+    expect(kTalonLight.bad, isNot(kTalonLight.warn));
+  });
+}

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -201,6 +201,7 @@ export async function initBackendAndDispatcher(
     initBackendPool,
     getBackendForRole,
     getBackendForChat,
+    getBackendIdForChat,
     rebindChat,
     releaseChat,
     isBackendAvailable,
@@ -274,22 +275,35 @@ export async function initBackendAndDispatcher(
         setChatModel(cid, undefined);
         resetVolatileState = true;
       } else {
-        const result = await rebindChat(cid, settings.backend, config);
+        // A boot-time rebind failure is usually TRANSIENT (backend slow to
+        // spawn, auth endpoint briefly unreachable) — it must not destroy
+        // the user's persisted choice, session, and history. Retry once,
+        // then keep the setting and move on: the chat runs on the default
+        // backend until a later switch succeeds, and clients keep showing
+        // the user's chosen backend from settings (the source of truth).
+        let result = await rebindChat(cid, settings.backend, config);
+        if (!result.ok) {
+          await new Promise((r) => setTimeout(r, 1500));
+          result = await rebindChat(cid, settings.backend, config);
+        }
         if (!result.ok) {
           log(
             "bot",
-            `Per-chat backend rebind failed for ${cid} → ${settings.backend}: ${result.error} — resetting chat to default backend`,
+            `Per-chat backend rebind failed for ${cid} → ${settings.backend}: ${result.error} — keeping the setting; will serve on the default backend until re-selected`,
           );
-          await releaseChat(cid);
-          setChatBackend(cid, undefined);
-          setChatModel(cid, undefined);
-          resetVolatileState = true;
         }
       }
     }
 
+    // Only validate the stored model against the backend that will really
+    // serve this chat. After a kept-but-unbound override (transient rebind
+    // failure above) the chat temporarily runs on the default backend — the
+    // stored model belongs to the chosen backend, so validating it against
+    // the default would wrongly clear it.
+    const bindingMatchesSetting =
+      !settings.backend || getBackendIdForChat(cid) === settings.backend;
     const currentModel = getAllChatSettings()[cid]?.model;
-    if (currentModel) {
+    if (currentModel && bindingMatchesSetting) {
       const be = getBackendForChat(cid);
       try {
         const valid = await isModelValidForBackend(be, currentModel);

--- a/src/frontend/native/index.ts
+++ b/src/frontend/native/index.ts
@@ -140,10 +140,16 @@ export function createNativeFrontend(
     let model: string | undefined;
     let backend: string | undefined;
     try {
-      backend = getBackendIdForChat(entry.id);
+      // The persisted per-chat setting is the source of truth for what the
+      // user picked; the in-memory binding can lag it (boot-time rebind
+      // still pending or transiently failed). Reporting the binding here
+      // made clients show a chat "reset" to the default backend after a
+      // daemon restart even though the user's choice was intact.
+      backend = settings.backend ?? getBackendIdForChat(entry.id);
       model = getChatModelForBackend(entry.id, backend);
     } catch {
-      /* backend pool not ready (early boot) — omit model/backend */
+      backend = settings.backend;
+      /* backend pool not ready (early boot) — omit model */
     }
     return {
       id: entry.id,
@@ -472,7 +478,9 @@ export function createNativeFrontend(
     let active = config.model;
     if (chatId) {
       try {
-        backendId = getBackendIdForChat(chatId);
+        // Persisted setting first — see toClientChat.
+        backendId =
+          getChatSettings(chatId).backend ?? getBackendIdForChat(chatId);
         active = getChatModelForBackend(chatId, backendId) ?? config.model;
       } catch {
         /* pool not ready — keep global defaults */
@@ -541,7 +549,10 @@ export function createNativeFrontend(
     const backends = listAvailableBackends(config);
     let active: string = config.backend;
     try {
-      if (chatId) active = getBackendIdForChat(chatId);
+      if (chatId) {
+        // Persisted setting first — see toClientChat.
+        active = getChatSettings(chatId).backend ?? getBackendIdForChat(chatId);
+      }
     } catch {
       /* pool not ready — report the global default backend */
     }
@@ -566,12 +577,32 @@ export function createNativeFrontend(
     if (!available.some((b) => b.id === target)) {
       return { ok: false, error: "Backend not available" };
     }
-    if (getBackendIdForChat(chatId) === target) return { ok: true };
+    const persisted = getChatSettings(chatId).backend;
+    if (getBackendIdForChat(chatId) === target) {
+      // Already live on the target — just make sure the choice is persisted.
+      if (persisted !== target && target !== config.backend) {
+        setChatBackend(chatId, target);
+        broadcastChatUpdated(entry);
+      }
+      return { ok: true };
+    }
 
     const result = await rebindChat(chatId, target, config);
     if (!result.ok) {
       return { ok: false, error: result.error ?? "Rebind failed" };
     }
+
+    // Re-selecting the backend this chat is already persisted to is a
+    // RE-ATTACH (e.g. the boot-time rebind failed transiently and the user —
+    // or a client retry — picks it again). The conversation belongs to that
+    // backend; resetting the session and wiping history here destroyed real
+    // conversations and surfaced as a phantom "backend reset" in clients.
+    if (persisted === target) {
+      broadcastChatUpdated(entry);
+      broadcast({ kind: "status", status: status() });
+      return { ok: true };
+    }
+
     setChatBackend(chatId, target);
     resetSession(chatId);
     clearHistory(chatId);


### PR DESCRIPTION
## Summary

Follow-up to #438 addressing three reported issues.

### Phantom "backend reset" on reconnect (daemon)
Root cause was daemon-side, in two layers:
1. **`bootstrap.ts` destroyed state on transient failures**: if a chat's persisted backend failed its boot-time rebind (slow spawn, brief auth/network error), bootstrap cleared the persisted backend + model and wiped the session and history. Now it retries once and otherwise *keeps* the setting — the chat serves on the default backend until re-selected, with nothing destroyed. Model validation is skipped while the live binding lags the setting (it was validating against the wrong backend and clearing valid models).
2. **The bridge reported the in-memory binding, not the persisted choice**: `toClientChat`/`listModels`/`listBackends` now report the persisted per-chat backend, so clients never display a phantom reset. And `setBackend` treats re-selecting the already-persisted backend as a **re-attach** — previously that path reset the session, cleared history, and posted "Switched — starting a fresh conversation".

### Images in conversation history (app)
- User bubbles never rendered attached images at all — uploads vanished from the conversation and history. They render now.
- Inline images were cropped by `BoxFit.cover` into a 320×320 window; now `BoxFit.contain` at natural aspect ratio (340×420 cap).

### Theming: Auto / Light / Dark (app)
- New palette-driven theme system: `TalonPalette` dark + light variants, `TalonTheme` mode notifier persisted in prefs, auto mode follows platform brightness live (`didChangePlatformBrightness`).
- **Appearance** section in Settings; changes apply instantly, including on pushed routes (palette revision notifier).
- Code-block syntax highlighting, Material theme, scrollbars, and switches all follow the palette. Full const-sweep across the UI so every surface repaints on theme change.

## Test plan
- App: `flutter analyze --fatal-infos` clean; `flutter test` — **59 tests pass** (4 new theme tests: mode resolution, auto-follow, revision semantics, light-palette contrast guard)
- Daemon: `tsc --noEmit` clean; native/bridge suites pass; full suite green except a pre-existing local-midnight UTC/local date flake in `config.test.ts` (green on UTC runners) and the network-gated kilo integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)