### PR TITLE
fix(publish): fix nfpm .deb build - ${BIN} not expanded in contents[].src

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -222,8 +222,14 @@ jobs:
           export VERSION="${GITHUB_REF_NAME#v}"
           mkdir -p dist
           # nfpm arch (Debian naming) → the matching linux binary.
+          # nfpm does NOT expand ${VAR} inside contents[].src (only in
+          # top-level scalar fields like arch/version), so copy each
+          # arch's binary to the fixed path nfpm.yaml references instead
+          # of templating src per-arch.
           build_deb() {
-            export ARCH="$1" BIN="$2"
+            export ARCH="$1"
+            cp "$2" dist/talon-bin
+            chmod +x dist/talon-bin
             nfpm package -f nfpm.yaml -p deb -t "dist/talon_${VERSION}_${ARCH}.deb"
           }
           build_deb amd64 bin/talon-linux-x64

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,6 +1,11 @@
 # nfpm packaging manifest for the standalone Talon binary (.deb).
-# Built per-arch in the `deb` job of publish.yml; VERSION / ARCH / BIN are
-# supplied via the environment (nfpm expands ${VAR} natively).
+# Built per-arch in the `deb` job of publish.yml; VERSION / ARCH are
+# supplied via the environment (nfpm expands ${VAR} in top-level scalar
+# fields like `arch`/`version` natively). NOTE: nfpm does NOT expand
+# ${VAR} inside `contents[].src` — that field is a literal glob pattern,
+# not a templated string. So the workflow copies each arch's binary to
+# the fixed path below (dist/talon-bin) before invoking nfpm, rather than
+# templating `src` per-arch.
 #
 # Talon is a self-contained `bun build --compile` binary — no Node runtime
 # dependency — so there are no Debian `depends`. Backends (claude, codex,
@@ -18,7 +23,7 @@ vendor: Dylan Neve
 homepage: https://github.com/dylanneve1/talon
 license: MIT
 contents:
-  - src: ${BIN}
+  - src: dist/talon-bin
     dst: /usr/bin/talon
     file_info:
       mode: 0755


### PR DESCRIPTION
## Summary
- Every Debian package build has failed since v1.23.0 (15+ consecutive Publish runs) with `glob failed: ${BIN}: no matching files`.
- Root cause: nfpm expands `${VAR}` in top-level scalar fields (`arch`, `version`) but **not** inside `contents[].src` — that field is a literal glob pattern, not a templated string. The old comment claiming nfpm expands `${VAR}` "natively" for that field was wrong.
- Fix: `build_deb()` now copies each arch's binary to a fixed path (`dist/talon-bin`) before invoking nfpm, and `nfpm.yaml` references that literal path instead of `${BIN}`.

## Verification
Reproduced the failure and the fix locally with the exact nfpm version pinned in the workflow (2.43.0):
- Before fix: `nfpm package -f nfpm.yaml -p deb ...` with `BIN` exported → `glob failed: ${BIN}: no matching files` (matches the CI failure).
- After fix: `nfpm package` succeeds, produces a valid `.deb` with `dpkg-deb --info` showing correct `Version`/`Architecture` substitution from `VERSION`/`ARCH` env vars (those still work — only `src` was broken).

## Test plan
- [ ] Merge and confirm the next release's `Debian package` job in Publish succeeds
- [ ] Confirm `talon_<version>_amd64.deb` and `talon_<version>_arm64.deb` are attached to the release and install cleanly (`dpkg -i` / `apt install ./talon_*.deb`)

Note: this only fixes the Debian package job. The npm publish job is failing separately (404 on `npm publish`, likely an expired/misscoped `NPM_TOKEN` secret) and needs a token rotation on Dylan's side — out of scope for this PR.