### PR TITLE
Robustness hardening + MCP hub: constant-memory MCP serving for all backends

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -99,13 +99,34 @@ interface Backend {
 across all backends — each backend's `one-shot.ts` translates the
 runtime events into Markdown-flavoured run-log entries.
 
+### `core/mcp-hub/` — MCP over HTTP for every backend
+
+All MCP servers are served by the daemon's MCP hub on the gateway
+HTTP server (streamable HTTP), and every backend connects with its
+SDK's HTTP/remote transport instead of spawning stdio subprocesses:
+
+- `/mcp/talon/<frontend>/<chatId>` — Talon's own tool set, composed
+  **in-process** (`talon-server.ts`); the per-chat binding travels in
+  the URL rather than `TALON_CHAT_ID` env. Zero subprocesses.
+- `/mcp/plugin/<serverName>/<chatId>` — external plugin / brave
+  servers, proxied (`proxy-server.ts`) to hub-owned stdio children
+  (`children.ts`) that are shared across sessions, reaped after an
+  idle TTL (`TALON_MCP_HUB_IDLE_MS`, default 10 min), and *retired*
+  on plugin reload — in-flight tool calls drain on the old process
+  while new calls spawn fresh from the reloaded registry.
+
+Before the hub, each backend spawned its own copy of every MCP server
+per chat (claude-sdk/codex per turn; openai-agents and kilo/opencode
+per chat, held indefinitely) and daemon memory grew linearly with the
+number of chats.
+
 ## Backend-specific notes
 
 ### Claude SDK
 
 Spawns the `claude` CLI as a subprocess per turn via
 `@anthropic-ai/claude-agent-sdk`. MCP servers are passed in
-`Options.mcpServers`; the SDK spawns them inside its subprocess.
+`Options.mcpServers` as `type: "http"` hub URLs.
 Turn termination via `PostToolBatch` hook + `continue: false` returns.
 
 Requires the `claude` CLI on `PATH` and ChatGPT auth (or

--- a/src/__tests__/claude-sdk-options.test.ts
+++ b/src/__tests__/claude-sdk-options.test.ts
@@ -767,29 +767,27 @@ describe("buildMcpServers (heartbeat-tier paths)", () => {
     expect(servers).not.toHaveProperty("telegram-tools");
   });
 
-  it("env includes TALON_CHAT_ID, TALON_FRONTEND, TALON_BRIDGE_URL", async () => {
+  it("hub URL carries chatId + frontend and targets the bridge port", async () => {
     mockGetConfig.mockReturnValue({ frontend: "telegram" });
     mockGetBridgePort.mockReturnValue(31337);
     const { buildMcpServers } =
       await import("../backend/claude-sdk/options.js");
     const servers = buildMcpServers("352042062");
-    const env = (servers["telegram-tools"] as { env: Record<string, string> })
-      .env;
-    expect(env).toMatchObject({
-      TALON_CHAT_ID: "352042062",
-      TALON_FRONTEND: "telegram",
-      TALON_BRIDGE_URL: "http://127.0.0.1:31337",
+    expect(servers["telegram-tools"]).toEqual({
+      type: "http",
+      url: "http://127.0.0.1:31337/mcp/talon/telegram/352042062",
+      alwaysLoad: true,
     });
   });
 
-  it("heartbeat sentinel: TALON_CHAT_ID is 'heartbeat' when chatId='heartbeat'", async () => {
+  it("heartbeat sentinel: hub URL carries 'heartbeat' when chatId='heartbeat'", async () => {
     mockGetConfig.mockReturnValue({ frontend: "telegram" });
     const { buildMcpServers } =
       await import("../backend/claude-sdk/options.js");
     const servers = buildMcpServers("heartbeat");
-    const env = (servers["telegram-tools"] as { env: Record<string, string> })
-      .env;
-    expect(env.TALON_CHAT_ID).toBe("heartbeat");
+    expect(servers["telegram-tools"].url).toMatch(
+      /\/mcp\/talon\/telegram\/heartbeat$/,
+    );
   });
 
   it("multi-frontend + brave produces 3 servers", async () => {
@@ -806,29 +804,17 @@ describe("buildMcpServers (heartbeat-tier paths)", () => {
       "telegram-tools",
     ]);
     // Both frontend servers get the heartbeat sentinel.
-    expect(
-      (servers["telegram-tools"] as { env: Record<string, string> }).env
-        .TALON_CHAT_ID,
-    ).toBe("heartbeat");
-    expect(
-      (servers["teams-tools"] as { env: Record<string, string> }).env
-        .TALON_CHAT_ID,
-    ).toBe("heartbeat");
+    expect(servers["telegram-tools"].url).toMatch(/\/heartbeat$/);
+    expect(servers["teams-tools"].url).toMatch(/\/heartbeat$/);
   });
 
-  it("each frontend gets its own TALON_FRONTEND env (no cross-pollination)", async () => {
+  it("each frontend gets its own hub URL (no cross-pollination)", async () => {
     mockGetConfig.mockReturnValue({ frontend: ["telegram", "teams"] });
     const { buildMcpServers } =
       await import("../backend/claude-sdk/options.js");
     const servers = buildMcpServers("heartbeat");
-    expect(
-      (servers["telegram-tools"] as { env: Record<string, string> }).env
-        .TALON_FRONTEND,
-    ).toBe("telegram");
-    expect(
-      (servers["teams-tools"] as { env: Record<string, string> }).env
-        .TALON_FRONTEND,
-    ).toBe("teams");
+    expect(servers["telegram-tools"].url).toContain("/mcp/talon/telegram/");
+    expect(servers["teams-tools"].url).toContain("/mcp/talon/teams/");
   });
 
   it("includes brave-search when braveApiKey set, even for terminal-only", async () => {

--- a/src/__tests__/codex-backend.test.ts
+++ b/src/__tests__/codex-backend.test.ts
@@ -85,11 +85,9 @@ describe("codex / buildCodexMcpServers", () => {
       frontends: ["telegram"],
     });
     expect(servers["telegram-tools"]).toBeDefined();
-    expect(servers["telegram-tools"].env).toMatchObject({
-      TALON_CHAT_ID: "352042062",
-      TALON_FRONTEND: "telegram",
-      TALON_BRIDGE_URL: "http://127.0.0.1:19876",
-    });
+    expect(servers["telegram-tools"].url).toBe(
+      "http://127.0.0.1:19876/mcp/talon/telegram/352042062",
+    );
   });
 
   it("emits one server per frontend when multiple are configured", () => {
@@ -100,20 +98,20 @@ describe("codex / buildCodexMcpServers", () => {
     });
     expect(servers["telegram-tools"]).toBeDefined();
     expect(servers["discord-tools"]).toBeDefined();
-    expect(servers["telegram-tools"].env?.TALON_FRONTEND).toBe("telegram");
-    expect(servers["discord-tools"].env?.TALON_FRONTEND).toBe("discord");
+    expect(servers["telegram-tools"].url).toContain("/mcp/talon/telegram/");
+    expect(servers["discord-tools"].url).toContain("/mcp/talon/discord/");
   });
 
-  it("includes the plugin MCP servers from getPluginMcpServers", () => {
+  it("includes the plugin MCP servers from the registry as hub URLs", () => {
     const servers = buildCodexMcpServers({
       chatId: "c1",
       bridgeUrl: "http://127.0.0.1:19876",
       frontends: ["telegram"],
     });
     expect(servers["mempalace-tools"]).toBeDefined();
-    expect(servers["mempalace-tools"].env).toMatchObject({
-      MEMPALACE_PATH: "/palace",
-    });
+    expect(servers["mempalace-tools"].url).toBe(
+      "http://127.0.0.1:19876/mcp/plugin/mempalace-tools/c1",
+    );
   });
 
   it("includes brave-search when braveApiKey is provided", () => {
@@ -124,9 +122,9 @@ describe("codex / buildCodexMcpServers", () => {
       braveApiKey: "BSA-test-key",
     });
     expect(servers["brave-search"]).toBeDefined();
-    expect(servers["brave-search"].env).toMatchObject({
-      BRAVE_API_KEY: "BSA-test-key",
-    });
+    expect(servers["brave-search"].url).toContain(
+      "/mcp/plugin/brave-search/c1",
+    );
   });
 
   it("omits brave-search when no API key is provided", () => {
@@ -150,18 +148,18 @@ describe("codex / buildCodexMcpServers", () => {
     expect(servers["mempalace-tools"]).toBeDefined();
   });
 
-  it("each server has a command + args + env shape", () => {
+  it("each server is a hub URL entry (no local spawn fields)", () => {
     const servers = buildCodexMcpServers({
       chatId: "c1",
       bridgeUrl: "http://127.0.0.1:19876",
       frontends: ["telegram"],
     });
     for (const [name, server] of Object.entries(servers)) {
-      expect(typeof server.command, `${name}.command`).toBe("string");
-      expect(Array.isArray(server.args), `${name}.args`).toBe(true);
-      expect(server.env === undefined || typeof server.env === "object").toBe(
-        true,
+      expect(typeof server.url, `${name}.url`).toBe("string");
+      expect(server.url, `${name}.url`).toMatch(
+        /^http:\/\/127\.0\.0\.1:19876\/mcp\//,
       );
+      expect(server, name).not.toHaveProperty("command");
     }
   });
 

--- a/src/__tests__/integration/stub-claude/fake-claude.mjs
+++ b/src/__tests__/integration/stub-claude/fake-claude.mjs
@@ -39,6 +39,7 @@ import { randomUUID } from "node:crypto";
 // directly so it doesn't matter there, but keeping it consistent.
 import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 const LOG_FILE = process.env.STUB_CLAUDE_LOG;
 const log = (msg) => {
@@ -82,12 +83,18 @@ const getMcpClient = async (serverName) => {
     return null;
   }
   try {
-    const transport = new StdioClientTransport({
-      command: cfg.command,
-      args: cfg.args ?? [],
-      env: cfg.env ? { ...process.env, ...cfg.env } : { ...process.env },
-      stderr: "pipe",
-    });
+    // Mirror the real binary's transport selection: `type: "http"` (the
+    // shape Talon's MCP hub emits) connects over streamable HTTP; the
+    // command/args shape spawns a stdio subprocess.
+    const transport =
+      cfg.type === "http" || cfg.url
+        ? new StreamableHTTPClientTransport(new URL(cfg.url))
+        : new StdioClientTransport({
+            command: cfg.command,
+            args: cfg.args ?? [],
+            env: cfg.env ? { ...process.env, ...cfg.env } : { ...process.env },
+            stderr: "pipe",
+          });
     const client = new McpClient(
       { name: "stub-claude", version: "0.0.0" },
       { capabilities: {} },

--- a/src/__tests__/integration/stub-codex/fake-codex.mjs
+++ b/src/__tests__/integration/stub-codex/fake-codex.mjs
@@ -33,6 +33,7 @@ import { randomUUID } from "node:crypto";
 
 import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 const LOG_FILE = process.env.STUB_CODEX_LOG;
 const log = (msg) => {
@@ -112,20 +113,24 @@ const mcpClients = new Map();
 const getMcpClient = async (serverName) => {
   if (mcpClients.has(serverName)) return mcpClients.get(serverName);
   const cfg = MCP_SERVERS?.[serverName];
-  if (!cfg || !cfg.command) {
+  if (!cfg || (!cfg.command && !cfg.url)) {
     log(`getMcpClient: no config for server ${serverName}`);
     return null;
   }
   try {
-    const transport = new StdioClientTransport({
-      command: cfg.command,
-      args: Array.isArray(cfg.args) ? cfg.args : [],
-      env:
-        cfg.env && typeof cfg.env === "object"
-          ? { ...process.env, ...cfg.env }
-          : { ...process.env },
-      stderr: "pipe",
-    });
+    // `url` is the streamable-HTTP shape Talon's MCP hub emits (the real
+    // codex binary connects the same way); command/args is legacy stdio.
+    const transport = cfg.url
+      ? new StreamableHTTPClientTransport(new URL(cfg.url))
+      : new StdioClientTransport({
+          command: cfg.command,
+          args: Array.isArray(cfg.args) ? cfg.args : [],
+          env:
+            cfg.env && typeof cfg.env === "object"
+              ? { ...process.env, ...cfg.env }
+              : { ...process.env },
+          stderr: "pipe",
+        });
     const client = new McpClient(
       { name: "stub-codex", version: "0.0.0" },
       { capabilities: {} },

--- a/src/__tests__/integration/stub-remote/fake-remote-server.ts
+++ b/src/__tests__/integration/stub-remote/fake-remote-server.ts
@@ -20,6 +20,7 @@ import { randomUUID } from "node:crypto";
 
 import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 export interface RemoteTurnItem {
   type: "text" | "tool";
@@ -37,9 +38,12 @@ export interface RemoteTurn {
 
 interface McpRegistration {
   name: string;
-  command: string;
-  args: string[];
-  env: Record<string, string>;
+  /** Stdio shape (`type: "local"`). */
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  /** Remote shape (`type: "remote"`) — Talon's MCP hub URL. */
+  url?: string;
 }
 
 export interface FakeRemoteServer {
@@ -74,7 +78,10 @@ export async function startFakeRemoteServer(
   const mcpServers = new Map<string, McpRegistration>();
   const mcpClients = new Map<
     string,
-    { client: McpClient; transport: StdioClientTransport }
+    {
+      client: McpClient;
+      transport: StdioClientTransport | StreamableHTTPClientTransport;
+    }
   >();
   let currentTurn: RemoteTurn = { emit: [] };
   let lastAssistant: Record<string, unknown> | null = null;
@@ -118,17 +125,23 @@ export async function startFakeRemoteServer(
     if (mcpClients.has(name)) return mcpClients.get(name)!;
     const cfg = mcpServers.get(name);
     if (!cfg) return null;
-    const mergedEnv: Record<string, string> = {};
-    for (const [k, v] of Object.entries(process.env)) {
-      if (typeof v === "string") mergedEnv[k] = v;
+    let transport: StdioClientTransport | StreamableHTTPClientTransport;
+    if (cfg.url) {
+      // Remote registration — Talon's MCP hub over streamable HTTP.
+      transport = new StreamableHTTPClientTransport(new URL(cfg.url));
+    } else {
+      const mergedEnv: Record<string, string> = {};
+      for (const [k, v] of Object.entries(process.env)) {
+        if (typeof v === "string") mergedEnv[k] = v;
+      }
+      Object.assign(mergedEnv, cfg.env ?? {});
+      transport = new StdioClientTransport({
+        command: cfg.command ?? "",
+        args: cfg.args ?? [],
+        env: mergedEnv,
+        stderr: "pipe",
+      });
     }
-    Object.assign(mergedEnv, cfg.env);
-    const transport = new StdioClientTransport({
-      command: cfg.command,
-      args: cfg.args,
-      env: mergedEnv,
-      stderr: "pipe",
-    });
     const client = new McpClient(
       { name: "fake-remote", version: "0.0.0" },
       { capabilities: {} },
@@ -286,7 +299,12 @@ export async function startFakeRemoteServer(
               : cfg.env && typeof cfg.env === "object"
                 ? cfg.env
                 : {};
-          if (name && cmdArr.length > 0) {
+          const remoteUrl =
+            typeof cfg.url === "string" && cfg.url ? cfg.url : undefined;
+          if (name && remoteUrl) {
+            // `type: "remote"` — Talon's MCP hub endpoint.
+            mcpServers.set(name, { name, url: remoteUrl });
+          } else if (name && cmdArr.length > 0) {
             mcpServers.set(name, {
               name,
               command: cmdArr[0],

--- a/src/__tests__/kilo-server.test.ts
+++ b/src/__tests__/kilo-server.test.ts
@@ -94,7 +94,7 @@ describe("kilo server helpers", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("ensureChatMcpServer registers the chat server with the right env", async () => {
+  it("ensureChatMcpServer registers the chat server with the hub URL", async () => {
     const oc = makeClient();
 
     const serverName = await ensureChatMcpServer(oc as never, "chat/1");
@@ -104,11 +104,8 @@ describe("kilo server helpers", () => {
     expect(oc.mcp.add.mock.calls[0][0]).toMatchObject({
       name: "talon-tools-chat_1",
       config: {
-        environment: {
-          TALON_BRIDGE_URL: "http://127.0.0.1:17777",
-          TALON_CHAT_ID: "chat/1",
-          TALON_FRONTEND: "discord",
-        },
+        type: "remote",
+        url: "http://127.0.0.1:17777/mcp/talon/discord/chat%2F1",
       },
     });
   });

--- a/src/__tests__/mcp-hub.test.ts
+++ b/src/__tests__/mcp-hub.test.ts
@@ -1,0 +1,242 @@
+/**
+ * MCP hub — end-to-end tests over a real gateway HTTP server.
+ *
+ * A real `Gateway` is started on an ephemeral port and a real MCP
+ * client (`@modelcontextprotocol/sdk` StreamableHTTPClientTransport)
+ * connects to the hub endpoints, exactly as the backends do in
+ * production. Covers:
+ *
+ *   - in-process Talon tool serving (tools/list + a bridged tools/call
+ *     that round-trips through the gateway's /action dispatch)
+ *   - per-URL (frontend, chatId) binding
+ *   - session lifecycle (unknown session → 404, DELETE terminates)
+ *   - proxied plugin children (spawned once, shared, tool call
+ *     forwarded) using a tiny stdio MCP server subprocess
+ *   - child retirement on reload (next acquire respawns)
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+vi.mock("../util/watchdog.js", () => ({
+  getHealthStatus: vi.fn(() => ({
+    healthy: true,
+    totalMessagesProcessed: 0,
+    recentErrorCount: 0,
+    msSinceLastMessage: 0,
+  })),
+}));
+
+vi.mock("../storage/sessions.js", () => ({
+  getActiveSessionCount: vi.fn(() => 0),
+}));
+
+vi.mock("../core/engine/dispatcher.js", () => ({
+  getActiveCount: vi.fn(() => 0),
+}));
+
+// One fake plugin server: a self-contained stdio MCP server script the
+// hub spawns as a child (node -e).
+const FAKE_PLUGIN_SCRIPT = `
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+const server = new McpServer({ name: "fake-plugin-tools", version: "1.0.0" });
+server.tool("echo_pid", "Echo the input plus this process pid", { text: z.string() }, async ({ text }) => ({
+  content: [{ type: "text", text: text + ":" + process.pid }],
+}));
+await server.connect(new StdioServerTransport());
+`;
+
+vi.mock("../core/plugin/index.js", () => ({
+  handlePluginAction: vi.fn(async () => null),
+  getPluginMcpServers: vi.fn(() => ({
+    "fake-plugin-tools": {
+      command: process.execPath,
+      args: ["--input-type=module", "-e", FAKE_PLUGIN_SCRIPT],
+      env: {},
+    },
+  })),
+}));
+
+vi.mock("write-file-atomic", () => ({
+  default: { sync: vi.fn() },
+}));
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Gateway } from "../core/engine/gateway.js";
+import {
+  initHub,
+  shutdownHub,
+  reloadHubChildren,
+  talonHubUrl,
+  pluginHubUrl,
+} from "../core/mcp-hub/index.js";
+import { getActiveChildKeys } from "../core/mcp-hub/children.js";
+
+let gateway: Gateway;
+let bridgeUrl: string;
+
+async function connectClient(url: string): Promise<Client> {
+  const client = new Client(
+    { name: "hub-test-client", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  await client.connect(new StreamableHTTPClientTransport(new URL(url)));
+  return client;
+}
+
+beforeAll(async () => {
+  initHub({});
+  gateway = new Gateway("daemon");
+  const port = await gateway.start(0);
+  bridgeUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await shutdownHub();
+  await gateway.stop();
+});
+
+describe("mcp-hub / talon tool serving (in-process)", () => {
+  it("serves the frontend tool set over streamable HTTP", async () => {
+    const client = await connectClient(
+      talonHubUrl(bridgeUrl, "telegram", "chat-1"),
+    );
+    try {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain("end_turn");
+      expect(names).toContain("send");
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("tool calls bridge into the gateway bound to the URL's chatId", async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    gateway.setFrontendHandler(async (body) => {
+      seen.push(body);
+      return { ok: true };
+    });
+    // The gateway requires an active context for ambient routing.
+    gateway.setContext(4242, "4242", "telegram");
+
+    const client = await connectClient(
+      talonHubUrl(bridgeUrl, "telegram", "4242"),
+    );
+    try {
+      // end_turn WITH text routes through the bridge as send_message
+      // (a silent end_turn makes no bridge call by design).
+      const result = await client.callTool({
+        name: "end_turn",
+        arguments: { text: "hello from the hub" },
+      });
+      expect(result.isError ?? false).toBe(false);
+      expect(seen.length).toBeGreaterThan(0);
+      expect(seen[0]._chatId).toBe("4242");
+      expect(seen[0].action).toBe("send_message");
+      expect(seen[0].text).toBe("hello from the hub");
+    } finally {
+      gateway.setFrontendHandler(null);
+      gateway.clearContext(4242);
+      await client.close();
+    }
+  });
+
+  it("rejects unknown frontends and unknown sessions", async () => {
+    const bad = await fetch(`${bridgeUrl}/mcp/talon/nosuch/c1`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "t", version: "1" },
+        },
+      }),
+    });
+    expect(bad.status).toBe(404);
+
+    const stale = await fetch(`${bridgeUrl}/mcp/talon/telegram/c1`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "mcp-session-id": "not-a-session",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+    });
+    expect(stale.status).toBe(404);
+  });
+});
+
+describe("mcp-hub / plugin child proxying", () => {
+  it("proxies tool list + call to a spawned child, shared across sessions", async () => {
+    const url = pluginHubUrl(bridgeUrl, "fake-plugin-tools", "chat-A");
+    const clientA = await connectClient(url);
+    const clientB = await connectClient(url);
+    try {
+      const { tools } = await clientA.listTools();
+      expect(tools.map((t) => t.name)).toContain("echo_pid");
+
+      const resultA = (await clientA.callTool({
+        name: "echo_pid",
+        arguments: { text: "hello" },
+      })) as { content: Array<{ type: string; text: string }> };
+      const resultB = (await clientB.callTool({
+        name: "echo_pid",
+        arguments: { text: "hello" },
+      })) as { content: Array<{ type: string; text: string }> };
+
+      const pidA = resultA.content[0].text.split(":")[1];
+      const pidB = resultB.content[0].text.split(":")[1];
+      // Two sessions, ONE child process.
+      expect(pidA).toBe(pidB);
+      expect(getActiveChildKeys()).toContain("fake-plugin-tools\u0000chat-A");
+    } finally {
+      await clientA.close();
+      await clientB.close();
+    }
+  }, 20_000);
+
+  it("reload retires children; next call respawns a fresh process", async () => {
+    const url = pluginHubUrl(bridgeUrl, "fake-plugin-tools", "chat-B");
+    const client = await connectClient(url);
+    try {
+      const before = (await client.callTool({
+        name: "echo_pid",
+        arguments: { text: "x" },
+      })) as { content: Array<{ type: string; text: string }> };
+      const pidBefore = before.content[0].text.split(":")[1];
+
+      reloadHubChildren();
+      expect(getActiveChildKeys()).not.toContain(
+        "fake-plugin-tools\u0000chat-B",
+      );
+
+      // Same session keeps working — the proxy re-acquires a new child.
+      const after = (await client.callTool({
+        name: "echo_pid",
+        arguments: { text: "x" },
+      })) as { content: Array<{ type: string; text: string }> };
+      const pidAfter = after.content[0].text.split(":")[1];
+      expect(pidAfter).not.toBe(pidBefore);
+    } finally {
+      await client.close();
+    }
+  }, 20_000);
+});

--- a/src/__tests__/mcp-plugin-double-wrap.test.ts
+++ b/src/__tests__/mcp-plugin-double-wrap.test.ts
@@ -1,23 +1,19 @@
 /**
- * Regression: plugin MCP servers must not be double-wrapped.
+ * Regression: plugin MCP server commands must reach the hub launcher
+ * exactly as `getPluginMcpServers()` built them.
  *
- * `getPluginMcpServers()` (core/plugin.ts) already runs every plugin
- * command through the supervisor wrap (`wrapMcpServer`), so the
- * command/args it returns are launcher-ready. The per-backend MCP config
- * builders must therefore pass those through UNCHANGED.
+ * History: before the MCP hub, every backend flattened plugin specs
+ * into its own spawn config, and codex / openai-agents / remote-server
+ * once re-applied `wrapMcpCommand(...)` on top of the already-wrapped
+ * spec — a `[supervisor, …, supervisor, …, realCmd]` double-wrap that
+ * broke plugin MCP servers.
  *
- * Previously codex / openai-agents / remote-server re-applied
- * `wrapMcpCommand(...)` on top, producing a
- * `[supervisor, …, supervisor, …, realCmd]` double-wrap that broke plugin
- * MCP servers (the inner supervisor was launched as if it were the server).
- * claude-sdk already consumed the map raw, which is the correct contract.
- *
- * kilo and opencode are covered transitively: both route plugin servers
- * through the shared `remote-server` `ensurePluginMcpServers` path.
- *
- * This test pins the contract on the codex builder (a pure, synchronous
- * function): a plugin entry that is already launcher-shaped must come out
- * byte-identical — no second wrapper prepended.
+ * With the hub, backends never see commands at all — they emit hub
+ * URLs (pinned by codex-backend.test.ts). The pass-through contract
+ * now lives in ONE place: the hub's child spawner must consume the
+ * launcher-ready spec unchanged. This test pins that: the spec the
+ * hub would spawn for a plugin server is byte-identical to what
+ * `getPluginMcpServers()` returned.
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -43,28 +39,26 @@ vi.mock("../core/plugin/index.js", () => ({
   getPluginMcpServers: vi.fn(() => structuredClone(LAUNCHER_READY)),
 }));
 
-import { buildCodexMcpServers } from "../backend/codex/mcp-config.js";
+import { _pluginSpecForTesting } from "../core/mcp-hub/index.js";
 
 describe("plugin MCP servers are not double-wrapped", () => {
-  it("codex passes the launcher-ready command/args through unchanged", () => {
-    const servers = buildCodexMcpServers({
-      chatId: "c1",
-      bridgeUrl: "http://127.0.0.1:19876",
-      frontends: ["telegram"],
-    });
-
-    const plugin = servers["mempalace-tools"];
-    expect(plugin).toBeDefined();
+  it("the hub spawns the launcher-ready command/args unchanged", () => {
+    const spec = _pluginSpecForTesting(
+      "mempalace-tools",
+      "c1",
+      "http://127.0.0.1:19876",
+    );
 
     const expected = LAUNCHER_READY["mempalace-tools"];
     // Exact pass-through: re-wrapping would replace `command` with the
     // supervisor binary and push the original command down into `args`.
-    expect(plugin.command).toBe(expected.command);
-    expect(plugin.args).toEqual(expected.args);
+    expect(spec.command).toBe(expected.command);
+    expect(spec.args).toEqual(expected.args);
+    expect(spec.env).toEqual(expected.env);
 
     // Belt-and-braces: the launcher entrypoint token must appear exactly
     // once across the final argv — a second wrap would duplicate it.
-    const launcherHits = plugin.args.filter((a) =>
+    const launcherHits = spec.args.filter((a) =>
       a.includes("mcp-launch.js"),
     ).length;
     expect(launcherHits).toBe(1);

--- a/src/__tests__/openai-agents-mcp-pool.test.ts
+++ b/src/__tests__/openai-agents-mcp-pool.test.ts
@@ -23,13 +23,15 @@ let activeBundleCount = 0;
 let closeCount = 0;
 
 vi.mock("@openai/agents", () => {
-  // Stub MCPServerStdio so the constructor doesn't try to spawn a
-  // real subprocess. Records the options for later inspection.
-  class FakeMCPServerStdio {
+  // Stub MCPServerStreamableHttp so the constructor doesn't open a
+  // real HTTP connection. Records the options for later inspection.
+  class FakeMCPServerStreamableHttp {
     name: string;
+    url: string;
     cacheToolsList: boolean | undefined;
-    constructor(opts: { name: string; cacheToolsList?: boolean }) {
+    constructor(opts: { name: string; url: string; cacheToolsList?: boolean }) {
       this.name = opts.name;
+      this.url = opts.url;
       this.cacheToolsList = opts.cacheToolsList;
     }
     async connect(): Promise<void> {
@@ -63,7 +65,7 @@ vi.mock("@openai/agents", () => {
   }
 
   return {
-    MCPServerStdio: FakeMCPServerStdio,
+    MCPServerStreamableHttp: FakeMCPServerStreamableHttp,
     connectMcpServers,
   };
 });
@@ -211,7 +213,7 @@ describe("openai-agents / mcp-pool", () => {
     expect(getActiveBundleIds()).toEqual([]);
   });
 
-  it("each MCPServerStdio is constructed with cacheToolsList=true", async () => {
+  it("each MCPServerStreamableHttp is constructed with cacheToolsList=true", async () => {
     await getOrCreateBundle(inputs("chat-A"));
     expect(connectCalls.length).toBe(1);
 

--- a/src/__tests__/remote-server-mcp.test.ts
+++ b/src/__tests__/remote-server-mcp.test.ts
@@ -41,11 +41,9 @@ import {
 
 interface RecordedMcpAdd {
   name: string;
-  config: {
-    type: string;
-    command: string[];
-    environment?: Record<string, string>;
-  };
+  config:
+    | { type: "local"; command: string[]; environment?: Record<string, string> }
+    | { type: "remote"; url: string };
 }
 
 /**
@@ -164,11 +162,10 @@ describe("remote-server / mcp helpers", () => {
       expect(name).toBe("talon-tools-chatA");
       expect(mcpAddCalls).toHaveLength(1);
       expect(mcpAddCalls[0].name).toBe("talon-tools-chatA");
-      expect(mcpAddCalls[0].config.type).toBe("local");
-      expect(mcpAddCalls[0].config.environment).toMatchObject({
-        TALON_CHAT_ID: "chatA",
-        TALON_FRONTEND: "telegram",
-      });
+      expect(mcpAddCalls[0].config.type).toBe("remote");
+      expect(
+        (mcpAddCalls[0].config as { type: "remote"; url: string }).url,
+      ).toContain("/mcp/talon/telegram/chatA");
       expect(getRegisteredMcpServerNames(state)).toContain("talon-tools-chatA");
     });
 

--- a/src/__tests__/telegram-command-menu.test.ts
+++ b/src/__tests__/telegram-command-menu.test.ts
@@ -1,0 +1,51 @@
+/**
+ * telegramCommandMenu — the /update entry must track the exact gate its
+ * handler uses (devBuild + git checkout), so the Telegram menu never
+ * advertises a command that isn't registered, and dev builds actually
+ * see /update in the menu (it used to be wired but unlisted).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetRepoRoot = vi.fn<() => string | null>(() => "/repo");
+
+vi.mock("../core/update/self-update.js", () => ({
+  getRepoRoot: () => mockGetRepoRoot(),
+}));
+
+import {
+  TELEGRAM_COMMANDS,
+  telegramCommandMenu,
+} from "../frontend/telegram/commands/definitions.js";
+
+describe("telegramCommandMenu", () => {
+  beforeEach(() => {
+    mockGetRepoRoot.mockReturnValue("/repo");
+  });
+
+  it("includes /update right after /restart on dev builds from a checkout", () => {
+    const menu = telegramCommandMenu({ devBuild: true });
+    const names = menu.map((c) => c.command);
+    expect(names.indexOf("update")).toBe(names.indexOf("restart") + 1);
+  });
+
+  it("omits /update on non-dev builds", () => {
+    const names = telegramCommandMenu({ devBuild: false }).map(
+      (c) => c.command,
+    );
+    expect(names).not.toContain("update");
+  });
+
+  it("omits /update when there is no git checkout (packaged binary)", () => {
+    mockGetRepoRoot.mockReturnValue(null);
+    const names = telegramCommandMenu({ devBuild: true }).map((c) => c.command);
+    expect(names).not.toContain("update");
+  });
+
+  it("never mutates the base menu", () => {
+    const before = TELEGRAM_COMMANDS.length;
+    telegramCommandMenu({ devBuild: true });
+    expect(TELEGRAM_COMMANDS.length).toBe(before);
+    expect(TELEGRAM_COMMANDS.map((c) => c.command)).not.toContain("update");
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -115,6 +115,21 @@ onBackendChange((holder, newBackend, info) => {
 let shuttingDown = false;
 
 const SHUTDOWN_TIMEOUT_MS = 15_000;
+const DRAIN_TIMEOUT_MS = 5_000;
+
+/**
+ * One best-effort teardown step. A failing subsystem (a frontend that
+ * won't stop, a plugin that throws in destroy, a dynamic import that
+ * fails mid-shutdown) must not abort the rest of the sequence — the
+ * WAL checkpoint and pidfile removal below have to run regardless.
+ */
+async function shutdownStep(name: string, fn: () => unknown): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    logError("shutdown", `${name} failed`, err);
+  }
+}
 
 async function gracefulShutdown(signal: string): Promise<void> {
   if (shuttingDown) return;
@@ -127,29 +142,52 @@ async function gracefulShutdown(signal: string): Promise<void> {
   }, SHUTDOWN_TIMEOUT_MS);
   forceTimer.unref();
 
-  const pending = getActiveCount();
-  if (pending > 0) {
-    log("shutdown", `Waiting for ${pending} in-flight queries to drain...`);
-    await new Promise((r) => setTimeout(r, 5000));
+  // Drain in-flight queries: poll instead of a fixed sleep, so an idle
+  // daemon exits immediately and a busy one gets the full budget.
+  if (getActiveCount() > 0) {
+    log(
+      "shutdown",
+      `Waiting for ${getActiveCount()} in-flight queries to drain...`,
+    );
+    const deadline = Date.now() + DRAIN_TIMEOUT_MS;
+    while (getActiveCount() > 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    const remaining = getActiveCount();
+    if (remaining > 0) {
+      logWarn(
+        "shutdown",
+        `Drain timed out with ${remaining} queries still in flight`,
+      );
+    }
   }
 
-  await Promise.allSettled(frontends.map((frontend) => frontend.stop()));
+  await shutdownStep("frontends", () =>
+    Promise.allSettled(frontends.map((frontend) => frontend.stop())),
+  );
   if (config.backend === "opencode") {
-    const { stopOpenCodeServer } = await import("./backend/opencode/index.js");
-    stopOpenCodeServer();
+    await shutdownStep("opencode server", async () => {
+      const { stopOpenCodeServer } =
+        await import("./backend/opencode/index.js");
+      stopOpenCodeServer();
+    });
   }
   // Destroy plugins (cleanup resources)
   if (config.plugins.length > 0) {
-    const { destroyPlugins } = await import("./core/plugin/index.js");
-    await destroyPlugins();
+    await shutdownStep("plugins", async () => {
+      const { destroyPlugins } = await import("./core/plugin/index.js");
+      await destroyPlugins();
+    });
   }
-  stopPulseTimer();
-  stopHeartbeatTimer();
-  await awaitHeartbeat();
-  stopCronTimer();
-  await shutdownTriggers();
-  stopWatchdog();
-  stopUploadCleanup();
+  await shutdownStep("pulse timer", stopPulseTimer);
+  await shutdownStep("heartbeat", async () => {
+    stopHeartbeatTimer();
+    await awaitHeartbeat();
+  });
+  await shutdownStep("cron timer", stopCronTimer);
+  await shutdownStep("triggers", shutdownTriggers);
+  await shutdownStep("watchdog", stopWatchdog);
+  await shutdownStep("upload cleanup", stopUploadCleanup);
   flushDatabase();
   // Guarded removal: after a /restart handoff the successor has already
   // written its own pid here — deleting unconditionally would orphan it
@@ -171,6 +209,10 @@ process.on("uncaughtException", (err) => {
   }
   logError("bot", "Uncaught exception", err);
   flushDatabase();
+  // Same pid-guarded removal as the graceful path — a crashed daemon
+  // must not leave a record that makes `talon status` chase a dead or
+  // recycled pid.
+  removePidRecordIfOwnedBy(process.pid);
   process.exit(1);
 });
 
@@ -226,5 +268,7 @@ async function main(): Promise<void> {
 
 main().catch((err) => {
   logError("bot", "Fatal startup error", err);
+  flushDatabase();
+  removePidRecordIfOwnedBy(process.pid);
   process.exit(1);
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -188,6 +188,10 @@ async function gracefulShutdown(signal: string): Promise<void> {
   await shutdownStep("triggers", shutdownTriggers);
   await shutdownStep("watchdog", stopWatchdog);
   await shutdownStep("upload cleanup", stopUploadCleanup);
+  await shutdownStep("mcp hub", async () => {
+    const { shutdownHub } = await import("./core/mcp-hub/index.js");
+    await shutdownHub();
+  });
   flushDatabase();
   // Guarded removal: after a /restart handoff the successor has already
   // written its own pid here — deleting unconditionally would orphan it

--- a/src/backend/claude-sdk/factory.ts
+++ b/src/backend/claude-sdk/factory.ts
@@ -14,7 +14,6 @@
 import { registerBackend } from "../../core/agent-runtime/backend-registry.js";
 import type { BackendFactory } from "../../core/agent-runtime/backend-registry.js";
 import { log } from "../../util/log.js";
-import { getPluginMcpServers } from "../../core/plugin/index.js";
 import {
   composeBackend,
   type ChatBackend,
@@ -31,6 +30,7 @@ import {
   warmSession as claudeWarmSession,
   getActiveQuery,
   buildMcpServers,
+  buildPluginMcpServers,
   runOneShotAgent as claudeRunOneShotAgent,
   evictOrphanSubprocesses as claudeEvictOrphanSubprocesses,
 } from "./index.js";
@@ -92,10 +92,9 @@ const claudeSdkFactory: BackendFactory = {
         // subprocess receives an OS-agnostic shutdown via stdio, then
         // install the fresh set.
         await qi.setMcpServers({});
-        const bridgeUrl = `http://127.0.0.1:${ctx.getBridgePort()}`;
         const freshServers = {
           ...buildMcpServers(chatId),
-          ...getPluginMcpServers(bridgeUrl, chatId),
+          ...buildPluginMcpServers(chatId),
         };
         const result = await qi.setMcpServers(freshServers);
         // setMcpServers resolves on REGISTER, not CONNECT — MCP startup is

--- a/src/backend/claude-sdk/index.ts
+++ b/src/backend/claude-sdk/index.ts
@@ -8,7 +8,11 @@
 export { initAgent, updateSystemPrompt } from "./state.js";
 export { warmSession } from "./warm.js";
 export { getActiveQuery } from "./handler.js";
-export { buildMcpServers, getActiveFrontends } from "./options.js";
+export {
+  buildMcpServers,
+  buildPluginMcpServers,
+  getActiveFrontends,
+} from "./options.js";
 export { getBridgePort } from "./state.js";
 export {
   runOneShotAgent,

--- a/src/backend/claude-sdk/one-shot.ts
+++ b/src/backend/claude-sdk/one-shot.ts
@@ -16,9 +16,8 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { OneShotAgentParams } from "../../core/types.js";
 import { log } from "../../util/log.js";
-import { getPluginMcpServers } from "../../core/plugin/index.js";
 import { ALLOWED_TOOLS_BACKGROUND } from "../../core/constants.js";
-import { buildMcpServers } from "./options.js";
+import { buildMcpServers, buildPluginMcpServers } from "./options.js";
 
 const DEFAULT_SUBPROCESS_KILL_GRACE_MS = 5 * 1000;
 
@@ -113,17 +112,21 @@ function assembleMcpServers(contextLabel: string): Record<string, unknown> {
     } catch {
       frontendServers = {};
     }
-    return {
-      ...frontendServers,
-      ...(getPluginMcpServers("", "heartbeat") as Record<string, unknown>),
-    };
+    let pluginServers: Record<string, unknown> = {};
+    try {
+      pluginServers = buildPluginMcpServers("heartbeat");
+    } catch {
+      pluginServers = {};
+    }
+    return { ...frontendServers, ...pluginServers };
   }
   if (contextLabel === "dream") {
     if (!oneShotConfig.mempalace) return {};
-    return getPluginMcpServers("", "dream", ["mempalace"]) as Record<
-      string,
-      unknown
-    >;
+    try {
+      return buildPluginMcpServers("dream", ["mempalace"]);
+    } catch {
+      return {};
+    }
   }
   return {};
 }

--- a/src/backend/claude-sdk/options.ts
+++ b/src/backend/claude-sdk/options.ts
@@ -5,7 +5,6 @@
  * MCP servers, system prompt) into the Options shape expected by the SDK.
  */
 
-import { resolve } from "node:path";
 import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "@anthropic-ai/claude-agent-sdk";
 import type {
   Options,
@@ -19,14 +18,13 @@ import type {
 import type { PreparedSystemPrompt } from "../shared/system-prompt.js";
 import { getSession } from "../../storage/sessions.js";
 import { getChatSettings } from "../../storage/chat-settings.js";
-import { getPluginMcpServers } from "../../core/plugin/index.js";
 import { resolveModelId } from "../../core/models/catalog.js";
-import { wrapMcpServer } from "../../util/mcp-launcher.js";
 import { isTurnTerminator } from "../../core/tools/index.js";
 import {
-  buildTalonMcpEnv,
-  talonMcpServerCommand,
-} from "../../core/tools/mcp-env.js";
+  talonHubUrl,
+  pluginHubUrl,
+  hubPluginServerNames,
+} from "../../core/mcp-hub/index.js";
 import { nonTerminalFrontends } from "../shared/frontends.js";
 import { log, logError } from "../../util/log.js";
 import { getConfig, getBridgePort } from "./state.js";
@@ -58,45 +56,32 @@ export function getActiveFrontends(): readonly string[] {
   return nonTerminalFrontends(getConfig().frontend);
 }
 
+/** Hub-backed MCP server entry — the SDK's `type: "http"` config. */
+export type HubMcpEntry = {
+  type: "http";
+  url: string;
+  alwaysLoad?: boolean;
+};
+
 /**
  * Build the MCP servers map for a chat query.
  * Includes frontend-specific tool servers and Brave Search, if configured.
+ *
+ * Every entry points at the daemon's MCP hub (`core/mcp-hub`) over
+ * streamable HTTP: the Talon tool servers run in-process there (zero
+ * subprocesses per chat — chat binding travels in the URL, not env),
+ * and brave-search is a single hub-managed child shared by all chats.
  */
-export function buildMcpServers(chatId: string): Record<
-  string,
-  {
-    command: string;
-    args: string[];
-    env: Record<string, string>;
-    alwaysLoad?: boolean;
-  }
-> {
+export function buildMcpServers(chatId: string): Record<string, HubMcpEntry> {
   const config = getConfig();
   const bridgeUrl = `http://127.0.0.1:${getBridgePort()}`;
 
-  // Shared spawn spec — see talonMcpServerCommand for the tsx-loader
-  // and Windows rationale.
-  const [mcpCommand, ...mcpArgs] = talonMcpServerCommand();
+  const servers: Record<string, HubMcpEntry> = {};
 
-  // Frontend-specific MCP tool servers (one per non-terminal frontend)
-  const frontends = getActiveFrontends();
-
-  const servers: Record<
-    string,
-    {
-      command: string;
-      args: string[];
-      env: Record<string, string>;
-      alwaysLoad?: boolean;
-    }
-  > = {};
-
-  for (const frontend of frontends) {
-    const serverName = `${frontend}-tools`;
-    servers[serverName] = wrapMcpServer({
-      command: mcpCommand,
-      args: mcpArgs,
-      env: buildTalonMcpEnv({ bridgeUrl, chatId, frontend, config }),
+  for (const frontend of getActiveFrontends()) {
+    servers[`${frontend}-tools`] = {
+      type: "http",
+      url: talonHubUrl(bridgeUrl, frontend, chatId),
       // Always include the frontend's tools in the turn-1 prompt instead of
       // deferring them behind the SDK's tool search. These are the bot's
       // primary surface — it needs `end_turn`/`send`/`react` on EVERY turn to
@@ -112,21 +97,37 @@ export function buildMcpServers(chatId: string): Record<
       // lever here. Cost: ~50 frontend tool schemas loaded every turn (~10k
       // tokens, cached, negligible on the 1M-context models Talon runs).
       alwaysLoad: true,
-    });
+    };
   }
 
   // Brave Search MCP server (if configured)
   if (config.braveApiKey) {
-    servers["brave-search"] = wrapMcpServer({
-      command: resolve(
-        import.meta.dirname ?? ".",
-        "../../../node_modules/.bin/brave-search-mcp-server",
-      ),
-      args: [],
-      env: { BRAVE_API_KEY: config.braveApiKey },
-    });
+    servers["brave-search"] = {
+      type: "http",
+      url: pluginHubUrl(bridgeUrl, "brave-search", chatId),
+    };
   }
 
+  return servers;
+}
+
+/**
+ * Build the plugin MCP server map for a chat query — hub URLs for every
+ * registry-provided plugin server, optionally filtered to `only` plugin
+ * names (heartbeat/dream tiers restrict their tool surface this way).
+ */
+export function buildPluginMcpServers(
+  chatId: string,
+  only?: string[],
+): Record<string, HubMcpEntry> {
+  const bridgeUrl = `http://127.0.0.1:${getBridgePort()}`;
+  const servers: Record<string, HubMcpEntry> = {};
+  for (const name of hubPluginServerNames(only)) {
+    servers[name] = {
+      type: "http",
+      url: pluginHubUrl(bridgeUrl, name, chatId),
+    };
+  }
   return servers;
 }
 
@@ -386,7 +387,7 @@ export function buildSdkOptions(
     ...thinkingConfig,
     mcpServers: {
       ...buildMcpServers(chatId),
-      ...getPluginMcpServers(`http://127.0.0.1:${getBridgePort()}`, chatId),
+      ...buildPluginMcpServers(chatId),
     },
     hooks: {
       PostToolUseFailure: [{ hooks: [postToolUseFailureHook] }],

--- a/src/backend/codex/mcp-config.ts
+++ b/src/backend/codex/mcp-config.ts
@@ -1,5 +1,5 @@
 /**
- * Convert Talon's MCP plugin map into Codex CLI's `--config` TOML
+ * Convert Talon's MCP server set into Codex CLI's `--config` TOML
  * overrides.
  *
  * Codex's MCP support is configured at startup via `~/.codex/config.toml`
@@ -8,30 +8,28 @@
  * `CodexOptions.config` — a JSON object the SDK flattens into dotted
  * paths and serialises as TOML literals.
  *
- * Talon supplies MCP servers via `getPluginMcpServers(bridgeUrl, chatId)`
- * — a record of name → `{command, args, env}`. This module flattens
- * them into the shape Codex's CLI expects:
+ * Every server is a streamable-HTTP entry pointing at the daemon's MCP
+ * hub (`core/mcp-hub`) — Codex connects with `mcp_servers.<name>.url`
+ * (the same transport `codex mcp add --url` configures). The hub hosts
+ * Talon's tools in-process and shares plugin/brave children across
+ * chats, so Codex no longer spawns a subprocess pair per server per
+ * turn:
  *
  *   {
  *     mcp_servers: {
- *       <name>: { command: "node", args: [...], env: { ... } },
+ *       <name>: { url: "http://127.0.0.1:<port>/mcp/..." },
  *       ...
  *     }
  *   }
- *
- * The chat-specific Talon MCP server (`telegram-tools` etc.) and the
- * Brave Search server are added alongside the plugin servers.
  */
 
-import { resolve } from "node:path";
 import type { CodexOptions } from "@openai/codex-sdk";
-import { wrapMcpCommand } from "../../util/mcp-launcher.js";
-import { getPluginMcpServers } from "../../core/plugin/index.js";
 import {
-  buildTalonMcpEnv,
-  talonMcpServerCommand,
-  type ToolExclusionConfig,
-} from "../../core/tools/mcp-env.js";
+  talonHubUrl,
+  pluginHubUrl,
+  hubPluginServerNames,
+} from "../../core/mcp-hub/index.js";
+import type { ToolExclusionConfig } from "../../core/tools/mcp-env.js";
 
 /**
  * AppToolApproval values accepted by Codex's `mcp_servers.<name>` table.
@@ -52,11 +50,10 @@ import {
  */
 export type CodexToolApprovalMode = "auto" | "prompt" | "approve";
 
-/** TOML-compatible record shape Codex's CLI accepts. */
+/** TOML-compatible record shape Codex's CLI accepts (HTTP transport). */
 export interface CodexMcpServer {
-  command: string;
-  args: string[];
-  env?: Record<string, string>;
+  /** Streamable-HTTP MCP endpoint (Talon's hub). */
+  url: string;
   /**
    * Per-server default approval mode applied to every tool the server
    * exposes (unless a `tools.<tool>.approval_mode` override is set).
@@ -134,47 +131,29 @@ export function buildCodexMcpServers(args: {
 
   const servers: Record<string, CodexMcpServer> = {};
 
-  // Frontend MCP tool servers (one per non-terminal frontend). Spawn
-  // spec is shared — see talonMcpServerCommand for the tsx-loader and
-  // Windows rationale.
+  // Frontend MCP tool servers (one per non-terminal frontend) — served
+  // in-process by the hub; the (frontend, chatId) binding travels in
+  // the URL. Tool-surface trimming is applied hub-side (initHub).
   for (const frontend of frontends) {
-    const serverName = `${frontend}-tools`;
-    const wrapped = wrapMcpCommand(talonMcpServerCommand());
-    servers[serverName] = {
-      command: wrapped[0],
-      args: wrapped.slice(1),
-      env: buildTalonMcpEnv({
-        bridgeUrl,
-        chatId,
-        frontend,
-        config: args.toolExclusions,
-      }),
+    servers[`${frontend}-tools`] = {
+      url: talonHubUrl(bridgeUrl, frontend, chatId),
       default_tools_approval_mode: TALON_MCP_DEFAULT_APPROVAL,
     };
   }
 
-  // Brave Search MCP server (if configured).
+  // Brave Search MCP server (if configured) — one hub child shared by
+  // every chat.
   if (braveApiKey) {
     servers["brave-search"] = {
-      command: resolve(
-        import.meta.dirname ?? ".",
-        "../../../node_modules/.bin/brave-search-mcp-server",
-      ),
-      args: [],
-      env: { BRAVE_API_KEY: braveApiKey },
+      url: pluginHubUrl(bridgeUrl, "brave-search", chatId),
       default_tools_approval_mode: TALON_MCP_DEFAULT_APPROVAL,
     };
   }
 
-  // Plugin MCP servers. `getPluginMcpServers` already runs each command
-  // through the supervisor wrap (`wrapMcpServer`), so the returned
-  // command/args are launcher-ready — do NOT wrap a second time.
-  const pluginServers = getPluginMcpServers(bridgeUrl, chatId);
-  for (const [name, cfg] of Object.entries(pluginServers)) {
+  // Plugin MCP servers — hub-managed children (chat-scoped, idle-reaped).
+  for (const name of hubPluginServerNames()) {
     servers[name] = {
-      command: cfg.command,
-      args: cfg.args,
-      env: cfg.env ?? {},
+      url: pluginHubUrl(bridgeUrl, name, chatId),
       default_tools_approval_mode: TALON_MCP_DEFAULT_APPROVAL,
     };
   }

--- a/src/backend/openai-agents/mcp-pool.ts
+++ b/src/backend/openai-agents/mcp-pool.ts
@@ -1,56 +1,36 @@
 /**
- * Per-chat persistent MCP bundle pool for the OpenAI Agents backend.
+ * Per-chat MCP bundle pool for the OpenAI Agents backend.
  *
- * Background
- * ──────────
+ * Every server is a lightweight `MCPServerStreamableHttp` client
+ * pointing at the daemon's MCP hub (`core/mcp-hub`): Talon's own tools
+ * run in-process there, and plugin/brave servers are hub-managed
+ * children shared across chats and reaped when idle.
  *
- * The original openai-agents handler called `buildOpenAIAgentsMcpServers`
- * once per turn and closed every spawned subprocess in `finally`. With
- * ~15 plugins active that's ~15 subprocess spawns per message per chat,
- * which on a small VPS:
+ * Historical note: this pool used to hold one **subprocess set** per
+ * chat (every plugin × every chat, held until release) — the daemon's
+ * memory grew linearly with the number of chats. With the hub, a
+ * bundle is just HTTP client objects; the process count is owned and
+ * bounded by the hub.
  *
- *   - adds 1–10s of cold-start latency to every turn,
- *   - intermittently races out as `MCP error -32001: Request timed out`
- *     when the spawn fan-out collides with another chat's MCP setup,
- *   - wastes 15× `cacheToolsList` opportunities — the SDK re-fetches
- *     every tool definition for every server on every turn.
+ * The bundle is still cached per chat (and released on reset/rebind)
+ * so `cacheToolsList` survives across turns and each turn skips the
+ * connect handshake.
  *
- * The Claude SDK backend keeps its MCP subprocess set alive for the
- * lifetime of the per-chat session and reuses them across turns. This
- * module brings the same pattern to openai-agents.
- *
- * Architecture
- * ────────────
- *
- *   - A `Map<chatId, OpenAIAgentsMcpBundle>` caches one bundle per chat.
- *   - `getOrCreateBundle(args)` returns the cached bundle, or builds +
- *     connects a fresh one (using `connectMcpServers` from the SDK for
- *     proper per-server timeouts + failure tracking).
- *   - `releaseBundle(chatId)` closes the bundle's subprocesses and drops
- *     the entry. Use when a chat is rebound off openai-agents, on
- *     session reset, or when the chat is destroyed.
- *   - `releaseAllBundles()` is the backend cleanup path — closes every
- *     live bundle so the factory's cleanup hook leaves no orphans.
- *
- * Concurrency
- * ───────────
- *
- * `getOrCreateBundle` serialises the build-or-return decision on a
- * per-chat in-flight Promise so two concurrent turns from the same chat
- * (cross-frontend, e.g. Telegram + Discord) reuse one bundle rather
- * than double-spawn. Different chats build independently in parallel.
+ * Concurrency: `getOrCreateBundle` serialises the build-or-return
+ * decision on a per-chat in-flight Promise so two concurrent turns from
+ * the same chat (cross-frontend, e.g. Telegram + Discord) reuse one
+ * bundle rather than double-connect. Different chats build
+ * independently in parallel.
  */
 
-import { connectMcpServers, MCPServerStdio } from "@openai/agents";
+import { connectMcpServers, MCPServerStreamableHttp } from "@openai/agents";
 import type { MCPServer } from "@openai/agents";
-import { resolve } from "node:path";
-import { wrapMcpCommand } from "../../util/mcp-launcher.js";
-import { getPluginMcpServers } from "../../core/plugin/index.js";
 import {
-  buildTalonMcpEnv,
-  talonMcpServerCommand,
-  type ToolExclusionConfig,
-} from "../../core/tools/mcp-env.js";
+  talonHubUrl,
+  pluginHubUrl,
+  hubPluginServerNames,
+} from "../../core/mcp-hub/index.js";
+import type { ToolExclusionConfig } from "../../core/tools/mcp-env.js";
 import { log, logWarn } from "../../util/log.js";
 
 /**
@@ -81,7 +61,11 @@ export interface BundleInputs {
   bridgeUrl: string;
   frontends: readonly string[];
   braveApiKey?: string;
-  /** Tool-surface trimming slice of the Talon config. */
+  /**
+   * Tool-surface trimming slice of the Talon config. Accepted for call
+   *-site stability; trimming is applied hub-side (initHub) where the
+   * Talon tool servers are composed.
+   */
   toolExclusions?: ToolExclusionConfig | null;
 }
 
@@ -187,58 +171,40 @@ export function getActiveBundleIds(): readonly string[] {
 async function buildBundle(args: BundleInputs): Promise<OpenAIAgentsMcpBundle> {
   const { chatId, bridgeUrl, frontends, braveApiKey } = args;
 
-  const built: MCPServerStdio[] = [];
+  const built: MCPServerStreamableHttp[] = [];
 
   // Frontend MCP tool servers (one per non-terminal frontend). Each
   // exposes the Talon-native delivery surface (send, react, end_turn,
-  // …) for that frontend, scoped to `chatId`. Spawn spec is shared —
-  // see talonMcpServerCommand for the tsx-loader / Windows rationale.
+  // …) for that frontend, scoped to `chatId` via the hub URL — the
+  // server itself runs in-process inside the daemon.
   for (const frontend of frontends) {
-    const wrapped = wrapMcpCommand(talonMcpServerCommand());
     built.push(
-      new MCPServerStdio({
+      new MCPServerStreamableHttp({
         name: `${frontend}-tools`,
-        command: wrapped[0],
-        args: wrapped.slice(1),
-        env: buildTalonMcpEnv({
-          bridgeUrl,
-          chatId,
-          frontend,
-          config: args.toolExclusions,
-        }),
+        url: talonHubUrl(bridgeUrl, frontend, chatId),
         cacheToolsList: true,
       }),
     );
   }
 
-  // Brave Search MCP server (if configured).
+  // Brave Search MCP server (if configured) — one hub child shared by
+  // every chat.
   if (braveApiKey) {
-    const braveCommand = resolve(
-      import.meta.dirname ?? ".",
-      "../../../node_modules/.bin/brave-search-mcp-server",
-    );
     built.push(
-      new MCPServerStdio({
+      new MCPServerStreamableHttp({
         name: "brave-search",
-        command: braveCommand,
-        args: [],
-        env: { BRAVE_API_KEY: braveApiKey },
+        url: pluginHubUrl(bridgeUrl, "brave-search", chatId),
         cacheToolsList: true,
       }),
     );
   }
 
-  // Plugin MCP servers. `getPluginMcpServers` already runs each command
-  // through the supervisor wrap (`wrapMcpServer`), so the returned
-  // command/args are launcher-ready — do NOT wrap a second time.
-  const pluginServers = getPluginMcpServers(bridgeUrl, chatId);
-  for (const [name, cfg] of Object.entries(pluginServers)) {
+  // Plugin MCP servers — hub-managed children (chat-scoped, idle-reaped).
+  for (const name of hubPluginServerNames()) {
     built.push(
-      new MCPServerStdio({
+      new MCPServerStreamableHttp({
         name,
-        command: cfg.command,
-        args: cfg.args,
-        env: cfg.env ?? {},
+        url: pluginHubUrl(bridgeUrl, name, chatId),
         cacheToolsList: true,
       }),
     );

--- a/src/backend/remote-server/client.ts
+++ b/src/backend/remote-server/client.ts
@@ -19,12 +19,19 @@
  * doesn't.
  */
 
-/** Minimal MCP server config shape both SDKs accept on `mcp.add`. */
-export interface RemoteMcpServerConfig {
-  type: "local";
-  command: string[];
-  environment?: Record<string, string>;
-}
+/** Minimal MCP server config shapes both SDKs accept on `mcp.add`. */
+export type RemoteMcpServerConfig =
+  | {
+      type: "local";
+      command: string[];
+      environment?: Record<string, string>;
+    }
+  | {
+      type: "remote";
+      /** Streamable-HTTP MCP endpoint (Talon's hub). */
+      url: string;
+      headers?: Record<string, string>;
+    };
 
 /** Permission-rule shape both SDKs share. */
 export interface RemotePermissionRule {

--- a/src/backend/remote-server/mcp.ts
+++ b/src/backend/remote-server/mcp.ts
@@ -35,12 +35,11 @@
  */
 
 import { log, logWarn } from "../../util/log.js";
-import { wrapMcpCommand } from "../../util/mcp-launcher.js";
-import { getPluginMcpServers } from "../../core/plugin/index.js";
 import {
-  buildTalonMcpEnv,
-  talonMcpServerCommand,
-} from "../../core/tools/mcp-env.js";
+  talonHubUrl,
+  pluginHubUrl,
+  hubPluginServerNames,
+} from "../../core/mcp-hub/index.js";
 import type { RemoteAgentClient } from "./client.js";
 import type { RemoteServerState } from "./state.js";
 import { errMsg } from "./state.js";
@@ -142,20 +141,16 @@ export async function ensureChatMcpServer<TClient extends RemoteAgentClient>(
     await client.mcp.add({
       name: serverName,
       config: {
-        type: "local",
-        // Wrap under Talon's launcher supervisor so the child dies cleanly
-        // when the SDK pipe closes OR Talon's bridge URL stops responding
-        // (catches the "agent-server-outlives-Talon" failure mode).
-        // Spawn spec shared with every other backend — see
-        // talonMcpServerCommand (and unlike the previous bare "tsx"
-        // specifier, it doesn't depend on the spawn cwd resolving tsx).
-        command: wrapMcpCommand(talonMcpServerCommand()),
-        environment: buildTalonMcpEnv({
-          bridgeUrl: `http://127.0.0.1:${state.gatewayPortFn()}`,
+        type: "remote",
+        // Talon's MCP hub serves the chat's tool set in-process over
+        // streamable HTTP — no subprocess on the agent-server side, and
+        // the (frontend, chatId) binding travels in the URL instead of
+        // env. Tool-surface trimming is applied hub-side (initHub).
+        url: talonHubUrl(
+          `http://127.0.0.1:${state.gatewayPortFn()}`,
+          state.frontendName,
           chatId,
-          frontend: state.frontendName,
-          config: state.config,
-        }),
+        ),
       },
     });
     state.registeredMcpServers.add(serverName);
@@ -193,10 +188,10 @@ export async function ensurePluginMcpServers<TClient extends RemoteAgentClient>(
   chatId: string,
 ): Promise<string[]> {
   const bridgeUrl = `http://127.0.0.1:${state.gatewayPortFn()}`;
-  const pluginServers = getPluginMcpServers(bridgeUrl, chatId);
+  const names = hubPluginServerNames();
   const registered: string[] = [];
 
-  for (const [name, cfg] of Object.entries(pluginServers)) {
+  for (const name of names) {
     if (state.registeredMcpServers.has(name)) {
       registered.push(name);
       continue;
@@ -206,12 +201,10 @@ export async function ensurePluginMcpServers<TClient extends RemoteAgentClient>(
       await client.mcp.add({
         name,
         config: {
-          type: "local",
-          // `getPluginMcpServers` already applied the supervisor wrap
-          // (`wrapMcpServer`), so the command/args are launcher-ready —
-          // do NOT wrap a second time.
-          command: [cfg.command, ...cfg.args],
-          environment: cfg.env ?? {},
+          type: "remote",
+          // Hub-managed child, shared across sessions and idle-reaped —
+          // the agent server holds an HTTP connection, not a subprocess.
+          url: pluginHubUrl(bridgeUrl, name, chatId),
         },
       });
       registered.push(name);

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -159,6 +159,16 @@ export async function bootstrap(
     rebuildSystemPrompt(config, getPluginPromptAdditions());
   }
 
+  // MCP hub — daemon-hosted MCP-over-HTTP for every backend (tool
+  // trimming + brave key come from config; endpoints mount on the
+  // gateway HTTP server).
+  const { initHub } = await import("./core/mcp-hub/index.js");
+  initHub({
+    disabledTools: config.disabledTools,
+    disabledToolTags: config.disabledToolTags,
+    braveApiKey: config.braveApiKey,
+  });
+
   initWorkspace(config.workspace);
   loadSessions();
   loadChatSettings();

--- a/src/core/engine/gateway.ts
+++ b/src/core/engine/gateway.ts
@@ -21,6 +21,11 @@ import { getHealthStatus } from "../../util/watchdog.js";
 import { getActiveSessionCount } from "../../storage/sessions.js";
 import { log, logError, logDebug } from "../../util/log.js";
 import { handleSharedAction } from "./gateway-actions/index.js";
+import {
+  handleHubRequest,
+  getHubSessionCount,
+  HUB_PATH_PREFIX,
+} from "../mcp-hub/index.js";
 import { handlePluginAction } from "../plugin/index.js";
 import type { FrontendActionHandler } from "../types.js";
 import { BOT_MESSAGE_ACTIONS, noteBotMessage } from "../soul/taps.js";
@@ -352,6 +357,7 @@ export class Gateway {
               bridge: {
                 activeChats: this.loom.activeContextCount(),
                 threads: this.loom.size(),
+                hubSessions: getHubSessionCount(),
               },
               queue: getActiveCount(),
               sessions: getActiveSessionCount(),
@@ -385,6 +391,14 @@ export class Gateway {
           res.end(JSON.stringify({ ok: true }));
           const handler = this.shutdownHandler;
           setImmediate(() => handler("gateway /shutdown"));
+          return;
+        }
+
+        if (req.url?.startsWith(HUB_PATH_PREFIX)) {
+          // MCP hub — daemon-hosted MCP-over-HTTP endpoints for every
+          // backend (see core/mcp-hub). Same 127.0.0.1 trust boundary
+          // as /action.
+          await handleHubRequest(req, res, `http://127.0.0.1:${this.port}`);
           return;
         }
 
@@ -490,6 +504,11 @@ export class Gateway {
         this.port = 0;
         resolve();
       });
+      // `close()` only stops NEW connections; MCP hub sessions hold
+      // long-lived SSE streams that would keep the close callback from
+      // ever firing. Terminate them — everything on this server is
+      // localhost request/response or SSE, safe to drop at stop time.
+      this.server.closeAllConnections();
     });
   }
 }

--- a/src/core/mcp-hub/children.ts
+++ b/src/core/mcp-hub/children.ts
@@ -1,0 +1,254 @@
+/**
+ * Hub child manager — the single owner of external MCP server
+ * subprocesses (plugins, brave-search).
+ *
+ * Before the hub, every chat turn (claude-sdk, codex) or every chat
+ * lifetime (openai-agents, kilo/opencode) spawned its own copy of every
+ * plugin MCP server — memory grew linearly with chats. The hub instead
+ * keeps one child per key and reaps it after an idle TTL, so resident
+ * cost tracks *recently active* keys, not every chat ever seen.
+ *
+ * Keys: chat-scoped plugins get `name + chatId` (they read
+ * `TALON_CHAT_ID` at boot, so instances cannot be shared across chats
+ * without changing plugin semantics); chat-agnostic servers (brave)
+ * use a shared key. Either way the spec factory decides — this module
+ * only manages lifecycles.
+ *
+ * Each child is spawned through the same supervisor wrap as before
+ * (stdout JSON filtering + orphan cleanup if the daemon is SIGKILLed),
+ * connected once over stdio, and shared by every hub session that
+ * proxies to it. The tools list is cached per child lifetime — plugin
+ * reload restarts children, which naturally invalidates the cache.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { log, logError, logWarn } from "../../util/log.js";
+
+export type ChildSpec = {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+};
+
+export type ChildHandle = {
+  /** Cached tools/list result — fetched once per child lifetime. */
+  listTools(): Promise<Tool[]>;
+  /** Forward one tool call; tracked so retirement can drain in-flight work. */
+  callTool(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<CallToolResult>;
+  /** Mark activity so the idle reaper skips this child. */
+  touch(): void;
+};
+
+type ChildEntry = {
+  handle: ChildHandle;
+  key: string;
+  lastActivity: number;
+  /** In-flight request count — retirement waits for this to hit zero. */
+  pending: number;
+  /**
+   * Set when the child was replaced (plugin reload) but still has
+   * in-flight calls. Closed as soon as `pending` drains (or by the
+   * retire grace timer, whichever comes first).
+   */
+  retired: boolean;
+  close: () => Promise<void>;
+};
+
+const children = new Map<string, ChildEntry>();
+const inflight = new Map<string, Promise<ChildHandle>>();
+
+/** Idle TTL for hub children; tunable for tests / tight deployments. */
+function idleTtlMs(): number {
+  const raw = Number(process.env.TALON_MCP_HUB_IDLE_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 10 * 60_000;
+}
+
+const REAP_INTERVAL_MS = 60_000;
+let reaper: ReturnType<typeof setInterval> | null = null;
+
+async function spawnChild(key: string, spec: ChildSpec): Promise<ChildHandle> {
+  const transport = new StdioClientTransport({
+    command: spec.command,
+    args: spec.args,
+    // Merge over the daemon env — same visibility the SDK-spawned
+    // subprocesses had (PATH, HOME, proxy vars, …).
+    env: { ...(process.env as Record<string, string>), ...spec.env },
+    stderr: "inherit",
+  });
+  const client = new Client(
+    { name: "talon-mcp-hub", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  await client.connect(transport);
+
+  let toolsCache: Tool[] | null = null;
+  const track = async <T>(fn: () => Promise<T>): Promise<T> => {
+    entry.pending++;
+    try {
+      return await fn();
+    } finally {
+      entry.pending--;
+      if (entry.retired && entry.pending === 0) {
+        void entry.close();
+      }
+    }
+  };
+  const entry: ChildEntry = {
+    key,
+    lastActivity: Date.now(),
+    pending: 0,
+    retired: false,
+    // Idempotent: retirement can race its own grace timer.
+    close: (() => {
+      let closing: Promise<void> | null = null;
+      return () =>
+        (closing ??= (async () => {
+          try {
+            await client.close();
+          } catch (err) {
+            logWarn("gateway", `hub child ${key} close failed: ${String(err)}`);
+          }
+        })());
+    })(),
+    handle: {
+      touch: () => {
+        entry.lastActivity = Date.now();
+      },
+      listTools: () =>
+        track(async () => {
+          if (toolsCache) return toolsCache;
+          const result = await client.listTools();
+          toolsCache = result.tools;
+          return toolsCache;
+        }),
+      callTool: (name, args) =>
+        track(
+          () =>
+            client.callTool({
+              name,
+              arguments: args,
+            }) as Promise<CallToolResult>,
+        ),
+    },
+  };
+
+  // If the child dies on its own (crash, plugin bug), drop the entry so
+  // the next request respawns instead of hitting a dead pipe forever.
+  transport.onclose = () => {
+    if (children.get(key) === entry) {
+      children.delete(key);
+      log("gateway", `hub child ${key} exited — will respawn on demand`);
+    }
+  };
+
+  children.set(key, entry);
+  log("gateway", `hub child started: ${key}`);
+  return entry.handle;
+}
+
+/**
+ * Return the live child for `key`, or spawn it from `spec()`. Concurrent
+ * callers share one spawn. The spec factory is called only on spawn, so
+ * it always reflects the current plugin registry (reload-safe).
+ */
+export function acquireChild(
+  key: string,
+  spec: () => ChildSpec,
+): Promise<ChildHandle> {
+  const existing = children.get(key);
+  if (existing) {
+    existing.lastActivity = Date.now();
+    return Promise.resolve(existing.handle);
+  }
+  const pending = inflight.get(key);
+  if (pending) return pending;
+
+  const promise = (async () => {
+    try {
+      return await spawnChild(key, spec());
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+  inflight.set(key, promise);
+  return promise;
+}
+
+/** Close every child immediately. Daemon shutdown path. */
+export async function closeAllChildren(): Promise<void> {
+  const entries = [...children.values()];
+  children.clear();
+  await Promise.allSettled(entries.map((entry) => entry.close()));
+  if (entries.length > 0) {
+    log("gateway", `hub: closed ${entries.length} MCP child(ren)`);
+  }
+}
+
+/**
+ * Grace window for retired children: an in-flight tool call gets this
+ * long to finish on the old process before it's closed under it.
+ */
+const RETIRE_GRACE_MS = 60_000;
+
+/**
+ * Retire every child: remove from the registry so the NEXT acquire
+ * spawns fresh (reloaded plugin code), but let in-flight calls finish
+ * on the old process. A chat mid-tool-call during `/reload-plugins`
+ * sees its call complete normally; the old child closes once its last
+ * call drains (or after the grace window, whichever comes first).
+ */
+export function retireAllChildren(): void {
+  const entries = [...children.values()];
+  children.clear();
+  for (const entry of entries) {
+    entry.retired = true;
+    if (entry.pending === 0) {
+      void entry.close();
+      continue;
+    }
+    log(
+      "gateway",
+      `hub child ${entry.key} retired with ${entry.pending} in-flight call(s) — draining`,
+    );
+    const force = setTimeout(() => void entry.close(), RETIRE_GRACE_MS);
+    force.unref?.();
+  }
+  if (entries.length > 0) {
+    log("gateway", `hub: retired ${entries.length} MCP child(ren)`);
+  }
+}
+
+function reapIdle(): void {
+  const cutoff = Date.now() - idleTtlMs();
+  for (const [key, entry] of children) {
+    if (entry.lastActivity >= cutoff) continue;
+    children.delete(key);
+    entry.close().catch((err) => {
+      logError("gateway", `hub reap of ${key} failed`, err);
+    });
+    log("gateway", `hub child reaped (idle): ${key}`);
+  }
+}
+
+export function startChildReaper(): void {
+  if (reaper) return;
+  reaper = setInterval(reapIdle, REAP_INTERVAL_MS);
+  reaper.unref?.();
+}
+
+export function stopChildReaper(): void {
+  if (reaper) {
+    clearInterval(reaper);
+    reaper = null;
+  }
+}
+
+/** Diagnostic: live child keys (tests, /status introspection). */
+export function getActiveChildKeys(): string[] {
+  return [...children.keys()];
+}

--- a/src/core/mcp-hub/index.ts
+++ b/src/core/mcp-hub/index.ts
@@ -1,0 +1,335 @@
+/**
+ * MCP hub — daemon-hosted MCP over streamable HTTP, one endpoint for
+ * every backend.
+ *
+ * Motivation: every backend used to spawn its own stdio copy of every
+ * MCP server per chat (claude-sdk/codex per turn; openai-agents and
+ * kilo/opencode per chat, held indefinitely) — two processes per server
+ * per chat once the supervisor wrap is counted. Memory grew linearly
+ * with chats. The hub inverts the ownership: the daemon hosts
+ *
+ *   /mcp/talon/<frontend>/<chatId>   Talon's own tools, IN-PROCESS
+ *                                    (zero subprocesses; chat binding
+ *                                    comes from the URL, not env)
+ *   /mcp/plugin/<serverName>/<chatId> external plugin / brave servers,
+ *                                    proxied to hub-managed children
+ *                                    that are shared across sessions
+ *                                    and reaped when idle
+ *
+ * and every backend connects with its SDK's HTTP/remote MCP transport
+ * (claude-sdk `type:"http"`, openai-agents `MCPServerStreamableHttp`,
+ * codex `mcp_servers.<name>.url`, kilo/opencode `type:"remote"`).
+ *
+ * What stays exactly as before:
+ *   - per-chat tool isolation (binding is per-session from the URL)
+ *   - plugin semantics (chat-scoped children keep TALON_CHAT_ID env)
+ *   - tool-surface trimming (disabledTools / disabledToolTags)
+ *   - plugin reloading (reload closes children; next request respawns
+ *     from the current registry — see reloadHubChildren)
+ *   - orphan cleanup (children still run under the supervisor wrap)
+ *
+ * Endpoints live on the gateway HTTP server (127.0.0.1-bound, same
+ * trust boundary as /action).
+ */
+
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { getPluginMcpServers } from "../plugin/index.js";
+import { wrapMcpServer } from "../../util/mcp-launcher.js";
+import { log, logError } from "../../util/log.js";
+import { buildTalonToolServer, VALID_TOOL_FRONTENDS } from "./talon-server.js";
+import { buildProxyServer } from "./proxy-server.js";
+import {
+  acquireChild,
+  closeAllChildren,
+  retireAllChildren,
+  startChildReaper,
+  stopChildReaper,
+  type ChildSpec,
+} from "./children.js";
+import type { ToolFrontend } from "../tools/types.js";
+
+export const HUB_PATH_PREFIX = "/mcp/";
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+export type HubConfig = {
+  disabledTools?: readonly string[];
+  disabledToolTags?: readonly string[];
+  braveApiKey?: string;
+};
+
+let hubConfig: HubConfig = {};
+
+/** Set at bootstrap; safe to call again on config reload. */
+export function initHub(config: HubConfig): void {
+  hubConfig = config;
+  startChildReaper();
+}
+
+// ── URL builders (used by every backend) ────────────────────────────────────
+
+/** URL of the in-process Talon tool server for one (frontend, chat). */
+export function talonHubUrl(
+  bridgeUrl: string,
+  frontend: string,
+  chatId: string,
+): string {
+  return `${bridgeUrl}${HUB_PATH_PREFIX}talon/${encodeURIComponent(frontend)}/${encodeURIComponent(chatId)}`;
+}
+
+/** URL of a hub-proxied plugin/brave server for one chat. */
+export function pluginHubUrl(
+  bridgeUrl: string,
+  serverName: string,
+  chatId: string,
+): string {
+  return `${bridgeUrl}${HUB_PATH_PREFIX}plugin/${encodeURIComponent(serverName)}/${encodeURIComponent(chatId)}`;
+}
+
+/**
+ * Names of every hub-served plugin server — what backends enumerate to
+ * build their per-chat URL maps. Registry-backed, so it reflects plugin
+ * reloads immediately. (brave-search is served by the hub too, but each
+ * backend adds it explicitly alongside its frontend tools, matching the
+ * pre-hub structure.)
+ */
+export function hubPluginServerNames(only?: string[]): string[] {
+  // Specs are built with placeholder identity — only the names matter.
+  return Object.keys(getPluginMcpServers("", "hub-enum", only));
+}
+
+// ── Server construction per session ─────────────────────────────────────────
+
+type HubTarget =
+  | { kind: "talon"; frontend: ToolFrontend; chatId: string }
+  | { kind: "plugin"; serverName: string; chatId: string };
+
+function parseHubPath(rawUrl: string): HubTarget | null {
+  const path = rawUrl.split("?")[0];
+  if (!path.startsWith(HUB_PATH_PREFIX)) return null;
+  const parts = path
+    .slice(HUB_PATH_PREFIX.length)
+    .split("/")
+    .map((part) => decodeURIComponent(part));
+  if (parts.length !== 3 || !parts[1] || !parts[2]) return null;
+  const [kind, name, chatId] = parts;
+  if (kind === "talon") {
+    if (!VALID_TOOL_FRONTENDS.has(name)) return null;
+    return { kind: "talon", frontend: name as ToolFrontend, chatId };
+  }
+  if (kind === "plugin") return { kind: "plugin", serverName: name, chatId };
+  return null;
+}
+
+function braveSpec(): ChildSpec {
+  return wrapMcpServer({
+    command: resolve(
+      import.meta.dirname ?? ".",
+      "../../../node_modules/.bin/brave-search-mcp-server",
+    ),
+    args: [],
+    env: { BRAVE_API_KEY: hubConfig.braveApiKey ?? "" },
+  });
+}
+
+/**
+ * Resolve the child spec for a plugin server name. Looked up lazily at
+ * spawn time so a reload always spawns from the current registry.
+ * Throws when the name is unknown (plugin removed / never existed).
+ */
+function pluginSpec(
+  serverName: string,
+  chatId: string,
+  bridgeUrl: string,
+): ChildSpec {
+  if (serverName === "brave-search") return braveSpec();
+  const specs = getPluginMcpServers(bridgeUrl, chatId);
+  const spec = specs[serverName];
+  if (!spec) throw new Error(`Unknown hub plugin server: ${serverName}`);
+  return { command: spec.command, args: [...spec.args], env: spec.env };
+}
+
+/** Test-only: expose the spec resolution for the pass-through contract. */
+export const _pluginSpecForTesting = pluginSpec;
+
+function buildServerFor(target: HubTarget, bridgeUrl: string) {
+  if (target.kind === "talon") {
+    return buildTalonToolServer({
+      frontend: target.frontend,
+      chatId: target.chatId,
+      bridgeUrl,
+      disabledTools: hubConfig.disabledTools,
+      disabledToolTags: hubConfig.disabledToolTags,
+    });
+  }
+  // brave-search is chat-agnostic (one shared child); plugins read
+  // TALON_CHAT_ID at boot, so their children stay chat-scoped and the
+  // idle reaper bounds the fleet.
+  const key =
+    target.serverName === "brave-search"
+      ? "brave-search"
+      : `${target.serverName}\u0000${target.chatId}`;
+  return buildProxyServer(target.serverName, () =>
+    acquireChild(key, () =>
+      pluginSpec(target.serverName, target.chatId, bridgeUrl),
+    ),
+  );
+}
+
+// ── Session registry ────────────────────────────────────────────────────────
+
+type SessionEntry = {
+  transport: StreamableHTTPServerTransport;
+  lastSeen: number;
+};
+
+const sessions = new Map<string, SessionEntry>();
+
+/**
+ * Sessions whose client vanished without a DELETE (crashed subprocess,
+ * kill -9) are closed after this idle window. Every well-behaved client
+ * terminates explicitly, so this only catches stragglers.
+ */
+const SESSION_IDLE_MS = 30 * 60_000;
+const SESSION_REAP_INTERVAL_MS = 5 * 60_000;
+let sessionReaper: ReturnType<typeof setInterval> | null = null;
+
+function startSessionReaper(): void {
+  if (sessionReaper) return;
+  sessionReaper = setInterval(() => {
+    const cutoff = Date.now() - SESSION_IDLE_MS;
+    for (const [id, entry] of sessions) {
+      if (entry.lastSeen >= cutoff) continue;
+      sessions.delete(id);
+      entry.transport.close().catch(() => {});
+      log("gateway", `hub session reaped (idle): ${id.slice(0, 8)}…`);
+    }
+  }, SESSION_REAP_INTERVAL_MS);
+  sessionReaper.unref?.();
+}
+
+// ── HTTP entry point (invoked by the gateway) ───────────────────────────────
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  const raw = Buffer.concat(chunks).toString("utf-8");
+  if (!raw) return undefined;
+  return JSON.parse(raw);
+}
+
+function jsonRpcError(
+  res: ServerResponse,
+  status: number,
+  message: string,
+): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: -32000, message },
+      id: null,
+    }),
+  );
+}
+
+/**
+ * Handle one request under /mcp/. `bridgeUrl` is the gateway's own base
+ * URL (the gateway knows its bound port; the hub does not).
+ */
+export async function handleHubRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  bridgeUrl: string,
+): Promise<void> {
+  startSessionReaper();
+  try {
+    const sessionId = req.headers["mcp-session-id"];
+    if (typeof sessionId === "string") {
+      const entry = sessions.get(sessionId);
+      if (!entry) {
+        jsonRpcError(res, 404, "Unknown or expired MCP session");
+        return;
+      }
+      entry.lastSeen = Date.now();
+      await entry.transport.handleRequest(req, res);
+      return;
+    }
+
+    if (req.method !== "POST") {
+      jsonRpcError(res, 405, "Method not allowed without a session");
+      return;
+    }
+
+    let body: unknown;
+    try {
+      body = await readJsonBody(req);
+    } catch {
+      jsonRpcError(res, 400, "Invalid JSON body");
+      return;
+    }
+    if (!isInitializeRequest(body)) {
+      jsonRpcError(res, 400, "Expected an initialize request");
+      return;
+    }
+
+    const target = parseHubPath(req.url ?? "");
+    if (!target) {
+      jsonRpcError(res, 404, "Unknown hub endpoint");
+      return;
+    }
+
+    const server = buildServerFor(target, bridgeUrl);
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (id) => {
+        sessions.set(id, { transport, lastSeen: Date.now() });
+      },
+    });
+    transport.onclose = () => {
+      if (transport.sessionId) sessions.delete(transport.sessionId);
+    };
+    await server.connect(transport);
+    await transport.handleRequest(req, res, body);
+  } catch (err) {
+    logError("gateway", `hub request failed: ${req.method} ${req.url}`, err);
+    if (!res.headersSent) {
+      jsonRpcError(res, 500, "Internal hub error");
+    }
+  }
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+
+/**
+ * Plugin reload: RETIRE every child — the next request (from any chat)
+ * spawns fresh processes running the reloaded plugin code, while calls
+ * already in flight finish on the old process instead of erroring
+ * mid-turn. Live sessions keep working — their proxies re-acquire on
+ * the next call.
+ */
+export function reloadHubChildren(): void {
+  retireAllChildren();
+}
+
+/** Daemon shutdown: close sessions, children, and timers. */
+export async function shutdownHub(): Promise<void> {
+  stopChildReaper();
+  if (sessionReaper) {
+    clearInterval(sessionReaper);
+    sessionReaper = null;
+  }
+  const entries = [...sessions.values()];
+  sessions.clear();
+  await Promise.allSettled(entries.map((entry) => entry.transport.close()));
+  await closeAllChildren();
+}
+
+/** Diagnostic: live hub session count. */
+export function getHubSessionCount(): number {
+  return sessions.size;
+}

--- a/src/core/mcp-hub/proxy-server.ts
+++ b/src/core/mcp-hub/proxy-server.ts
@@ -1,0 +1,45 @@
+/**
+ * Hub proxy server — an in-process MCP server that forwards tools/list
+ * and tools/call to a hub-managed child (see children.ts).
+ *
+ * One proxy per hub session; many sessions share one child. The child
+ * is re-acquired through `getChild` on every request, so a child that
+ * was idle-reaped or crashed respawns transparently mid-session —
+ * clients never see the lifecycle, only (at worst) a slow first call.
+ *
+ * Tools-only by design: every MCP server Talon consumes (plugins,
+ * brave) exposes tools, and the backends only wire tools. Resource /
+ * prompt requests are not declared in capabilities, so well-behaved
+ * clients won't send them.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { ChildHandle } from "./children.js";
+
+export function buildProxyServer(
+  name: string,
+  getChild: () => Promise<ChildHandle>,
+): Server {
+  const server = new Server(
+    { name, version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const child = await getChild();
+    child.touch();
+    return { tools: await child.listTools() };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const child = await getChild();
+    child.touch();
+    return child.callTool(request.params.name, request.params.arguments ?? {});
+  });
+
+  return server;
+}

--- a/src/core/mcp-hub/talon-server.ts
+++ b/src/core/mcp-hub/talon-server.ts
@@ -1,0 +1,71 @@
+/**
+ * In-process Talon tool server — the hub-side twin of
+ * `core/tools/mcp-server.ts`.
+ *
+ * Same composition (composeTools + createBridge + textResult), but
+ * instead of reading `TALON_CHAT_ID`/`TALON_FRONTEND` from the env of a
+ * dedicated subprocess, the binding arrives per hub session from the
+ * request URL. One `McpServer` instance per session, zero processes —
+ * this replaces the two processes (supervisor + server) that every
+ * chat previously paid per configured frontend.
+ *
+ * Tool-surface trimming (`disabledTools` / `disabledToolTags`) applies
+ * exactly as in the subprocess version, including the `end_turn`
+ * exemption — tool-only backends need it to close every turn.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { composeTools } from "../tools/index.js";
+import { createBridge, textResult } from "../tools/bridge.js";
+import type { ToolFrontend, ToolTag } from "../tools/types.js";
+
+export const VALID_TOOL_FRONTENDS: ReadonlySet<string> = new Set([
+  "telegram",
+  "teams",
+  "terminal",
+  "discord",
+  "native",
+]);
+
+export type TalonServerOptions = {
+  frontend: ToolFrontend;
+  chatId: string;
+  /** Gateway base URL, e.g. http://127.0.0.1:19876 */
+  bridgeUrl: string;
+  disabledTools?: readonly string[];
+  disabledToolTags?: readonly string[];
+};
+
+/** Build a Talon tool MCP server bound to one (frontend, chatId) pair. */
+export function buildTalonToolServer(options: TalonServerOptions): McpServer {
+  const bridge = createBridge(options.bridgeUrl, options.chatId);
+  const server = new McpServer({
+    name: `${options.frontend}-tools`,
+    version: "3.0.0",
+  });
+
+  const excludeNames = (options.disabledTools ?? []).filter(
+    (name) => name !== "end_turn",
+  );
+  const excludeTags = (options.disabledToolTags ?? []) as ToolTag[];
+
+  const tools = composeTools({
+    frontend: options.frontend,
+    excludeTags,
+    excludeNames,
+  });
+  if (excludeTags.length > 0 && !tools.some((t) => t.name === "end_turn")) {
+    const endTurn = composeTools({ frontend: options.frontend }).find(
+      (t) => t.name === "end_turn",
+    );
+    if (endTurn) tools.push(endTurn);
+  }
+
+  for (const tool of tools) {
+    server.tool(tool.name, tool.description, tool.schema, async (params) =>
+      textResult(await tool.execute(params, bridge)),
+    );
+  }
+
+  return server;
+}

--- a/src/core/plugin/builtins.ts
+++ b/src/core/plugin/builtins.ts
@@ -145,6 +145,13 @@ export async function reloadPlugins(
   // Re-load built-in plugins using shared helper
   await loadBuiltinPlugins(config);
 
+  // Retire the hub's MCP children: the next tool call (any chat) spawns
+  // fresh processes from the reloaded registry, while in-flight calls
+  // drain on the old ones (stdio-era behaviour was per-turn respawn via
+  // the TALON_RELOAD_AT env bump; the hub owns lifecycles directly).
+  const { reloadHubChildren } = await import("../mcp-hub/index.js");
+  reloadHubChildren();
+
   const names = registry.all.map((p) => p.plugin.name);
   log(
     "plugin",

--- a/src/frontend/telegram/commands/admin.ts
+++ b/src/frontend/telegram/commands/admin.ts
@@ -25,7 +25,7 @@ import { collectDoctorReport } from "../../../core/doctor.js";
 import { handleAdminCommand } from "../admin.js";
 import { getMetrics } from "../../../util/metrics.js";
 import { isAuthorizedAdmin, type RegisterDeps } from "./state.js";
-import { TELEGRAM_COMMANDS } from "./definitions.js";
+import { telegramCommandMenu } from "./definitions.js";
 
 export function registerAdminCommands(
   bot: Bot,
@@ -207,7 +207,7 @@ export function registerAdminCommands(
   // only reaches this when nothing above matched. Only bare commands
   // are intercepted — a close miss gets a suggestion, anything else
   // keeps flowing to the agent as a normal message.
-  const commandNames = TELEGRAM_COMMANDS.map((c) => c.command);
+  const commandNames = telegramCommandMenu(config).map((c) => c.command);
   bot.on("message::bot_command", async (ctx, next) => {
     const typed = /^\/([a-zA-Z0-9_]+)(?:@(\w+))?\s*$/.exec(ctx.msg.text ?? "");
     if (!typed) return next();

--- a/src/frontend/telegram/commands/definitions.ts
+++ b/src/frontend/telegram/commands/definitions.ts
@@ -2,7 +2,14 @@
  * User-facing command menu — the single source for Telegram's command menu
  * (setMyCommands in index.ts) and the unknown-command suggester. Admin-only
  * commands (/admin) stay off the menu and out of suggestions deliberately.
+ *
+ * Conditionally-wired commands (/update) are appended by
+ * {@link telegramCommandMenu} under the same gate their handlers use —
+ * a static entry for a command that isn't registered would put a dead
+ * item in every non-dev deployment's menu.
  */
+
+import { getRepoRoot } from "../../../core/update/self-update.js";
 
 export const TELEGRAM_COMMANDS: ReadonlyArray<{
   command: string;
@@ -29,3 +36,25 @@ export const TELEGRAM_COMMANDS: ReadonlyArray<{
   { command: "plugins", description: "List loaded plugins" },
   { command: "help", description: "All commands and features" },
 ];
+
+/**
+ * The menu actually registered with Telegram for this deployment.
+ *
+ * `/update` only exists on developer builds running from a git checkout
+ * (see the handler gate in commands/admin.ts — packaged binaries have no
+ * source tree to pull into), so it joins the menu under the same
+ * condition, slotted next to /restart.
+ */
+export function telegramCommandMenu(config: {
+  devBuild?: boolean;
+}): Array<{ command: string; description: string }> {
+  const menu = [...TELEGRAM_COMMANDS];
+  if (config.devBuild && getRepoRoot()) {
+    const restartIdx = menu.findIndex((c) => c.command === "restart");
+    menu.splice(restartIdx + 1, 0, {
+      command: "update",
+      description: "Pull latest, reinstall, restart (admin)",
+    });
+  }
+  return menu;
+}

--- a/src/frontend/telegram/commands/index.ts
+++ b/src/frontend/telegram/commands/index.ts
@@ -23,7 +23,7 @@ import { registerSessionCommands } from "./session.js";
 import { registerSettingsCommands } from "./settings.js";
 import { registerAdminCommands } from "./admin.js";
 
-export { TELEGRAM_COMMANDS } from "./definitions.js";
+export { TELEGRAM_COMMANDS, telegramCommandMenu } from "./definitions.js";
 export { setAdminUserId } from "./state.js";
 
 export function registerCommands(

--- a/src/frontend/telegram/index.ts
+++ b/src/frontend/telegram/index.ts
@@ -18,7 +18,7 @@ import { initUserClient, disconnectUserClient } from "./userbot.js";
 import {
   registerCommands,
   setAdminUserId,
-  TELEGRAM_COMMANDS,
+  telegramCommandMenu,
 } from "./commands/index.js";
 import { setAccessControl } from "./handlers/index.js";
 import { registerMiddleware } from "./middleware.js";
@@ -89,7 +89,7 @@ export function createTelegramFrontend(
       registerCallbacks(bot, config, gateway);
 
       await bot.api.deleteMyCommands();
-      await bot.api.setMyCommands([...TELEGRAM_COMMANDS]);
+      await bot.api.setMyCommands(telegramCommandMenu(config));
       log("commands", "Registered bot commands with Telegram");
 
       const apiId = config.apiId ?? 0;

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -27,7 +27,7 @@
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { files } from "../util/paths.js";
-import { log } from "../util/log.js";
+import { log, logError } from "../util/log.js";
 import { SCHEMA, dbSql } from "./sql/statements.generated.js";
 
 /**
@@ -110,17 +110,42 @@ export function getDatabase(path: string = defaultPath()): SqlDatabase {
   if (db) return db;
   mkdirSync(dirname(path), { recursive: true });
   const database = new Database(path);
-  // WAL: readers don't block the writer, and crash recovery is
-  // journal-based instead of "hope the rename was atomic".
-  database.exec("PRAGMA journal_mode = WAL");
-  database.exec("PRAGMA synchronous = NORMAL");
-  database.exec("PRAGMA foreign_keys = ON");
-  ensureSchema(database);
+  try {
+    // WAL: readers don't block the writer, and crash recovery is
+    // journal-based instead of "hope the rename was atomic".
+    database.exec("PRAGMA journal_mode = WAL");
+    database.exec("PRAGMA synchronous = NORMAL");
+    database.exec("PRAGMA foreign_keys = ON");
+    ensureSchema(database);
+  } catch (err) {
+    // Setup failed — close the handle so a retry doesn't leak one
+    // open file descriptor (and WAL sidecar) per attempt.
+    try {
+      database.close();
+    } catch {
+      /* already closed */
+    }
+    throw err;
+  }
   db = database;
   return database;
 }
 
 let transactionDepth = 0;
+
+/**
+ * Best-effort rollback: a ROLLBACK that itself throws (database closed,
+ * I/O error) must not mask the original error from `fn`, and must not
+ * skip the depth bookkeeping — a stuck depth would silently turn every
+ * later top-level transaction into a savepoint.
+ */
+function tryExec(database: SqlDatabase, sql: string): void {
+  try {
+    database.exec(sql);
+  } catch (err) {
+    logError("db", `Transaction cleanup failed (${sql})`, err);
+  }
+}
 
 /** Run `fn` inside a transaction; rolls back on throw. Nested calls use SAVEPOINTs. */
 export function inTransaction<T>(fn: () => T): T {
@@ -132,13 +157,13 @@ export function inTransaction<T>(fn: () => T): T {
     try {
       const result = fn();
       database.exec(`RELEASE "${sp}"`);
-      transactionDepth--;
       return result;
     } catch (err) {
-      database.exec(`ROLLBACK TO "${sp}"`);
-      database.exec(`RELEASE "${sp}"`);
-      transactionDepth--;
+      tryExec(database, `ROLLBACK TO "${sp}"`);
+      tryExec(database, `RELEASE "${sp}"`);
       throw err;
+    } finally {
+      transactionDepth--;
     }
   }
   database.exec("BEGIN");
@@ -146,12 +171,12 @@ export function inTransaction<T>(fn: () => T): T {
   try {
     const result = fn();
     database.exec("COMMIT");
-    transactionDepth--;
     return result;
   } catch (err) {
-    database.exec("ROLLBACK");
-    transactionDepth--;
+    tryExec(database, "ROLLBACK");
     throw err;
+  } finally {
+    transactionDepth--;
   }
 }
 

--- a/src/storage/turn-meta.ts
+++ b/src/storage/turn-meta.ts
@@ -90,7 +90,15 @@ export function recordTurnMeta(
 /** Look up the meta for one message, typed by the caller, or null. */
 export function getTurnMeta<T>(chatId: string, msgId: string): T | null {
   ensureLoaded();
-  const raw = repo.get(chatId, msgId);
+  let raw: string | undefined;
+  try {
+    raw = repo.get(chatId, msgId);
+  } catch (err) {
+    // Reads are hydration-only — a storage fault must degrade to
+    // "no meta", not break the caller (matching recordTurnMeta).
+    logError("db", "Failed to read turn meta", err);
+    return null;
+  }
   if (raw === undefined) return null;
   try {
     return JSON.parse(raw) as T;


### PR DESCRIPTION
## Summary

Two work streams on one branch:

### 1. Robustness hardening (`e56d20a`)
- `gracefulShutdown`: every teardown step is best-effort — one failing subsystem no longer skips the WAL checkpoint or pidfile removal; the in-flight drain polls instead of a fixed 5s sleep.
- Crash exits (`uncaughtException`, fatal startup) remove their own pid record (pid-guarded) so a dead daemon can't leave a stale pidfile.
- `inTransaction`: depth bookkeeping in `finally`; a failing ROLLBACK can't mask the original error or corrupt nesting depth.
- `getDatabase`: closes the handle when pragma/schema setup fails.
- `getTurnMeta`: storage read faults degrade to `null` instead of throwing into frontend hydration.

### 2. MCP hub (`dfa3134`) — fixes memory growing linearly with chats
Every backend used to spawn its own stdio copy of every MCP server per chat (claude-sdk/codex per **turn**; openai-agents and kilo/opencode per **chat**, held until reset) — ~2 processes per server per chat with the supervisor wrap.

New `core/mcp-hub` serves MCP over streamable HTTP on the gateway:
- **Talon tools run in-process** — zero subprocesses; (frontend, chatId) binding travels in the URL, not env.
- **Plugin/brave servers are hub-owned children** — shared across sessions/turns, idle-reaped (`TALON_MCP_HUB_IDLE_MS`, default 10m), and *retired* on plugin reload so in-flight tool calls drain on the old process while new calls get the reloaded code.
- All four backends consume it natively: claude-sdk `type:"http"`, openai-agents `MCPServerStreamableHttp`, codex `mcp_servers.<name>.url`, kilo/opencode `type:"remote"`.

Preserved: per-chat tool isolation (incl. kilo/opencode visibility rotation), tool trimming, plugin chat-scoping semantics, supervisor orphan cleanup, heartbeat/dream tiers, plugin hot-reload.

## Test plan
- New `mcp-hub.test.ts` end-to-end: real gateway + real MCP HTTP client; in-process tool serving, bridge round-trip, session lifecycle, shared child proxying (two sessions → one pid), reload retirement (new pid after reload).
- Stub harnesses (claude/codex/kilo/opencode/openai-agents) updated to the HTTP shapes; full local suite green except live-backend legs, which CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)