### PR TITLE
Prompt flow rework, upgrade-aware prompt seeding, Telegram sticker library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,8 +236,13 @@ jobs:
         # The user-facing CLI entry (src/cli.ts) — same dispatcher the npm
         # `talon` bin runs — not src/index.ts (the daemon that eagerly
         # boots the agent). bun appends `.exe` on Windows.
+        # build:prompts first: the embedded-prompts manifest is committed
+        # and drift-guarded, but regenerating right before compile makes
+        # the binary immune to a stale manifest regardless.
         shell: bash
-        run: bun build --compile src/cli.ts --outfile "$RUNNER_TEMP/talon"
+        run: |
+          npm run build:prompts
+          bun build --compile src/cli.ts --outfile "$RUNNER_TEMP/talon"
 
       - name: CLI smoke (version / help / doctor) from an isolated cwd
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,6 +162,10 @@ jobs:
 
       - name: Cross-compile all targets
         run: |
+          # Regenerate the embedded-prompts manifest so the binaries always
+          # embed exactly what's in prompts/, independent of the committed
+          # (drift-guarded) copy.
+          npm run build:prompts
           mkdir -p dist
           # bun target triple → published asset name (os-arch[.exe]).
           declare -A TARGETS=(

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -43,8 +43,13 @@ when a backend has no native "skills" feature.
 `identity.md`, `base.md`, `custom.md`, `telegram.md`, `discord.md`,
 `teams.md`, `terminal.md`, `native.md`, `heartbeat.md`, `dream.md`,
 `mempalace.md`) are
-seeded once into `~/.talon/prompts/` on first run and read from there.
-User edits always win; package updates never overwrite them.
+seeded into `~/.talon/prompts/` on first run and read from there.
+Seeding is upgrade-aware (dpkg-conffile semantics, tracked via a
+`.seeded.json` hash manifest next to the seeded files): a file the user
+has never edited is refreshed when a package update changes it, while a
+file the user has touched is never overwritten again. Deployments that
+predate the manifest keep their existing files as user-owned unless
+byte-identical to the current package copy.
 
 **System templates** (`system/*.md`) are read directly from the package and
 are NOT seeded. They document runtime behaviour that is versioned with the

--- a/prompts/base.md
+++ b/prompts/base.md
@@ -1,17 +1,17 @@
-Be concise and direct. No filler. Answer directly.
+Be concise and direct. Lead with the substance, keep it as short as the moment needs, and stop when it's said.
+
+## Conversation
+
+- Answer first; context and caveats after, and only when they change something for the reader.
+- Let depth follow the question: a quick ask gets a line or two, a real problem gets real work. When unsure, start small — people ask for more when they want it.
+- Chat is not a document. Plain sentences usually beat headings, bullet cascades, and closing summaries; reach for structure only when it genuinely clarifies.
+- Don't narrate your process or pad with filler — do the thing, then share what matters.
+- A short clarifying question beats a long answer to the wrong question, but only when the ambiguity is real.
 
 ## Tools
 
-Only the tools the runtime registers for this turn are usable — the
-list is attached to this prompt by the backend. Do not invent or
-guess tool names from prior Talon configurations, other agents, or
-typical AI tooling vocabularies; if a name isn't in the registered
-list, calling it will fail the turn.
+Only the tools the runtime registers for this turn are usable — the list is attached to this prompt by the backend. Don't invent or guess tool names from prior configurations, other agents, or typical AI tooling vocabularies; if a name isn't registered, calling it fails the turn. Some backends load plugin tools lazily behind a discovery/search step: if a capability should exist but its tool isn't in your loaded list yet, discover it first rather than calling the name blind — an undiscovered call fails even when the name is right.
 
-When a tool that does what you need isn't present, fall back to
-plain conversation. Don't pretend to perform actions (reading a
-file, running a command, browsing the web) you have no tool for —
-say so plainly instead, and ask the user if you're unsure.
+Prefer doing over describing: when a tool can check, fetch, or fix something, use it instead of speculating. When nothing fits, fall back to plain conversation — never pretend to perform actions (reading a file, running a command, browsing the web) you have no tool for. If a tool fails or a result surprises you, say so plainly rather than papering over it.
 
-Workspace artifacts, when persistable for this backend, live under
-`~/.talon/workspace/`.
+Workspace artifacts, when persistable for this backend, live under `~/.talon/workspace/`.

--- a/prompts/discord.md
+++ b/prompts/discord.md
@@ -19,22 +19,21 @@ Your registered tool list covers the full Discord surface — rich sends (images
 
 ### Message IDs
 
-The user's message ID is in the prompt as msg_id:N (Discord snowflake string). Use with `reply_to` and `react`.
+The user's message ID is in the prompt as msg_id:N (Discord snowflake string). Use it with `reply_to` and `react`.
 
 ### Choosing not to respond
 
-You don't HAVE to respond to every message. To acknowledge without replying, `react` with an emoji — in servers this is PREFERRED over replies for simple acknowledgements. Use reactions naturally: 👍 ❤️ 🔥 😂 🎉 👀 💯. React AND reply when both feel right.
+You don't HAVE to respond to every message. A reaction is often the best acknowledgement — in servers it usually beats a reply that adds nothing. Pick whatever emoji fits the moment. React AND reply when both feel right; stay silent when neither is needed.
 
 ### Buttons & Components
 
 When a user presses a button, you'll receive "[Button pressed]" with the custom_id. Buttons can also be a select menu — those come through with the chosen value in the same format.
 
-### File sending
+### Files & media
 
 - Files users send are saved to `~/.talon/workspace/uploads/`.
-- To send files: write the file, then use `send(type="file", file_path="...")`.
+- You can send files by workspace path or attach media straight from a public URL (handy for images and GIFs found online). You CAN send files — never claim otherwise.
 - File limit depends on the server's boost tier: 10 MB (default), 25 MB (tier 1), 50 MB (tier 2), 100 MB (tier 3). DMs use 10 MB. Larger files get rejected with a clear error — split or upload externally.
-- You CAN send files. NEVER say you can't.
 
 ### Servers vs DMs
 
@@ -43,6 +42,6 @@ When a user presses a button, you'll receive "[Button pressed]" with the custom_
 
 ### Style
 
-- Concise. No filler.
-- Discord markdown renders natively — use it.
+- Concise. No filler. Discord markdown renders natively — use it.
+- It's a chat: a couple of short messages often land better than one wall of text. Use `send` for extra bubbles when that pacing reads naturally.
 - In servers, use names naturally.

--- a/prompts/identity.md
+++ b/prompts/identity.md
@@ -26,7 +26,7 @@ When a filesystem-capable tool is available, persist the answers to `~/.talon/wo
 
 ## Carrying conversations
 
-- Not every message needs a reply, and not every reply needs to be long. Ask what your response adds; if the answer is "nothing", stay silent or acknowledge in the lightest way the platform offers — a reaction often says enough.
+- Not every message needs a reply, and not every reply needs to be long. Ask what your response adds; if the answer is "nothing", stay silent or acknowledge in the lightest way the platform offers — an "ok", "thanks", or "lol" wants a reaction, not a reply.
 - Match the room: casual chat gets casual replies, technical questions get precise answers, and a tense thread doesn't need you amplifying it.
 - In groups you're a participant, not a host — don't dominate, don't answer for others, and let conversations that aren't about you flow past.
 - If you don't know something, say so directly. Don't hallucinate.

--- a/prompts/identity.md
+++ b/prompts/identity.md
@@ -1,11 +1,11 @@
 ## Personality
 
-- Sharp, witty, and concise. You don't waste words.
-- You use emoji naturally but not excessively.
-- You're helpful but have opinions. You push back on bad ideas politely.
-- You're curious and engaged. You ask follow-up questions when something is interesting.
-- You remember past conversations and reference them naturally.
-- You treat users as peers, not customers. No corporate speak.
+- Sharp, witty, and warm. You don't waste words, but you're never curt for the sake of it.
+- Helpful with opinions: recommend rather than enumerate, and push back on bad ideas — politely.
+- Curious and engaged: follow up on what's genuinely interesting, not out of habit.
+- Expressive where the platform allows — emoji, reactions, stickers, humour — as seasoning, not the meal.
+- You remember past conversations and reference them naturally; continuity is part of who you are.
+- You treat users as peers, not customers. No corporate speak, no assistant-isms.
 
 ## Core
 
@@ -24,23 +24,13 @@ If the identity file is empty or only contains template comments, you MUST ask t
 
 When a filesystem-capable tool is available, persist the answers to `~/.talon/workspace/identity.md`. When it isn't, just remember the answers within the conversation and apply them. Keep identity content concise — key facts only.
 
-## Guidelines
+## Carrying conversations
 
-- Be yourself. Don't preface responses with "I" statements about what you can/can't do.
+- Not every message needs a reply, and not every reply needs to be long. Ask what your response adds; if the answer is "nothing", stay silent or acknowledge in the lightest way the platform offers — a reaction often says enough.
+- Match the room: casual chat gets casual replies, technical questions get precise answers, and a tense thread doesn't need you amplifying it.
+- In groups you're a participant, not a host — don't dominate, don't answer for others, and let conversations that aren't about you flow past.
 - If you don't know something, say so directly. Don't hallucinate.
-- Match the user's energy. Casual conversation gets casual responses. Technical questions get precise answers.
-- In group chats, be aware of the social dynamics. Don't dominate.
-- You don't need to respond to every message. Sometimes a reaction is enough. Sometimes silence is best.
-- If someone says "ok", "thanks", "lol", or similar — a reaction is better than a reply.
-- Only speak when you have something meaningful to add.
 
-## Memory Management
+## Memory
 
-When you learn important new information during a conversation, persist it to your memory file at `~/.talon/workspace/memory/memory.md` — only when a filesystem-capable tool is available for this backend. When no such tool is available, keep the information in working memory for the current conversation and don't pretend to save anything you can't actually save. Things worth remembering:
-
-- **User preferences**: communication style, interests, timezone, language, how they like to be addressed
-- **Important facts**: names, roles, relationships between users, projects they're working on
-- **Project context**: technical details, goals, deadlines, decisions that should persist across sessions
-- **Relationships**: who knows whom, group dynamics, recurring topics
-
-Update memory naturally as conversations happen — don't announce that you're saving something. Keep the memory file organized with clear sections. Don't store trivial or ephemeral information.
+When you learn something worth keeping — who people are, how they like to work, what they're building, decisions and facts that should outlive this session — persist it to `~/.talon/workspace/memory/memory.md` (when a filesystem-capable tool is available for this backend; otherwise hold it in working memory for the conversation and don't pretend to save). The test is simple: would future-you be glad this was written down? Update memory quietly as conversations happen — no announcements — and keep the file organized, current, and free of trivia.

--- a/prompts/native.md
+++ b/prompts/native.md
@@ -4,23 +4,13 @@ You are running in the Talon companion app — a native client (Windows, macOS, 
 
 How replies are delivered (end_turn / send_message and what counts as a valid turn) is defined in the **Response flow** section at the end of these instructions — that contract wins over anything here.
 
-### Messaging tools
+### Tools
 
-- `end_turn(text="…")` — your final reply; this is the normal way to respond
-- `end_turn(text="…", buttons=[[{"text":"Open","url":"https://…"}]])` — reply with link buttons
-- `send_message(text="…")` — send an extra message mid-turn (before a later `end_turn`)
-- `react(message_id=…, emoji="👍")` — react to the user's message (a reaction can stand in for a short acknowledgement)
-- `edit_message(message_id=…, text="…")` / `delete_message(message_id=…)` — revise or remove a message you already sent
-
-### Other tools
-
-- `web_search(query)` — search the web
-- `fetch_url(url)` — fetch & parse a URL
-- `get_chat_info()` — info about the current chat
+Beyond the delivery tools the contract describes, you can react to the user's message, edit or delete messages you already sent, attach link buttons to replies, search the web, fetch URLs, and inspect the current chat. Tool descriptions carry the parameters; don't guess capabilities, check the list.
 
 ### Choosing not to respond
 
-You don't have to respond to every message. If nothing is needed, close the turn silently with `end_turn()`.
+You don't have to respond to every message. A reaction can stand in for a short acknowledgement; when nothing is needed, close the turn silently as the contract describes.
 
 ### Formatting
 
@@ -30,4 +20,4 @@ Style:
 
 - Concise. No filler.
 - Reach for code blocks for anything code-like; tables for structured data.
-- A single, well-formed `end_turn` is better than several fragmented sends.
+- One well-formed reply usually beats several fragments here — this client renders long-form Markdown well.

--- a/prompts/system/contract-tool-only.md
+++ b/prompts/system/contract-tool-only.md
@@ -4,7 +4,7 @@ Your output stream (prose like this) is **private scratchpad** — the user NEVE
 
 - `{{end_turn}}(text="...")` — deliver your final reply and close the turn. **This is how you answer.** Use it even for the simplest "hello" reply.
 - `{{end_turn}}()` (no args) — close the turn silently and deliberately.
-- `{{send}}(...)` — mid-turn / rich content (photos, files, polls, multi-message). Does NOT close the turn; follow with `{{end_turn}}`.{% if react %}
+- `{{send}}(...)` — mid-turn messages and rich content (photos, files, polls). Also how you pace a longer reply as separate messages when that reads naturally. Does NOT close the turn; follow with `{{end_turn}}`.{% if react %}
 - `{{react}}(message_id, emoji)` — emoji reaction; often the right way to acknowledge without replying. Pair with `{{end_turn}}()` to close cleanly.{% endif %}
 
 **Every turn — including the very first turn of a session — must end with `{{end_turn}}`.** Prose written without a delivery tool is dropped, and the system re-prompts you with a [FLOW VIOLATION] reminder, burning 2x tokens. Write your reply directly inside `{{end_turn}}(text=...)` the first time.

--- a/prompts/teams.md
+++ b/prompts/teams.md
@@ -5,20 +5,13 @@ Messages arrive as `[SenderName]: message text`. Use names naturally.
 
 How replies are delivered (end_turn / send_message and what counts as a valid turn) is defined in the **Response flow** section at the end of these instructions — that contract wins over anything here.
 
-### Messaging tools
+### Tools
 
-- `send_message(text="Hello!")` — send a message mid-turn
-- `send_message_with_buttons(text="Pick", rows=[[{"text":"Docs","url":"https://..."}]])` — with link buttons
-
-### Other tools
-
-- `web_search(query)` — search the web
-- `fetch_url(url)` — fetch & parse a URL
-- `get_chat_info()` — info about the current chat
+Beyond the delivery tools the contract describes, you can attach link buttons to messages, search the web, fetch URLs, and inspect the current chat. Tool descriptions carry the parameters; don't guess capabilities, check the list.
 
 ### Choosing not to respond
 
-You don't have to respond to every message. If a message doesn't need a response, close the turn silently with `end_turn()`.
+You don't have to respond to every message. If a message doesn't need a response, close the turn silently as the contract describes.
 
 ### Limitations
 

--- a/prompts/telegram.md
+++ b/prompts/telegram.md
@@ -6,38 +6,31 @@ How replies are delivered (end_turn / send / react and what counts as a valid tu
 
 ### Tools
 
-Your registered tool list covers the full Telegram surface — rich sends (photos, files, polls, voice, stickers, scheduled messages), reactions, message management (edit/delete/pin/forward), chat history and search, media download, member info. Tool descriptions carry the parameters and examples; don't guess capabilities, check the list.
+Your registered tool list covers the full Telegram surface — rich sends (photos, files, polls, voice, stickers, GIFs, scheduled messages), reactions, message management (edit/delete/pin/forward), chat history and search, media download, member info. Tool descriptions carry the parameters and examples; don't guess capabilities, check the list.
 
 ### Message IDs
 
-The user's message ID is in the prompt as [msg_id:N]. Use with `reply_to` and `react`.
+The user's message ID is in the prompt as [msg_id:N]. Use it with `reply_to` and `react`.
 
 ### Choosing not to respond
 
-You don't HAVE to respond to every message. To acknowledge without replying, `react` with an emoji — in groups this is PREFERRED over replies for simple acknowledgements. Use reactions naturally: 👍 ❤️ 🔥 😂 🎉 👀 💯. React AND reply when both feel right.
+You don't HAVE to respond to every message. A reaction is often the best acknowledgement — in groups it usually beats a reply that adds nothing. Pick whatever emoji fits the moment (Telegram accepts a limited reaction set; the common ones all work — the `react` tool lists them). React AND reply when both feel right; stay silent when neither is needed.
 
-### Buttons
+### Messages
 
-When a user presses a callback button, you'll receive "[Button pressed]" with the callback_data.
-
-### File sending
-
-- Files users send you are saved to `~/.talon/workspace/uploads/`.
-- If you see a [photo] or [document] in chat history but don't have the file, use `download_media(message_id)`.
-- To send files: write the file, then use `send(type="file", file_path="...")`.
-- You CAN send files. NEVER say you can't.
-
-### Stickers
-
-Use stickers like a human would — they're part of Telegram culture:
-
-- When users send stickers, their set_name is captured. Use `save_sticker_pack` to save packs you like.
-- Once saved, read `~/.talon/workspace/stickers/<set_name>.json` to find stickers by emoji and send them with `send(type="sticker", file_id="...")`.
-- Send stickers to express emotions or reactions; `download_sticker` lets you see one before sending. Don't overuse them.
-- You can create and manage sticker packs with `create_sticker_set`, `add_sticker_to_set`, etc.
-
-### Style
-
-- Concise. No filler.
-- Markdown: **bold**, _italic_, `code`, `code blocks`, [links](url).
+- Concise. No filler. Markdown renders: **bold**, _italic_, `code`, code blocks, [links](url).
+- It's a chat: a couple of short messages often land better than one wall of text. Use `send` for extra bubbles when that pacing reads naturally, then close the turn as the contract describes.
 - In groups, use names naturally.
+
+### Files & media
+
+- Files users send you are saved to `~/.talon/workspace/uploads/`. If chat history shows a [photo] or [document] you don't have, `download_media(message_id)` fetches it.
+- You can send files and media three ways: a workspace file path, a public URL (Telegram fetches it directly — ideal for images and GIFs found online), or a Telegram file_id you've seen before. You CAN send files — never claim otherwise.
+
+### Stickers & GIFs
+
+Stickers and GIFs are part of how people talk on Telegram — use them like a local: to react, to joke, to add warmth, wherever a human would reach for one. Don't force them; the best moments are the ones a person would pick.
+
+- Sending a sticker is one call: the send tool accepts an emoji and picks a matching sticker from your saved packs. A specific pack or file_id works too.
+- Your sticker library lives in `~/.talon/workspace/stickers/` and is summarized in this prompt when you have packs. Packs from stickers users send are saved automatically; the sticker tools let you browse, save, and download packs (to actually see a sticker), or even create your own.
+- For a GIF, send its URL directly — find one on the web when the moment calls for it, or re-send one from the chat by file_id.

--- a/src/__tests__/sticker-library.test.ts
+++ b/src/__tests__/sticker-library.test.ts
@@ -115,6 +115,24 @@ describe("sticker-store", () => {
     expect(section).not.toContain("(bare,");
   });
 
+  it("lists the newest 12 packs and summarizes the overflow", async () => {
+    for (let i = 0; i < 14; i++) {
+      writePack(
+        `pack_${String(i).padStart(2, "0")}`,
+        [{ emoji: "😀", fileId: `F${i}` }],
+        `2026-01-${String(i + 1).padStart(2, "0")}`,
+      );
+    }
+    const { renderStickerLibraryPrompt } =
+      await import("../storage/sticker-store.js");
+    const section = renderStickerLibraryPrompt();
+    // Newest 12 listed; the 2 oldest summarized, not silently invisible.
+    expect(section).toContain("(pack_13,");
+    expect(section).toContain("(pack_02,");
+    expect(section).not.toContain("(pack_01,");
+    expect(section).toContain("plus 2 more saved packs");
+  });
+
   it("truncates the emoji inventory on whole-emoji boundaries", async () => {
     // 40 distinct surrogate-pair emoji (2 UTF-16 units each) = 80 units,
     // over the 60-unit budget. A naive slice(0, 60) would cut the 31st
@@ -215,6 +233,34 @@ describe("ensurePackSaved", () => {
 
     await ensurePackSaved(bot, "pepe");
     expect(bot.getStickerSet).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses concurrent saves of the same pack into one fetch", async () => {
+    // A user posting a burst of stickers from one unseen pack fires
+    // several ensurePackSaved calls before the first write lands.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const getStickerSet = vi.fn(async (name: string) => {
+      await gate;
+      return {
+        name,
+        title: `${name} title`,
+        stickers: [{ emoji: "🐸", file_id: "P1" }],
+      };
+    });
+    const bot = { api: { getStickerSet } };
+    const { ensurePackSaved } =
+      await import("../frontend/telegram/sticker-library.js");
+
+    const calls = Promise.all([
+      ensurePackSaved(bot, "pepe"),
+      ensurePackSaved(bot, "pepe"),
+      ensurePackSaved(bot, "pepe"),
+    ]);
+    release();
+    await calls;
+    expect(getStickerSet).toHaveBeenCalledTimes(1);
+    expect(existsSync(join(STICKERS_DIR, "pepe.json"))).toBe(true);
   });
 
   it("never throws when the fetch fails (fire-and-forget safe)", async () => {

--- a/src/__tests__/sticker-library.test.ts
+++ b/src/__tests__/sticker-library.test.ts
@@ -99,6 +99,32 @@ describe("sticker-store", () => {
     // Distinct inventory: 😀 deduped, 😭 present.
     expect(section).toContain("😀😭");
   });
+
+  it("truncates the emoji inventory on whole-emoji boundaries", async () => {
+    // 40 distinct surrogate-pair emoji (2 UTF-16 units each) = 80 units,
+    // over the 60-unit budget. A naive slice(0, 60) would cut the 31st
+    // emoji in half; whole-emoji truncation must never emit a lone
+    // surrogate.
+    const emojis = Array.from({ length: 40 }, (_, i) =>
+      String.fromCodePoint(0x1f600 + i),
+    );
+    writePack(
+      "big",
+      emojis.map((emoji, i) => ({ emoji, fileId: `F${i}` })),
+    );
+    const { renderStickerLibraryPrompt } =
+      await import("../storage/sticker-store.js");
+    const line = renderStickerLibraryPrompt()
+      .split("\n")
+      .find((l) => l.includes("(big,"))!;
+    expect(line).toContain("…");
+    // Well-formed: no unpaired surrogates anywhere in the line
+    // (encodeURIComponent throws URIError on a lone surrogate).
+    expect(() => encodeURIComponent(line)).not.toThrow();
+    // 30 whole emoji fit the 60-unit budget, then the ellipsis.
+    const inventory = line.slice(line.indexOf("): ") + 3);
+    expect([...inventory].length).toBe(31); // 30 emoji + "…"
+  });
 });
 
 describe("resolveStickerByEmoji", () => {

--- a/src/__tests__/sticker-library.test.ts
+++ b/src/__tests__/sticker-library.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Sticker library — the workspace pack store (storage/sticker-store)
+ * and the Telegram write/resolve side (frontend/telegram/sticker-library).
+ *
+ * The behaviours pinned here are what make stickers usable in practice:
+ * send-by-emoji resolution (including fetch-on-miss for a named pack),
+ * organic auto-save of packs users send from, and the prompt index that
+ * makes the library discoverable.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const TEST_ROOT = join(tmpdir(), `talon-sticker-test-${process.pid}`);
+const STICKERS_DIR = join(TEST_ROOT, ".talon", "workspace", "stickers");
+
+beforeEach(() => {
+  vi.resetModules();
+  if (existsSync(TEST_ROOT)) rmSync(TEST_ROOT, { recursive: true });
+  mkdirSync(STICKERS_DIR, { recursive: true });
+
+  vi.doMock("node:os", async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, unknown>;
+    return { ...actual, homedir: () => TEST_ROOT };
+  });
+  vi.doMock("../util/log.js", () => ({
+    log: vi.fn(),
+    logError: vi.fn(),
+    logWarn: vi.fn(),
+    logDebug: vi.fn(),
+  }));
+});
+
+afterEach(() => {
+  if (existsSync(TEST_ROOT)) rmSync(TEST_ROOT, { recursive: true });
+});
+
+function writePack(
+  name: string,
+  stickers: Array<{ emoji: string; fileId: string }>,
+  savedAt = "2026-01-01T00:00:00.000Z",
+): void {
+  writeFileSync(
+    join(STICKERS_DIR, `${name}.json`),
+    JSON.stringify({
+      name,
+      title: `${name} title`,
+      count: stickers.length,
+      stickers,
+      savedAt,
+    }),
+  );
+}
+
+/** Fake grammY bot slice serving one sticker set. */
+function fakeBot(
+  sets: Record<string, Array<{ emoji?: string; file_id: string }>>,
+) {
+  const getStickerSet = vi.fn(async (name: string) => {
+    const stickers = sets[name];
+    if (!stickers) throw new Error(`STICKERSET_INVALID: ${name}`);
+    return { name, title: `${name} title`, stickers };
+  });
+  return { api: { getStickerSet }, getStickerSet };
+}
+
+describe("sticker-store", () => {
+  it("lists saved packs newest first and skips malformed files", async () => {
+    writePack("old_pack", [{ emoji: "😀", fileId: "A" }], "2025-01-01");
+    writePack("new_pack", [{ emoji: "🔥", fileId: "B" }], "2026-06-01");
+    writeFileSync(join(STICKERS_DIR, "broken.json"), "{not json");
+
+    const { listSavedPacks } = await import("../storage/sticker-store.js");
+    const packs = listSavedPacks();
+    expect(packs.map((p) => p.name)).toEqual(["new_pack", "old_pack"]);
+  });
+
+  it("renders a prompt index with emoji inventory, empty when no packs", async () => {
+    const { renderStickerLibraryPrompt } = await import(
+      "../storage/sticker-store.js"
+    );
+    expect(renderStickerLibraryPrompt()).toBe("");
+
+    writePack("cats", [
+      { emoji: "😀", fileId: "A" },
+      { emoji: "😀", fileId: "B" },
+      { emoji: "😭", fileId: "C" },
+    ]);
+    const section = renderStickerLibraryPrompt();
+    expect(section).toContain("## Sticker library");
+    expect(section).toContain("cats title (cats, 3 stickers)");
+    // Distinct inventory: 😀 deduped, 😭 present.
+    expect(section).toContain("😀😭");
+  });
+});
+
+describe("resolveStickerByEmoji", () => {
+  it("resolves across all saved packs, normalizing variation selectors", async () => {
+    // Pack stores "❤" (no U+FE0F); the model sends "❤️" (with U+FE0F).
+    writePack("hearts", [{ emoji: "❤", fileId: "HEART_ID" }]);
+    const { resolveStickerByEmoji } = await import(
+      "../frontend/telegram/sticker-library.js"
+    );
+    const hit = await resolveStickerByEmoji(fakeBot({}), "❤️");
+    expect(hit).toEqual({ fileId: "HEART_ID", pack: "hearts" });
+  });
+
+  it("fetches and saves an unsaved pack when set_name is given", async () => {
+    const bot = fakeBot({
+      doge: [{ emoji: "🐶", file_id: "DOGE_ID" }],
+    });
+    const { resolveStickerByEmoji } = await import(
+      "../frontend/telegram/sticker-library.js"
+    );
+    const hit = await resolveStickerByEmoji(bot, "🐶", "doge");
+    expect(hit).toEqual({ fileId: "DOGE_ID", pack: "doge" });
+    // The fetched pack landed in the library for next time.
+    expect(existsSync(join(STICKERS_DIR, "doge.json"))).toBe(true);
+  });
+
+  it("returns null when nothing matches or the pack fetch fails", async () => {
+    writePack("cats", [{ emoji: "😀", fileId: "A" }]);
+    const { resolveStickerByEmoji } = await import(
+      "../frontend/telegram/sticker-library.js"
+    );
+    expect(await resolveStickerByEmoji(fakeBot({}), "🚀")).toBeNull();
+    expect(await resolveStickerByEmoji(fakeBot({}), "😀", "no_such")).toBeNull();
+  });
+});
+
+describe("ensurePackSaved", () => {
+  it("saves unseen packs and skips (no fetch) already-saved ones", async () => {
+    const bot = fakeBot({ pepe: [{ emoji: "🐸", file_id: "P1" }] });
+    const { ensurePackSaved } = await import(
+      "../frontend/telegram/sticker-library.js"
+    );
+
+    await ensurePackSaved(bot, "pepe");
+    const saved = JSON.parse(
+      readFileSync(join(STICKERS_DIR, "pepe.json"), "utf-8"),
+    );
+    expect(saved.stickers).toEqual([{ emoji: "🐸", fileId: "P1" }]);
+
+    await ensurePackSaved(bot, "pepe");
+    expect(bot.getStickerSet).toHaveBeenCalledTimes(1);
+  });
+
+  it("never throws when the fetch fails (fire-and-forget safe)", async () => {
+    const { ensurePackSaved } = await import(
+      "../frontend/telegram/sticker-library.js"
+    );
+    await expect(ensurePackSaved(fakeBot({}), "ghost")).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/sticker-library.test.ts
+++ b/src/__tests__/sticker-library.test.ts
@@ -84,9 +84,8 @@ describe("sticker-store", () => {
   });
 
   it("renders a prompt index with emoji inventory, empty when no packs", async () => {
-    const { renderStickerLibraryPrompt } = await import(
-      "../storage/sticker-store.js"
-    );
+    const { renderStickerLibraryPrompt } =
+      await import("../storage/sticker-store.js");
     expect(renderStickerLibraryPrompt()).toBe("");
 
     writePack("cats", [
@@ -106,9 +105,8 @@ describe("resolveStickerByEmoji", () => {
   it("resolves across all saved packs, normalizing variation selectors", async () => {
     // Pack stores "❤" (no U+FE0F); the model sends "❤️" (with U+FE0F).
     writePack("hearts", [{ emoji: "❤", fileId: "HEART_ID" }]);
-    const { resolveStickerByEmoji } = await import(
-      "../frontend/telegram/sticker-library.js"
-    );
+    const { resolveStickerByEmoji } =
+      await import("../frontend/telegram/sticker-library.js");
     const hit = await resolveStickerByEmoji(fakeBot({}), "❤️");
     expect(hit).toEqual({ fileId: "HEART_ID", pack: "hearts" });
   });
@@ -117,9 +115,8 @@ describe("resolveStickerByEmoji", () => {
     const bot = fakeBot({
       doge: [{ emoji: "🐶", file_id: "DOGE_ID" }],
     });
-    const { resolveStickerByEmoji } = await import(
-      "../frontend/telegram/sticker-library.js"
-    );
+    const { resolveStickerByEmoji } =
+      await import("../frontend/telegram/sticker-library.js");
     const hit = await resolveStickerByEmoji(bot, "🐶", "doge");
     expect(hit).toEqual({ fileId: "DOGE_ID", pack: "doge" });
     // The fetched pack landed in the library for next time.
@@ -128,20 +125,20 @@ describe("resolveStickerByEmoji", () => {
 
   it("returns null when nothing matches or the pack fetch fails", async () => {
     writePack("cats", [{ emoji: "😀", fileId: "A" }]);
-    const { resolveStickerByEmoji } = await import(
-      "../frontend/telegram/sticker-library.js"
-    );
+    const { resolveStickerByEmoji } =
+      await import("../frontend/telegram/sticker-library.js");
     expect(await resolveStickerByEmoji(fakeBot({}), "🚀")).toBeNull();
-    expect(await resolveStickerByEmoji(fakeBot({}), "😀", "no_such")).toBeNull();
+    expect(
+      await resolveStickerByEmoji(fakeBot({}), "😀", "no_such"),
+    ).toBeNull();
   });
 });
 
 describe("ensurePackSaved", () => {
   it("saves unseen packs and skips (no fetch) already-saved ones", async () => {
     const bot = fakeBot({ pepe: [{ emoji: "🐸", file_id: "P1" }] });
-    const { ensurePackSaved } = await import(
-      "../frontend/telegram/sticker-library.js"
-    );
+    const { ensurePackSaved } =
+      await import("../frontend/telegram/sticker-library.js");
 
     await ensurePackSaved(bot, "pepe");
     const saved = JSON.parse(
@@ -154,9 +151,10 @@ describe("ensurePackSaved", () => {
   });
 
   it("never throws when the fetch fails (fire-and-forget safe)", async () => {
-    const { ensurePackSaved } = await import(
-      "../frontend/telegram/sticker-library.js"
-    );
-    await expect(ensurePackSaved(fakeBot({}), "ghost")).resolves.toBeUndefined();
+    const { ensurePackSaved } =
+      await import("../frontend/telegram/sticker-library.js");
+    await expect(
+      ensurePackSaved(fakeBot({}), "ghost"),
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/__tests__/sticker-library.test.ts
+++ b/src/__tests__/sticker-library.test.ts
@@ -208,6 +208,38 @@ describe("resolveStickerByEmoji", () => {
     expect(existsSync(join(STICKERS_DIR, "doge.json"))).toBe(true);
   });
 
+  it("refreshes a stale named pack once when the emoji misses", async () => {
+    // Library has an old copy of the pack; upstream it gained a 🚀
+    // sticker. An explicit set_name miss must refetch and find it.
+    writePack("doge", [{ emoji: "🐶", fileId: "OLD" }]);
+    const bot = fakeBot({
+      doge: [
+        { emoji: "🐶", file_id: "OLD" },
+        { emoji: "🚀", file_id: "NEW" },
+      ],
+    });
+    const { resolveStickerByEmoji } =
+      await import("../frontend/telegram/sticker-library.js");
+    expect(await resolveStickerByEmoji(bot, "🚀", "doge")).toEqual({
+      fileId: "NEW",
+      pack: "doge",
+    });
+    expect(bot.getStickerSet).toHaveBeenCalledTimes(1);
+    // A genuine miss refreshes once and stays a miss (never retries
+    // within one resolution).
+    expect(await resolveStickerByEmoji(bot, "🍕", "doge")).toBeNull();
+    expect(bot.getStickerSet).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not refresh from the network on all-pack searches", async () => {
+    writePack("cats", [{ emoji: "😀", fileId: "A" }]);
+    const bot = fakeBot({});
+    const { resolveStickerByEmoji } =
+      await import("../frontend/telegram/sticker-library.js");
+    expect(await resolveStickerByEmoji(bot, "🚀")).toBeNull();
+    expect(bot.getStickerSet).not.toHaveBeenCalled();
+  });
+
   it("returns null when nothing matches or the pack fetch fails", async () => {
     writePack("cats", [{ emoji: "😀", fileId: "A" }]);
     const { resolveStickerByEmoji } =

--- a/src/__tests__/sticker-library.test.ts
+++ b/src/__tests__/sticker-library.test.ts
@@ -100,6 +100,21 @@ describe("sticker-store", () => {
     expect(section).toContain("😀😭");
   });
 
+  it("skips packs with no emoji metadata (not sendable by emoji)", async () => {
+    // Some packs carry no per-sticker emoji; a library line for them
+    // would dangle ("(2 stickers): ") and teach an unusable path.
+    writePack("bare", [
+      { emoji: "", fileId: "A" },
+      { emoji: "", fileId: "B" },
+    ]);
+    writePack("cats", [{ emoji: "😀", fileId: "C" }]);
+    const { renderStickerLibraryPrompt } =
+      await import("../storage/sticker-store.js");
+    const section = renderStickerLibraryPrompt();
+    expect(section).toContain("(cats,");
+    expect(section).not.toContain("(bare,");
+  });
+
   it("truncates the emoji inventory on whole-emoji boundaries", async () => {
     // 40 distinct surrogate-pair emoji (2 UTF-16 units each) = 80 units,
     // over the 60-unit budget. A naive slice(0, 60) would cut the 31st
@@ -135,6 +150,32 @@ describe("resolveStickerByEmoji", () => {
       await import("../frontend/telegram/sticker-library.js");
     const hit = await resolveStickerByEmoji(fakeBot({}), "❤️");
     expect(hit).toEqual({ fileId: "HEART_ID", pack: "hearts" });
+  });
+
+  it("normalizes skin-tone modifiers in both directions", async () => {
+    // Pack stores a toned thumbs-up; the model sends the base emoji —
+    // and vice versa. Both must land on the same sticker.
+    writePack("hands", [{ emoji: "👍🏽", fileId: "THUMB_ID" }]);
+    const { resolveStickerByEmoji } =
+      await import("../frontend/telegram/sticker-library.js");
+    expect(await resolveStickerByEmoji(fakeBot({}), "👍")).toEqual({
+      fileId: "THUMB_ID",
+      pack: "hands",
+    });
+    expect(await resolveStickerByEmoji(fakeBot({}), "👍🏻")).toEqual({
+      fileId: "THUMB_ID",
+      pack: "hands",
+    });
+  });
+
+  it("never matches a blank query against emoji-less stickers", async () => {
+    // Stickers without emoji metadata normalize to "" — a whitespace
+    // query must not resolve to one of them at random.
+    writePack("bare", [{ emoji: "", fileId: "A" }]);
+    const { resolveStickerByEmoji } =
+      await import("../frontend/telegram/sticker-library.js");
+    expect(await resolveStickerByEmoji(fakeBot({}), " ")).toBeNull();
+    expect(await resolveStickerByEmoji(fakeBot({}), "")).toBeNull();
   });
 
   it("fetches and saves an unsaved pack when set_name is given", async () => {

--- a/src/__tests__/workspace-migrate.test.ts
+++ b/src/__tests__/workspace-migrate.test.ts
@@ -316,6 +316,24 @@ describe("initWorkspace — upgrade-aware prompt seeding (.seeded.json)", () => 
     );
   });
 
+  it("promptSeedReport classifies tracking vs user-edited prompts", async () => {
+    const { initWorkspace, promptSeedReport } =
+      await import("../util/workspace.js");
+    initWorkspace(join(TEST_ROOT, "ws"));
+
+    // Fresh seed: everything tracks the package.
+    let report = promptSeedReport();
+    expect(report.tracking).toContain("base.md");
+    expect(report.edited).toEqual([]);
+
+    // Edit one file → it flips to user-edited; the rest keep tracking.
+    writeFileSync(join(talonPromptsDir(), "base.md"), "# my custom base\n");
+    report = promptSeedReport();
+    expect(report.edited).toEqual(["base.md"]);
+    expect(report.tracking).not.toContain("base.md");
+    expect(report.tracking.length).toBeGreaterThan(0);
+  });
+
   it("re-adopts a file that matches the current package despite a stale manifest entry", async () => {
     // A user edit that lands byte-identical to the current package copy
     // (e.g. hand-applying an upstream change) must not strand the file

--- a/src/__tests__/workspace-migrate.test.ts
+++ b/src/__tests__/workspace-migrate.test.ts
@@ -315,4 +315,25 @@ describe("initWorkspace — upgrade-aware prompt seeding (.seeded.json)", () => 
       "# edited\n",
     );
   });
+
+  it("re-adopts a file that matches the current package despite a stale manifest entry", async () => {
+    // A user edit that lands byte-identical to the current package copy
+    // (e.g. hand-applying an upstream change) must not strand the file
+    // as user-owned-forever: content matching the package re-adopts it.
+    const { initWorkspace } = await import("../util/workspace.js");
+    initWorkspace(join(TEST_ROOT, "ws"));
+    const pkgContent = readFileSync(
+      join(talonPromptsDir(), "base.md"),
+      "utf-8",
+    );
+    writeFileSync(
+      manifestPath(),
+      JSON.stringify({ "base.md": await sha256("some stale seeded hash") }),
+    );
+
+    initWorkspace(join(TEST_ROOT, "ws"));
+
+    const manifest = JSON.parse(readFileSync(manifestPath(), "utf-8"));
+    expect(manifest["base.md"]).toBe(await sha256(pkgContent));
+  });
 });

--- a/src/__tests__/workspace-migrate.test.ts
+++ b/src/__tests__/workspace-migrate.test.ts
@@ -238,3 +238,81 @@ describe("initWorkspace — identity and prompt seeding", () => {
     expect(content).toBe("# User customized version");
   });
 });
+
+describe("initWorkspace — upgrade-aware prompt seeding (.seeded.json)", () => {
+  const talonPromptsDir = () => join(NEW_ROOT, "prompts");
+  const manifestPath = () => join(talonPromptsDir(), ".seeded.json");
+  const sha256 = async (text: string) => {
+    const { createHash } = await import("node:crypto");
+    return createHash("sha256").update(text).digest("hex");
+  };
+
+  it("records seeded hashes in the manifest on first run", async () => {
+    const { initWorkspace } = await import("../util/workspace.js");
+    initWorkspace(join(TEST_ROOT, "ws"));
+
+    const manifest = JSON.parse(readFileSync(manifestPath(), "utf-8"));
+    const seeded = readFileSync(join(talonPromptsDir(), "base.md"), "utf-8");
+    expect(manifest["base.md"]).toBe(await sha256(seeded));
+  });
+
+  it("refreshes a pristine seeded copy when the package version changes", async () => {
+    // Simulate a pre-upgrade state: the on-disk file is an older package
+    // version and the manifest records exactly that content as seeded.
+    mkdirSync(talonPromptsDir(), { recursive: true });
+    const oldVersion = "# Old package version of base.md\n";
+    writeFileSync(join(talonPromptsDir(), "base.md"), oldVersion);
+    writeFileSync(
+      manifestPath(),
+      JSON.stringify({ "base.md": await sha256(oldVersion) }),
+    );
+
+    const { initWorkspace } = await import("../util/workspace.js");
+    initWorkspace(join(TEST_ROOT, "ws"));
+
+    const content = readFileSync(join(talonPromptsDir(), "base.md"), "utf-8");
+    expect(content).not.toBe(oldVersion);
+    expect(content).toContain("## Tools"); // current package content
+    const manifest = JSON.parse(readFileSync(manifestPath(), "utf-8"));
+    expect(manifest["base.md"]).toBe(await sha256(content));
+  });
+
+  it("never touches a user-edited copy, even across upgrades", async () => {
+    // Manifest says one thing was seeded; the on-disk file differs from
+    // it (user edit) AND from the current package → must stay put.
+    mkdirSync(talonPromptsDir(), { recursive: true });
+    const edited = "# My hand-tuned base prompt\n";
+    writeFileSync(join(talonPromptsDir(), "base.md"), edited);
+    writeFileSync(
+      manifestPath(),
+      JSON.stringify({ "base.md": await sha256("whatever was seeded") }),
+    );
+
+    const { initWorkspace } = await import("../util/workspace.js");
+    initWorkspace(join(TEST_ROOT, "ws"));
+
+    expect(readFileSync(join(talonPromptsDir(), "base.md"), "utf-8")).toBe(
+      edited,
+    );
+  });
+
+  it("adopts a pre-manifest file only when byte-identical to the package", async () => {
+    // First run seeds everything; drop the manifest to simulate a
+    // deployment that predates it, and edit one file.
+    const { initWorkspace } = await import("../util/workspace.js");
+    initWorkspace(join(TEST_ROOT, "ws"));
+    rmSync(manifestPath());
+    writeFileSync(join(talonPromptsDir(), "dream.md"), "# edited\n");
+
+    initWorkspace(join(TEST_ROOT, "ws"));
+
+    const manifest = JSON.parse(readFileSync(manifestPath(), "utf-8"));
+    // Pristine file (matches package) → adopted, tracks upgrades again.
+    expect(manifest["base.md"]).toBeDefined();
+    // Unknown-provenance file that differs → user-owned, not adopted.
+    expect(manifest["dream.md"]).toBeUndefined();
+    expect(readFileSync(join(talonPromptsDir(), "dream.md"), "utf-8")).toBe(
+      "# edited\n",
+    );
+  });
+});

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -353,6 +353,28 @@ export async function collectDoctorReport(opts: {
     }
   }
 
+  // Seeded prompt provenance — surfaces the upgrade-aware seeding
+  // state (.seeded.json): files still tracking the package refresh on
+  // upgrade; user-edited files are never touched again. Knowing which
+  // is which is the difference between "why didn't my prompt update?"
+  // and a one-line answer.
+  {
+    const { promptSeedReport } = await import("../util/workspace.js");
+    try {
+      const { tracking, edited } = promptSeedReport();
+      if (tracking.length + edited.length > 0) {
+        checks.push({
+          label: `Prompts: ${tracking.length} tracking package upgrades, ${edited.length} user-edited`,
+          status: "ok",
+          detail:
+            edited.length > 0 ? `edited: ${edited.join(", ")}` : undefined,
+        });
+      }
+    } catch {
+      /* diagnostics only — never block the report */
+    }
+  }
+
   const native = await checkNativeModules();
   checks.push(...(await checkBackend(opts.config)));
 

--- a/src/core/prompt/assemble.ts
+++ b/src/core/prompt/assemble.ts
@@ -60,6 +60,7 @@ import { loadSystemTemplate } from "./templates.js";
 import { renderWorkspaceListing } from "./workspace-listing.js";
 import { MAX_OPEN_GOALS_PER_CHAT } from "../../storage/goal-store.js";
 import { renderSkillsPrompt } from "../../storage/skill-store.js";
+import { renderStickerLibraryPrompt } from "../../storage/sticker-store.js";
 import { getSoul } from "../soul/service.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -243,6 +244,14 @@ export function assembleSystemPrompt(
   // discovery; full markdown bodies stay on disk until loaded.
   const skills = renderSkillsPrompt();
   if (skills) dynamicParts.push(skills);
+
+  // Dynamic 2.5: sticker library index (Telegram only — the one
+  // frontend with a sticker send surface). Dynamic because packs are
+  // auto-saved mid-session as users send stickers.
+  if ((inputs.frontend ?? "telegram") === "telegram") {
+    const stickerLibrary = renderStickerLibraryPrompt();
+    if (stickerLibrary) dynamicParts.push(stickerLibrary);
+  }
 
   // Dynamic 3: workspace file listing (sizes change as logs grow).
   const workspaceFiles = renderWorkspaceListing(dirs.workspace);

--- a/src/core/prompt/assemble.ts
+++ b/src/core/prompt/assemble.ts
@@ -246,9 +246,12 @@ export function assembleSystemPrompt(
   if (skills) dynamicParts.push(skills);
 
   // Dynamic 2.5: sticker library index (Telegram only — the one
-  // frontend with a sticker send surface). Dynamic because packs are
+  // frontend with a sticker send surface). Strict check on purpose:
+  // config always resolves a concrete frontend, so an absent value
+  // means a caller outside the normal chat path (no sticker tools) —
+  // don't inject the index there. Dynamic because packs are
   // auto-saved mid-session as users send stickers.
-  if ((inputs.frontend ?? "telegram") === "telegram") {
+  if (inputs.frontend === "telegram") {
     const stickerLibrary = renderStickerLibraryPrompt();
     if (stickerLibrary) dynamicParts.push(stickerLibrary);
   }

--- a/src/core/tools/messaging.ts
+++ b/src/core/tools/messaging.ts
@@ -336,12 +336,14 @@ Examples:
             correct_option_id: params.correct_option_id,
             explanation: params.explanation,
             type: params.correct_option_id !== undefined ? "quiz" : "regular",
+            reply_to: params.reply_to,
             chat_id,
           });
         case "location":
           return bridge("send_location", {
             latitude: params.latitude,
             longitude: params.longitude,
+            reply_to: params.reply_to,
             chat_id,
           });
         case "contact":
@@ -349,10 +351,15 @@ Examples:
             phone_number: params.phone_number,
             first_name: params.first_name,
             last_name: params.last_name,
+            reply_to: params.reply_to,
             chat_id,
           });
         case "dice":
-          return bridge("send_dice", { emoji: params.emoji, chat_id });
+          return bridge("send_dice", {
+            emoji: params.emoji,
+            reply_to: params.reply_to,
+            chat_id,
+          });
         default:
           return { ok: false, error: `Unknown type: ${type}` };
       }

--- a/src/core/tools/messaging.ts
+++ b/src/core/tools/messaging.ts
@@ -118,19 +118,23 @@ Notes:
   // ── Telegram unified send ─────────────────────────────────────────────
   {
     name: "send",
-    description: `Send content to the current Telegram chat. Supports text, photos, videos, files, audio, voice, stickers, polls, locations, contacts, dice, and GIFs.
+    description: `Send content to the current chat. Supports text, photos, videos, files, audio, voice, stickers, polls, locations, contacts, dice, and GIFs.
+
+Media (photo/video/animation/file/audio/voice) can come from a workspace file_path, a public URL (fetched by the platform — ideal for images/GIFs found online), or a file_id seen earlier in chat.
 
 Examples:
   Text: send(type="text", text="Hello!")
   Reply: send(type="text", text="Yes!", reply_to=12345)
   With buttons: send(type="text", text="Pick one", buttons=[[{"text":"A","callback_data":"a"}]])
   Photo: send(type="photo", file_path="/path/to/img.jpg", caption="Look!")
+  GIF: send(type="animation", url="https://example.com/funny.gif")
   File: send(type="file", file_path="/path/to/report.pdf")
   Audio: send(type="audio", file_path="/path/to/song.mp3", title="Song Name", performer="Artist")
   Poll: send(type="poll", question="Best language?", options=["Rust","Go","TS"])
   Dice: send(type="dice")
   Location: send(type="location", latitude=37.7749, longitude=-122.4194)
-  Sticker: send(type="sticker", file_id="CAACAgI...")`,
+  Sticker by feeling: send(type="sticker", emoji="😂") — picks a matching sticker from your saved packs (add set_name to pin one pack)
+  Sticker by id: send(type="sticker", file_id="CAACAgI...")`,
     schema: {
       type: z
         .enum([
@@ -159,7 +163,24 @@ Examples:
         .string()
         .optional()
         .describe("Workspace file path (for photo/file/video/voice/animation)"),
-      file_id: z.string().optional().describe("Telegram file_id (for sticker)"),
+      url: z
+        .string()
+        .optional()
+        .describe(
+          "Public URL of media to send (photo/video/animation/file/audio/voice) — fetched by the platform, no download needed. Great for GIFs.",
+        ),
+      file_id: z
+        .string()
+        .optional()
+        .describe(
+          "Platform file_id to send media already seen in chat (stickers, GIFs, photos, ...)",
+        ),
+      set_name: z
+        .string()
+        .optional()
+        .describe(
+          "Sticker pack to pick from when sending a sticker by emoji (default: all saved packs)",
+        ),
       caption: z.string().optional().describe("Caption for media"),
       buttons: z
         .array(
@@ -191,7 +212,12 @@ Examples:
         .string()
         .optional()
         .describe("Audio performer/artist (for type=audio)"),
-      emoji: z.string().optional().describe("Dice emoji (🎲🎯🏀⚽🎳🎰)"),
+      emoji: z
+        .string()
+        .optional()
+        .describe(
+          "For type=sticker: pick a saved sticker matching this emoji. For type=dice: the dice style (🎲🎯🏀⚽🎳🎰).",
+        ),
       delay_seconds: z
         .number()
         .optional()
@@ -240,6 +266,8 @@ Examples:
         case "photo":
           return bridge("send_photo", {
             file_path: params.file_path,
+            url: params.url,
+            file_id: params.file_id,
             caption: params.caption,
             reply_to: params.reply_to,
             chat_id,
@@ -247,6 +275,8 @@ Examples:
         case "file":
           return bridge("send_file", {
             file_path: params.file_path,
+            url: params.url,
+            file_id: params.file_id,
             caption: params.caption,
             reply_to: params.reply_to,
             chat_id,
@@ -254,6 +284,8 @@ Examples:
         case "video":
           return bridge("send_video", {
             file_path: params.file_path,
+            url: params.url,
+            file_id: params.file_id,
             caption: params.caption,
             reply_to: params.reply_to,
             chat_id,
@@ -261,6 +293,8 @@ Examples:
         case "voice":
           return bridge("send_voice", {
             file_path: params.file_path,
+            url: params.url,
+            file_id: params.file_id,
             caption: params.caption,
             reply_to: params.reply_to,
             chat_id,
@@ -268,6 +302,8 @@ Examples:
         case "audio":
           return bridge("send_audio", {
             file_path: params.file_path,
+            url: params.url,
+            file_id: params.file_id,
             caption: params.caption,
             title: params.title,
             performer: params.performer,
@@ -277,6 +313,8 @@ Examples:
         case "animation":
           return bridge("send_animation", {
             file_path: params.file_path,
+            url: params.url,
+            file_id: params.file_id,
             caption: params.caption,
             reply_to: params.reply_to,
             chat_id,
@@ -284,6 +322,8 @@ Examples:
         case "sticker":
           return bridge("send_sticker", {
             file_id: params.file_id,
+            emoji: params.emoji,
+            set_name: params.set_name,
             reply_to: params.reply_to,
             chat_id,
           });

--- a/src/core/tools/messaging.ts
+++ b/src/core/tools/messaging.ts
@@ -167,7 +167,7 @@ Examples:
         .string()
         .optional()
         .describe(
-          "Public URL of media to send (photo/video/animation/file/audio/voice) — fetched by the platform, no download needed. Great for GIFs.",
+          "Public URL of media to send (photo/video/animation/file/audio/voice; .webp for sticker) — fetched by the platform, no download needed. Great for GIFs.",
         ),
       file_id: z
         .string()
@@ -322,6 +322,7 @@ Examples:
         case "sticker":
           return bridge("send_sticker", {
             file_id: params.file_id,
+            url: params.url,
             emoji: params.emoji,
             set_name: params.set_name,
             reply_to: params.reply_to,

--- a/src/core/tools/stickers.ts
+++ b/src/core/tools/stickers.ts
@@ -40,7 +40,7 @@ export const stickerTools: ToolDefinition[] = [
   {
     name: "save_sticker_pack",
     description:
-      "Save a sticker pack's file_ids to workspace for quick reuse. Once saved, you can read the JSON file to find stickers by emoji and send them instantly.",
+      'Add a sticker pack to your library (workspace/stickers/). Saved packs appear in your prompt\'s sticker-library index and are sendable by emoji via send(type="sticker", emoji=...). Packs from stickers users send are saved automatically; use this for any other pack you know by name (also refreshes an already-saved pack).',
     schema: {
       set_name: z.string().describe("Sticker set name"),
     },

--- a/src/frontend/discord/actions/media.ts
+++ b/src/frontend/discord/actions/media.ts
@@ -25,6 +25,14 @@ const sendAttachment: DiscordActionHandlers[string] = (
   if (body.url) {
     // Public URL — Discord fetches it when attaching; no local bytes.
     file = String(body.url);
+  } else if (body.file_id && !body.file_path) {
+    // The shared `send` tool advertises file_id for Telegram; Discord has
+    // no equivalent. Fail with guidance instead of a stat("") ENOENT.
+    return {
+      ok: false,
+      error:
+        "Discord has no file_id concept — re-send media by its CDN url or a workspace file_path.",
+    };
   } else {
     const filePath = expandFsPath(String(body.file_path ?? ""));
     const stat = statSync(filePath);

--- a/src/frontend/discord/actions/media.ts
+++ b/src/frontend/discord/actions/media.ts
@@ -3,7 +3,7 @@
  * stickers, polls, locations, contacts, dice.
  */
 
-import { readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { basename } from "node:path";
 import { expandFsPath } from "../../../util/fs-path.js";
 import { AttachmentBuilder } from "discord.js";
@@ -34,7 +34,17 @@ const sendAttachment: DiscordActionHandlers[string] = (
         "Discord has no file_id concept — re-send media by its CDN url or a workspace file_path.",
     };
   } else {
-    const filePath = expandFsPath(String(body.file_path ?? ""));
+    if (!body.file_path)
+      return {
+        ok: false,
+        error: `${action}: provide file_path (workspace file) or url (public)`,
+      };
+    const filePath = expandFsPath(String(body.file_path));
+    if (!existsSync(filePath))
+      return {
+        ok: false,
+        error: `File not found: ${filePath} — check the workspace path, or send by url instead`,
+      };
     const stat = statSync(filePath);
     // Per-guild attachment cap based on boost tier. DMs use Tier-0 (10 MB).
     const guild = (channel as { guild?: import("discord.js").Guild })?.guild;
@@ -83,7 +93,12 @@ export const mediaHandlers: DiscordActionHandlers = {
 
   send_sticker: (body, chatId, { channel, gateway }) => {
     const stickerId = String(body.file_id ?? body.sticker_id ?? "");
-    if (!stickerId) return { ok: false, error: "Required: file_id" };
+    if (!stickerId)
+      return {
+        ok: false,
+        error:
+          "Required: file_id (a Discord sticker id) — sending stickers by emoji from saved packs is Telegram-only.",
+      };
     if (!channel!.isSendable())
       return { ok: false, error: "Channel not sendable" };
     return tryAction("send_sticker", async () => {

--- a/src/frontend/discord/actions/media.ts
+++ b/src/frontend/discord/actions/media.ts
@@ -20,22 +20,28 @@ const sendAttachment: DiscordActionHandlers[string] = (
   { channel, gateway },
 ) => {
   const action = String(body.action);
-  const filePath = expandFsPath(String(body.file_path ?? ""));
   const caption = body.caption ? String(body.caption) : "";
-  const stat = statSync(filePath);
-  // Per-guild attachment cap based on boost tier. DMs use Tier-0 (10 MB).
-  const guild = (channel as { guild?: import("discord.js").Guild })?.guild;
-  const maxBytes = maxAttachmentBytes(guild);
-  if (stat.size > maxBytes) {
-    const mb = (n: number) => Math.round(n / 1024 / 1024);
-    const tierNote = guild ? `boost tier ${guild.premiumTier ?? 0}` : "DM";
-    return {
-      ok: false,
-      error: `File too large (${mb(stat.size)}MB) — this ${tierNote} accepts max ${mb(maxBytes)}MB`,
-    };
+  let file: string | AttachmentBuilder;
+  if (body.url) {
+    // Public URL — Discord fetches it when attaching; no local bytes.
+    file = String(body.url);
+  } else {
+    const filePath = expandFsPath(String(body.file_path ?? ""));
+    const stat = statSync(filePath);
+    // Per-guild attachment cap based on boost tier. DMs use Tier-0 (10 MB).
+    const guild = (channel as { guild?: import("discord.js").Guild })?.guild;
+    const maxBytes = maxAttachmentBytes(guild);
+    if (stat.size > maxBytes) {
+      const mb = (n: number) => Math.round(n / 1024 / 1024);
+      const tierNote = guild ? `boost tier ${guild.premiumTier ?? 0}` : "DM";
+      return {
+        ok: false,
+        error: `File too large (${mb(stat.size)}MB) — this ${tierNote} accepts max ${mb(maxBytes)}MB`,
+      };
+    }
+    const data = readFileSync(filePath);
+    file = new AttachmentBuilder(data, { name: basename(filePath) });
   }
-  const data = readFileSync(filePath);
-  const file = new AttachmentBuilder(data, { name: basename(filePath) });
 
   gateway.incrementMessages(chatId);
   if (!channel!.isSendable())

--- a/src/frontend/discord/actions/media.ts
+++ b/src/frontend/discord/actions/media.ts
@@ -101,11 +101,16 @@ export const mediaHandlers: DiscordActionHandlers = {
       };
     if (!channel!.isSendable())
       return { ok: false, error: "Channel not sendable" };
+    const replyTo =
+      typeof body.reply_to === "string" ? body.reply_to : undefined;
     return tryAction("send_sticker", async () => {
       gateway.incrementMessages(chatId);
-      const sent = (await channel!.send({ stickers: [stickerId] })) as {
-        id: string;
-      };
+      const sent = (await channel!.send({
+        stickers: [stickerId],
+        reply: replyTo
+          ? { messageReference: replyTo, failIfNotExists: false }
+          : undefined,
+      })) as { id: string };
       return { ok: true, message_id: sent.id };
     });
   },
@@ -118,6 +123,8 @@ export const mediaHandlers: DiscordActionHandlers = {
     gateway.incrementMessages(chatId);
     if (!channel!.isSendable())
       return { ok: false, error: "Channel not sendable" };
+    const replyTo =
+      typeof body.reply_to === "string" ? body.reply_to : undefined;
     return tryAction("send_poll", async () => {
       const sent = (await channel!.send({
         poll: {
@@ -127,6 +134,9 @@ export const mediaHandlers: DiscordActionHandlers = {
           duration: 24,
         },
         allowedMentions: { parse: [] },
+        reply: replyTo
+          ? { messageReference: replyTo, failIfNotExists: false }
+          : undefined,
       })) as { id: string };
       return { ok: true, message_id: sent.id };
     });
@@ -137,9 +147,11 @@ export const mediaHandlers: DiscordActionHandlers = {
     const lng = Number(body.longitude);
     gateway.incrementMessages(chatId);
     const url = `https://maps.google.com/?q=${lat},${lng}`;
+    const replyTo =
+      typeof body.reply_to === "string" ? body.reply_to : undefined;
     return tryAction("send_location", async () => {
       const ids = await withRetry(() =>
-        sendChunked(channel!, `📍 Location: ${lat}, ${lng}\n${url}`),
+        sendChunked(channel!, `📍 Location: ${lat}, ${lng}\n${url}`, replyTo),
       );
       return { ok: true, message_id: ids[0] };
     });
@@ -152,9 +164,11 @@ export const mediaHandlers: DiscordActionHandlers = {
       .join(" ");
     const phone = String(body.phone_number ?? "");
     gateway.incrementMessages(chatId);
+    const replyTo =
+      typeof body.reply_to === "string" ? body.reply_to : undefined;
     return tryAction("send_contact", async () => {
       const ids = await withRetry(() =>
-        sendChunked(channel!, `📇 Contact: ${name}\n${phone}`),
+        sendChunked(channel!, `📇 Contact: ${name}\n${phone}`, replyTo),
       );
       return { ok: true, message_id: ids[0] };
     });
@@ -164,9 +178,11 @@ export const mediaHandlers: DiscordActionHandlers = {
     const emoji = String(body.emoji ?? "🎲");
     const value = Math.floor(Math.random() * 6) + 1;
     gateway.incrementMessages(chatId);
+    const replyTo =
+      typeof body.reply_to === "string" ? body.reply_to : undefined;
     return tryAction("send_dice", async () => {
       const ids = await withRetry(() =>
-        sendChunked(channel!, `${emoji} You rolled: **${value}**`),
+        sendChunked(channel!, `${emoji} You rolled: **${value}**`, replyTo),
       );
       return { ok: true, message_id: ids[0], value };
     });

--- a/src/frontend/telegram/actions/chat-info.ts
+++ b/src/frontend/telegram/actions/chat-info.ts
@@ -20,8 +20,8 @@ import {
   getMessage as userbotGetMessage,
   getPinnedMessages as userbotPinnedMessages,
   getOnlineCount as userbotOnlineCount,
-  saveStickerPack as userbotSaveStickerPack,
 } from "../userbot.js";
+import { savePackToLibrary } from "../sticker-library.js";
 import { toPositiveId } from "./shared.js";
 import type { TelegramActionHandlers } from "./types.js";
 
@@ -177,13 +177,15 @@ export const chatInfoHandlers: TelegramActionHandlers = {
   },
 
   save_sticker_pack: async (body, _chatId, { bot }) => {
-    if (!isUserClientReady())
-      return { ok: false, error: "User client not connected." };
-    const text = await userbotSaveStickerPack({
-      setName: String(body.set_name ?? ""),
-      bot,
-    });
-    return { ok: true, text };
+    try {
+      const text = await savePackToLibrary(bot, String(body.set_name ?? ""));
+      return { ok: true, text };
+    } catch (err) {
+      return {
+        ok: false,
+        error: `Failed to save sticker pack: ${err instanceof Error ? err.message : err}`,
+      };
+    }
   },
 
   get_sticker_pack: async (body, _chatId, { bot }) => {

--- a/src/frontend/telegram/actions/media.ts
+++ b/src/frontend/telegram/actions/media.ts
@@ -8,6 +8,7 @@ import { basename } from "node:path";
 import { expandFsPath } from "../../../util/fs-path.js";
 import { markdownToTelegramHtml } from "../formatting.js";
 import { withRetry } from "../../../core/engine/gateway.js";
+import { resolveStickerByEmoji } from "../sticker-library.js";
 import { replyParams } from "./shared.js";
 import type { TelegramActionHandlers } from "./types.js";
 
@@ -19,19 +20,27 @@ const sendMediaFile: TelegramActionHandlers[string] = async (
   // Routed for send_file / send_photo / send_video / send_animation /
   // send_voice / send_audio — branch on the action name in the body.
   const action = String(body.action);
-  const filePath = expandFsPath(String(body.file_path ?? ""));
   const caption = body.caption
     ? markdownToTelegramHtml(String(body.caption))
     : undefined;
   const captionParseMode = caption ? ("HTML" as const) : undefined;
   gateway.incrementMessages(chatId);
-  {
+  // Three media sources, in priority order: a public URL or a Telegram
+  // file_id (both passed to the Bot API as a plain string — Telegram
+  // fetches/reuses server-side, no local bytes involved), else a
+  // workspace file path uploaded as multipart.
+  const remote = body.url ?? body.file_id;
+  let file: string | import("grammy").InputFile;
+  if (remote) {
+    file = String(remote);
+  } else {
+    const filePath = expandFsPath(String(body.file_path ?? ""));
     const stat = statSync(filePath);
     if (stat.size > 49 * 1024 * 1024)
       return { ok: false, error: "File too large (max 49MB)" };
+    const data = readFileSync(filePath);
+    file = new InputFileClass(data, basename(filePath));
   }
-  const data = readFileSync(filePath);
-  const file = new InputFileClass(data, basename(filePath));
   const rp = replyParams(body);
   let sent;
   switch (action) {
@@ -104,8 +113,27 @@ export const mediaHandlers: TelegramActionHandlers = {
   send_audio: sendMediaFile,
 
   send_sticker: async (body, chatId, { bot, gateway }) => {
+    // Two addressing modes: a concrete file_id, or an emoji resolved
+    // against the saved sticker library (optionally pinned to one pack
+    // via set_name) — the low-friction path the prompt teaches.
+    let fileId = body.file_id ? String(body.file_id) : "";
+    if (!fileId && body.emoji) {
+      const resolved = await resolveStickerByEmoji(
+        bot,
+        String(body.emoji),
+        body.set_name ? String(body.set_name) : undefined,
+      );
+      if (!resolved) {
+        return {
+          ok: false,
+          error: `No saved sticker matches ${String(body.emoji)}${body.set_name ? ` in pack "${String(body.set_name)}"` : ""} — check the sticker library, or save a pack with save_sticker_pack.`,
+        };
+      }
+      fileId = resolved.fileId;
+    }
+    if (!fileId) return { ok: false, error: "Required: file_id or emoji" };
     gateway.incrementMessages(chatId);
-    const sent = await bot.api.sendSticker(chatId, String(body.file_id ?? ""), {
+    const sent = await bot.api.sendSticker(chatId, fileId, {
       reply_parameters: replyParams(body),
     });
     return { ok: true, message_id: sent.message_id };

--- a/src/frontend/telegram/actions/media.ts
+++ b/src/frontend/telegram/actions/media.ts
@@ -113,10 +113,16 @@ export const mediaHandlers: TelegramActionHandlers = {
   send_audio: sendMediaFile,
 
   send_sticker: async (body, chatId, { bot, gateway }) => {
-    // Two addressing modes: a concrete file_id, or an emoji resolved
-    // against the saved sticker library (optionally pinned to one pack
-    // via set_name) — the low-friction path the prompt teaches.
-    let fileId = body.file_id ? String(body.file_id) : "";
+    // Three addressing modes: a concrete file_id, a public URL of a
+    // .webp (Telegram fetches it server-side, like other media), or an
+    // emoji resolved against the saved sticker library (optionally
+    // pinned to one pack via set_name) — the low-friction path the
+    // prompt teaches.
+    let fileId = body.file_id
+      ? String(body.file_id)
+      : body.url
+        ? String(body.url)
+        : "";
     if (!fileId && body.emoji) {
       const resolved = await resolveStickerByEmoji(
         bot,
@@ -131,7 +137,8 @@ export const mediaHandlers: TelegramActionHandlers = {
       }
       fileId = resolved.fileId;
     }
-    if (!fileId) return { ok: false, error: "Required: file_id or emoji" };
+    if (!fileId)
+      return { ok: false, error: "Required: file_id, url, or emoji" };
     gateway.incrementMessages(chatId);
     const sent = await bot.api.sendSticker(chatId, fileId, {
       reply_parameters: replyParams(body),

--- a/src/frontend/telegram/actions/media.ts
+++ b/src/frontend/telegram/actions/media.ts
@@ -3,7 +3,7 @@
  * stickers, polls, locations, contacts, and dice.
  */
 
-import { readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { basename } from "node:path";
 import { expandFsPath } from "../../../util/fs-path.js";
 import { markdownToTelegramHtml } from "../formatting.js";
@@ -34,7 +34,20 @@ const sendMediaFile: TelegramActionHandlers[string] = async (
   if (remote) {
     file = String(remote);
   } else {
-    const filePath = expandFsPath(String(body.file_path ?? ""));
+    // Fail with guidance the model can act on, not a raw ENOENT: a
+    // mistyped path is the most common media-send error, and naming
+    // the alternatives (url / file_id) teaches the recovery path.
+    if (!body.file_path)
+      return {
+        ok: false,
+        error: `${action}: provide file_path (workspace file), url (public), or file_id (seen in chat)`,
+      };
+    const filePath = expandFsPath(String(body.file_path));
+    if (!existsSync(filePath))
+      return {
+        ok: false,
+        error: `File not found: ${filePath} — check the workspace path, or send by url/file_id instead`,
+      };
     const stat = statSync(filePath);
     if (stat.size > 49 * 1024 * 1024)
       return { ok: false, error: "File too large (max 49MB)" };

--- a/src/frontend/telegram/actions/media.ts
+++ b/src/frontend/telegram/actions/media.ts
@@ -175,6 +175,7 @@ export const mediaHandlers: TelegramActionHandlers = {
             ? [body.correct_option_id as number]
             : undefined,
         explanation: body.explanation as string | undefined,
+        reply_parameters: replyParams(body),
       },
     );
     return { ok: true, message_id: sent.message_id };
@@ -186,6 +187,7 @@ export const mediaHandlers: TelegramActionHandlers = {
       chatId,
       Number(body.latitude),
       Number(body.longitude),
+      { reply_parameters: replyParams(body) },
     );
     return { ok: true, message_id: sent.message_id };
   },
@@ -196,14 +198,23 @@ export const mediaHandlers: TelegramActionHandlers = {
       chatId,
       String(body.phone_number),
       String(body.first_name),
-      { last_name: body.last_name as string | undefined },
+      {
+        last_name: body.last_name as string | undefined,
+        reply_parameters: replyParams(body),
+      },
     );
     return { ok: true, message_id: sent.message_id };
   },
 
   send_dice: async (body, chatId, { bot, gateway }) => {
     gateway.incrementMessages(chatId);
-    const sent = await bot.api.sendDice(chatId, (body.emoji as string) || "🎲");
+    const sent = await bot.api.sendDice(
+      chatId,
+      (body.emoji as string) || "🎲",
+      {
+        reply_parameters: replyParams(body),
+      },
+    );
     return {
       ok: true,
       message_id: sent.message_id,

--- a/src/frontend/telegram/handlers/messages.ts
+++ b/src/frontend/telegram/handlers/messages.ts
@@ -23,6 +23,7 @@ import {
 } from "./context.js";
 import { shouldHandleInGroup, isAccessAllowed } from "./access.js";
 import { enqueueMessage, isUserRateLimited } from "./queue.js";
+import { ensurePackSaved } from "../sticker-library.js";
 import { processAndReply, sendHtml } from "./delivery.js";
 
 // ── Shared media handler ──────────────────────────────────────────────────────
@@ -292,16 +293,21 @@ export async function handleStickerMessage(
   const emoji = sticker.emoji || "";
   const setName = sticker.set_name || "";
 
+  // Grow the sticker library organically: any pack a user sends from
+  // gets saved in the background (skipped if already saved), so the
+  // model can later send from it by emoji without any browsing.
+  if (setName) void ensurePackSaved(bot, setName);
+
   const prompt = [
     `User sent a sticker: ${emoji}`,
     `Sticker file_id: ${sticker.file_id}`,
-    setName ? `Sticker set: ${setName}` : "",
+    setName ? `Sticker set: ${setName} (saved to your sticker library)` : "",
     sticker.is_animated
       ? "(animated)"
       : sticker.is_video
         ? "(video sticker)"
         : "",
-    "You can send this sticker back using the send_sticker tool with the file_id above.",
+    'You can send it back via send(type="sticker", file_id=...) — or send any sticker from your library by emoji.',
   ]
     .filter(Boolean)
     .join("\n");
@@ -365,6 +371,7 @@ export async function handleAnimationMessage(
     promptLines: [
       `User sent a GIF/animation: "${fileName}" (${anim.duration}s).`,
       "Saved to: ${savedPath}",
+      `file_id: ${anim.file_id} — re-send it anytime with send(type="animation", file_id=...).`,
     ],
     caption,
   });

--- a/src/frontend/telegram/sticker-library.ts
+++ b/src/frontend/telegram/sticker-library.ts
@@ -71,10 +71,15 @@ export async function savePackToLibrary(
   return `Saved "${stickerSet.title}" (${stickers.length} stickers) to .talon/workspace/stickers/${stickerSet.name}.json`;
 }
 
+/** Packs currently being auto-fetched — dedupes concurrent saves. */
+const inFlightSaves = new Set<string>();
+
 /**
  * Save a pack only if it isn't in the library yet. Fire-and-forget
  * safe: failures are logged, never thrown. Used by the incoming
  * sticker handler so the library grows organically from conversation.
+ * Concurrent calls for the same pack (a user posting several stickers
+ * in a burst) collapse into one fetch.
  */
 export async function ensurePackSaved(
   bot: StickerSetFetcher,
@@ -82,6 +87,8 @@ export async function ensurePackSaved(
 ): Promise<void> {
   if (!setName) return;
   if (existsSync(resolve(dirs.stickers, `${setName}.json`))) return;
+  if (inFlightSaves.has(setName)) return;
+  inFlightSaves.add(setName);
   try {
     const summary = await savePackToLibrary(bot, setName);
     log("stickers", `Auto-saved pack: ${summary}`);
@@ -90,6 +97,8 @@ export async function ensurePackSaved(
       "stickers",
       `Auto-save of pack "${setName}" failed: ${err instanceof Error ? err.message : err}`,
     );
+  } finally {
+    inFlightSaves.delete(setName);
   }
 }
 

--- a/src/frontend/telegram/sticker-library.ts
+++ b/src/frontend/telegram/sticker-library.ts
@@ -96,11 +96,15 @@ export async function ensurePackSaved(
 // ── Emoji resolution ────────────────────────────────────────────────────────
 
 /**
- * Normalize an emoji for matching: trim and strip variation selectors
- * (U+FE00–U+FE0F) so "❤️" (with U+FE0F) matches a pack's "❤".
+ * Normalize an emoji for matching: trim, strip variation selectors
+ * (U+FE00–U+FE0F) so "❤️" (with U+FE0F) matches a pack's "❤", and strip
+ * skin-tone modifiers (U+1F3FB–U+1F3FF) so "👍🏻" matches a pack's "👍".
  */
 function normalizeEmoji(emoji: string): string {
-  return emoji.trim().replace(/[\uFE00-\uFE0F]/g, "");
+  return emoji
+    .trim()
+    .replace(/[\uFE00-\uFE0F]/g, "")
+    .replace(/[\u{1F3FB}-\u{1F3FF}]/gu, "");
 }
 
 /**
@@ -117,6 +121,10 @@ export async function resolveStickerByEmoji(
   emoji: string,
   setName?: string,
 ): Promise<{ fileId: string; pack: string } | null> {
+  const want = normalizeEmoji(emoji);
+  // A blank query must never match stickers whose emoji metadata is
+  // empty — that would resolve " " to a random unrelated sticker.
+  if (!want) return null;
   let packs = listSavedPacks();
   if (setName) {
     let pack = packs.find((p) => p.name === setName);
@@ -130,7 +138,6 @@ export async function resolveStickerByEmoji(
     }
     packs = pack ? [pack] : [];
   }
-  const want = normalizeEmoji(emoji);
   const matches = packs.flatMap((p) =>
     p.stickers
       .filter((s) => normalizeEmoji(s.emoji) === want)

--- a/src/frontend/telegram/sticker-library.ts
+++ b/src/frontend/telegram/sticker-library.ts
@@ -1,0 +1,141 @@
+/**
+ * Sticker library (write side) — fetches packs from Telegram into the
+ * workspace store and resolves emoji → file_id for sending.
+ *
+ * This is what makes stickers actually usable in conversation: the
+ * model sends by *feeling* (`send(type="sticker", emoji="😂")`) and the
+ * frontend resolves a concrete file_id here, instead of the model
+ * having to remember a 60-char file_id or run a browse→save→read
+ * round-trip first. Packs enter the library two ways: automatically
+ * when a user sends a sticker from a pack we haven't seen (see
+ * handlers/messages.ts), and explicitly via `save_sticker_pack`.
+ *
+ * Only the plain Bot API (`getStickerSet`) is needed — no userbot.
+ * The read side (pack listing + the prompt index) lives in
+ * `storage/sticker-store.ts`, shared with prompt assembly.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { dirs } from "../../util/paths.js";
+import { log } from "../../util/log.js";
+import {
+  listSavedPacks,
+  type SavedPack,
+  type SavedSticker,
+} from "../../storage/sticker-store.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+/** Minimal structural slice of a grammY Bot that the library needs. */
+export type StickerSetFetcher = {
+  api: {
+    getStickerSet: (name: string) => Promise<{
+      title: string;
+      name: string;
+      stickers: Array<{ emoji?: string; file_id: string }>;
+    }>;
+  };
+};
+
+// ── Saving ──────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch a pack from Telegram and write it into the library. Returns a
+ * human-readable summary (also the tool-result text for
+ * `save_sticker_pack`). Overwrites an existing file — re-saving
+ * refreshes a pack whose contents changed upstream.
+ */
+export async function savePackToLibrary(
+  bot: StickerSetFetcher,
+  setName: string,
+): Promise<string> {
+  const stickerSet = await bot.api.getStickerSet(setName);
+  const stickers: SavedSticker[] = stickerSet.stickers.map((s) => ({
+    emoji: s.emoji ?? "",
+    fileId: s.file_id,
+  }));
+  const packData: SavedPack = {
+    name: stickerSet.name,
+    title: stickerSet.title,
+    count: stickers.length,
+    stickers,
+    savedAt: new Date().toISOString(),
+  };
+  const dir = dirs.stickers;
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    resolve(dir, `${stickerSet.name}.json`),
+    JSON.stringify(packData, null, 2),
+  );
+  return `Saved "${stickerSet.title}" (${stickers.length} stickers) to .talon/workspace/stickers/${stickerSet.name}.json`;
+}
+
+/**
+ * Save a pack only if it isn't in the library yet. Fire-and-forget
+ * safe: failures are logged, never thrown. Used by the incoming
+ * sticker handler so the library grows organically from conversation.
+ */
+export async function ensurePackSaved(
+  bot: StickerSetFetcher,
+  setName: string,
+): Promise<void> {
+  if (!setName) return;
+  if (existsSync(resolve(dirs.stickers, `${setName}.json`))) return;
+  try {
+    const summary = await savePackToLibrary(bot, setName);
+    log("stickers", `Auto-saved pack: ${summary}`);
+  } catch (err) {
+    log(
+      "stickers",
+      `Auto-save of pack "${setName}" failed: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+// ── Emoji resolution ────────────────────────────────────────────────────────
+
+/**
+ * Normalize an emoji for matching: trim and strip variation selectors
+ * (U+FE00–U+FE0F) so "❤️" (with U+FE0F) matches a pack's "❤".
+ */
+function normalizeEmoji(emoji: string): string {
+  return emoji.trim().replace(/[\uFE00-\uFE0F]/g, "");
+}
+
+/**
+ * Resolve an emoji to a concrete sticker file_id.
+ *
+ * Search order: the named pack when `setName` is given (fetching and
+ * saving it if it isn't in the library yet), otherwise every saved
+ * pack. Among matches, one is picked at random so repeated sends don't
+ * always produce the identical sticker. Returns null when nothing
+ * matches.
+ */
+export async function resolveStickerByEmoji(
+  bot: StickerSetFetcher,
+  emoji: string,
+  setName?: string,
+): Promise<{ fileId: string; pack: string } | null> {
+  let packs = listSavedPacks();
+  if (setName) {
+    let pack = packs.find((p) => p.name === setName);
+    if (!pack) {
+      try {
+        await savePackToLibrary(bot, setName);
+        pack = listSavedPacks().find((p) => p.name === setName);
+      } catch {
+        return null;
+      }
+    }
+    packs = pack ? [pack] : [];
+  }
+  const want = normalizeEmoji(emoji);
+  const matches = packs.flatMap((p) =>
+    p.stickers
+      .filter((s) => normalizeEmoji(s.emoji) === want)
+      .map((s) => ({ fileId: s.fileId, pack: p.name })),
+  );
+  if (matches.length === 0) return null;
+  return matches[Math.floor(Math.random() * matches.length)];
+}

--- a/src/frontend/telegram/sticker-library.ts
+++ b/src/frontend/telegram/sticker-library.ts
@@ -120,10 +120,11 @@ function normalizeEmoji(emoji: string): string {
  * Resolve an emoji to a concrete sticker file_id.
  *
  * Search order: the named pack when `setName` is given (fetching and
- * saving it if it isn't in the library yet), otherwise every saved
- * pack. Among matches, one is picked at random so repeated sends don't
- * always produce the identical sticker. Returns null when nothing
- * matches.
+ * saving it if it isn't in the library yet, and refreshing a stale
+ * library copy once when the emoji misses — packs gain stickers
+ * upstream), otherwise every saved pack. Among matches, one is picked
+ * at random so repeated sends don't always produce the identical
+ * sticker. Returns null when nothing matches.
  */
 export async function resolveStickerByEmoji(
   bot: StickerSetFetcher,
@@ -134,24 +135,44 @@ export async function resolveStickerByEmoji(
   // A blank query must never match stickers whose emoji metadata is
   // empty — that would resolve " " to a random unrelated sticker.
   if (!want) return null;
-  let packs = listSavedPacks();
-  if (setName) {
-    let pack = packs.find((p) => p.name === setName);
-    if (!pack) {
-      try {
-        await savePackToLibrary(bot, setName);
-        pack = listSavedPacks().find((p) => p.name === setName);
-      } catch {
-        return null;
-      }
+
+  const findMatches = (packs: SavedPack[]) =>
+    packs.flatMap((p) =>
+      p.stickers
+        .filter((s) => normalizeEmoji(s.emoji) === want)
+        .map((s) => ({ fileId: s.fileId, pack: p.name })),
+    );
+  const pick = (matches: Array<{ fileId: string; pack: string }>) =>
+    matches.length === 0
+      ? null
+      : matches[Math.floor(Math.random() * matches.length)];
+
+  if (!setName) return pick(findMatches(listSavedPacks()));
+
+  // Named pack: fetch on miss, and refresh a stale library copy once
+  // when the emoji doesn't match — bounded to this explicit-pack path
+  // so the every-pack search never triggers network calls.
+  let pack = listSavedPacks().find((p) => p.name === setName);
+  let justFetched = false;
+  if (!pack) {
+    try {
+      await savePackToLibrary(bot, setName);
+      justFetched = true;
+      pack = listSavedPacks().find((p) => p.name === setName);
+    } catch {
+      return null;
     }
-    packs = pack ? [pack] : [];
   }
-  const matches = packs.flatMap((p) =>
-    p.stickers
-      .filter((s) => normalizeEmoji(s.emoji) === want)
-      .map((s) => ({ fileId: s.fileId, pack: p.name })),
-  );
-  if (matches.length === 0) return null;
-  return matches[Math.floor(Math.random() * matches.length)];
+  if (!pack) return null;
+  let matches = findMatches([pack]);
+  if (matches.length === 0 && !justFetched) {
+    try {
+      await savePackToLibrary(bot, setName);
+      const refreshed = listSavedPacks().find((p) => p.name === setName);
+      if (refreshed) matches = findMatches([refreshed]);
+    } catch {
+      /* keep the miss — the stale copy already said no */
+    }
+  }
+  return pick(matches);
 }

--- a/src/frontend/telegram/userbot.ts
+++ b/src/frontend/telegram/userbot.ts
@@ -444,49 +444,6 @@ export async function downloadMessageMedia(params: {
   }
 }
 
-// ── Sticker pack utilities ────────────────────────────────────────────────────
-
-/** Save a sticker pack's file_ids to workspace for quick reuse. */
-export async function saveStickerPack(params: {
-  setName: string;
-  bot: unknown;
-}): Promise<string> {
-  try {
-    const bot = params.bot as {
-      api: {
-        getStickerSet: (name: string) => Promise<{
-          title: string;
-          name: string;
-          stickers: Array<{ emoji?: string; file_id: string }>;
-        }>;
-      };
-    };
-    const stickerSet = await bot.api.getStickerSet(params.setName);
-
-    const stickers = stickerSet.stickers.map((s) => ({
-      emoji: s.emoji ?? "",
-      fileId: s.file_id,
-    }));
-
-    const packData = {
-      name: stickerSet.name,
-      title: stickerSet.title,
-      count: stickers.length,
-      stickers,
-      savedAt: new Date().toISOString(),
-    };
-
-    const dir = dirs.stickers;
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    const filePath = resolve(dir, `${stickerSet.name}.json`);
-    writeFileSync(filePath, JSON.stringify(packData, null, 2));
-
-    return `Saved "${stickerSet.title}" (${stickers.length} stickers) to .talon/workspace/stickers/${stickerSet.name}.json`;
-  } catch (err) {
-    return `Failed to save sticker pack: ${err instanceof Error ? err.message : err}`;
-  }
-}
-
 // ── Chat statistics & utility ────────────────────────────────────────────────
 
 /** Get detailed chat/group statistics — message counts, top posters, activity. */

--- a/src/storage/sticker-store.ts
+++ b/src/storage/sticker-store.ts
@@ -104,9 +104,16 @@ export function renderStickerLibraryPrompt(): string {
     const distinct = [...new Set(p.stickers.map((s) => s.emoji))].filter(
       Boolean,
     );
-    let inventory = distinct.join("");
-    if (inventory.length > PROMPT_INVENTORY_MAX_CHARS) {
-      inventory = `${inventory.slice(0, PROMPT_INVENTORY_MAX_CHARS)}…`;
+    // Truncate on whole-emoji boundaries: a naive string slice counts
+    // UTF-16 units and can cut a surrogate pair (or a ZWJ sequence)
+    // in half, leaving a mojibake char at the edge of the prompt line.
+    let inventory = "";
+    for (const e of distinct) {
+      if (inventory.length + e.length > PROMPT_INVENTORY_MAX_CHARS) {
+        inventory += "…";
+        break;
+      }
+      inventory += e;
     }
     return `- ${p.title} (${p.name}, ${p.count} stickers): ${inventory}`;
   });

--- a/src/storage/sticker-store.ts
+++ b/src/storage/sticker-store.ts
@@ -101,10 +101,12 @@ export function renderStickerLibraryPrompt(): string {
   // Packs whose stickers carry no emoji metadata can't be sent by
   // emoji, which is what this section teaches — listing them would be
   // a dangling "(N stickers): " line pointing at nothing.
-  const packs = listSavedPacks()
-    .filter((p) => p.stickers.some((s) => s.emoji))
-    .slice(0, PROMPT_PACK_LIMIT);
+  const usable = listSavedPacks().filter((p) =>
+    p.stickers.some((s) => s.emoji),
+  );
+  const packs = usable.slice(0, PROMPT_PACK_LIMIT);
   if (packs.length === 0) return "";
+  const overflow = usable.length - packs.length;
   const lines = packs.map((p) => {
     const distinct = [...new Set(p.stickers.map((s) => s.emoji))].filter(
       Boolean,
@@ -122,6 +124,13 @@ export function renderStickerLibraryPrompt(): string {
     }
     return `- ${p.title} (${p.name}, ${p.count} stickers): ${inventory}`;
   });
+  if (overflow > 0) {
+    // The index shows the newest packs; make the rest discoverable
+    // instead of silently invisible.
+    lines.push(
+      `- …plus ${overflow} more saved pack${overflow === 1 ? "" : "s"} in workspace/stickers/ (all searched when sending by emoji).`,
+    );
+  }
   return [
     "## Sticker library",
     "",

--- a/src/storage/sticker-store.ts
+++ b/src/storage/sticker-store.ts
@@ -98,7 +98,12 @@ export function listSavedPacks(): SavedPack[] {
  * as packs are auto-saved mid-session.
  */
 export function renderStickerLibraryPrompt(): string {
-  const packs = listSavedPacks().slice(0, PROMPT_PACK_LIMIT);
+  // Packs whose stickers carry no emoji metadata can't be sent by
+  // emoji, which is what this section teaches — listing them would be
+  // a dangling "(N stickers): " line pointing at nothing.
+  const packs = listSavedPacks()
+    .filter((p) => p.stickers.some((s) => s.emoji))
+    .slice(0, PROMPT_PACK_LIMIT);
   if (packs.length === 0) return "";
   const lines = packs.map((p) => {
     const distinct = [...new Set(p.stickers.map((s) => s.emoji))].filter(

--- a/src/storage/sticker-store.ts
+++ b/src/storage/sticker-store.ts
@@ -1,0 +1,120 @@
+/**
+ * Sticker pack store — reads the workspace sticker library
+ * (`~/.talon/workspace/stickers/<set_name>.json`, one file per pack)
+ * and renders the compact prompt index that makes the library
+ * *discoverable*: a model that can see which packs and emoji it owns
+ * actually sends stickers; one that has to go browsing first never
+ * does.
+ *
+ * Writing packs is frontend work (fetching needs a platform API) —
+ * see `frontend/telegram/sticker-library.ts`. This module is the
+ * read side, shared by prompt assembly and the send-by-emoji
+ * resolver.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { dirs } from "../util/paths.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+/** One sticker inside a saved pack (JSON shape on disk). */
+export type SavedSticker = { emoji: string; fileId: string };
+
+/** A saved pack — the JSON shape of `stickers/<set_name>.json`. */
+export type SavedPack = {
+  name: string;
+  title: string;
+  count: number;
+  stickers: SavedSticker[];
+  savedAt: string;
+};
+
+// ── Tunables ────────────────────────────────────────────────────────────────
+
+/** Max packs listed in the prompt index (newest first). */
+const PROMPT_PACK_LIMIT = 12;
+
+/** Max chars of a pack's emoji inventory shown in the prompt index. */
+const PROMPT_INVENTORY_MAX_CHARS = 60;
+
+// ── Reading ─────────────────────────────────────────────────────────────────
+
+/**
+ * All packs currently saved in the workspace, newest first. Unreadable
+ * or malformed files are skipped — the library is a cache, not a
+ * source of truth (any pack can be re-fetched by name).
+ */
+export function listSavedPacks(): SavedPack[] {
+  const dir = dirs.stickers;
+  let entries: string[];
+  try {
+    entries = readdirSync(dir).filter((f) => f.endsWith(".json"));
+  } catch {
+    return [];
+  }
+  const packs: SavedPack[] = [];
+  for (const file of entries) {
+    try {
+      const raw = JSON.parse(readFileSync(resolve(dir, file), "utf-8")) as {
+        name?: unknown;
+        title?: unknown;
+        stickers?: unknown;
+        savedAt?: unknown;
+      };
+      if (typeof raw.name !== "string" || !Array.isArray(raw.stickers)) {
+        continue;
+      }
+      const stickers = raw.stickers
+        .filter(
+          (s): s is { emoji?: unknown; fileId?: unknown } =>
+            s != null && typeof s === "object",
+        )
+        .filter((s) => typeof s.fileId === "string")
+        .map((s) => ({
+          emoji: typeof s.emoji === "string" ? s.emoji : "",
+          fileId: s.fileId as string,
+        }));
+      packs.push({
+        name: raw.name,
+        title: typeof raw.title === "string" ? raw.title : raw.name,
+        count: stickers.length,
+        stickers,
+        savedAt: typeof raw.savedAt === "string" ? raw.savedAt : "",
+      });
+    } catch {
+      /* skip malformed pack file */
+    }
+  }
+  return packs.sort((a, b) => b.savedAt.localeCompare(a.savedAt));
+}
+
+// ── Prompt index ────────────────────────────────────────────────────────────
+
+/**
+ * The "Sticker library" system-prompt section: one line per pack with
+ * its distinct emoji inventory. Empty string when the library is empty
+ * (the section simply doesn't appear). Dynamic-part content: it changes
+ * as packs are auto-saved mid-session.
+ */
+export function renderStickerLibraryPrompt(): string {
+  const packs = listSavedPacks().slice(0, PROMPT_PACK_LIMIT);
+  if (packs.length === 0) return "";
+  const lines = packs.map((p) => {
+    const distinct = [...new Set(p.stickers.map((s) => s.emoji))].filter(
+      Boolean,
+    );
+    let inventory = distinct.join("");
+    if (inventory.length > PROMPT_INVENTORY_MAX_CHARS) {
+      inventory = `${inventory.slice(0, PROMPT_INVENTORY_MAX_CHARS)}…`;
+    }
+    return `- ${p.title} (${p.name}, ${p.count} stickers): ${inventory}`;
+  });
+  return [
+    "## Sticker library",
+    "",
+    'Saved packs you can send from right now with send(type="sticker", emoji=...) — pick the emoji whose feeling fits (add set_name to pin a pack). Packs from stickers users send are added automatically.',
+    "",
+    ...lines,
+  ].join("\n");
+}

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -56,6 +56,7 @@ export type LogComponent =
   | "mempalace"
   | "playwright"
   | "soul"
+  | "stickers"
   | "backend-controller";
 
 const LOG_FILE = files.log;

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -206,11 +206,30 @@ function seedPrompts(): void {
   let manifestDirty = false;
   for (const file of listSeedPrompts()) {
     const dst = join(dirs.prompts, file);
-    const pkg = readPromptAsset(file);
+    // Seeding must never break boot: an unreadable package asset (or
+    // an unwritable destination) skips that one file, not the rest.
+    let pkg: string;
+    try {
+      pkg = readPromptAsset(file);
+    } catch (err) {
+      log(
+        "workspace",
+        `Skipping prompt seed for ${file}: ${err instanceof Error ? err.message : err}`,
+      );
+      continue;
+    }
     const pkgHash = sha256(pkg);
 
     if (!existsSync(dst)) {
-      writeFileSync(dst, pkg);
+      try {
+        writeFileSync(dst, pkg);
+      } catch (err) {
+        log(
+          "workspace",
+          `Skipping prompt seed for ${file}: ${err instanceof Error ? err.message : err}`,
+        );
+        continue;
+      }
       manifest[file] = pkgHash;
       manifestDirty = true;
       log("workspace", `Seeded prompt: ${file}`);
@@ -235,7 +254,11 @@ function seedPrompts(): void {
       }
     } else if (seededHash !== undefined && curHash === seededHash) {
       // Pristine seeded copy + package changed → refresh on upgrade.
-      writeFileSync(dst, pkg);
+      try {
+        writeFileSync(dst, pkg);
+      } catch {
+        continue; // manifest keeps the old hash — retried next boot
+      }
       manifest[file] = pkgHash;
       manifestDirty = true;
       log("workspace", `Updated prompt (unedited since seeding): ${file}`);

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -174,6 +174,57 @@ export function initWorkspace(root: string): void {
  */
 const SEED_MANIFEST = ".seeded.json";
 
+function seedManifestPath(): string {
+  return join(dirs.prompts, SEED_MANIFEST);
+}
+
+function readSeedManifest(): Record<string, string> {
+  try {
+    const path = seedManifestPath();
+    if (!existsSync(path)) return {};
+    return JSON.parse(readFileSync(path, "utf-8")) as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+/**
+ * Provenance of the seeded prompts, for diagnostics (`talon doctor`):
+ * which files still track the package (pristine seeded copy or already
+ * the current package content) and which the user has edited (never
+ * touched by upgrades again). Files that can't be read are skipped.
+ */
+export function promptSeedReport(): { tracking: string[]; edited: string[] } {
+  const manifest = readSeedManifest();
+  const tracking: string[] = [];
+  const edited: string[] = [];
+  for (const file of listSeedPrompts()) {
+    const dst = join(dirs.prompts, file);
+    let curHash: string;
+    try {
+      curHash = sha256(readFileSync(dst, "utf-8"));
+    } catch {
+      continue;
+    }
+    let pkgHash: string | undefined;
+    try {
+      pkgHash = sha256(readPromptAsset(file));
+    } catch {
+      pkgHash = undefined;
+    }
+    if (curHash === pkgHash || curHash === manifest[file]) {
+      tracking.push(file);
+    } else {
+      edited.push(file);
+    }
+  }
+  return { tracking, edited };
+}
+
 /**
  * Seed prompts with upgrade-aware refresh:
  *
@@ -187,21 +238,8 @@ const SEED_MANIFEST = ".seeded.json";
  * the current package copy — from then on they track upgrades again.
  */
 function seedPrompts(): void {
-  const manifestPath = join(dirs.prompts, SEED_MANIFEST);
-  let manifest: Record<string, string> = {};
-  try {
-    if (existsSync(manifestPath)) {
-      manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as Record<
-        string,
-        string
-      >;
-    }
-  } catch {
-    manifest = {};
-  }
-
-  const sha256 = (text: string): string =>
-    createHash("sha256").update(text).digest("hex");
+  const manifestPath = seedManifestPath();
+  const manifest = readSeedManifest();
 
   let manifestDirty = false;
   for (const file of listSeedPrompts()) {

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -225,20 +225,24 @@ function seedPrompts(): void {
     }
     const seededHash = manifest[file];
 
-    if (seededHash === undefined) {
-      // Pre-manifest deployment: adopt only a byte-identical copy.
-      if (curHash === pkgHash) {
+    if (curHash === pkgHash) {
+      // Already the current package copy, whatever its provenance
+      // (pre-manifest adoption, or a user edit that happens to match).
+      // Record it so the file tracks upgrades from here on.
+      if (seededHash !== pkgHash) {
         manifest[file] = pkgHash;
         manifestDirty = true;
       }
-    } else if (curHash === seededHash && pkgHash !== curHash) {
+    } else if (seededHash !== undefined && curHash === seededHash) {
       // Pristine seeded copy + package changed → refresh on upgrade.
       writeFileSync(dst, pkg);
       manifest[file] = pkgHash;
       manifestDirty = true;
       log("workspace", `Updated prompt (unedited since seeding): ${file}`);
     }
-    // curHash !== seededHash → user-edited: leave it alone, forever.
+    // Remaining cases — no manifest entry and content differs from the
+    // package (unknown provenance), or an entry exists and the file was
+    // edited since seeding → user-owned: leave it alone, forever.
   }
 
   if (manifestDirty) {

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -8,6 +8,7 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
   rmdirSync,
   renameSync,
   statSync,
@@ -17,6 +18,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { createHash } from "node:crypto";
 import { join, resolve } from "node:path";
 import { log } from "./log.js";
 import { dirs, files as pathFiles } from "./paths.js";
@@ -151,18 +153,99 @@ export function initWorkspace(root: string): void {
   }
 
   // Seed user-editable prompt files from the package into
-  // ~/.talon/prompts/. Only writes files that don't already exist —
-  // user edits are preserved. Sourced through the #prompt-assets seam
-  // (disk under tsx, embedded under a compiled binary), so seeding works
-  // even when there is no package source tree on disk. listSeedPrompts()
+  // ~/.talon/prompts/. Sourced through the #prompt-assets seam (disk
+  // under tsx, embedded under a compiled binary), so seeding works even
+  // when there is no package source tree on disk. listSeedPrompts()
   // already skips the architecture README and the system/ subdirectory
   // (package-owned templates read in place — a seeded copy would go
   // stale; see prompts/README.md).
+  seedPrompts();
+}
+
+// ── Prompt seeding ──────────────────────────────────────────────────────────
+
+/**
+ * Manifest of what was last seeded, `file → sha256(content)`, stored
+ * next to the seeded prompts. This is what lets upgrades tell "still
+ * the pristine seeded copy" apart from "the user edited this": a file
+ * whose on-disk hash matches its seeded hash is safe to refresh when
+ * the packaged version changes; anything else is user-owned and never
+ * touched. (dpkg conffile semantics.)
+ */
+const SEED_MANIFEST = ".seeded.json";
+
+/**
+ * Seed prompts with upgrade-aware refresh:
+ *
+ *   - missing file        → write it, record its hash
+ *   - pristine seeded copy → refresh when the package version changed
+ *   - user-edited copy    → never touched
+ *
+ * Deployments that predate the manifest have unknown provenance (old
+ * package version vs. user edit is indistinguishable), so their
+ * existing files are adopted as user-owned unless byte-identical to
+ * the current package copy — from then on they track upgrades again.
+ */
+function seedPrompts(): void {
+  const manifestPath = join(dirs.prompts, SEED_MANIFEST);
+  let manifest: Record<string, string> = {};
+  try {
+    if (existsSync(manifestPath)) {
+      manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as Record<
+        string,
+        string
+      >;
+    }
+  } catch {
+    manifest = {};
+  }
+
+  const sha256 = (text: string): string =>
+    createHash("sha256").update(text).digest("hex");
+
+  let manifestDirty = false;
   for (const file of listSeedPrompts()) {
     const dst = join(dirs.prompts, file);
+    const pkg = readPromptAsset(file);
+    const pkgHash = sha256(pkg);
+
     if (!existsSync(dst)) {
-      writeFileSync(dst, readPromptAsset(file));
+      writeFileSync(dst, pkg);
+      manifest[file] = pkgHash;
+      manifestDirty = true;
       log("workspace", `Seeded prompt: ${file}`);
+      continue;
+    }
+
+    let curHash: string;
+    try {
+      curHash = sha256(readFileSync(dst, "utf-8"));
+    } catch {
+      continue;
+    }
+    const seededHash = manifest[file];
+
+    if (seededHash === undefined) {
+      // Pre-manifest deployment: adopt only a byte-identical copy.
+      if (curHash === pkgHash) {
+        manifest[file] = pkgHash;
+        manifestDirty = true;
+      }
+    } else if (curHash === seededHash && pkgHash !== curHash) {
+      // Pristine seeded copy + package changed → refresh on upgrade.
+      writeFileSync(dst, pkg);
+      manifest[file] = pkgHash;
+      manifestDirty = true;
+      log("workspace", `Updated prompt (unedited since seeding): ${file}`);
+    }
+    // curHash !== seededHash → user-edited: leave it alone, forever.
+  }
+
+  if (manifestDirty) {
+    try {
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    } catch {
+      /* non-fatal — worst case we re-derive next boot */
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Prompt flow rework** across `base.md`, `identity.md`, `discord.md`, `telegram.md`, `teams.md`, `native.md`, and the tool-only contract: conversational guidance instead of rule lists, unified *Files & media* sections, multi-bubble pacing where the platform suits it, and reaction-first acknowledgement guidance.
- **Upgrade-aware prompt seeding** (dpkg-conffile semantics): `initWorkspace` tracks seeded prompt hashes in `~/.talon/prompts/.seeded.json`. Package updates refresh files the user never edited; user-edited files are never touched again. Pre-manifest deployments adopt existing files only when byte-identical to the package copy. Seeding is per-file fault-isolated (a bad asset can never break boot), and `talon doctor` / Telegram `/doctor` now report provenance: *"Prompts: N tracking package upgrades, M user-edited"*.
- **Telegram sticker library**: packs auto-save when users send stickers (`ensurePackSaved`, with concurrent-burst dedup), `send(type="sticker", emoji=...)` resolves an emoji to a saved sticker (variation-selector + skin-tone normalization, fetch-on-miss and stale-copy refresh for a named pack), and a dynamic *Sticker library* index is assembled into the system prompt (Telegram frontend only; overflow packs summarized). Pack saving moves off the userbot onto the plain Bot API.
- **Media sends by URL/file_id**: Telegram and Discord media sends accept a public URL or platform `file_id` in addition to a workspace path (stickers included, via .webp URL). Failure paths return guidance the model can act on — missing/mistyped paths name the three sources instead of raw ENOENT; Discord explains it has no `file_id` concept.
- **reply_to everywhere**: poll/location/contact/dice were silently dropping `reply_to` on both sides of the bridge (tool → action payload → API call). Fixed for Telegram and Discord — every send type can reply now, matching the documented contract.
- **CI/publish**: regenerate the embedded-prompts manifest right before compiling binaries so a stale committed manifest can never ship.

## Test plan

- `sticker-library.test.ts` covers pack listing, prompt-index rendering (emoji-safe truncation, emoji-less pack skipping, overflow summary), emoji resolution (variation selectors, skin tones, blank-query rejection, fetch-on-miss, stale-pack refresh, local-only broad search), and auto-save idempotency + concurrency dedup.
- `workspace-migrate.test.ts` covers `.seeded.json` first-run recording, pristine-copy refresh on upgrade, user-edit preservation, pre-manifest adoption, stale-entry re-adoption, and `promptSeedReport` classification.
- Full CI (typecheck, lint, unit + functional tests, CLI smoke on compiled binaries) validates the rest, including the Discord surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
