### PR TITLE
feat: verbose error passthrough + daemon log viewer in companion

### DIFF
--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -139,8 +139,47 @@ jobs:
           flutter pub get
           dart run flutter_launcher_icons -f icons-windows.yaml || true
 
+      # The app version tracks Talon's own (release-please bumps
+      # package.json every release) — nothing is hand-bumped. versionCode
+      # must be a monotonically increasing int for Android upgrades:
+      # MAJOR*100000 + MINOR*1000 + PATCH (1.33.0 → 133000).
+      - name: Derive app version from Talon release
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('$GITHUB_WORKSPACE/package.json').version")
+          IFS=. read -r MAJOR MINOR PATCH <<< "${VERSION%%-*}"
+          BUILD_NUMBER=$((MAJOR * 100000 + MINOR * 1000 + PATCH))
+          echo "APP_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "APP_BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
+          echo "Companion version: $VERSION ($BUILD_NUMBER)"
+
+      # Stable release signing (see android/app/build.gradle.kts): decode
+      # the keystore secret so every release APK carries the same signature
+      # and installs over the previous one. Skipped (falls back to debug
+      # signing) when the secret isn't configured, e.g. on forks.
+      - name: Set up Android release keystore
+        if: matrix.platform == 'android'
+        shell: bash
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "No ANDROID_KEYSTORE_BASE64 secret — falling back to debug signing."
+            exit 0
+          fi
+          KEYSTORE_FILE="$RUNNER_TEMP/talon-release.p12"
+          printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_FILE"
+          {
+            echo "TALON_ANDROID_KEYSTORE_FILE=$KEYSTORE_FILE"
+            echo "TALON_ANDROID_KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD"
+          } >> "$GITHUB_ENV"
+
       - name: Build
-        run: ${{ matrix.build }}
+        shell: bash
+        run: ${{ matrix.build }} --build-name="$APP_VERSION" --build-number="$APP_BUILD_NUMBER"
 
       - name: Package
         shell: bash

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -147,7 +147,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          VERSION=$(node -p "require('$GITHUB_WORKSPACE/package.json').version")
+          # Relative require: $GITHUB_WORKSPACE is a backslash path on
+          # Windows and turns into escape sequences inside the JS string.
+          VERSION=$(node -p "require('../../package.json').version")
           IFS=. read -r MAJOR MINOR PATCH <<< "${VERSION%%-*}"
           BUILD_NUMBER=$((MAJOR * 100000 + MINOR * 1000 + PATCH))
           echo "APP_VERSION=$VERSION" >> "$GITHUB_ENV"

--- a/apps/companion/android/app/build.gradle.kts
+++ b/apps/companion/android/app/build.gradle.kts
@@ -29,11 +29,33 @@ android {
         versionName = flutter.versionName
     }
 
+    // Stable release signing so an APK from one release installs OVER the
+    // previous one. CI decodes the ANDROID_KEYSTORE_BASE64 secret and points
+    // these env vars at it; without them (local dev, forks without the
+    // secret) the build falls back to debug signing, where every machine's
+    // throwaway key makes upgrades require an uninstall.
+    val releaseKeystore = System.getenv("TALON_ANDROID_KEYSTORE_FILE")
+        ?.let { file(it) }
+        ?.takeIf { it.exists() }
+    signingConfigs {
+        if (releaseKeystore != null) {
+            create("release") {
+                storeFile = releaseKeystore
+                storeType = "PKCS12"
+                storePassword = System.getenv("TALON_ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("TALON_ANDROID_KEY_ALIAS") ?: "talon"
+                keyPassword = System.getenv("TALON_ANDROID_KEYSTORE_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = if (releaseKeystore != null) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 }

--- a/apps/companion/lib/src/models/bridge_models.dart
+++ b/apps/companion/lib/src/models/bridge_models.dart
@@ -448,6 +448,45 @@ class ToolActivity {
   Duration get elapsed => (finishedAt ?? DateTime.now()).difference(startedAt);
 }
 
+/// One daemon log line from `GET /logs` — the log viewer's row model.
+class DaemonLogEntry {
+  /// Epoch milliseconds (0 when the line carried no timestamp).
+  final int ts;
+
+  /// pino level name: trace/debug/info/warn/error/fatal.
+  final String level;
+
+  /// Subsystem tag (e.g. "agent", "native"), empty when absent.
+  final String component;
+  final String msg;
+
+  /// Concise error message, when the line logged one.
+  final String? err;
+
+  /// Full stack trace, when the line logged one.
+  final String? stack;
+
+  const DaemonLogEntry({
+    required this.ts,
+    required this.level,
+    required this.component,
+    required this.msg,
+    this.err,
+    this.stack,
+  });
+
+  factory DaemonLogEntry.fromJson(Map<String, dynamic> j) => DaemonLogEntry(
+        ts: _int(j['ts']),
+        level: _string(j['level'], 'info'),
+        component: _string(j['component']),
+        msg: _string(j['msg']),
+        err: j['err'] is String ? j['err'] as String : null,
+        stack: j['stack'] is String ? j['stack'] as String : null,
+      );
+
+  DateTime get time => DateTime.fromMillisecondsSinceEpoch(ts);
+}
+
 /// One full-text search hit from `GET /search`.
 class SearchHit {
   final String chatId;

--- a/apps/companion/lib/src/services/bridge_client.dart
+++ b/apps/companion/lib/src/services/bridge_client.dart
@@ -177,6 +177,23 @@ class BridgeClient {
   Future<ConfigSnapshot> setConfig(Map<String, dynamic> update) async =>
       ConfigSnapshot.fromJson(await _postJson('/config', update));
 
+  /// Newest daemon log entries (oldest first). [level] is a minimum severity
+  /// (e.g. "warn" returns warn+error+fatal); [component] an exact subsystem tag.
+  Future<List<DaemonLogEntry>> logs({
+    int lines = 300,
+    String? level,
+    String? component,
+  }) async {
+    final j = await _getJson('/logs', {
+      'lines': '$lines',
+      if (level != null) 'level': level,
+      if (component != null) 'component': component,
+    });
+    return _list(j['entries'])
+        .map((e) => DaemonLogEntry.fromJson(_map(e)))
+        .toList();
+  }
+
   /// Fire a daemon-level control action ("restart", "dream"). Returns the
   /// daemon's ok/message result (never throws on an application-level failure —
   /// the server answers 200 with `ok:false`).

--- a/apps/companion/lib/src/state/app_state.dart
+++ b/apps/companion/lib/src/state/app_state.dart
@@ -677,6 +677,18 @@ class AppState extends ChangeNotifier {
     return result;
   }
 
+  /// Newest daemon log entries for the log viewer. Throws on transport
+  /// failure — the screen owns the error presentation.
+  Future<List<DaemonLogEntry>> daemonLogs({
+    int lines = 300,
+    String? level,
+    String? component,
+  }) async {
+    final client = _client;
+    if (client == null) throw BridgeException('Not connected');
+    return client.logs(lines: lines, level: level, component: component);
+  }
+
   /// Fire a daemon-level control action over the bridge ("restart", "dream").
   /// Unlike [restartDaemon] (which drives a locally-managed process), this asks
   /// the *running* daemon to act on itself, so it works over a remote bridge

--- a/apps/companion/lib/src/ui/logs_screen.dart
+++ b/apps/companion/lib/src/ui/logs_screen.dart
@@ -1,0 +1,509 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/bridge_models.dart';
+import '../services/log.dart';
+import '../state/app_state.dart';
+import '../theme.dart';
+import 'glass.dart';
+
+/// Daemon log viewer — a nicely rendered tail of the daemon's log file
+/// (served by `GET /logs`), with severity/component/text filtering, live
+/// follow, and per-row expansion for error details and stack traces.
+class LogsScreen extends StatefulWidget {
+  final AppState state;
+  const LogsScreen({super.key, required this.state});
+
+  @override
+  State<LogsScreen> createState() => _LogsScreenState();
+}
+
+class _LogsScreenState extends State<LogsScreen> {
+  List<DaemonLogEntry> _entries = const [];
+  bool _loading = true;
+  String? _error;
+
+  /// Minimum severity to request (null = everything).
+  String? _minLevel;
+
+  /// Exact component filter (null = all components).
+  String? _component;
+
+  /// Components seen across loads, so the filter menu stays stable even
+  /// when the current filter hides some of them.
+  final Set<String> _knownComponents = {};
+
+  /// Live follow: refresh every few seconds and stick to the bottom.
+  bool _follow = true;
+  Timer? _followTimer;
+
+  final _search = TextEditingController();
+  final _scroll = ScrollController();
+
+  /// Row index → expanded, for entries with error/stack detail.
+  final Set<int> _expanded = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+    _armFollow();
+    _search.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _followTimer?.cancel();
+    _search.dispose();
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  void _armFollow() {
+    _followTimer?.cancel();
+    if (!_follow) return;
+    _followTimer = Timer.periodic(
+      const Duration(seconds: 3),
+      (_) => _load(quiet: true),
+    );
+  }
+
+  Future<void> _load({bool quiet = false}) async {
+    if (!quiet) {
+      setState(() {
+        _loading = true;
+        _error = null;
+      });
+    }
+    try {
+      final entries = await widget.state.daemonLogs(
+        lines: 400,
+        level: _minLevel,
+        component: _component,
+      );
+      if (!mounted) return;
+      setState(() {
+        _entries = entries;
+        _knownComponents.addAll(
+          entries.map((e) => e.component).where((c) => c.isNotEmpty),
+        );
+        _loading = false;
+        _error = null;
+        _expanded.clear();
+      });
+      if (_follow) _jumpToBottom();
+    } catch (e) {
+      AppLog.warn('logs', 'daemon log fetch failed', e);
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = e.toString();
+      });
+    }
+  }
+
+  void _jumpToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scroll.hasClients) {
+        _scroll.jumpTo(_scroll.position.maxScrollExtent);
+      }
+    });
+  }
+
+  List<DaemonLogEntry> get _visible {
+    final q = _search.text.trim().toLowerCase();
+    if (q.isEmpty) return _entries;
+    return _entries
+        .where(
+          (e) =>
+              e.msg.toLowerCase().contains(q) ||
+              e.component.toLowerCase().contains(q) ||
+              (e.err?.toLowerCase().contains(q) ?? false),
+        )
+        .toList();
+  }
+
+  Future<void> _copyVisible() async {
+    final buf = StringBuffer();
+    for (final e in _visible) {
+      buf.writeln(
+        '${_fmtTime(e.time)} ${e.level.toUpperCase().padRight(5)} '
+        '${e.component.isEmpty ? '' : '[${e.component}] '}${e.msg}'
+        '${e.err != null ? ' — ${e.err}' : ''}',
+      );
+    }
+    await Clipboard.setData(ClipboardData(text: buf.toString()));
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${_visible.length} log lines copied')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<int>(
+      valueListenable: TalonTheme.revision,
+      builder: (context, _, __) => TalonBackdrop(
+        child: Scaffold(
+          backgroundColor: Colors.transparent,
+          appBar: AppBar(
+            backgroundColor: Colors.transparent,
+            title: const Text('Daemon logs'),
+            actions: [
+              IconButton(
+                tooltip: _follow ? 'Pause live follow' : 'Follow live',
+                onPressed: () {
+                  setState(() => _follow = !_follow);
+                  _armFollow();
+                  if (_follow) _load(quiet: true);
+                },
+                icon: Icon(
+                  _follow ? Icons.pause_circle_outline : Icons.play_circle_outline,
+                  color: _follow ? TalonColors.accent : null,
+                ),
+              ),
+              IconButton(
+                tooltip: 'Refresh',
+                onPressed: _load,
+                icon: const Icon(Icons.refresh),
+              ),
+              IconButton(
+                tooltip: 'Copy visible lines',
+                onPressed: _visible.isEmpty ? null : _copyVisible,
+                icon: const Icon(Icons.copy_all_outlined),
+              ),
+            ],
+          ),
+          body: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 4, 16, 10),
+                child: _filterBar(),
+              ),
+              Expanded(child: _body()),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _filterBar() {
+    const levels = [
+      (null, 'All'),
+      ('info', 'Info+'),
+      ('warn', 'Warn+'),
+      ('error', 'Errors'),
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    for (final (value, label) in levels)
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8),
+                        child: ChoiceChip(
+                          label: Text(label),
+                          selected: _minLevel == value,
+                          showCheckmark: false,
+                          backgroundColor: TalonColors.surface,
+                          selectedColor:
+                              TalonColors.accent.withValues(alpha: 0.22),
+                          side: BorderSide(
+                            color: _minLevel == value
+                                ? TalonColors.accent
+                                : TalonColors.glassStroke,
+                          ),
+                          labelStyle: TextStyle(
+                            fontSize: 12.5,
+                            color: _minLevel == value
+                                ? TalonColors.text
+                                : TalonColors.textDim,
+                          ),
+                          onSelected: (_) {
+                            setState(() => _minLevel = value);
+                            _load();
+                          },
+                        ),
+                      ),
+                    _componentChip(),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: _search,
+          style: const TextStyle(fontSize: 13.5),
+          decoration: InputDecoration(
+            isDense: true,
+            hintText: 'Filter log lines…',
+            prefixIcon: const Icon(Icons.search, size: 18),
+            suffixIcon: _search.text.isEmpty
+                ? null
+                : IconButton(
+                    icon: const Icon(Icons.clear, size: 16),
+                    onPressed: _search.clear,
+                  ),
+            border: OutlineInputBorder(
+              borderRadius: TalonRadius.rMd,
+              borderSide: BorderSide(color: TalonColors.glassStroke),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _componentChip() {
+    final label = _component ?? 'Component';
+    return ActionChip(
+      avatar: Icon(
+        Icons.filter_alt_outlined,
+        size: 14,
+        color: _component != null ? TalonColors.accent : TalonColors.textFaint,
+      ),
+      label: Text(label),
+      backgroundColor: TalonColors.surface,
+      side: BorderSide(
+        color:
+            _component != null ? TalonColors.accent : TalonColors.glassStroke,
+      ),
+      labelStyle: TextStyle(
+        fontSize: 12.5,
+        color: _component != null ? TalonColors.text : TalonColors.textDim,
+      ),
+      onPressed: _pickComponent,
+    );
+  }
+
+  Future<void> _pickComponent() async {
+    final components = _knownComponents.toList()..sort();
+    final picked = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: TalonColors.void1,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (ctx) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          padding: const EdgeInsets.all(12),
+          children: [
+            ListTile(
+              title: const Text('All components'),
+              trailing: _component == null
+                  ? Icon(Icons.check, color: TalonColors.accent)
+                  : null,
+              onTap: () => Navigator.pop(ctx, ''),
+            ),
+            for (final c in components)
+              ListTile(
+                title: Text(c, style: TalonType.mono),
+                trailing: c == _component
+                    ? Icon(Icons.check, color: TalonColors.accent)
+                    : null,
+                onTap: () => Navigator.pop(ctx, c),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (picked == null || !mounted) return;
+    setState(() => _component = picked.isEmpty ? null : picked);
+    await _load();
+  }
+
+  Widget _body() {
+    if (_loading && _entries.isEmpty) {
+      return const Center(child: CircularProgressIndicator(strokeWidth: 2));
+    }
+    if (_error != null && _entries.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.cloud_off_outlined,
+                  size: 34, color: TalonColors.textFaint),
+              const SizedBox(height: 10),
+              Text(
+                'Could not load logs',
+                style: TextStyle(
+                    fontWeight: FontWeight.w600, color: TalonColors.text),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                _error!,
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 12.5, color: TalonColors.textDim),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(onPressed: _load, child: const Text('Retry')),
+            ],
+          ),
+        ),
+      );
+    }
+    final rows = _visible;
+    if (rows.isEmpty) {
+      return Center(
+        child: Text(
+          'No matching log lines',
+          style: TextStyle(color: TalonColors.textFaint),
+        ),
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: Scrollbar(
+        controller: _scroll,
+        child: ListView.builder(
+          controller: _scroll,
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 16),
+          physics: const AlwaysScrollableScrollPhysics(),
+          itemCount: rows.length,
+          itemBuilder: (context, i) => _row(rows[i], i),
+        ),
+      ),
+    );
+  }
+
+  Widget _row(DaemonLogEntry e, int index) {
+    final color = _levelColor(e.level);
+    final hasDetail = e.err != null || e.stack != null;
+    final expanded = _expanded.contains(index);
+    return InkWell(
+      onTap: hasDetail
+          ? () => setState(() {
+                if (expanded) {
+                  _expanded.remove(index);
+                } else {
+                  _expanded.add(index);
+                }
+              })
+          : null,
+      borderRadius: TalonRadius.rSm,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(top: 5),
+                  child: Container(
+                    width: 7,
+                    height: 7,
+                    decoration:
+                        BoxDecoration(shape: BoxShape.circle, color: color),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  e.ts == 0 ? '—' : _fmtTime(e.time),
+                  style: TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 11.5,
+                    color: TalonColors.textFaint,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                if (e.component.isNotEmpty) ...[
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                    decoration: BoxDecoration(
+                      color: TalonColors.surfaceHi,
+                      borderRadius: TalonRadius.rPill,
+                    ),
+                    child: Text(
+                      e.component,
+                      style: TextStyle(
+                        fontSize: 10.5,
+                        fontWeight: FontWeight.w600,
+                        color: TalonColors.textDim,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                ],
+                Expanded(
+                  child: Text(
+                    e.msg.isEmpty ? '—' : e.msg,
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 12,
+                      height: 1.45,
+                      color: _isSevere(e.level) ? color : TalonColors.text,
+                    ),
+                  ),
+                ),
+                if (hasDetail)
+                  Icon(
+                    expanded ? Icons.expand_less : Icons.expand_more,
+                    size: 15,
+                    color: TalonColors.textFaint,
+                  ),
+              ],
+            ),
+            if (expanded && hasDetail)
+              Container(
+                margin: const EdgeInsets.only(left: 15, top: 6),
+                padding: const EdgeInsets.all(10),
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: TalonColors.bad.withValues(alpha: 0.07),
+                  borderRadius: TalonRadius.rSm,
+                  border: Border.all(
+                    color: TalonColors.bad.withValues(alpha: 0.25),
+                  ),
+                ),
+                child: SelectableText(
+                  [
+                    if (e.err != null) e.err!,
+                    if (e.stack != null) e.stack!,
+                  ].join('\n\n'),
+                  style: TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 11.5,
+                    height: 1.45,
+                    color: TalonColors.textDim,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  bool _isSevere(String level) =>
+      level == 'warn' || level == 'error' || level == 'fatal';
+
+  Color _levelColor(String level) => switch (level) {
+        'error' || 'fatal' => TalonColors.bad,
+        'warn' => TalonColors.warn,
+        'info' => TalonColors.ok,
+        _ => TalonColors.textFaint, // trace / debug
+      };
+
+  String _fmtTime(DateTime t) {
+    String two(int n) => n.toString().padLeft(2, '0');
+    return '${two(t.hour)}:${two(t.minute)}:${two(t.second)}';
+  }
+}

--- a/apps/companion/lib/src/ui/settings_screen.dart
+++ b/apps/companion/lib/src/ui/settings_screen.dart
@@ -8,6 +8,7 @@ import '../state/app_state.dart';
 import '../theme.dart';
 import 'connect_screen.dart';
 import 'glass.dart';
+import 'logs_screen.dart';
 
 /// Severity for a diagnostics check row.
 enum _Health { ok, warn, bad, info }
@@ -146,6 +147,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
             subtitle: 'Consolidate memory + write the diary immediately',
             pending: _dreaming,
             onTap: _dreaming ? null : _triggerDream,
+          ),
+          const SizedBox(height: 10),
+          _ControlButton(
+            icon: Icons.receipt_long_outlined,
+            label: 'View logs',
+            subtitle: 'Live daemon log — filter by severity or subsystem',
+            pending: false,
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => LogsScreen(state: widget.state),
+              ),
+            ),
           ),
         ],
       ),

--- a/apps/companion/test/fixtures/protocol_v1.json
+++ b/apps/companion/test/fixtures/protocol_v1.json
@@ -59,5 +59,13 @@
       "text": "find the fox",
       "ts": 1767225000000
     }
+  },
+  "logEntry": {
+    "ts": 1767225600000,
+    "level": "error",
+    "component": "agent",
+    "msg": "[d_abc123] SDK error: You've hit your weekly limit",
+    "err": "You've hit your weekly limit · resets Jul 10, 9am",
+    "stack": "Error: limit\n  at runChatTurn"
   }
 }

--- a/apps/companion/test/protocol_fixture_test.dart
+++ b/apps/companion/test/protocol_fixture_test.dart
@@ -73,4 +73,16 @@ void main() {
     expect(r.message.role, Role.user);
     expect(r.message.text, 'find the fox');
   });
+
+  test('canonical log entry parses', () {
+    final e = DaemonLogEntry.fromJson(
+        (fixture['logEntry'] as Map).cast<String, dynamic>());
+    expect(e.ts, 1767225600000);
+    expect(e.level, 'error');
+    expect(e.component, 'agent');
+    expect(e.msg, contains('SDK error'));
+    expect(e.err, contains('weekly limit'));
+    expect(e.stack, contains('runChatTurn'));
+    expect(e.time.millisecondsSinceEpoch, 1767225600000);
+  });
 }

--- a/src/__tests__/claude-sdk-result-error.test.ts
+++ b/src/__tests__/claude-sdk-result-error.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Result-level error capture (stream.ts processResultMessage).
+ *
+ * The Claude SDK doesn't throw on API errors — usage limits, 429s and
+ * auth failures arrive as a synthetic assistant message plus a result
+ * flagged `is_error` (subtype "success") or an error subtype. These
+ * tests pin that both shapes populate `state.resultErrorText` with the
+ * real error text so the handler fails the turn verbosely instead of
+ * treating it as a normal (empty) reply.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createStreamState,
+  processResultMessage,
+} from "../backend/claude-sdk/stream.js";
+import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
+
+const LIMIT_TEXT = "You've hit your weekly limit · resets Jul 10, 9am";
+
+function successResult(
+  overrides: Partial<Record<string, unknown>> = {},
+): SDKResultMessage {
+  return {
+    type: "result",
+    subtype: "success",
+    duration_ms: 1000,
+    duration_api_ms: 900,
+    is_error: false,
+    num_turns: 1,
+    result: "hello",
+    stop_reason: "end_turn",
+    total_cost_usd: 0,
+    usage: { input_tokens: 1, output_tokens: 1 },
+    modelUsage: {},
+    permission_denials: [],
+    uuid: "00000000-0000-0000-0000-000000000000",
+    session_id: "s",
+    ...overrides,
+  } as unknown as SDKResultMessage;
+}
+
+describe("processResultMessage error capture", () => {
+  it("leaves resultErrorText unset on a clean success", () => {
+    const state = createStreamState();
+    processResultMessage(successResult(), state, "opus");
+    expect(state.resultErrorText).toBeUndefined();
+  });
+
+  it("captures the API error text from an is_error success result (usage limit)", () => {
+    const state = createStreamState();
+    processResultMessage(
+      successResult({ is_error: true, result: LIMIT_TEXT }),
+      state,
+      "opus",
+    );
+    expect(state.resultErrorText).toBe(LIMIT_TEXT);
+  });
+
+  it("falls back to the trailing assistant text when an is_error result has no text", () => {
+    const state = createStreamState();
+    state.lastTrailingText = LIMIT_TEXT;
+    processResultMessage(
+      successResult({ is_error: true, result: "" }),
+      state,
+      "opus",
+    );
+    expect(state.resultErrorText).toBe(LIMIT_TEXT);
+  });
+
+  it("captures diagnostics from an error-subtype result", () => {
+    const state = createStreamState();
+    processResultMessage(
+      successResult({
+        subtype: "error_during_execution",
+        is_error: true,
+        result: undefined,
+        errors: ["[ede_diagnostic] result_type=x", "spawn ENOENT"],
+      }),
+      state,
+      "opus",
+    );
+    expect(state.resultErrorText).toBe("spawn ENOENT");
+  });
+
+  it("names the subtype when an error result carries no usable text", () => {
+    const state = createStreamState();
+    processResultMessage(
+      successResult({
+        subtype: "error_max_turns",
+        is_error: true,
+        result: undefined,
+        errors: [],
+      }),
+      state,
+      "opus",
+    );
+    expect(state.resultErrorText).toBe(
+      "Claude SDK turn failed (error_max_turns)",
+    );
+  });
+});

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -257,6 +257,31 @@ describe("classify", () => {
     const err = classify(new Error("context_length_exceeded"));
     expect(err.reason).toBe("context_length");
   });
+
+  // Claude subscription usage limits — the SDK surfaces these as user-facing
+  // text (rateLimitMessages.ts upstream), not as a 429-marked error.
+  it("classifies Claude Code limit messages as usage_limit (not retryable)", () => {
+    for (const msg of [
+      "You've hit your weekly limit · resets Jul 10, 9am",
+      "You’ve hit your Opus limit · resets 3am", // curly apostrophe variant
+      "You've hit your session limit",
+      "You're out of extra usage · resets Jul 12, 1pm",
+      "Claude AI usage limit reached|1751234567",
+    ]) {
+      const err = classify(new Error(msg));
+      expect(err.reason, msg).toBe("usage_limit");
+      expect(err.retryable, msg).toBe(false);
+    }
+  });
+
+  it("does not confuse usage limits with generic rate limits", () => {
+    expect(classify(new Error("429 Too Many Requests")).reason).toBe(
+      "rate_limit",
+    );
+    expect(
+      classify(new Error("You've hit your weekly limit")).reason,
+    ).toBe("usage_limit");
+  });
 });
 
 describe("friendlyMessage", () => {
@@ -317,6 +342,41 @@ describe("friendlyMessage", () => {
   it("returns telegram_api message", () => {
     const err = new TalonError("Telegram failed", { reason: "telegram_api" });
     expect(friendlyMessage(err)).toContain("Telegram API");
+  });
+
+  it("passes usage-limit messages through verbatim", () => {
+    const msg = "You've hit your weekly limit · resets Jul 10, 9am";
+    expect(friendlyMessage(new Error(msg))).toBe(msg);
+  });
+
+  it("falls back to the usage_limit template when the message is empty", () => {
+    const err = new TalonError("", { reason: "usage_limit" });
+    expect(friendlyMessage(err)).toContain("Usage limit reached");
+  });
+
+  it("appends the underlying detail for unknown errors", () => {
+    const msg = friendlyMessage(new Error("spawn ENOENT /usr/bin/rg"));
+    expect(msg).toContain("Something went wrong");
+    expect(msg).toContain("spawn ENOENT /usr/bin/rg");
+  });
+
+  it("appends the underlying detail for auth errors", () => {
+    const msg = friendlyMessage(new Error("401 invalid x-api-key header"));
+    expect(msg).toContain("API key");
+    expect(msg).toContain("invalid x-api-key");
+  });
+
+  it("clips long details and collapses whitespace", () => {
+    const long = `boom ${"x".repeat(500)}\n\nnext   line`;
+    const msg = friendlyMessage(new Error(long));
+    expect(msg.length).toBeLessThan(400);
+    expect(msg).not.toContain("\n\nnext");
+  });
+
+  it("keeps transient reasons terse (no detail appended)", () => {
+    expect(friendlyMessage(new Error("ECONNREFUSED 1.2.3.4"))).not.toContain(
+      "1.2.3.4",
+    );
   });
 });
 

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -278,9 +278,9 @@ describe("classify", () => {
     expect(classify(new Error("429 Too Many Requests")).reason).toBe(
       "rate_limit",
     );
-    expect(
-      classify(new Error("You've hit your weekly limit")).reason,
-    ).toBe("usage_limit");
+    expect(classify(new Error("You've hit your weekly limit")).reason).toBe(
+      "usage_limit",
+    );
   });
 });
 

--- a/src/__tests__/native-logs.test.ts
+++ b/src/__tests__/native-logs.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Bridge log parsing (frontend/native/logs.ts) — pino JSON tail →
+ * wire LogEntry[], with level/component filtering and malformed-line
+ * tolerance.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseLogTail } from "../frontend/native/logs.js";
+import { isLogLevel } from "../frontend/native/protocol.js";
+
+function line(obj: Record<string, unknown>): string {
+  return JSON.stringify(obj);
+}
+
+const SAMPLE = [
+  line({ level: 30, time: 1000, component: "agent", msg: "turn started" }),
+  line({ level: 40, time: 2000, component: "native", msg: "slow client" }),
+  line({
+    level: 50,
+    time: 3000,
+    component: "agent",
+    msg: "SDK error",
+    err: "You've hit your weekly limit",
+    stack: "Error: ...\n  at x",
+  }),
+  line({ level: 20, time: 4000, component: "db", msg: "checkpoint" }),
+].join("\n");
+
+describe("parseLogTail", () => {
+  it("parses pino lines into wire entries, newest last", () => {
+    const entries = parseLogTail(SAMPLE, { limit: 10 });
+    expect(entries).toHaveLength(4);
+    expect(entries[0]).toEqual({
+      ts: 1000,
+      level: "info",
+      component: "agent",
+      msg: "turn started",
+    });
+    expect(entries[2].err).toBe("You've hit your weekly limit");
+    expect(entries[2].stack).toContain("at x");
+  });
+
+  it("applies the limit from the tail (most recent kept)", () => {
+    const entries = parseLogTail(SAMPLE, { limit: 2 });
+    expect(entries.map((e) => e.ts)).toEqual([3000, 4000]);
+  });
+
+  it("filters by minimum level", () => {
+    const entries = parseLogTail(SAMPLE, { limit: 10, minLevel: "warn" });
+    expect(entries.map((e) => e.level)).toEqual(["warn", "error"]);
+  });
+
+  it("filters by component", () => {
+    const entries = parseLogTail(SAMPLE, { limit: 10, component: "agent" });
+    expect(entries).toHaveLength(2);
+    expect(entries.every((e) => e.component === "agent")).toBe(true);
+  });
+
+  it("skips malformed lines (partial first line of a byte window)", () => {
+    const raw = `okens":123}\n${SAMPLE}\nnot json at all\n{"broken":`;
+    const entries = parseLogTail(raw, { limit: 10 });
+    expect(entries).toHaveLength(4);
+  });
+
+  it("maps unknown numeric levels to info and missing fields to defaults", () => {
+    const entries = parseLogTail(line({ level: 35, msg: "odd" }), {
+      limit: 10,
+    });
+    expect(entries[0].level).toBe("info");
+    expect(entries[0].ts).toBe(0);
+    expect(entries[0].component).toBeUndefined();
+  });
+});
+
+describe("isLogLevel", () => {
+  it("accepts wire levels and rejects everything else", () => {
+    expect(isLogLevel("warn")).toBe(true);
+    expect(isLogLevel("fatal")).toBe(true);
+    expect(isLogLevel("verbose")).toBe(false);
+    expect(isLogLevel("")).toBe(false);
+  });
+});

--- a/src/__tests__/native-protocol-fixture.test.ts
+++ b/src/__tests__/native-protocol-fixture.test.ts
@@ -16,6 +16,7 @@ import {
   type BridgeStatus,
   type ClientChat,
   type ClientMessage,
+  type LogEntry,
   type SearchResult,
 } from "../frontend/native/protocol.js";
 
@@ -30,6 +31,7 @@ const fixture = JSON.parse(
   chat: ClientChat;
   status: BridgeStatus;
   searchResult: SearchResult;
+  logEntry: LogEntry;
 };
 
 describe("bridge protocol fixture (shared with the companion app)", () => {
@@ -72,5 +74,15 @@ describe("bridge protocol fixture (shared with the companion app)", () => {
     const r: SearchResult = fixture.searchResult;
     expect(r.chatTitle).toBe("Protocol design");
     expect(r.message.role).toBe("user");
+  });
+
+  it("log entry shape matches LogEntry", () => {
+    const e: LogEntry = fixture.logEntry;
+    expect(e.ts).toBe(1767225600000);
+    expect(e.level).toBe("error");
+    expect(e.component).toBe("agent");
+    expect(e.msg).toContain("SDK error");
+    expect(e.err).toContain("weekly limit");
+    expect(e.stack).toContain("runChatTurn");
   });
 });

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -384,6 +384,19 @@ export async function* runChatTurn(
         armPostResultWatchdog();
       }
     }
+
+    // The SDK doesn't throw on API errors — it converts them into a
+    // synthetic assistant message and finishes the turn with an error-
+    // flagged result (usage limits, 429s, auth failures all land here).
+    // Rethrow the captured error text so this turn takes the SAME path
+    // as a thrown SDK error: retry decision, failed-turn accounting, and
+    // an `error` event carrying the real message — instead of being
+    // treated as a normal reply (which, with no delivery tool call,
+    // would trip the flow-violation re-prompt loop and burn more turns
+    // against an already-exhausted limit).
+    if (state.resultErrorText) {
+      throw new Error(state.resultErrorText);
+    }
   } catch (err) {
     if (!postResultForceClosed) {
       const buildRetryStream = (

--- a/src/backend/claude-sdk/stream.ts
+++ b/src/backend/claude-sdk/stream.ts
@@ -75,6 +75,17 @@ export type StreamState = {
    * doesn't poison the visible-text delta buffer.
    */
   unflushedThinkingDelta: string;
+  /**
+   * Set when the SDK's final result message reported a failed turn —
+   * either an error subtype (`error_during_execution`, `error_max_turns`,
+   * …) or `is_error: true` on a `success` result. The latter is how API
+   * errors surface: the SDK converts them (usage limits, 429s, auth
+   * failures) into a synthetic assistant message and finishes the turn
+   * "successfully" with the error text in `result` — it never throws.
+   * Carries the best error text available so the handler can fail the
+   * turn with the REAL message instead of treating it as a normal reply.
+   */
+  resultErrorText: string | undefined;
 };
 
 export function createStreamState(): StreamState {
@@ -96,6 +107,7 @@ export function createStreamState(): StreamState {
     turnTerminated: false,
     unflushedTextDelta: "",
     unflushedThinkingDelta: "",
+    resultErrorText: undefined,
   };
 }
 
@@ -357,6 +369,27 @@ export function processResultMessage(
     typeof msg.result === "string"
   ) {
     state.currentBlockText = msg.result;
+  }
+
+  // Failed turn. Two shapes (see StreamState.resultErrorText):
+  //  - error subtype: no `result` field, but `errors[]` carries diagnostics.
+  //  - success subtype with is_error: `result` (and the trailing assistant
+  //    text) IS the API error message, e.g. "You've hit your weekly limit
+  //    · resets Jul 10, 9am". Prefer that text — it's the user-facing one.
+  if (msg.subtype !== "success") {
+    const diagnostics = (msg.errors ?? [])
+      .filter((e) => typeof e === "string" && !e.startsWith("[ede_diagnostic]"))
+      .join("; ")
+      .slice(0, 500);
+    state.resultErrorText =
+      state.lastTrailingText.trim() ||
+      diagnostics ||
+      `Claude SDK turn failed (${msg.subtype})`;
+  } else if (msg.is_error) {
+    state.resultErrorText =
+      (typeof msg.result === "string" && msg.result.trim()) ||
+      state.lastTrailingText.trim() ||
+      "Claude SDK turn failed (API error)";
   }
 }
 

--- a/src/core/agent-runtime/events.ts
+++ b/src/core/agent-runtime/events.ts
@@ -259,6 +259,10 @@ export function addUsage(a: UsageSnapshot, b: UsageSnapshot): UsageSnapshot {
  */
 const REASON_TO_KIND: Partial<Record<TalonError["reason"], AgentErrorKind>> = {
   rate_limit: "rate_limit",
+  // Subscription usage limits share the rate_limit kind — same family for
+  // event consumers; `retryable: false` (carried through) is what
+  // distinguishes them from a transient 429.
+  usage_limit: "rate_limit",
   overloaded: "overload",
   context_length: "context_overflow",
   session_expired: "session_expired",

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -9,6 +9,7 @@
 
 type ErrorReason =
   | "rate_limit"
+  | "usage_limit"
   | "overloaded"
   | "network"
   | "auth"
@@ -18,6 +19,19 @@ type ErrorReason =
   | "forbidden"
   | "telegram_api"
   | "unknown";
+
+/**
+ * Claude subscription usage-limit messages, as produced by Claude Code /
+ * the Agent SDK (see rateLimitMessages.ts upstream: "You've hit your
+ * weekly limit · resets Jul 10, 9am", "You're out of extra usage", …)
+ * plus the legacy "Claude AI usage limit reached|<ts>" format. These are
+ * already user-facing text — classification marks them `usage_limit` so
+ * `friendlyMessage` passes them through instead of collapsing them to a
+ * generic template. Unlike `rate_limit` (a transient 429), a usage limit
+ * doesn't clear on a short retry, so `retryable` stays false.
+ */
+const USAGE_LIMIT_RE =
+  /you['’]ve hit your .{0,40}limit|you['’]re out of extra usage|claude ai usage limit reached|usage limit reached/i;
 
 // ── TalonError class ────────────────────────────────────────────────────────
 
@@ -73,6 +87,18 @@ export function classify(err: unknown): TalonError {
   // would produce a spurious status on the returned TalonError)
   const statusMatch = msg.match(/\b([45]\d{2})\b/);
   const status = statusMatch ? parseInt(statusMatch[1], 10) : undefined;
+
+  // Subscription usage limit — checked before the generic rate-limit
+  // branch ("usage limit reached" would otherwise never be reached, and
+  // "You've hit your…" carries no 429/rate-limit marker at all).
+  if (USAGE_LIMIT_RE.test(msg)) {
+    return new TalonError(msg, {
+      reason: "usage_limit",
+      retryable: false,
+      status: status ?? 429,
+      cause,
+    });
+  }
 
   // Rate limit
   if (/rate.?limit|429|too many requests/i.test(msg)) {
@@ -190,6 +216,7 @@ export function classify(err: unknown): TalonError {
 
 const FRIENDLY_MESSAGES: Record<ErrorReason, string> = {
   rate_limit: "Rate limited. Try again in a moment.",
+  usage_limit: "Usage limit reached. Try again after it resets.",
   overloaded:
     "Upstream model is busy right now. Retrying with a faster fallback...",
   network: "Connection issue. Retrying shortly.",
@@ -204,7 +231,29 @@ const FRIENDLY_MESSAGES: Record<ErrorReason, string> = {
 };
 
 /**
+ * Reasons whose template alone tells the user nothing actionable — the
+ * underlying error detail is appended so "Something went wrong" always
+ * says WHAT went wrong. Templated reasons like `network`/`overloaded`
+ * stay terse: they're transient and the detail is just transport noise.
+ */
+const DETAIL_REASONS: ReadonlySet<ErrorReason> = new Set([
+  "auth",
+  "bad_request",
+  "forbidden",
+  "unknown",
+]);
+
+/** Collapse whitespace and clip the raw error for inline display. */
+function clipDetail(msg: string, max = 300): string {
+  const flat = msg.replace(/\s+/g, " ").trim();
+  if (!flat || flat === "[non-stringifiable error]") return "";
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
+}
+
+/**
  * Get a user-friendly error message. For rate limits, includes retry timing.
+ * Usage-limit and session-expired messages pass through verbatim (they're
+ * already user-facing); generic reasons carry the underlying detail.
  */
 export function friendlyMessage(err: unknown): string {
   const classified = err instanceof TalonError ? err : classify(err);
@@ -214,10 +263,19 @@ export function friendlyMessage(err: unknown): string {
     return `Rate limited. Try again in ${seconds} seconds.`;
   }
 
-  // Session expired messages are already user-friendly from the backend
-  if (classified.reason === "session_expired") {
-    return classified.message;
+  // Already user-friendly from the backend — pass through as-is.
+  if (
+    classified.reason === "session_expired" ||
+    classified.reason === "usage_limit"
+  ) {
+    return classified.message || FRIENDLY_MESSAGES[classified.reason];
   }
 
-  return FRIENDLY_MESSAGES[classified.reason];
+  const base = FRIENDLY_MESSAGES[classified.reason];
+  if (DETAIL_REASONS.has(classified.reason)) {
+    const detail = clipDetail(classified.message);
+    // Skip when the detail adds nothing over the template itself.
+    if (detail && detail !== base) return `${base}\n\nDetail: ${detail}`;
+  }
+  return base;
 }

--- a/src/frontend/native/index.ts
+++ b/src/frontend/native/index.ts
@@ -22,7 +22,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { spawn } from "node:child_process";
 import { log, logError } from "../../util/log.js";
-import { dirs } from "../../util/paths.js";
+import { dirs, files } from "../../util/paths.js";
 import { PKG_ROOT } from "../../cli/context.js";
 import { getSessionInfo } from "../../storage/sessions.js";
 import { buildContextDisplay } from "../shared/status-context.js";
@@ -66,6 +66,7 @@ import { extractSessionName } from "../../backend/shared/session-name.js";
 import { BridgeServer, type BridgeServerHandlers } from "./server.js";
 import { createNativeActionHandler } from "./actions.js";
 import { removeBridgeDiscovery, writeBridgeDiscovery } from "./discovery.js";
+import { readLogEntries } from "./logs.js";
 import {
   BRIDGE_PROTOCOL_VERSION,
   BOT_SENDER_ID,
@@ -1144,6 +1145,8 @@ export function createNativeFrontend(
       return snap;
     },
     control,
+    logs: ({ lines, minLevel, component }) =>
+      readLogEntries(files.log, { limit: lines, minLevel, component }),
     liveTurnEvents,
     mediaPath: (id) => media.get(id) ?? null,
   };

--- a/src/frontend/native/logs.ts
+++ b/src/frontend/native/logs.ts
@@ -1,0 +1,92 @@
+/**
+ * Daemon log access for the client bridge.
+ *
+ * Parses the pino JSON log file (`~/.talon/talon.log`, one object per
+ * line — see util/log.ts) into the wire `LogEntry` shape so clients can
+ * render the daemon's log without shipping a pino parser of their own.
+ * Pure functions over a raw tail string; file I/O stays with the caller.
+ */
+
+import { tailFile } from "../../util/tail-file.js";
+import type { LogEntry, LogLevel } from "./protocol.js";
+
+/** pino numeric levels → wire level names. */
+const PINO_LEVELS: Record<number, LogLevel> = {
+  10: "trace",
+  20: "debug",
+  30: "info",
+  40: "warn",
+  50: "error",
+  60: "fatal",
+};
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+};
+
+export type LogQuery = {
+  /** Max entries returned (most recent last). */
+  limit: number;
+  /** Minimum severity — entries below it are dropped. */
+  minLevel?: LogLevel;
+  /** Exact component match (e.g. "agent", "native"). */
+  component?: string;
+};
+
+/**
+ * Parse a raw tail of the pino log file into wire entries, newest last.
+ * Malformed lines (partial first line of the byte window, rotation
+ * artifacts) are skipped rather than failing the whole request.
+ */
+export function parseLogTail(raw: string, query: LogQuery): LogEntry[] {
+  const minRank = query.minLevel ? LEVEL_RANK[query.minLevel] : 0;
+  const entries: LogEntry[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const levelNum = typeof obj.level === "number" ? obj.level : 30;
+    if (levelNum < minRank) continue;
+    const component =
+      typeof obj.component === "string" ? obj.component : undefined;
+    if (query.component && component !== query.component) continue;
+    entries.push({
+      ts: typeof obj.time === "number" ? obj.time : 0,
+      level: PINO_LEVELS[levelNum] ?? "info",
+      ...(component ? { component } : {}),
+      msg: typeof obj.msg === "string" ? obj.msg : "",
+      ...(typeof obj.err === "string" ? { err: obj.err } : {}),
+      ...(typeof obj.stack === "string" ? { stack: obj.stack } : {}),
+    });
+  }
+  return entries.slice(-query.limit);
+}
+
+/**
+ * Read + parse the newest `query.limit` entries from `path`. The byte
+ * window scales with the request so filtered queries (level/component)
+ * still have material to fill from, capped so a hostile `lines` value
+ * can't make the daemon slurp the whole file.
+ */
+export function readLogEntries(path: string, query: LogQuery): LogEntry[] {
+  const maxBytes = Math.min(2 * 1024 * 1024, Math.max(64 * 1024, query.limit * 2048));
+  let raw: string;
+  try {
+    // Line budget is generous vs `limit` so level-filtered queries can
+    // still return `limit` matches from a mostly-info tail.
+    raw = tailFile(path, query.limit * 20, maxBytes);
+  } catch {
+    return [];
+  }
+  return parseLogTail(raw, query);
+}

--- a/src/frontend/native/logs.ts
+++ b/src/frontend/native/logs.ts
@@ -79,7 +79,10 @@ export function parseLogTail(raw: string, query: LogQuery): LogEntry[] {
  * can't make the daemon slurp the whole file.
  */
 export function readLogEntries(path: string, query: LogQuery): LogEntry[] {
-  const maxBytes = Math.min(2 * 1024 * 1024, Math.max(64 * 1024, query.limit * 2048));
+  const maxBytes = Math.min(
+    2 * 1024 * 1024,
+    Math.max(64 * 1024, query.limit * 2048),
+  );
   let raw: string;
   try {
     // Line budget is generous vs `limit` so level-filtered queries can

--- a/src/frontend/native/protocol.ts
+++ b/src/frontend/native/protocol.ts
@@ -142,6 +142,40 @@ export type BridgeStatus = {
   startedAt: string;
 };
 
+/** Wire severity for a daemon log entry (mirrors pino's level names). */
+export type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+
+const LOG_LEVELS: readonly LogLevel[] = [
+  "trace",
+  "debug",
+  "info",
+  "warn",
+  "error",
+  "fatal",
+];
+
+/** Narrow an untrusted query-param string to a wire log level. */
+export function isLogLevel(v: string): v is LogLevel {
+  return (LOG_LEVELS as readonly string[]).includes(v);
+}
+
+/**
+ * One daemon log line, served by `GET /logs` for the client's log viewer
+ * (additive in v1 — older clients simply never call the endpoint).
+ */
+export type LogEntry = {
+  /** Epoch milliseconds. */
+  ts: number;
+  level: LogLevel;
+  /** Subsystem tag (e.g. "agent", "native", "gateway"), when present. */
+  component?: string;
+  msg: string;
+  /** Concise error message, when the line logged one. */
+  err?: string;
+  /** Full stack trace, when the line logged one. */
+  stack?: string;
+};
+
 /** A selectable model for the picker. */
 export type ModelOption = {
   id: string;

--- a/src/frontend/native/server.ts
+++ b/src/frontend/native/server.ts
@@ -24,11 +24,14 @@ import { extname } from "node:path";
 import { log, logError, logDebug } from "../../util/log.js";
 import {
   BRIDGE_PROTOCOL_VERSION,
+  isLogLevel,
   type BackendOption,
   type BridgeEvent,
   type BridgeStatus,
   type ClientChat,
   type ClientMessage,
+  type LogEntry,
+  type LogLevel,
   type ModelOption,
   type SearchResult,
 } from "./protocol.js";
@@ -92,6 +95,12 @@ export type BridgeServerHandlers = {
   setConfig(update: Record<string, unknown>): ConfigSnapshot;
   /** Fire a daemon-level control action (e.g. "restart", "dream"). */
   control(action: string): Promise<{ ok: boolean; message: string }>;
+  /** Newest daemon log entries (for the client's log viewer). */
+  logs(opts: {
+    lines: number;
+    minLevel?: LogLevel;
+    component?: string;
+  }): LogEntry[];
   /** Events reconstructing any in-progress turns, for a just-connected client. */
   liveTurnEvents(): BridgeEvent[];
   /** Resolve a media id to an absolute file path (or null if unknown). */
@@ -405,6 +414,22 @@ export class BridgeServer {
       if (method === "GET" && path === "/media") {
         const id = url.searchParams.get("id") ?? "";
         return await this.serveMedia(res, id);
+      }
+
+      if (method === "GET" && path === "/logs") {
+        const lines = Math.min(
+          asPositiveInt(url.searchParams.get("lines")) ?? 200,
+          1000,
+        );
+        const level = url.searchParams.get("level") ?? "";
+        const component = url.searchParams.get("component") ?? undefined;
+        return this.json(res, 200, {
+          entries: this.handlers.logs({
+            lines,
+            minLevel: isLogLevel(level) ? level : undefined,
+            component,
+          }),
+        });
       }
 
       if (method === "GET" && path === "/config")


### PR DESCRIPTION
## Problem

1. When a Claude usage limit is hit, users see **"Something went wrong. Try again or /reset."** instead of the actual limit message. Root cause: the Claude Agent SDK doesn't *throw* on API errors — it converts them (usage limits, 429s, auth failures) into a synthetic assistant message and finishes the turn with an error-flagged result (`is_error: true`, or an error subtype). Talon ignored those flags, so the turn looked like a normal empty reply: messaging frontends tripped the flow-violation re-prompt loop (burning more turns against an exhausted limit), and whatever eventually surfaced was classified `unknown` → generic template.
2. There was no way to see the daemon log from the companion app.

## Changes

### Verbose errors
- **`core/errors.ts`**: new `usage_limit` reason recognizing Claude's subscription-limit messages (`"You've hit your weekly limit · resets Jul 10, 9am"`, `"You're out of extra usage"`, legacy `"Claude AI usage limit reached|<ts>"` — formats verified against the Claude Code source). `friendlyMessage()` passes these through verbatim; they're already user-facing text. Non-retryable (a weekly limit won't clear on a 60s retry).
- **`backend/claude-sdk/stream.ts` + `handler.ts`**: `processResultMessage` captures error-flagged results into `StreamState.resultErrorText` (preferring the API's user-facing text, falling back to `errors[]` diagnostics / the subtype). The handler rethrows it so failed turns take the *same* path as thrown SDK errors — retry decision, failed-turn accounting, and an `error` event carrying the real message — instead of the flow-violation loop. Interrupted turns are unaffected (they end `is_error: false`).
- **`friendlyMessage()`**: generic reasons (`unknown`, `bad_request`, `auth`, `forbidden`) now append the underlying error detail (clipped, whitespace-collapsed) so "Something went wrong" always says what went wrong. Transient reasons (network/overloaded) stay terse.

### Log viewer
- **Daemon**: new `GET /logs?lines=&level=&component=` bridge endpoint. `frontend/native/logs.ts` parses the pino JSON `talon.log` tail into typed `LogEntry` wire objects (level names, component, msg, err, stack), malformed-line tolerant, byte-window capped.
- **Companion**: new **Logs** screen (Settings → Controls → View logs): severity chips (All/Info+/Warn+/Errors), component picker, text filter, live follow (3s auto-refresh, stick-to-bottom), monospace rendering with level-colored rows, expandable error/stack detail, copy-visible-lines. Shared protocol fixture extended (`logEntry`) and asserted from both the TS and Dart contract suites.

## Testing
- New: `claude-sdk-result-error.test.ts` (result-error capture shapes), `native-logs.test.ts` (pino tail parsing/filtering), usage-limit + detail-verbosity cases in `errors.test.ts`, `logEntry` fixture assertions on both sides.
- `tsc --noEmit` clean; affected vitest suites pass locally. Flutter analyze/test via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)