### PR TITLE
refactor(weaver): decompose the turn runner into single-purpose collaborators

### DIFF
--- a/src/__tests__/weaver-collaborators.test.ts
+++ b/src/__tests__/weaver-collaborators.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RetrievedMemory } from "../core/agent-runtime/capabilities.js";
+import {
+  AgentRunError,
+  type AgentEvent,
+} from "../core/agent-runtime/events.js";
+import { makeBareModelRef } from "../core/agent-runtime/model-ref.js";
+import {
+  carryTurnEvents,
+  prefetchMemory,
+  resolveWarp,
+  startTypingLoop,
+} from "../core/weaver/index.js";
+
+async function* stream(...events: AgentEvent[]): AsyncGenerator<AgentEvent> {
+  for (const event of events) yield event;
+}
+
+describe("shuttle", () => {
+  it("forwards events in stream order and captures the completed result", async () => {
+    const seen: string[] = [];
+    const result = await carryTurnEvents(
+      stream(
+        { type: "text_delta", text: "he" },
+        { type: "assistant_message", text: "hello" },
+        {
+          type: "completed",
+          result: {
+            text: "hello",
+            durationMs: 5,
+            usage: {
+              inputTokens: 1,
+              outputTokens: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+            },
+          },
+        },
+      ),
+      async (event) => {
+        seen.push(event.type);
+      },
+    );
+
+    expect(seen).toEqual(["text_delta", "assistant_message", "completed"]);
+    expect(result?.text).toBe("hello");
+    expect(result?.usage.outputTokens).toBe(2);
+  });
+
+  it("settles deliveryAck: resolve on sink success, reject on sink throw", async () => {
+    const resolved = vi.fn();
+    const rejected = vi.fn();
+
+    await carryTurnEvents(
+      stream({
+        type: "assistant_message",
+        text: "ok",
+        deliveryAck: { resolve: resolved, reject: rejected },
+      }),
+      async () => {},
+    );
+    expect(resolved).toHaveBeenCalledTimes(1);
+    expect(rejected).not.toHaveBeenCalled();
+
+    const failure = new Error("send failed");
+    await carryTurnEvents(
+      stream({
+        type: "assistant_message",
+        text: "ok",
+        deliveryAck: { resolve: resolved, reject: rejected },
+      }),
+      async () => {
+        throw failure;
+      },
+    );
+    expect(rejected).toHaveBeenCalledWith(failure);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves deliveryAck even when no sink is supplied", async () => {
+    const resolved = vi.fn();
+    await carryTurnEvents(
+      stream({
+        type: "assistant_message",
+        text: "ok",
+        deliveryAck: { resolve: resolved, reject: vi.fn() },
+      }),
+    );
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows an error terminator as AgentRunError after forwarding it", async () => {
+    const seen: string[] = [];
+    await expect(
+      carryTurnEvents(
+        stream({
+          type: "error",
+          error: { kind: "rate_limit", message: "limited", retryable: false },
+        }),
+        async (event) => {
+          seen.push(event.type);
+        },
+      ),
+    ).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(AgentRunError);
+      expect((err as AgentRunError).kind).toBe("rate_limit");
+      expect((err as AgentRunError).retryable).toBe(false);
+      return true;
+    });
+    expect(seen).toEqual(["error"]);
+  });
+});
+
+describe("warp resolver", () => {
+  const chatRef = makeBareModelRef("claude", "chat-model", "discovered");
+  const input = { chatId: "c", source: "message", reqId: "test" };
+
+  it("binds the chat's resolved model when no override is set", async () => {
+    const warp = await resolveWarp(
+      {
+        resolveActiveModel: async () => ({
+          model: "chat-model",
+          ref: chatRef,
+          backendId: "claude",
+        }),
+      },
+      input,
+    );
+    expect(warp).toEqual({
+      ok: true,
+      ref: chatRef,
+      backendId: "claude",
+      overridden: false,
+    });
+  });
+
+  it("refuses the turn with a /model prompt when no model resolves", async () => {
+    const warp = await resolveWarp(
+      {
+        resolveActiveModel: async () => ({
+          model: null,
+          ref: null,
+          backendId: "kilo",
+        }),
+      },
+      input,
+    );
+    expect(warp.ok).toBe(false);
+    if (!warp.ok) {
+      expect(warp.backendId).toBe("kilo");
+      expect(warp.message).toContain("No model selected");
+      expect(warp.message).toContain("backendDefaults.kilo");
+    }
+  });
+
+  it("applies a resolvable per-run override and flags it", async () => {
+    const overrideRef = makeBareModelRef("claude", "cheap-model", "discovered");
+    const warp = await resolveWarp(
+      {
+        resolveActiveModel: async () => ({
+          model: "chat-model",
+          ref: chatRef,
+          backendId: "claude",
+        }),
+        resolveModelOverride: async () => overrideRef,
+      },
+      { ...input, modelOverride: "cheap-model" },
+    );
+    expect(warp).toEqual({
+      ok: true,
+      ref: overrideRef,
+      backendId: "claude",
+      overridden: true,
+    });
+  });
+
+  it.each([
+    ["unresolvable", async (): Promise<null> => null],
+    [
+      "throwing",
+      async (): Promise<null> => {
+        throw new Error("catalog changed");
+      },
+    ],
+  ] as const)(
+    "falls back to the chat model on a %s override",
+    async (_label, resolveModelOverride) => {
+      const warp = await resolveWarp(
+        {
+          resolveActiveModel: async () => ({
+            model: "chat-model",
+            ref: chatRef,
+            backendId: "claude",
+          }),
+          resolveModelOverride,
+        },
+        { ...input, modelOverride: "stale-model" },
+      );
+      expect(warp).toEqual({
+        ok: true,
+        ref: chatRef,
+        backendId: "claude",
+        overridden: false,
+      });
+    },
+  );
+});
+
+describe("typing loop", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends immediately, refreshes on the interval, and stops cleanly", () => {
+    vi.useFakeTimers();
+    const sendTyping = vi.fn(async () => {});
+
+    const stop = startTypingLoop(sendTyping, 7, "chat", 4000);
+    expect(sendTyping).toHaveBeenCalledTimes(1);
+    expect(sendTyping).toHaveBeenCalledWith(7, "chat");
+
+    vi.advanceTimersByTime(8000);
+    expect(sendTyping).toHaveBeenCalledTimes(3);
+
+    stop();
+    vi.advanceTimersByTime(8000);
+    expect(sendTyping).toHaveBeenCalledTimes(3);
+  });
+
+  it("swallows send failures instead of failing the turn", async () => {
+    vi.useFakeTimers();
+    const sendTyping = vi.fn(async () => {
+      throw new Error("indicator dropped");
+    });
+
+    const stop = startTypingLoop(sendTyping, 7, "chat", 4000);
+    await vi.advanceTimersByTimeAsync(4000);
+    stop();
+    expect(sendTyping).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("memory prefetch", () => {
+  const input = {
+    chatId: "c",
+    text: "hello",
+    senderName: "Dylan",
+    isGroup: false,
+    reqId: "test",
+  };
+
+  it("returns the retriever's result", async () => {
+    const memory: RetrievedMemory = {
+      source: "mempalace",
+      query: "hello",
+      items: [],
+    };
+    await expect(prefetchMemory(async () => memory, input)).resolves.toBe(
+      memory,
+    );
+  });
+
+  it("fails closed when the retriever throws", async () => {
+    await expect(
+      prefetchMemory(async () => {
+        throw new Error("palace on fire");
+      }, input),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/weaver.test.ts
+++ b/src/__tests__/weaver.test.ts
@@ -157,6 +157,32 @@ describe("weaver", () => {
   });
 });
 
+describe("weaver turn-start hook", () => {
+  it("fires once per executed turn, but not on a no-model refusal", async () => {
+    const onTurnStart = vi.fn();
+    const backend = stubBackend();
+    let model: ReturnType<typeof stubResolveActiveModel> | null =
+      stubResolveActiveModel();
+    const weaver = new Weaver({
+      getBackend: () => backend,
+      resolveActiveModel: async () =>
+        model ? model() : { model: null, ref: null, backendId: "claude" },
+      context: { acquire: vi.fn(), release: vi.fn(), getMessageCount: () => 0 },
+      sendTyping: vi.fn(async () => {}),
+      onActivity: vi.fn(),
+      onTurnStart,
+    });
+
+    await weaver.runTurn(params({ chatId: "hooked" }));
+    expect(onTurnStart).toHaveBeenCalledTimes(1);
+
+    model = null; // next resolution refuses the turn
+    const refused = await weaver.runTurn(params({ chatId: "hooked" }));
+    expect(refused.text).toContain("No model selected");
+    expect(onTurnStart).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("thread execution context", () => {
   it("brackets a turn: acquire resets the per-turn counter, release clears", () => {
     const thread = new Thread("c");

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -28,7 +28,7 @@ import {
   initTriggers,
   resumeAfterRestart as resumeTriggersAfterRestart,
 } from "./core/background/triggers/index.js";
-import { initDream } from "./core/background/dream.js";
+import { initDream, maybeStartDream } from "./core/background/dream.js";
 import { initHeartbeat } from "./core/background/heartbeat/index.js";
 import { log, logWarn, logDebug } from "./util/log.js";
 import type { TalonConfig } from "./util/config.js";
@@ -409,6 +409,10 @@ export async function initBackendAndDispatcher(
         chatId,
       ),
     onActivity: () => resetPulseTimer(),
+    // Turn-start hook: fire-and-forget dream (background memory
+    // consolidation) check. Wired here so the Weaver stays ignorant of
+    // the dream subsystem.
+    onTurnStart: maybeStartDream,
   });
 
   initPulse();

--- a/src/core/engine/gateway.ts
+++ b/src/core/engine/gateway.ts
@@ -16,7 +16,7 @@ import {
 import pRetry, { AbortError } from "p-retry";
 import { classify } from "../errors.js";
 import { getActiveCount } from "./dispatcher.js";
-import { Loom, getActiveLoom } from "../weaver/index.js";
+import { Loom, getActiveLoom, type ContextRegistry } from "../weaver/index.js";
 import { getHealthStatus } from "../../util/watchdog.js";
 import { getActiveSessionCount } from "../../storage/sessions.js";
 import { log, logError, logDebug } from "../../util/log.js";
@@ -89,13 +89,14 @@ export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
 export class Gateway {
   /**
    * Per-chat live state is owned by the Weaver's Loom. The gateway holds no
-   * registry of its own — it delegates here. `getActiveLoom()` returns the
-   * Weaver's Loom once the dispatcher is wired; the standalone fallback covers
-   * unit tests and the brief startup window before init (when no turn — and so
-   * no context — can exist anyway).
+   * registry of its own — it delegates here, and only through the
+   * `ContextRegistry` face (the gateway never creates or evicts Threads).
+   * `getActiveLoom()` returns the Weaver's Loom once the dispatcher is wired;
+   * the standalone fallback covers unit tests and the brief startup window
+   * before init (when no turn — and so no context — can exist anyway).
    */
   private readonly ownLoom = new Loom();
-  private get loom(): Loom {
+  private get loom(): ContextRegistry {
     return getActiveLoom() ?? this.ownLoom;
   }
 

--- a/src/core/weaver/index.ts
+++ b/src/core/weaver/index.ts
@@ -1,9 +1,16 @@
 export { Thread, type Warp, type ThreadSnapshot } from "./thread.js";
 export { ThreadSession, type SessionSummary } from "./thread-session.js";
-export { Loom } from "./loom.js";
+export { Loom, type ContextRegistry } from "./loom.js";
+export { carryTurnEvents, type EventSink } from "./shuttle.js";
+export { startTypingLoop, TYPING_REFRESH_MS } from "./typing-loop.js";
+export { prefetchMemory } from "./memory-prefetch.js";
+export {
+  resolveWarp,
+  type WarpResolution,
+  type WarpResolverDeps,
+} from "./warp-resolver.js";
 export {
   Weaver,
-  getWeaver,
   getActiveLoom,
   initWeaver,
   type WeaverDeps,

--- a/src/core/weaver/loom.ts
+++ b/src/core/weaver/loom.ts
@@ -1,4 +1,30 @@
-import { Thread } from "./thread.js";
+import { Thread, type ThreadSnapshot } from "./thread.js";
+
+/**
+ * The context-tracking face of the Loom — everything the gateway needs
+ * to bracket turns and answer numeric-keyed queries, and nothing else.
+ * The gateway depends on this interface (not the concrete Loom), so its
+ * contract with the registry is explicit and a test can substitute a
+ * stub without dragging in Thread creation or eviction.
+ */
+export interface ContextRegistry {
+  /** Acquire the execution context for a turn. See `Loom.acquireContext`. */
+  acquireContext(numericChatId: number, stringId?: string): Thread;
+  /** Release one context hold, addressed by numeric or string id. */
+  releaseContext(id: number | string): void;
+  /** Count one bridge-sent message against the chat's current turn. */
+  noteMessageSent(numericChatId: number): void;
+  /** Messages the bridge has sent during the chat's current turn. */
+  messageCount(numericChatId: number): number;
+  /** Whether a turn is currently holding the chat's execution context. */
+  hasActiveContext(numericChatId: number): boolean;
+  /** Number of chats currently holding an execution context. */
+  activeContextCount(): number;
+  /** Resolve a string chat id to the numeric id of its active context. */
+  numericForStringId(stringId: string): number | null;
+  /** Number of live Threads in the registry. */
+  size(): number;
+}
 
 /**
  * Loom — the single registry of live chat Threads.
@@ -9,7 +35,7 @@ import { Thread } from "./thread.js";
  * route inbound tool calls and report active chats without owning any
  * per-chat state of its own.
  */
-export class Loom {
+export class Loom implements ContextRegistry {
   private readonly threads = new Map<string, Thread>();
   private readonly byNumeric = new Map<number, Thread>();
 
@@ -42,6 +68,11 @@ export class Loom {
 
   chatIds(): string[] {
     return [...this.threads.keys()];
+  }
+
+  /** An immutable view of every live Thread. Reading is side-effect free. */
+  snapshot(): ThreadSnapshot[] {
+    return [...this.threads.values()].map((thread) => thread.describe());
   }
 
   // ── Execution context (gateway-facing; absorbed ChatContext) ────────────────

--- a/src/core/weaver/memory-prefetch.ts
+++ b/src/core/weaver/memory-prefetch.ts
@@ -1,0 +1,49 @@
+/**
+ * Memory prefetch (Phase B) — optional pre-retrieval of palace memory
+ * for live user messages, strictly fail-closed: a broken palace must
+ * never block chat delivery. The result is dynamic turn context passed
+ * through ChatRunParams; it never touches the frozen prompt.
+ */
+
+import type { RetrievedMemory } from "../agent-runtime/capabilities.js";
+import type { MemoryRetriever } from "../memory/retrieval.js";
+import { logDebug, logWarn } from "../../util/log.js";
+
+export type PrefetchMemoryInput = {
+  chatId: string;
+  text: string;
+  senderName: string;
+  isGroup: boolean;
+  /** Request id for log correlation. */
+  reqId: string;
+};
+
+export async function prefetchMemory(
+  retrieve: MemoryRetriever,
+  input: PrefetchMemoryInput,
+): Promise<RetrievedMemory | undefined> {
+  try {
+    const retrieved = await retrieve({
+      runKind: "chat",
+      chatId: input.chatId,
+      text: input.text,
+      senderName: input.senderName,
+      isGroup: input.isGroup,
+    });
+    if (retrieved) {
+      logDebug(
+        "dispatcher",
+        `[${input.reqId}] memory pre-retrieval: ${retrieved.items.length} item(s), ` +
+          `${retrieved.items.reduce((n, i) => n + i.text.length, 0)} chars`,
+      );
+    }
+    return retrieved;
+  } catch (err) {
+    logWarn(
+      "dispatcher",
+      `[${input.reqId}] memory pre-retrieval failed (running turn without it): ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+    return undefined;
+  }
+}

--- a/src/core/weaver/shuttle.ts
+++ b/src/core/weaver/shuttle.ts
@@ -1,0 +1,63 @@
+/**
+ * Shuttle — carries the weft across the warp: consumes a backend's
+ * canonical `AgentEvent` stream and forwards every event to the
+ * frontend's `onEvent` sink (no callback bridge, no back-translation).
+ *
+ * The Shuttle owns the three stream-consumption invariants so no caller
+ * can get them subtly wrong:
+ *
+ *   - **ordering** — events are awaited in stream order, so a consumer
+ *     that needs serial delivery gets it;
+ *   - **ack settlement** — `assistant_message.deliveryAck` is ALWAYS
+ *     settled, even when no `onEvent` sink is supplied or the sink
+ *     ignores the event. Otherwise the callback-shaped backend
+ *     (handler-to-events) blocks forever awaiting delivery
+ *     confirmation. The frontend's job is just to deliver and throw on
+ *     failure; the Shuttle maps that onto the ack (resolve on success →
+ *     block delivered; reject on throw → backend retries, e.g. Codex
+ *     oversized-message path);
+ *   - **terminators** — the `completed` event's `AgentResult` is
+ *     captured for the return value, and an `error` terminator is
+ *     rethrown as `AgentRunError` so callers' catch paths keep working.
+ */
+
+import {
+  AgentRunError,
+  type AgentEvent,
+  type AgentResult,
+} from "../agent-runtime/events.js";
+
+export type EventSink = (event: AgentEvent) => void | Promise<void>;
+
+/**
+ * Pump the stream to completion. Returns the `completed` event's
+ * result (if the backend emitted one); throws `AgentRunError` when the
+ * stream terminates with an `error` event.
+ */
+export async function carryTurnEvents(
+  stream: AsyncIterable<AgentEvent>,
+  onEvent?: EventSink,
+): Promise<AgentResult | undefined> {
+  let agentResult: AgentResult | undefined;
+  for await (const event of stream) {
+    if (event.type === "completed") {
+      agentResult = event.result;
+    }
+
+    if (event.type === "assistant_message" && event.deliveryAck) {
+      try {
+        await onEvent?.(event);
+        event.deliveryAck.resolve();
+      } catch (err) {
+        event.deliveryAck.reject(err);
+      }
+      continue;
+    }
+
+    await onEvent?.(event);
+    if (event.type === "error") {
+      throw new AgentRunError(event.error);
+    }
+  }
+  return agentResult;
+}

--- a/src/core/weaver/typing-loop.ts
+++ b/src/core/weaver/typing-loop.ts
@@ -1,0 +1,36 @@
+/**
+ * Typing loop — keeps the frontend's typing indicator alive for the
+ * duration of a turn. Sends immediately, then re-sends on an interval;
+ * every send is fail-soft (logged, never thrown) because a dropped
+ * indicator must not fail the turn.
+ */
+
+import { logWarn } from "../../util/log.js";
+
+/** Platforms expire typing indicators after ~5s; refresh under that. */
+export const TYPING_REFRESH_MS = 4000;
+
+export type SendTyping = (
+  numericChatId: number,
+  stringId?: string,
+) => Promise<void>;
+
+/** Start the loop. Call the returned function to stop it. */
+export function startTypingLoop(
+  sendTyping: SendTyping,
+  numericChatId: number,
+  stringId: string,
+  intervalMs = TYPING_REFRESH_MS,
+): () => void {
+  const send = (label: string) => {
+    sendTyping(numericChatId, stringId).catch((err: unknown) => {
+      logWarn(
+        "dispatcher",
+        `${label} failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  };
+  send("sendTyping");
+  const timer = setInterval(() => send("sendTyping interval"), intervalMs);
+  return () => clearInterval(timer);
+}

--- a/src/core/weaver/warp-resolver.ts
+++ b/src/core/weaver/warp-resolver.ts
@@ -1,0 +1,123 @@
+/**
+ * WarpResolver — turns an incoming turn into the model/backend binding
+ * (the warp) it will run on.
+ *
+ * Owns the whole resolution ladder so the Weaver never sees a partial
+ * state: active-model resolution, the send-time null-model guard, and
+ * the per-run override (triggers/cron) with its fall-back-to-chat-model
+ * safety. The result is a discriminated union — either a bound warp or
+ * a refusal with the user-facing message to deliver — so callers can't
+ * forget to handle the "no model" case.
+ */
+
+import type { ModelRef } from "../agent-runtime/model-ref.js";
+import { logDebug, logWarn } from "../../util/log.js";
+
+export type WarpResolverDeps = {
+  /**
+   * Walks the 5-step active-model resolution chain for the chat. When
+   * `model`/`ref` are both `null` (catalog-driven backend with no
+   * per-chat pick and no operator default) the turn is refused — see
+   * `resolve()`.
+   */
+  resolveActiveModel: (chatId: string) => Promise<{
+    model: string | null;
+    ref: ModelRef | null;
+    backendId: string;
+  }>;
+  /**
+   * Validates + materialises an explicit per-run model id against the
+   * chat's backend. Returns `null` when the id isn't selectable, so
+   * the resolver falls back to the chat model. Restricted to the
+   * chat's own backend so the session still resumes.
+   */
+  resolveModelOverride?: (
+    chatId: string,
+    modelId: string,
+  ) => Promise<ModelRef | null>;
+};
+
+export type ResolveWarpInput = {
+  chatId: string;
+  /** Optional per-run model override (triggers/cron). */
+  modelOverride?: string;
+  /** Turn source, used only for override logging. */
+  source: string;
+  /** Request id for log correlation. */
+  reqId: string;
+};
+
+export type WarpResolution =
+  | {
+      ok: true;
+      /** The ModelRef the turn runs on (post-override). */
+      ref: ModelRef;
+      backendId: string;
+      /** A per-run override was applied for this turn. */
+      overridden: boolean;
+    }
+  | {
+      ok: false;
+      backendId: string;
+      /** User-facing refusal ("use /model to pick one"). */
+      message: string;
+    };
+
+export async function resolveWarp(
+  deps: WarpResolverDeps,
+  input: ResolveWarpInput,
+): Promise<WarpResolution> {
+  const { chatId, modelOverride, source, reqId } = input;
+
+  // Send-time null-model guard. When the active-model resolver returns
+  // no usable model, refuse to call the backend — it would either error
+  // opaquely or run on the wrong default.
+  const { model, ref, backendId } = await deps.resolveActiveModel(chatId);
+  if (model === null || ref === null) {
+    logWarn(
+      "dispatcher",
+      `[${reqId}] refusing query: no model resolved (chat=${chatId}, backend=${backendId})`,
+    );
+    return {
+      ok: false,
+      backendId,
+      message:
+        `No model selected for backend \`${backendId}\`. ` +
+        `Use /model to pick one — or set ` +
+        `\`backendDefaults.${backendId}\` in talon.json to apply a ` +
+        `default for all chats on this backend.`,
+    };
+  }
+
+  // Per-run model override (triggers/cron). Resolve against the chat's
+  // backend; on success swap the ref for this turn only, on failure fall
+  // back to the chat model so a stale override never kills the run.
+  let runRef = ref;
+  if (modelOverride && deps.resolveModelOverride) {
+    try {
+      const overrideRef = await deps.resolveModelOverride(
+        chatId,
+        modelOverride,
+      );
+      if (overrideRef) {
+        runRef = overrideRef;
+        logDebug(
+          "dispatcher",
+          `[${reqId}] model override → ${modelOverride} (${source})`,
+        );
+      } else {
+        logWarn(
+          "dispatcher",
+          `[${reqId}] model override "${modelOverride}" not resolvable on backend ${backendId}; using chat model`,
+        );
+      }
+    } catch (err) {
+      logWarn(
+        "dispatcher",
+        `[${reqId}] model override resolution threw: ${err instanceof Error ? err.message : String(err)}; using chat model`,
+      );
+    }
+  }
+
+  return { ok: true, ref: runRef, backendId, overridden: runRef !== ref };
+}

--- a/src/core/weaver/weaver.ts
+++ b/src/core/weaver/weaver.ts
@@ -1,18 +1,43 @@
+/**
+ * Weaver — the turn orchestrator. `runTurn` serializes each turn onto
+ * its chat's Thread (per-chat FIFO, cross-chat parallel) and drives the
+ * turn lifecycle by composing the weaver's single-purpose collaborators:
+ *
+ *   - `resolveWarp` (warp-resolver.ts) — model/backend binding + the
+ *     null-model guard and per-run override fallback;
+ *   - `startTypingLoop` (typing-loop.ts) — keeps the frontend's typing
+ *     indicator alive for the duration of the turn;
+ *   - `prefetchMemory` (memory-prefetch.ts) — optional fail-closed
+ *     palace pre-retrieval for live user messages;
+ *   - `carryTurnEvents` (shuttle.ts) — pumps the backend's AgentEvent
+ *     stream into the frontend sink, settles delivery acks, captures
+ *     the result and rethrows error terminators.
+ *
+ * The Weaver itself only sequences those stages and brackets them with
+ * the Thread's execution context — it holds no per-chat state (that's
+ * the Thread's) and no policy of its own beyond ordering.
+ */
+
 import { randomBytes } from "node:crypto";
-import type {
-  Backend,
-  RetrievedMemory,
-} from "../agent-runtime/capabilities.js";
-import { AgentRunError, type AgentResult } from "../agent-runtime/events.js";
+import type { Backend } from "../agent-runtime/capabilities.js";
+import type { AgentResult } from "../agent-runtime/events.js";
 import type { ModelRef } from "../agent-runtime/model-ref.js";
-import { maybeStartDream } from "../background/dream.js";
 import type { MemoryRetriever } from "../memory/retrieval.js";
 import type { ContextManager, ExecuteParams, ExecuteResult } from "../types.js";
 import { log, logDebug, logWarn } from "../../util/log.js";
 import { Loom } from "./loom.js";
+import { prefetchMemory } from "./memory-prefetch.js";
+import { carryTurnEvents } from "./shuttle.js";
 import type { Thread, ThreadSnapshot } from "./thread.js";
+import { startTypingLoop } from "./typing-loop.js";
+import { resolveWarp } from "./warp-resolver.js";
 
 export type WeaverDeps = {
+  /**
+   * Read fresh per call so backend swaps (chat-role rebinds or
+   * per-chat overrides via the controller) take effect on the next
+   * query without a dispatcher re-init.
+   */
   getBackend: (chatId?: string) => Backend;
   resolveActiveModel: (chatId: string) => Promise<{
     model: string | null;
@@ -27,6 +52,14 @@ export type WeaverDeps = {
   sendTyping: (chatId: number, stringId?: string) => Promise<void>;
   onActivity: () => void;
   /**
+   * Optional fire-and-forget hook invoked at the start of every turn,
+   * after the warp is bound and before the backend is called. The
+   * composition root wires background work here (e.g. dream memory
+   * consolidation) so the Weaver stays ignorant of those subsystems.
+   * Must not throw and must not block — it is called synchronously.
+   */
+  onTurnStart?: () => void;
+  /**
    * Optional memory pre-retrieval (Phase B). Called for `source: "message"`
    * turns after model/backend resolution and context acquisition, before
    * `runChatTurn(...)`. Fail-closed: errors are logged and the turn runs
@@ -38,6 +71,7 @@ export type WeaverDeps = {
 export class Weaver {
   readonly loom: Loom;
   private readonly deps: WeaverDeps;
+  private activeCount = 0;
 
   constructor(deps: WeaverDeps, loom = new Loom()) {
     this.deps = deps;
@@ -49,6 +83,7 @@ export class Weaver {
     return thread.enqueue(() => this.run(thread, params));
   }
 
+  /** Number of turns currently running (not queued) across all chats. */
   getActiveCount(): number {
     return this.activeCount;
   }
@@ -59,13 +94,8 @@ export class Weaver {
    * frontends. Reading is side-effect free.
    */
   snapshot(): ThreadSnapshot[] {
-    return this.loom
-      .chatIds()
-      .map((id) => this.loom.get(id)?.describe())
-      .filter((s): s is ThreadSnapshot => s !== undefined);
+    return this.loom.snapshot();
   }
-
-  private activeCount = 0;
 
   private async run(
     thread: Thread,
@@ -83,95 +113,32 @@ export class Weaver {
     thread: Thread,
     params: ExecuteParams,
   ): Promise<ExecuteResult> {
-    const {
-      getBackend,
-      resolveActiveModel,
-      resolveModelOverride,
-      context,
-      sendTyping,
-      onActivity,
-      retrieveMemory,
-    } = this.deps;
-    // Read the backend fresh per call so backend swaps (chat-role
-    // rebinds or per-chat overrides via the controller) take effect on
-    // the next query without a dispatcher re-init.
-    const backend = getBackend(params.chatId);
+    const { context, onActivity, retrieveMemory } = this.deps;
+    const backend = this.deps.getBackend(params.chatId);
     const reqId = randomBytes(4).toString("hex");
 
-    // Send-time null-model guard. When the active-model resolver
-    // returns no usable model (catalog-driven backend with no per-chat
-    // pick and no operator default), refuse to call the backend — it
-    // would either error opaquely or run on the wrong default. Reply
-    // with a clear "use /model to pick one" message routed through the
-    // same event sink the backend would use for output (as an
-    // `assistant_message` event, so the frontend delivers it normally).
-    const {
-      model: resolvedModel,
-      ref: resolvedRef,
-      backendId,
-    } = await resolveActiveModel(params.chatId);
-    if (resolvedModel === null || resolvedRef === null) {
-      const message =
-        `No model selected for backend \`${backendId}\`. ` +
-        `Use /model to pick one — or set ` +
-        `\`backendDefaults.${backendId}\` in talon.json to apply a ` +
-        `default for all chats on this backend.`;
-      logWarn(
-        "dispatcher",
-        `[${reqId}] refusing query: no model resolved (chat=${params.chatId}, backend=${backendId})`,
-      );
+    const warp = await resolveWarp(this.deps, {
+      chatId: params.chatId,
+      modelOverride: params.modelOverride,
+      source: params.source,
+      reqId,
+    });
+    if (!warp.ok) {
+      // Refusals are delivered through the same event sink the backend
+      // would use for output (as an `assistant_message` event, so the
+      // frontend delivers it normally).
       try {
-        await params.onEvent?.({ type: "assistant_message", text: message });
+        await params.onEvent?.({
+          type: "assistant_message",
+          text: warp.message,
+        });
       } catch (err) {
         logWarn(
           "dispatcher",
           `onEvent(no-model) threw: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
-      return {
-        text: message,
-        durationMs: 0,
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        bridgeMessageCount: context.getMessageCount(
-          params.numericChatId,
-          params.chatId,
-        ),
-      };
-    }
-
-    // Per-run model override (triggers/cron). Resolve against the chat's
-    // backend; on success swap the ref for this turn only, on failure fall
-    // back to the chat model so a stale override never kills the run. The
-    // override is restricted to the chat's own backend, so the session still
-    // resumes — only the model changes.
-    let runRef = resolvedRef;
-    if (params.modelOverride && resolveModelOverride) {
-      try {
-        const overrideRef = await resolveModelOverride(
-          params.chatId,
-          params.modelOverride,
-        );
-        if (overrideRef) {
-          runRef = overrideRef;
-          logDebug(
-            "dispatcher",
-            `[${reqId}] model override → ${params.modelOverride} (${params.source})`,
-          );
-        } else {
-          logWarn(
-            "dispatcher",
-            `[${reqId}] model override "${params.modelOverride}" not resolvable on backend ${backendId}; using chat model`,
-          );
-        }
-      } catch (err) {
-        logWarn(
-          "dispatcher",
-          `[${reqId}] model override resolution threw: ${err instanceof Error ? err.message : String(err)}; using chat model`,
-        );
-      }
+      return this.emptyResult(warp.message, params);
     }
 
     // Bind the warp — record the model/backend actually resolved for this turn
@@ -179,157 +146,104 @@ export class Weaver {
     // last turn (per-chat rebind, per-run override, or config drift) is logged
     // rather than passing silently.
     const { drifted, previous } = thread.bindWarp({
-      model: runRef.id,
-      backendId,
-      overridden: runRef !== resolvedRef,
+      model: warp.ref.id,
+      backendId: warp.backendId,
+      overridden: warp.overridden,
       boundAt: Date.now(),
     });
     if (drifted && previous) {
       logDebug(
         "dispatcher",
-        `[${reqId}] warp drift chat=${params.chatId}: ${previous.backendId}/${previous.model} → ${backendId}/${runRef.id}`,
+        `[${reqId}] warp drift chat=${params.chatId}: ${previous.backendId}/${previous.model} → ${warp.backendId}/${warp.ref.id}`,
       );
     }
 
-    // Dream check — fire-and-forget background memory consolidation if due
-    maybeStartDream();
+    this.deps.onTurnStart?.();
 
     logDebug(
       "dispatcher",
       `[${reqId}] ${params.source} chat=${params.chatId} started (active=${this.activeCount})`,
     );
     context.acquire(params.numericChatId, params.chatId);
-
-    let typingTimer: ReturnType<typeof setInterval> | undefined;
+    const stopTyping = startTypingLoop(
+      this.deps.sendTyping,
+      params.numericChatId,
+      params.chatId,
+    );
     try {
-      await sendTyping(params.numericChatId, params.chatId).catch(
-        (err: unknown) => {
-          logWarn(
-            "dispatcher",
-            `sendTyping failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        },
-      );
-      typingTimer = setInterval(() => {
-        sendTyping(params.numericChatId, params.chatId).catch(
-          (err: unknown) => {
-            logWarn(
-              "dispatcher",
-              `sendTyping interval failed: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          },
-        );
-      }, 4000);
-
-      // Consume the backend's native `AgentEvent` stream and forward
-      // every event straight to the frontend's `onEvent` sink (no
-      // callback bridge). Capture the `completed` event's `AgentResult`
-      // for the dispatcher's return value, and rethrow an `error`
-      // terminator as `AgentRunError` so callers' catch paths keep
-      // working. Events are awaited in stream order so a consumer that
-      // needs serial delivery gets it.
       if (!backend.chat) {
         throw new Error(
           `Backend "${backend.id}" has no chat capability — cannot run a turn.`,
         );
       }
 
-      // Phase B memory pre-retrieval: only for live user messages, only when
-      // a retriever dep is wired, and strictly fail-closed — a broken palace
-      // must never block chat delivery. The result is dynamic turn context
-      // passed through ChatRunParams; it never touches the frozen prompt.
-      let retrievedMemory: RetrievedMemory | undefined;
-      if (retrieveMemory && params.source === "message") {
-        try {
-          retrievedMemory = await retrieveMemory({
-            runKind: "chat",
-            chatId: params.chatId,
-            text: params.prompt,
-            senderName: params.senderName,
-            isGroup: params.isGroup,
-          });
-          if (retrievedMemory) {
-            logDebug(
-              "dispatcher",
-              `[${reqId}] memory pre-retrieval: ${retrievedMemory.items.length} item(s), ` +
-                `${retrievedMemory.items.reduce((n, i) => n + i.text.length, 0)} chars`,
-            );
-          }
-        } catch (err) {
-          logWarn(
-            "dispatcher",
-            `[${reqId}] memory pre-retrieval failed (running turn without it): ` +
-              (err instanceof Error ? err.message : String(err)),
-          );
-          retrievedMemory = undefined;
-        }
-      }
+      const retrievedMemory =
+        retrieveMemory && params.source === "message"
+          ? await prefetchMemory(retrieveMemory, {
+              chatId: params.chatId,
+              text: params.prompt,
+              senderName: params.senderName,
+              isGroup: params.isGroup,
+              reqId,
+            })
+          : undefined;
 
       const stream = backend.chat.runChatTurn({
         chatId: params.chatId,
-        model: runRef,
+        model: warp.ref,
         text: params.prompt,
         senderName: params.senderName,
         isGroup: params.isGroup,
         messageId: params.messageId,
         retrievedMemory,
       });
-      let agentResult: AgentResult | undefined;
-      for await (const event of stream) {
-        if (event.type === "completed") {
-          agentResult = event.result;
-        }
-
-        // The dispatcher owns `assistant_message.deliveryAck` settlement
-        // so it is ALWAYS resolved — even when no `onEvent` sink is
-        // supplied, or the sink ignores the event. Otherwise the
-        // callback-shaped backend (handler-to-events) blocks forever
-        // awaiting delivery confirmation. The frontend's job is just to
-        // deliver and throw on failure; the dispatcher maps that onto the
-        // ack (resolve on success → block delivered; reject on throw →
-        // backend retries, e.g. Codex oversized-message path).
-        if (event.type === "assistant_message" && event.deliveryAck) {
-          try {
-            await params.onEvent?.(event);
-            event.deliveryAck.resolve();
-          } catch (err) {
-            event.deliveryAck.reject(err);
-          }
-          continue;
-        }
-
-        await params.onEvent?.(event);
-        if (event.type === "error") {
-          throw new AgentRunError(event.error);
-        }
-      }
-      const result = {
-        text: agentResult?.text ?? "",
-        durationMs: agentResult?.durationMs ?? 0,
-        inputTokens: agentResult?.usage.inputTokens ?? 0,
-        outputTokens: agentResult?.usage.outputTokens ?? 0,
-        cacheRead: agentResult?.usage.cacheRead ?? 0,
-        cacheWrite: agentResult?.usage.cacheWrite ?? 0,
-      };
+      const agentResult = await carryTurnEvents(stream, params.onEvent);
 
       onActivity();
-
       logDebug(
         "dispatcher",
-        `[${reqId}] completed in ${result.durationMs}ms (in=${result.inputTokens} out=${result.outputTokens})`,
+        `[${reqId}] completed in ${agentResult?.durationMs ?? 0}ms ` +
+          `(in=${agentResult?.usage.inputTokens ?? 0} out=${agentResult?.usage.outputTokens ?? 0})`,
       );
 
-      return {
-        ...result,
-        bridgeMessageCount: context.getMessageCount(
-          params.numericChatId,
-          params.chatId,
-        ),
-      };
+      return this.toExecuteResult(agentResult, params);
     } finally {
-      clearInterval(typingTimer);
+      stopTyping();
       context.release(params.numericChatId, params.chatId);
     }
+  }
+
+  private toExecuteResult(
+    result: AgentResult | undefined,
+    params: ExecuteParams,
+  ): ExecuteResult {
+    return {
+      text: result?.text ?? "",
+      durationMs: result?.durationMs ?? 0,
+      inputTokens: result?.usage.inputTokens ?? 0,
+      outputTokens: result?.usage.outputTokens ?? 0,
+      cacheRead: result?.usage.cacheRead ?? 0,
+      cacheWrite: result?.usage.cacheWrite ?? 0,
+      bridgeMessageCount: this.deps.context.getMessageCount(
+        params.numericChatId,
+        params.chatId,
+      ),
+    };
+  }
+
+  private emptyResult(text: string, params: ExecuteParams): ExecuteResult {
+    return {
+      text,
+      durationMs: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      bridgeMessageCount: this.deps.context.getMessageCount(
+        params.numericChatId,
+        params.chatId,
+      ),
+    };
   }
 }
 
@@ -338,11 +252,6 @@ let weaver: Weaver | null = null;
 export function initWeaver(deps: WeaverDeps): Weaver {
   weaver = new Weaver(deps);
   log("dispatcher", "Weaver initialized");
-  return weaver;
-}
-
-export function getWeaver(): Weaver {
-  if (!weaver) throw new Error("Weaver not initialized");
   return weaver;
 }
 


### PR DESCRIPTION
## What

A SOLID pass over the Weaver/Loom hub. No behavior changes — the turn lifecycle, event ordering, ack semantics, log lines, and public API (`runTurn`, `snapshot`, `getActiveCount`, `getActiveLoom`) are all preserved, and the existing weaver/dispatcher suites pass unchanged.

### Single responsibility
`Weaver.executeInner` was a ~250-line method owning model resolution, the null-model guard, override fallback, warp binding, dream triggering, typing keep-alive, memory prefetch, stream pumping, ack settlement, and result assembly. Each concern now lives in its own module under `src/core/weaver/`:

| Module | Owns |
|---|---|
| `warp-resolver.ts` | active-model resolution, send-time null-model guard, per-run override with fall-back-to-chat-model safety — returns a discriminated `WarpResolution` so the refusal case can't be silently skipped |
| `shuttle.ts` | the `AgentEvent` pump: stream-order awaiting, `deliveryAck` settlement (always settled, even with no sink), `completed` capture, `error` → `AgentRunError` rethrow. The Thread docs already spoke of "the Shuttle carrying the weft" — it now exists |
| `typing-loop.ts` | typing-indicator heartbeat, fail-soft sends, single `stop()` handle |
| `memory-prefetch.ts` | fail-closed Phase B palace pre-retrieval |

`weaver.ts` is now pure orchestration (~stage ordering + the Thread context bracket) and shrinks by roughly two thirds.

### Dependency inversion
The turn loop hard-imported `maybeStartDream` from `core/background/dream.js`. That's now an injected `onTurnStart` hook on `WeaverDeps`, wired by `bootstrap.ts`. The Weaver no longer knows the dream subsystem exists, and unit-test Weavers no longer trip dream-state reads on every turn.

### Interface segregation
The gateway used the concrete `Loom` while only ever touching its context-tracking subset. It now depends on a `ContextRegistry` interface (acquire/release/message-count/active-context queries + `size()`); `Loom` implements it. The gateway can no longer create or evict Threads, and the contract between the two is explicit.

### Encapsulation / cleanup
- `Loom.snapshot()` owns snapshot assembly; the Weaver no longer reaches through `chatIds()`/`get()`.
- Removed the dead `getWeaver` export (nothing imported it).

### One intentional micro-change
The first typing-indicator send is no longer `await`ed before the turn proceeds (it's still initiated first, and failures are still logged, never thrown). A slow frontend no longer delays turn start; nothing downstream depended on the old ordering.

## Tests

New `weaver-collaborators.test.ts` covers each collaborator directly: warp binding, refusal message, override applied/unresolvable/throwing; ack resolve/reject/no-sink settlement and error rethrow; typing-loop start/refresh/stop and swallowed failures; prefetch pass-through and fail-closed. `weaver.test.ts` gains an `onTurnStart` contract test (fires per executed turn, not on refusals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)