### PR TITLE
fix(native): classify delivery tools at the source instead of client name-matching

### DIFF
--- a/apps/companion/lib/src/state/app_state.dart
+++ b/apps/companion/lib/src/state/app_state.dart
@@ -890,11 +890,9 @@ class AppState extends ChangeNotifier {
     final id = _string(e['id']);
     if (chatId == null || id == null) return false;
     final name = _string(e['name']) ?? 'tool';
-    // `end_turn` is the canonical delivery tool — its "result" is the assistant
-    // message that arrives separately, so no tool_result event ever lands for
-    // it. Showing it as a chip means an eternally-spinning row of noise.
-    if (_isInternalTool(name)) return true;
-
+    // No name-based filtering here: the daemon owns tool classification and
+    // never emits reply-delivery tools (end_turn / send_message / react) in
+    // `tool` events or history — their effect arrives as the message itself.
     final t = turnFor(chatId);
     final phase = _string(e['phase']);
     final output = _string(e['output']);
@@ -930,11 +928,6 @@ class AppState extends ChangeNotifier {
     }
     return true;
   }
-
-  static bool _isInternalTool(String name) =>
-      name.contains('desktop-tools') ||
-      name == 'end_turn' ||
-      name.endsWith('__end_turn');
 
   /// Seed the stores directly — for widget tests and the screenshot gallery,
   /// where rendering real content matters but a live bridge doesn't exist.

--- a/src/__tests__/end-turn.test.ts
+++ b/src/__tests__/end-turn.test.ts
@@ -19,6 +19,7 @@ import {
 import type { SDKAssistantMessage } from "@anthropic-ai/claude-agent-sdk";
 import { messagingTools } from "../core/tools/messaging.js";
 import {
+  isDeliveryTool,
   isTurnTerminator,
   stripMcpPrefix,
   ALL_TOOLS,
@@ -525,5 +526,46 @@ describe("turn-terminator integration with SDK production tool name shapes", () 
     }
     // Soft-opt-out wins: state stays open for follow-up tool calls.
     expect(state.turnTerminated).toBe(false);
+  });
+});
+
+describe("delivery-tool classification (isDeliveryTool)", () => {
+  it("the registry flags exactly the reply-delivery family", () => {
+    const flagged = ALL_TOOLS.filter((t) => t.delivery).map((t) => t.name);
+    expect(flagged.sort()).toEqual([
+      "end_turn",
+      "react",
+      "send",
+      "send_message",
+      "send_message_with_buttons",
+    ]);
+  });
+
+  it("matches bare names", () => {
+    expect(isDeliveryTool("end_turn")).toBe(true);
+    expect(isDeliveryTool("send_message")).toBe(true);
+    expect(isDeliveryTool("react")).toBe(true);
+  });
+
+  it("matches every prefixed shape backends emit", () => {
+    // Claude SDK / MCP canonical.
+    expect(isDeliveryTool("mcp__desktop-tools__end_turn")).toBe(true);
+    expect(isDeliveryTool("mcp__telegram-tools__send")).toBe(true);
+    // Kilo / OpenCode `<server>_<bare>` form.
+    expect(isDeliveryTool("desktop-tools_end_turn")).toBe(true);
+    expect(isDeliveryTool("talon-tools-352042062_send_message")).toBe(true);
+  });
+
+  it("leaves visible work alone — bridge tools, backend-native tools", () => {
+    // Bridge tools whose activity IS worth showing in a timeline.
+    expect(isDeliveryTool("edit_message")).toBe(false);
+    expect(isDeliveryTool("fetch_url")).toBe(false);
+    expect(isDeliveryTool("mcp__desktop-tools__edit_message")).toBe(false);
+    // Backend-native tools (Claude Code's own).
+    expect(isDeliveryTool("Bash")).toBe(false);
+    expect(isDeliveryTool("Read")).toBe(false);
+    // Names that merely resemble a delivery tool.
+    expect(isDeliveryTool("resend")).toBe(false);
+    expect(isDeliveryTool("end_turn_report")).toBe(false);
   });
 });

--- a/src/core/tools/index.ts
+++ b/src/core/tools/index.ts
@@ -56,6 +56,17 @@ const TURN_TERMINATOR_NAMES: ReadonlySet<string> = new Set(
 );
 
 /**
+ * Names of reply-delivery tools (`delivery: true` on the definition):
+ * their observable effect is the message/reaction itself, which
+ * frontends already surface as first-class output. Kept separate from
+ * `TURN_TERMINATOR_NAMES` — `send_message` delivers without ending the
+ * turn, and a future terminator need not be a delivery tool.
+ */
+const DELIVERY_TOOL_NAMES: ReadonlySet<string> = new Set(
+  ALL_TOOLS.filter((t) => t.delivery).map((t) => t.name),
+);
+
+/**
  * All tool names registered in Talon's tool catalog. Used by
  * `stripMcpPrefix` to recognise the bare name when a backend prefixes
  * the tool with its MCP server identifier in a non-standard way (e.g.
@@ -137,6 +148,24 @@ export function isTurnTerminator(
     if (flag === false) return false;
   }
   return true;
+}
+
+/**
+ * Whether a tool call by this name is reply-delivery plumbing
+ * (`delivery: true` on its definition) — `end_turn`, `send`,
+ * `send_message`, `react`, … Its effect reaches the user as a chat
+ * message or reaction, so activity timelines ("what the model did")
+ * must exclude it or the reply gets double-reported as work.
+ *
+ * Accepts bare names (`end_turn`) and every prefixed form
+ * `stripMcpPrefix` understands (`mcp__desktop-tools__end_turn`,
+ * Kilo's `desktop-tools_end_turn`).
+ */
+export function isDeliveryTool(toolName: string): boolean {
+  return (
+    DELIVERY_TOOL_NAMES.has(toolName) ||
+    DELIVERY_TOOL_NAMES.has(stripMcpPrefix(toolName))
+  );
 }
 
 /** Filter options for composing a tool set. */

--- a/src/core/tools/messaging.ts
+++ b/src/core/tools/messaging.ts
@@ -113,6 +113,7 @@ Notes:
     frontends: ["telegram", "teams", "discord", "native"],
     tag: "messaging",
     endsTurn: true,
+    delivery: true,
   },
 
   // ── Telegram unified send ─────────────────────────────────────────────
@@ -372,6 +373,7 @@ Examples:
     },
     frontends: ["telegram", "discord"],
     tag: "messaging",
+    delivery: true,
   },
 
   // ── Native send_message ────────────────────────────────────────────────
@@ -388,6 +390,7 @@ Examples:
     execute: (params, bridge) => bridge("send_message", params),
     frontends: ["teams", "native"],
     tag: "messaging",
+    delivery: true,
   },
 
   // ── Native send_message_with_buttons ──────────────────────────────────
@@ -412,6 +415,7 @@ Example: send_message_with_buttons(text="Choose:", rows=[[{"text":"Docs","url":"
     execute: (params, bridge) => bridge("send_message_with_buttons", params),
     frontends: ["teams", "native"],
     tag: "messaging",
+    delivery: true,
   },
 
   // ── react ─────────────────────────────────────────────────────────────
@@ -469,6 +473,7 @@ Valid emoji: 👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 �
     frontends: ["telegram", "discord", "native"],
     tag: "messaging",
     endsTurn: true,
+    delivery: true,
   },
 
   // ── edit_message ──────────────────────────────────────────────────────

--- a/src/core/tools/types.ts
+++ b/src/core/tools/types.ts
@@ -78,4 +78,15 @@ export interface ToolDefinition {
    * is the shared declarative signal, not the implementation.
    */
   readonly endsTurn?: boolean;
+
+  /**
+   * Reply-delivery plumbing: the tool's observable effect IS the
+   * message/reaction the user receives, which every frontend already
+   * surfaces as first-class output (a chat message, a reaction). Tools
+   * flagged here are excluded from activity timelines — the tool
+   * events a frontend shows or persists as "what the model did" —
+   * because reporting them there double-counts the reply as work.
+   * Declared on the definition so consumers never classify by name.
+   */
+  readonly delivery?: boolean;
 }

--- a/src/frontend/native/index.ts
+++ b/src/frontend/native/index.ts
@@ -30,6 +30,7 @@ import { resolveActiveModelForChat } from "../../core/models/active-model.js";
 import { forceDream } from "../../core/background/dream.js";
 import { execute } from "../../core/engine/dispatcher.js";
 import { toolInputToRecord } from "../../core/agent-runtime/events.js";
+import { isDeliveryTool } from "../../core/tools/index.js";
 import {
   pushMessage,
   getRecentHistory,
@@ -576,6 +577,12 @@ export function createNativeFrontend(
               broadcast({ kind: "delta", chatId: entry.id, text: event.text });
               break;
             case "tool_call": {
+              // Delivery plumbing (end_turn / send_message / react) never
+              // enters the tool timeline — its effect arrives as the
+              // `message`/reaction itself. Skipping here keeps the live
+              // stream, the mid-turn replay to late joiners, and the
+              // persisted turn meta consistent from one choke point.
+              if (isDeliveryTool(event.name)) break;
               const input = toolInputToRecord(event.name, event.input);
               turnTools.set(event.id, {
                 call: { id: event.id, name: event.name, input },
@@ -592,6 +599,7 @@ export function createNativeFrontend(
               break;
             }
             case "tool_result": {
+              if (isDeliveryTool(event.name)) break;
               const output = summarizeToolResult(event.result);
               const live = turnTools.get(event.id);
               if (live) {
@@ -1027,7 +1035,11 @@ export function createNativeFrontend(
           if (msg.role === "assistant") {
             const meta = getTurnMeta(id, msg.id);
             if (meta) {
-              if (meta.tools?.length) msg.tools = meta.tools;
+              // Delivery tools are excluded at record time, but metas
+              // persisted by older daemons still carry them — filter on
+              // the way out so upgraded installs get clean history too.
+              const tools = meta.tools?.filter((t) => !isDeliveryTool(t.name));
+              if (tools?.length) msg.tools = tools;
               if (meta.durationMs) msg.durationMs = meta.durationMs;
               if (meta.tokensIn) msg.tokensIn = meta.tokensIn;
               if (meta.tokensOut) msg.tokensOut = meta.tokensOut;

--- a/src/frontend/native/protocol.ts
+++ b/src/frontend/native/protocol.ts
@@ -35,6 +35,11 @@ export type ClientButton = { text: string; url?: string; data?: string };
  * A tool invocation that ran during an assistant turn, persisted so history
  * shows what the model did even after a reload/restart (additive in v1 —
  * older clients simply ignore the field).
+ *
+ * Reply-delivery tools (`end_turn` / `send_message` / `react`) never appear
+ * here or in `tool` events — the daemon classifies and excludes them at the
+ * source, because their effect already reaches clients as the `message` /
+ * `reaction` itself. Clients render tool timelines as-is, no name filtering.
  */
 export type ClientToolCall = {
   id: string;


### PR DESCRIPTION
## Bug

During a live conversation the companion app shows no `end_turn` in the tool timeline, but after closing and reopening the app (reconnect → history reload) every turn shows one `end_turn` tool chip.

## Root cause

Tool classification lived in the wrong place, as a string heuristic, applied inconsistently:

- The daemon broadcast **and persisted** every backend tool event, including its own reply-delivery plumbing (`end_turn`, `send_message`, `react`).
- The Flutter app hid them with a name-matching guess (`contains('desktop-tools')`, `== 'end_turn'`, `endsWith('__end_turn')`) — duplicated knowledge of the daemon's MCP server naming — applied **only** to live `tool` events, not to history hydration. So `GET /chats/:id/messages` leaked exactly what the live stream hid.

## Fix — the daemon owns classification, declared on the tool definition

- `ToolDefinition` gains a `delivery: true` flag, set on the reply-delivery family (`end_turn`, `send`, `send_message`, `send_message_with_buttons`, `react`) — tools whose observable effect already reaches clients as the `message`/`reaction` event itself, so reporting them in an activity timeline double-counts the reply as work.
- `core/tools` exports `isDeliveryTool()`, matching bare names and every prefixed shape `stripMcpPrefix` already understands (`mcp__<server>__<tool>` and Kilo/OpenCode's `<server>_<tool>`).
- The native frontend skips delivery tools at its single tool-event choke point, making the live stream, the mid-turn replay to late joiners, and the persisted turn meta consistent **by construction**. The history handler additionally filters metas persisted by older daemons, so upgraded installs get clean history without a data migration.
- The app deletes `_isInternalTool` entirely and renders tool timelines as-is — no client knows daemon naming conventions anymore. The protocol docs on `ClientToolCall` now state the invariant.

## Intended visible change

Non-delivery bridge tools (`fetch_url`, `edit_message`, …) now appear as live activity chips — matching what history always showed. The timeline reports real work and hides only plumbing, identically live and reloaded.

## Tests

New `isDeliveryTool` suite in `end-turn.test.ts`: the registry flags exactly the delivery family; bare + MCP-canonical + Kilo name shapes classify; bridge work tools, backend-native tools (`Bash`, `Read`), and lookalike names (`resend`, `end_turn_report`) don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)