### PR TITLE
feat(metrics): per-session, persistent, daily-bucketed metrics

### DIFF
--- a/docs/per-session-metrics.md
+++ b/docs/per-session-metrics.md
@@ -117,6 +117,15 @@ session" intent); migrate to a table only if query needs demand it.
 
 ### 3. Collection — a Weaver collaborator + injected hook
 
+> **As built:** collection landed via §6's option (b) instead — the existing
+> `backend/shared/metrics.ts` entry points (`recordTurnMetrics`,
+> `recordToolCall`, `recordFlowViolation`, `recordFailedTurnAccounting`) became
+> thin shims over the session store, each threading `chatId`. Every backend
+> already calls them on both success and failure paths, so no new Weaver
+> collaborator, `WeaverDeps` hook, or bootstrap wiring was needed. The
+> collaborator route below is retained as the design alternative if collection
+> ever needs to move out of the backends.
+
 Mirror the existing `onTurnStart` idiom (`WeaverDeps`), keeping the Weaver
 ignorant of the persistence subsystem (DIP):
 
@@ -221,10 +230,14 @@ needed. `/metrics` reads `buckets[today]` for "today", `lifetime` for all-time.
 - Discord: validate via CI (`gh pr checks`) per repo convention — no local
   Discord toolchain.
 
-## Open questions (resolve at implementation)
+## Open questions — resolved at implementation
 
-1. Blob column vs dedicated table (see §2) — start with blob.
-2. Day-bucket retention count (default 30) and whether it's configurable.
-3. Whether to keep any per-backend fleet dimension, and where (see §6).
-4. Timezone for the day boundary (local vs UTC) — pick UTC for determinism
-   unless a user-facing "today" should be local.
+1. Blob column vs dedicated table (see §2) — **blob column** (`sessions.metrics
+   TEXT`), reconciled on open for pre-existing databases.
+2. Day-bucket retention — **fixed at 30 days**, evicted oldest-first inside
+   `metricBucket()`; not configurable until someone needs it.
+3. Per-backend fleet dimension — **kept per-session** under
+   `MetricsGrain.backend`, aggregated across sessions by `getMetrics()` /
+   `getTodayMetrics()` at read time.
+4. Day boundary timezone — **UTC** (`todayUtc()`), for determinism; `/metrics`
+   labels the today section "today (UTC)".

--- a/docs/per-session-metrics.md
+++ b/docs/per-session-metrics.md
@@ -15,7 +15,7 @@ store — module-level `Map`s of counters and histograms. Two consequences:
    zeroes `/metrics`.
 2. **They are fleet-wide, not per-chat.** Chat ids are deliberately never
    interpolated into metric keys (the store caps at 500 keys). So "how much
-   has *this* chat done" isn't answerable from the metrics store — only the
+   has _this_ chat done" isn't answerable from the metrics store — only the
    separate `SessionUsage` accounting (`src/storage/sessions.ts`) is per-chat,
    and it only tracks tokens/cost/response-time, not tool calls, api-call
    distributions, flow violations, etc.
@@ -59,10 +59,10 @@ A new per-session metrics block, persisted next to `SessionUsage`. Two grains:
 
 ```ts
 type CounterSet = {
-  queries: number;              // turns
+  queries: number; // turns
   turnsWithTools: number;
-  toolCalls: number;            // total across turns
-  apiCalls: number;             // total upstream round-trips
+  toolCalls: number; // total across turns
+  apiCalls: number; // total upstream round-trips
   turnsFailed: number;
   flowViolationsRetried: number;
   flowViolationsCapExhausted: number;
@@ -74,16 +74,16 @@ type CounterSet = {
 
 type LatencyAgg = {
   count: number;
-  sumMs: number;                // → avg = sumMs / count
-  minMs: number;                // fastest
-  maxMs: number;                // slowest
+  sumMs: number; // → avg = sumMs / count
+  minMs: number; // fastest
+  maxMs: number; // slowest
 };
 
 type DailyMetrics = CounterSet & { latency: LatencyAgg };
 
 type SessionMetrics = {
   lifetime: CounterSet & { latency: LatencyAgg };
-  buckets: Record<string, DailyMetrics>;   // keyed YYYY-MM-DD, bounded
+  buckets: Record<string, DailyMetrics>; // keyed YYYY-MM-DD, bounded
 };
 ```
 
@@ -97,8 +97,8 @@ type SessionMetrics = {
 
 ### 2. Persistence
 
-Follow the existing sessions layering (schema.sql → sql/*.sql →
-repositories/*-repo.ts → store). Two options, pick at implementation:
+Follow the existing sessions layering (schema.sql → sql/_.sql →
+repositories/_-repo.ts → store). Two options, pick at implementation:
 
 - **(preferred) A `metrics TEXT` column on the `sessions` row** — one JSON blob
   per chat, same write-through-cache + per-write-commit discipline as
@@ -139,10 +139,10 @@ ignorant of the persistence subsystem (DIP):
   builds the `TurnMetricSummary` from the observed turn. The richer per-turn
   signal (tool-call count, api-call count, flow violations) currently only
   exists in the backend's `StreamState`, not on `AgentResult`. Two sub-steps:
-    1. Surface tool/api counts on the `completed` event / `AgentResult` (or
-       tee the `AgentEvent` stream in the shuttle to count `tool_call`/`usage`
-       events) so the Weaver can see them without reaching into backends.
-    2. The collaborator maps that into `TurnMetricSummary`.
+  1. Surface tool/api counts on the `completed` event / `AgentResult` (or
+     tee the `AgentEvent` stream in the shuttle to count `tool_call`/`usage`
+     events) so the Weaver can see them without reaching into backends.
+  2. The collaborator maps that into `TurnMetricSummary`.
 - The composition root (`src/bootstrap.ts`, where `initDispatcher`/`WeaverDeps`
   is wired, ~line 363) wires `onTurnComplete` to a session-metrics writer.
 
@@ -164,7 +164,11 @@ type TurnMetricSummary = {
 New API on `src/storage/sessions.ts` (domain logic only, no SQL):
 
 ```ts
-export function recordSessionMetrics(chatId: string, turn: TurnMetricSummary, today: string): void
+export function recordSessionMetrics(
+  chatId: string,
+  turn: TurnMetricSummary,
+  today: string,
+): void;
 ```
 
 - Fold the turn into `lifetime` and into `buckets[today]` (create the day
@@ -188,7 +192,7 @@ needed. `/metrics` reads `buckets[today]` for "today", `lifetime` for all-time.
   `LatencyAgg`s (sum counts/sums, min of mins, max of maxes). Renders both
   "today" and "lifetime" columns.
 - Optionally enrich `ThreadSnapshot`/`SessionSummary` (`src/core/weaver/
-  thread*.ts`) with a per-session metrics summary so a single chat's numbers
+thread*.ts`) with a per-session metrics summary so a single chat's numbers
   show in `/status` — this is the "harvest from the loom" read seam.
 - The renderers (`diagnostics.ts`, discord `helpers.ts`) adapt to the new
   shape (avg/min/max instead of p50/p95/p99).
@@ -215,7 +219,12 @@ needed. `/metrics` reads `buckets[today]` for "today", `lifetime` for all-time.
 ## Migration / compatibility
 
 - `normaliseSession()` backfills an empty `SessionMetrics` for pre-existing
-  session rows (same pattern as the `SessionUsage` field backfills).
+  session rows (same pattern as the `SessionUsage` field backfills); persisted
+  blobs are validated/normalised once at hydration (`sessions-repo`).
+- **Reset vs delete:** conversation resets (`resetSession` — /new, model
+  switches, error recovery) carry the chat's metrics forward into the fresh
+  row; only `deleteSession` (chat deletion) drops them. Without this, an
+  error-recovery reset would erase the very failure counters that recorded it.
 - No data migration needed for the removed global store — it was never
   persisted, so there's nothing to migrate; fleet numbers simply start
   accumulating per-session from deploy.
@@ -233,7 +242,7 @@ needed. `/metrics` reads `buckets[today]` for "today", `lifetime` for all-time.
 ## Open questions — resolved at implementation
 
 1. Blob column vs dedicated table (see §2) — **blob column** (`sessions.metrics
-   TEXT`), reconciled on open for pre-existing databases.
+TEXT`), reconciled on open for pre-existing databases.
 2. Day-bucket retention — **fixed at 30 days**, evicted oldest-first inside
    `metricBucket()`; not configurable until someone needs it.
 3. Per-backend fleet dimension — **kept per-session** under

--- a/docs/per-session-metrics.md
+++ b/docs/per-session-metrics.md
@@ -1,0 +1,230 @@
+# Per-session metrics (design)
+
+> Status: **PLAN — not yet implemented.** This document is the design of
+> record for making Talon's metrics (a) persist across restart, (b) bind to
+> the chat session rather than a global in-process store, and (c) reset each
+> day via retained daily rollup buckets. Implementation lands in follow-up
+> commits on this branch.
+
+## Motivation
+
+Metrics today (`src/util/metrics.ts`) are a **global, in-process, low-cardinality**
+store — module-level `Map`s of counters and histograms. Two consequences:
+
+1. **They vanish on restart.** Nothing serializes them; a process bounce
+   zeroes `/metrics`.
+2. **They are fleet-wide, not per-chat.** Chat ids are deliberately never
+   interpolated into metric keys (the store caps at 500 keys). So "how much
+   has *this* chat done" isn't answerable from the metrics store — only the
+   separate `SessionUsage` accounting (`src/storage/sessions.ts`) is per-chat,
+   and it only tracks tokens/cost/response-time, not tool calls, api-call
+   distributions, flow violations, etc.
+
+We want metrics **owned by the chat session**, harvested by the Weaver (the
+per-chat hub), persisted in SQLite alongside the rest of session state, and
+bucketed by day so "today's numbers" reset at the day boundary while history
+is retained.
+
+## Decisions (locked)
+
+- **Full session-harvested model.** Per-session counters persist in the
+  session store; `/metrics` becomes an aggregation harvested across all
+  sessions; the global `src/util/metrics.ts` store is **removed**.
+- **Daily rollup buckets.** Keep cumulative per-session totals AND snapshot
+  per-day deltas keyed by `YYYY-MM-DD`. "Today" resets at the day boundary;
+  history is retained.
+- **Latency is per-session.** Response-latency lives on the session (it
+  already partly does via `totalResponseMs`/`lastResponseMs`/
+  `fastestResponseMs`). We keep per-session latency aggregates; we do **not**
+  keep a global latency histogram. Fleet latency is derived by aggregating
+  per-session latency aggregates (count/sum/min/max → avg/min/max), not true
+  fleet percentiles. This is the accepted trade of dropping the global store.
+
+## Architecture
+
+The Weaver/Loom/Thread subsystem (`src/core/weaver/`, `docs/weaver.md`) is the
+single owner of per-chat live state and the intended multi-frontend hub. Per-
+session metrics belong here. The collection seam is the Weaver turn runner,
+which was recently decomposed into single-purpose collaborators (PR #477).
+
+### 1. Data model — `SessionMetrics`
+
+A new per-session metrics block, persisted next to `SessionUsage`. Two grains:
+
+- **Lifetime cumulative** — monotonic counters/aggregates over the session's
+  whole life (survives restart, never reset).
+- **Daily buckets** — `Record<string /* YYYY-MM-DD */, DailyMetrics>` capturing
+  per-day deltas. A bounded ring (e.g. keep last N days, default 30) so the
+  blob can't grow without limit. "Today's" figures are `buckets[today]`.
+
+```ts
+type CounterSet = {
+  queries: number;              // turns
+  turnsWithTools: number;
+  toolCalls: number;            // total across turns
+  apiCalls: number;             // total upstream round-trips
+  turnsFailed: number;
+  flowViolationsRetried: number;
+  flowViolationsCapExhausted: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+};
+
+type LatencyAgg = {
+  count: number;
+  sumMs: number;                // → avg = sumMs / count
+  minMs: number;                // fastest
+  maxMs: number;                // slowest
+};
+
+type DailyMetrics = CounterSet & { latency: LatencyAgg };
+
+type SessionMetrics = {
+  lifetime: CounterSet & { latency: LatencyAgg };
+  buckets: Record<string, DailyMetrics>;   // keyed YYYY-MM-DD, bounded
+};
+```
+
+> Note on histograms vs aggregates: the old store kept a 1000-sample ring per
+> histogram to compute p50/p95/p99. Per-session-per-day we keep **count/sum/
+> min/max** instead of a sample ring — cheaper to persist, aggregates cleanly
+> across sessions, and enough for avg/fastest/slowest. True percentiles are
+> the one thing we give up; documented and accepted above. Tool-call-per-turn
+> and api-call-per-turn distributions collapse to totals + `queries` (so
+> "avg tool calls/turn" is still derivable).
+
+### 2. Persistence
+
+Follow the existing sessions layering (schema.sql → sql/*.sql →
+repositories/*-repo.ts → store). Two options, pick at implementation:
+
+- **(preferred) A `metrics TEXT` column on the `sessions` row** — one JSON blob
+  per chat, same write-through-cache + per-write-commit discipline as
+  `SessionUsage`. Simplest; metrics live and die with the session row
+  (`resetSession` already drops the row). Requires: add column to
+  `schema.sql`, extend `sessions.sql` upsert/select, regenerate
+  `statements.generated.ts` via `npm run build:sql`, map in
+  `sessions-repo.ts`, backfill/normalise in `normaliseSession()`.
+- **(alt) A dedicated `session_metrics` table** keyed by `(chat_id, day)` —
+  first-class daily rows, better for querying/retention, more plumbing. Choose
+  this if we later want SQL-level day-range queries or per-day retention
+  policies independent of the session row.
+
+Start with the blob column (matches `SessionUsage`'s home and the "bind to the
+session" intent); migrate to a table only if query needs demand it.
+
+### 3. Collection — a Weaver collaborator + injected hook
+
+Mirror the existing `onTurnStart` idiom (`WeaverDeps`), keeping the Weaver
+ignorant of the persistence subsystem (DIP):
+
+- Add `onTurnComplete?(summary: TurnMetricSummary): void` to `WeaverDeps`
+  (`src/core/weaver/weaver.ts`). Fire-and-forget, must not throw/block.
+- The Weaver invokes it in **both** the success path (after
+  `carryTurnEvents` returns, where `agentResult`/`durationMs` are in hand,
+  `weaver.ts:200-209`) and the failure/finally path — so failed turns are
+  accounted (parity with `recordFailedTurnAccounting`).
+- A new single-purpose collaborator (`src/core/weaver/turn-metrics.ts`)
+  builds the `TurnMetricSummary` from the observed turn. The richer per-turn
+  signal (tool-call count, api-call count, flow violations) currently only
+  exists in the backend's `StreamState`, not on `AgentResult`. Two sub-steps:
+    1. Surface tool/api counts on the `completed` event / `AgentResult` (or
+       tee the `AgentEvent` stream in the shuttle to count `tool_call`/`usage`
+       events) so the Weaver can see them without reaching into backends.
+    2. The collaborator maps that into `TurnMetricSummary`.
+- The composition root (`src/bootstrap.ts`, where `initDispatcher`/`WeaverDeps`
+  is wired, ~line 363) wires `onTurnComplete` to a session-metrics writer.
+
+```ts
+type TurnMetricSummary = {
+  chatId: string;
+  backend: string;
+  durationMs: number;
+  toolCalls: number;
+  apiCalls: number;
+  failed: boolean;
+  usage: TokenUsageSnapshot;
+  flowViolations?: { retried: number; capExhausted: number };
+};
+```
+
+### 4. Writer — session store API
+
+New API on `src/storage/sessions.ts` (domain logic only, no SQL):
+
+```ts
+export function recordSessionMetrics(chatId: string, turn: TurnMetricSummary, today: string): void
+```
+
+- Fold the turn into `lifetime` and into `buckets[today]` (create the day
+  bucket if absent; evict oldest when over the retention cap).
+- `today` is passed in (date is computed by the caller/bootstrap, not inside
+  the store — keeps the store deterministic/testable and avoids `Date.now()`
+  scattering).
+- Persist the whole session row (existing `persist()`), same failure-swallow
+  discipline (never breaks a turn).
+
+The daily reset is **emergent**, not a scheduled job: each turn writes into the
+current day's bucket, so a new day naturally starts a fresh bucket. No cron
+needed. `/metrics` reads `buckets[today]` for "today", `lifetime` for all-time.
+
+### 5. Read side — `/metrics` and `/status`
+
+- `/metrics` (`src/frontend/{telegram,discord}/commands/admin.ts`) currently
+  calls `getMetrics()` from the global store. Replace with an aggregator that
+  harvests across sessions: iterate `getAllSessions()` (or a new
+  `getFleetMetrics(day)` in the store), summing `CounterSet`s and merging
+  `LatencyAgg`s (sum counts/sums, min of mins, max of maxes). Renders both
+  "today" and "lifetime" columns.
+- Optionally enrich `ThreadSnapshot`/`SessionSummary` (`src/core/weaver/
+  thread*.ts`) with a per-session metrics summary so a single chat's numbers
+  show in `/status` — this is the "harvest from the loom" read seam.
+- The renderers (`diagnostics.ts`, discord `helpers.ts`) adapt to the new
+  shape (avg/min/max instead of p50/p95/p99).
+
+### 6. Removal of the global store
+
+- Delete `src/util/metrics.ts` (or reduce to nothing) and its callers:
+  - `src/backend/shared/metrics.ts` stops calling `incrementCounter`/
+    `recordHistogram`. `recordTurnMetrics`/`recordToolCall`/
+    `recordFlowViolation`/`recordFailedTurnAccounting` either (a) move their
+    signal onto the per-turn summary the Weaver collects, or (b) become
+    thin shims the Weaver's collaborator consumes. Net: the per-turn metric
+    vocabulary is preserved, but its sink is the session store, not a global
+    Map.
+  - Update tests: `src/__tests__/metrics.test.ts`, `backend-metrics-usage.test.ts`,
+    `live-turn-overlay.test.ts`, `codex-handler.test.ts` (they import
+    `resetMetrics`/`getMetrics`).
+- Keep the per-backend dimension **as a fleet aggregation** if still wanted:
+  since chat→backend can vary per turn, per-backend fleet numbers are best
+  kept as a small global counter OR derived by tagging each turn's backend in
+  the summary and bucketing per-backend inside the fleet aggregator. TBD at
+  implementation; the per-session model is the priority.
+
+## Migration / compatibility
+
+- `normaliseSession()` backfills an empty `SessionMetrics` for pre-existing
+  session rows (same pattern as the `SessionUsage` field backfills).
+- No data migration needed for the removed global store — it was never
+  persisted, so there's nothing to migrate; fleet numbers simply start
+  accumulating per-session from deploy.
+
+## Testing
+
+- Unit: `recordSessionMetrics` folds counters, creates/evicts day buckets,
+  merges latency aggregates; `normaliseSession` backfills.
+- Weaver: `onTurnComplete` fires on success AND failure paths with correct
+  summary; does not throw into the turn.
+- Fleet aggregator: sums across sessions, min/max merge correctness.
+- Discord: validate via CI (`gh pr checks`) per repo convention — no local
+  Discord toolchain.
+
+## Open questions (resolve at implementation)
+
+1. Blob column vs dedicated table (see §2) — start with blob.
+2. Day-bucket retention count (default 30) and whether it's configurable.
+3. Whether to keep any per-backend fleet dimension, and where (see §6).
+4. Timezone for the day boundary (local vs UTC) — pick UTC for determinism
+   unless a user-facing "today" should be local.

--- a/src/__tests__/backend-conformance.test.ts
+++ b/src/__tests__/backend-conformance.test.ts
@@ -153,12 +153,14 @@ describe("backend conformance — shared SSE event processor", () => {
 
     for (const event of events) {
       await processStreamEvent(event, {
+        chatId: "test-chat",
         sessionId,
         state: kiloState,
         seenToolCallIds: seenKilo,
         backendLabel: "Kilo",
       });
       await processStreamEvent(event, {
+        chatId: "test-chat",
         sessionId,
         state: opencodeState,
         seenToolCallIds: seenOpenCode,
@@ -199,12 +201,14 @@ describe("backend conformance — shared SSE event processor", () => {
     };
 
     const kiloOutcome = await processStreamEvent(event, {
+      chatId: "test-chat",
       sessionId: ourSession,
       state: kiloState,
       seenToolCallIds: new Set(),
       backendLabel: "Kilo",
     });
     const opencodeOutcome = await processStreamEvent(event, {
+      chatId: "test-chat",
       sessionId: ourSession,
       state: opencodeState,
       seenToolCallIds: new Set(),
@@ -249,12 +253,14 @@ describe("backend conformance — shared SSE event processor", () => {
 
     for (const event of events) {
       await processStreamEvent(event, {
+        chatId: "test-chat",
         sessionId,
         state: kiloState,
         seenToolCallIds: new Set(),
         backendLabel: "Kilo",
       });
       await processStreamEvent(event, {
+        chatId: "test-chat",
         sessionId,
         state: opencodeState,
         seenToolCallIds: new Set(),

--- a/src/__tests__/backend-metrics-usage.test.ts
+++ b/src/__tests__/backend-metrics-usage.test.ts
@@ -18,6 +18,7 @@ afterEach(() => resetMetrics());
 describe("recordTurnMetrics usage piping", () => {
   it("aggregates token counters globally and per backend", () => {
     recordTurnMetrics({
+      chatId: "test",
       backend: "claude",
       durationMs: 100,
       usage: {
@@ -28,6 +29,7 @@ describe("recordTurnMetrics usage piping", () => {
       },
     });
     recordTurnMetrics({
+      chatId: "test",
       backend: "codex",
       durationMs: 200,
       usage: {
@@ -51,6 +53,7 @@ describe("recordTurnMetrics usage piping", () => {
 
   it("records cache_hit_percent histograms per turn", () => {
     recordTurnMetrics({
+      chatId: "test",
       backend: "claude",
       durationMs: 100,
       // 8000 / (8000 + 2000) → 80%
@@ -65,11 +68,11 @@ describe("recordTurnMetrics usage piping", () => {
     const { histograms } = getMetrics();
     expect(histograms["cache_hit_percent"].count).toBe(1);
     expect(histograms["cache_hit_percent"].avg).toBe(80);
-    expect(histograms["backend.claude.cache_hit_percent"].avg).toBe(80);
   });
 
   it("skips the cache histogram for zero-input turns, keeps counters", () => {
     recordTurnMetrics({
+      chatId: "test",
       backend: "kilo",
       durationMs: 100,
       usage: { inputTokens: 0, outputTokens: 5, cacheRead: 0, cacheWrite: 0 },
@@ -81,7 +84,7 @@ describe("recordTurnMetrics usage piping", () => {
   });
 
   it("is a no-op without a usage snapshot (usage-less backends)", () => {
-    recordTurnMetrics({ backend: "opencode", durationMs: 100 });
+    recordTurnMetrics({ chatId: "test", backend: "opencode", durationMs: 100 });
 
     const { counters } = getMetrics();
     expect(counters["tokens.input_total"]).toBeUndefined();

--- a/src/__tests__/backend-metrics-usage.test.ts
+++ b/src/__tests__/backend-metrics-usage.test.ts
@@ -10,7 +10,12 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { recordTurnMetrics } from "../backend/shared/metrics.js";
-import { getMetrics, resetMetrics } from "../util/metrics.js";
+import {
+  getMetrics,
+  getTodayMetrics,
+  incrementCounter,
+  resetMetrics,
+} from "../util/metrics.js";
 
 beforeEach(() => resetMetrics());
 afterEach(() => resetMetrics());
@@ -89,5 +94,24 @@ describe("recordTurnMetrics usage piping", () => {
     const { counters } = getMetrics();
     expect(counters["tokens.input_total"]).toBeUndefined();
     expect(counters["queries_total"]).toBe(1);
+  });
+
+  it("surfaces the turn in today's bucket, without legacy counters", () => {
+    incrementCounter("legacy.process_counter", 3);
+    recordTurnMetrics({ chatId: "test", backend: "claude", durationMs: 250 });
+
+    const today = getTodayMetrics();
+    expect(today.counters["queries_total"]).toBe(1);
+    expect(today.counters["backend.claude.queries"]).toBe(1);
+    expect(today.histograms["response_latency_ms"]).toMatchObject({
+      count: 1,
+      avg: 250,
+      min: 250,
+      max: 250,
+    });
+    // Legacy in-process counters are lifetime-only.
+    expect(today.counters["legacy.process_counter"]).toBeUndefined();
+    // …but still visible in the lifetime snapshot.
+    expect(getMetrics().counters["legacy.process_counter"]).toBe(3);
   });
 });

--- a/src/__tests__/codex-handler.test.ts
+++ b/src/__tests__/codex-handler.test.ts
@@ -320,11 +320,15 @@ describe("codex / handleMessage — happy path", () => {
     expect(metrics.counters["backend.codex.queries"]).toBe(1);
     expect(metrics.histograms["api_calls_per_turn"]).toMatchObject({
       count: 1,
-      p50: 2,
+      avg: 2,
+      min: 2,
+      max: 2,
     });
     expect(metrics.histograms["tool_calls_per_turn"]).toMatchObject({
       count: 1,
-      p50: 0,
+      avg: 0,
+      min: 0,
+      max: 0,
     });
   });
 
@@ -906,7 +910,9 @@ describe("codex / handleMessage — tool use", () => {
     expect(metrics.counters["turns_with_tools_total"]).toBe(1);
     expect(metrics.histograms["tool_calls_per_turn"]).toMatchObject({
       count: 1,
-      p50: 1,
+      avg: 1,
+      min: 1,
+      max: 1,
     });
   });
 
@@ -1648,7 +1654,9 @@ describe("codex / handleMessage — non-MCP items", () => {
     expect(metrics.counters["turns_with_tools_total"]).toBe(1);
     expect(metrics.histograms["tool_calls_per_turn"]).toMatchObject({
       count: 1,
-      p50: 4,
+      avg: 4,
+      min: 4,
+      max: 4,
     });
   });
 

--- a/src/__tests__/kilo-events.test.ts
+++ b/src/__tests__/kilo-events.test.ts
@@ -20,6 +20,7 @@ const SESSION_ID = "sess_abc";
 
 function baseContext(overrides: Record<string, unknown> = {}) {
   return {
+    chatId: "test-chat",
     sessionId: SESSION_ID,
     state: createStreamState(),
     seenToolCallIds: new Set<string>(),

--- a/src/__tests__/metrics.test.ts
+++ b/src/__tests__/metrics.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import {
-  incrementCounter,
-  recordHistogram,
-  getMetrics,
-  resetMetrics,
-} from "../util/metrics.js";
+import { incrementCounter, getMetrics, resetMetrics } from "../util/metrics.js";
 
 describe("metrics", () => {
   beforeEach(() => resetMetrics());
@@ -16,24 +11,8 @@ describe("metrics", () => {
     expect(getMetrics().counters["test.count"]).toBe(5);
   });
 
-  it("records histograms with percentiles", () => {
-    for (let i = 1; i <= 100; i++) recordHistogram("latency", i);
-    const h = getMetrics().histograms["latency"];
-    expect(h.count).toBe(100);
-    expect(h.p50).toBe(51);
-    expect(h.p95).toBe(96);
-    expect(h.p99).toBe(100);
-    expect(h.avg).toBe(51);
-  });
-
-  it("caps histogram at MAX_HISTOGRAM_SIZE", () => {
-    for (let i = 0; i < 1500; i++) recordHistogram("big", i);
-    expect(getMetrics().histograms["big"].count).toBe(1000);
-  });
-
   it("resets all metrics", () => {
     incrementCounter("x");
-    recordHistogram("y", 1);
     resetMetrics();
     const m = getMetrics();
     expect(Object.keys(m.counters)).toHaveLength(0);
@@ -44,33 +23,8 @@ describe("metrics", () => {
     expect(getMetrics().histograms).toEqual({});
   });
 
-  it("drops NaN, Infinity, and -Infinity from histograms", () => {
-    recordHistogram("clean", 10);
-    recordHistogram("clean", NaN);
-    recordHistogram("clean", Infinity);
-    recordHistogram("clean", -Infinity);
-    recordHistogram("clean", 20);
-    const h = getMetrics().histograms["clean"];
-    expect(h.count).toBe(2);
-    expect(h.avg).toBe(15);
-  });
-
-  it("caps counter keys at MAX_METRIC_KEYS", () => {
-    // Fill up to the cap (500)
-    for (let i = 0; i < 500; i++) incrementCounter(`key_${i}`);
-    expect(Object.keys(getMetrics().counters)).toHaveLength(500);
-    // New key beyond cap is silently dropped
-    incrementCounter("overflow_key");
-    expect(getMetrics().counters["overflow_key"]).toBeUndefined();
-    // Existing keys still work
-    incrementCounter("key_0", 5);
-    expect(getMetrics().counters["key_0"]).toBe(6);
-  });
-
-  it("caps histogram keys at MAX_METRIC_KEYS", () => {
-    for (let i = 0; i < 500; i++) recordHistogram(`h_${i}`, i);
-    expect(Object.keys(getMetrics().histograms)).toHaveLength(500);
-    recordHistogram("overflow_hist", 42);
-    expect(getMetrics().histograms["overflow_hist"]).toBeUndefined();
+  it("keeps compatibility counters for non-chat instrumentation", () => {
+    incrementCounter("legacy.counter", 2);
+    expect(getMetrics().counters["legacy.counter"]).toBe(2);
   });
 });

--- a/src/__tests__/sessions.test.ts
+++ b/src/__tests__/sessions.test.ts
@@ -28,6 +28,8 @@ const {
   incrementTurns,
   recordUsage,
   resetSession,
+  deleteSession,
+  recordSessionMetrics,
   getSessionInfo,
   setSessionId,
   setLastBotMessageId,
@@ -193,6 +195,32 @@ describe("sessions", () => {
       const fresh = getSession(chatId);
       expect(fresh.turns).toBe(0);
       expect(fresh.sessionId).toBeUndefined();
+    });
+
+    it("carries metric history across the reset", () => {
+      const chatId = "test-reset-metrics";
+      setSessionId(chatId, "sid");
+      recordSessionMetrics(chatId, { backend: "claude", durationMs: 120 });
+
+      resetSession(chatId);
+
+      const fresh = getSession(chatId);
+      expect(fresh.sessionId).toBeUndefined();
+      expect(fresh.turns).toBe(0);
+      expect(fresh.usage.totalInputTokens).toBe(0);
+      expect(fresh.metrics.lifetime.counters.queries).toBe(1);
+    });
+  });
+
+  describe("deleteSession", () => {
+    it("drops the chat entirely, metrics included", () => {
+      const chatId = "test-delete-metrics";
+      recordSessionMetrics(chatId, { backend: "claude", durationMs: 120 });
+
+      deleteSession(chatId);
+
+      const fresh = getSession(chatId);
+      expect(fresh.metrics.lifetime.counters.queries).toBe(0);
     });
   });
 

--- a/src/__tests__/telegram-helpers.test.ts
+++ b/src/__tests__/telegram-helpers.test.ts
@@ -159,18 +159,17 @@ describe("renderMetricsMessages", () => {
       histograms: {
         response_latency_ms: {
           count: 3,
-          p50: 250,
-          p95: 1_250,
-          p99: 2_000,
           avg: 900,
+          min: 250,
+          max: 2_000,
         },
       },
     });
 
     expect(messages).toHaveLength(1);
-    expect(messages[0]).toContain("p50=250ms");
-    expect(messages[0]).toContain("p95=1s");
     expect(messages[0]).toContain("avg=900ms");
+    expect(messages[0]).toContain("min=250ms");
+    expect(messages[0]).toContain("max=2s");
   });
 
   it("renders count histograms as plain numbers under Distributions", () => {
@@ -179,23 +178,22 @@ describe("renderMetricsMessages", () => {
       histograms: {
         response_latency_ms: {
           count: 3,
-          p50: 250,
-          p95: 1_250,
-          p99: 2_000,
           avg: 900,
+          min: 250,
+          max: 2_000,
         },
-        tool_calls_per_turn: { count: 21, p50: 1, p95: 33, p99: 100, avg: 9 },
+        tool_calls_per_turn: { count: 21, avg: 9, min: 1, max: 100 },
       },
     });
 
     const out = messages.join("\n");
     // Duration histograms stay under Latency with time units…
     expect(out).toContain("<b>Latency</b>");
-    expect(out).toContain("p50=250ms");
+    expect(out).toContain("avg=900ms");
     // …while per-turn counts get their own section, unit-free.
     expect(out).toContain("<b>Distributions</b>");
-    expect(out).toContain("p50=1  p95=33 p99=100  avg=9");
-    expect(out).not.toContain("p50=1ms");
+    expect(out).toContain("avg=9  min=1 max=100");
+    expect(out).not.toContain("min=1ms");
   });
 
   it("sorts the tool_calls group by count, busiest first", () => {

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -336,7 +336,7 @@ export async function* runChatTurn(
         }
 
         for (const tool of result.tools) {
-          recordToolCall(tool.name, "claude");
+          recordToolCall(chatId, tool.name, "claude");
           captureIntoState(tool.name, tool.input);
           if (isTurnTerminator(tool.name, tool.input)) {
             state.turnTerminated = true;
@@ -487,6 +487,7 @@ export async function* runChatTurn(
 
   const durationMs = Date.now() - t0;
   recordTurnMetrics({
+    chatId,
     backend: "claude",
     durationMs,
     toolCalls: state.toolCalls,
@@ -543,7 +544,10 @@ export async function* runChatTurn(
     : ({ violated: false } as const);
 
   if (violation.violated) {
-    recordFlowViolation(violation.shouldRetry ? "retried" : "cap_exhausted");
+    recordFlowViolation(
+      chatId,
+      violation.shouldRetry ? "retried" : "cap_exhausted",
+    );
     log(
       "agent",
       `[${chatId}] flow violation: ${violation.reason}. ${

--- a/src/backend/codex/handler/events.ts
+++ b/src/backend/codex/handler/events.ts
@@ -182,7 +182,7 @@ function recordCodexToolMetric(
   // Shared vocabulary: `tool_calls.<bare>` (prefix-stripped, so codex
   // MCP calls land on the same keys as every other backend) plus the
   // `backend.codex.tool_calls` dimension.
-  recordToolCall(toolName, "codex");
+  recordToolCall(ctx.chatId, toolName, "codex");
   ctx.codexToolMetrics.count += 1;
 }
 

--- a/src/backend/codex/handler/message.ts
+++ b/src/backend/codex/handler/message.ts
@@ -571,6 +571,7 @@ export async function handleMessage(
   const responseText = finalizeResponseText(streamState);
   const durationMs = Date.now() - t0;
   recordTurnMetrics({
+    chatId,
     backend: "codex",
     durationMs,
     toolCalls: codexToolMetrics.count,

--- a/src/backend/kilo/handler/message.ts
+++ b/src/backend/kilo/handler/message.ts
@@ -220,6 +220,7 @@ export async function handleMessage(
   const responseText = finalizeResponseText(state);
   const durationMs = Date.now() - t0;
   recordTurnMetrics({
+    chatId,
     backend: "kilo",
     durationMs,
     toolCalls: state.toolCalls,

--- a/src/backend/kilo/handler/turn.ts
+++ b/src/backend/kilo/handler/turn.ts
@@ -289,6 +289,7 @@ async function subscribeToTurnEvents(inputs: SubscribeInputs): Promise<void> {
       }
 
       const outcome = await processStreamEvent(event, {
+        chatId,
         sessionId,
         state,
         seenToolCallIds,

--- a/src/backend/openai-agents/handler/events.ts
+++ b/src/backend/openai-agents/handler/events.ts
@@ -103,7 +103,7 @@ function handleToolCalled(item: unknown, ctx: HandleRunItemContext): void {
     }
   }
 
-  recordToolCall(toolName, "openai-agents");
+  recordToolCall(ctx.chatId, toolName, "openai-agents");
   recordToolUse(ctx.state, toolName, input);
 
   if (ctx.onToolUse) {

--- a/src/backend/openai-agents/handler/message.ts
+++ b/src/backend/openai-agents/handler/message.ts
@@ -398,6 +398,7 @@ export async function handleMessage(
   const responseText = finalizeResponseText(streamState);
   const durationMs = Date.now() - t0;
   recordTurnMetrics({
+    chatId,
     backend: "openai-agents",
     durationMs,
     toolCalls: streamState.toolCalls,
@@ -443,7 +444,10 @@ export async function handleMessage(
       : ({ violated: false } as const);
 
   if (violation.violated) {
-    recordFlowViolation(violation.shouldRetry ? "retried" : "cap_exhausted");
+    recordFlowViolation(
+      chatId,
+      violation.shouldRetry ? "retried" : "cap_exhausted",
+    );
     log(
       "agent",
       `[${chatId}] flow violation: trailing prose (${violation.trailing.length} chars) without end_turn/send. ${

--- a/src/backend/opencode/handler/message.ts
+++ b/src/backend/opencode/handler/message.ts
@@ -232,6 +232,7 @@ export async function handleMessage(
   const responseText = finalizeResponseText(state);
   const durationMs = Date.now() - t0;
   recordTurnMetrics({
+    chatId,
     backend: "opencode",
     durationMs,
     toolCalls: state.toolCalls,

--- a/src/backend/opencode/handler/turn.ts
+++ b/src/backend/opencode/handler/turn.ts
@@ -277,6 +277,7 @@ async function subscribeToTurnEvents(inputs: SubscribeInputs): Promise<void> {
       }
 
       const outcome = await processStreamEvent(event, {
+        chatId,
         sessionId,
         state,
         seenToolCallIds,

--- a/src/backend/remote-server/events.ts
+++ b/src/backend/remote-server/events.ts
@@ -64,7 +64,7 @@ export type ProcessEventOutcome =
 /** Common context passed to the per-event helper. */
 export interface EventProcessingContext {
   /** Chat id for session-scoped metrics. */
-  chatId?: string;
+  chatId: string;
   /** Session id we're scoped to — events for other sessions are dropped. */
   sessionId: string;
   /** Stream state accumulator (shared/). */
@@ -279,11 +279,7 @@ async function processPartUpdate(
   }
   // Count every tool the model calls — shared vocabulary across
   // backends (prefix-stripped name + backend dimension).
-  recordToolCall(
-    ctx.chatId ?? "__unknown__",
-    toolName,
-    ctx.backendLabel.toLowerCase(),
-  );
+  recordToolCall(ctx.chatId, toolName, ctx.backendLabel.toLowerCase());
   recordToolUse(ctx.state, toolName, input);
   if (ctx.onToolUse) {
     try {

--- a/src/backend/remote-server/events.ts
+++ b/src/backend/remote-server/events.ts
@@ -63,6 +63,8 @@ export type ProcessEventOutcome =
 
 /** Common context passed to the per-event helper. */
 export interface EventProcessingContext {
+  /** Chat id for session-scoped metrics. */
+  chatId?: string;
   /** Session id we're scoped to — events for other sessions are dropped. */
   sessionId: string;
   /** Stream state accumulator (shared/). */
@@ -277,7 +279,11 @@ async function processPartUpdate(
   }
   // Count every tool the model calls — shared vocabulary across
   // backends (prefix-stripped name + backend dimension).
-  recordToolCall(toolName, ctx.backendLabel.toLowerCase());
+  recordToolCall(
+    ctx.chatId ?? "__unknown__",
+    toolName,
+    ctx.backendLabel.toLowerCase(),
+  );
   recordToolUse(ctx.state, toolName, input);
   if (ctx.onToolUse) {
     try {

--- a/src/backend/shared/metrics.ts
+++ b/src/backend/shared/metrics.ts
@@ -38,10 +38,14 @@
  * registry. Never interpolate chat ids, model ids, or user input.
  */
 
-import { incrementCounter, recordHistogram } from "../../util/metrics.js";
 import { stripMcpPrefix } from "../../core/tools/index.js";
-import { cacheHitPercent, type TokenUsageSnapshot } from "./usage.js";
-import { clearLiveTurn, recordUsage } from "../../storage/sessions.js";
+import type { TokenUsageSnapshot } from "./usage.js";
+import {
+  clearLiveTurn,
+  recordSessionMetricEvent,
+  recordSessionMetrics,
+  recordUsage,
+} from "../../storage/sessions.js";
 
 /**
  * Count one tool call. `toolName` may be raw from any backend —
@@ -49,13 +53,21 @@ import { clearLiveTurn, recordUsage } from "../../storage/sessions.js";
  * (`talon-tools-123_send`), or bare — it is normalised so every
  * backend lands on the same `tool_calls.<bare>` key.
  */
-export function recordToolCall(toolName: string, backend?: string): void {
-  incrementCounter(`tool_calls.${stripMcpPrefix(toolName)}`);
-  if (backend) incrementCounter(`backend.${backend}.tool_calls`);
+export function recordToolCall(
+  chatId: string,
+  toolName: string,
+  backend?: string,
+): void {
+  recordSessionMetricEvent(chatId, {
+    toolCalls: 1,
+    toolName: stripMcpPrefix(toolName),
+    backend,
+  });
 }
 
 /** Per-turn rollup recorded once at the end of every chat turn. */
 export type TurnMetricInputs = {
+  chatId: string;
   /** Backend id, e.g. "claude", "codex", "kilo", "openai-agents", "opencode". */
   backend: string;
   durationMs: number;
@@ -78,45 +90,7 @@ export type TurnMetricInputs = {
  * ("queries_total")` pairs (and codex's private `codex.*` family).
  */
 export function recordTurnMetrics(inputs: TurnMetricInputs): void {
-  recordHistogram("response_latency_ms", inputs.durationMs);
-  recordHistogram(
-    `backend.${inputs.backend}.response_latency_ms`,
-    inputs.durationMs,
-  );
-  incrementCounter("queries_total");
-  incrementCounter(`backend.${inputs.backend}.queries`);
-
-  if (inputs.failed) incrementCounter(`backend.${inputs.backend}.turn_failed`);
-
-  if (inputs.toolCalls !== undefined) {
-    recordHistogram("tool_calls_per_turn", inputs.toolCalls);
-    if (inputs.toolCalls > 0) incrementCounter("turns_with_tools_total");
-  }
-  if (inputs.apiCalls !== undefined && inputs.apiCalls > 0) {
-    incrementCounter("api_calls_total", inputs.apiCalls);
-    recordHistogram("api_calls_per_turn", inputs.apiCalls);
-  }
-
-  if (inputs.usage) {
-    const u = inputs.usage;
-    const b = `backend.${inputs.backend}`;
-    incrementCounter("tokens.input_total", u.inputTokens);
-    incrementCounter("tokens.output_total", u.outputTokens);
-    incrementCounter("tokens.cache_read_total", u.cacheRead);
-    incrementCounter("tokens.cache_write_total", u.cacheWrite);
-    incrementCounter(`${b}.tokens.input`, u.inputTokens);
-    incrementCounter(`${b}.tokens.output`, u.outputTokens);
-    incrementCounter(`${b}.tokens.cache_read`, u.cacheRead);
-    incrementCounter(`${b}.tokens.cache_write`, u.cacheWrite);
-    // Only meaningful when the turn actually consumed input — an
-    // all-zero snapshot (failed turn, usage-less backend) would skew
-    // the distribution with hard zeros.
-    if (u.inputTokens + u.cacheRead > 0) {
-      const pct = cacheHitPercent(u);
-      recordHistogram("cache_hit_percent", pct);
-      recordHistogram(`${b}.cache_hit_percent`, pct);
-    }
-  }
+  recordSessionMetrics(inputs.chatId, inputs);
 }
 
 /**
@@ -152,6 +126,7 @@ export function recordFailedTurnAccounting(inputs: {
   contextWindow?: number;
 }): void {
   recordTurnMetrics({
+    chatId: inputs.chatId,
     backend: inputs.backend,
     durationMs: inputs.durationMs,
     toolCalls: inputs.toolCalls,
@@ -188,12 +163,12 @@ export function recordFailedTurnAccounting(inputs: {
  * reminder" unanswerable for that backend.
  */
 export function recordFlowViolation(
+  chatId: string,
   outcome: "retried" | "cap_exhausted",
 ): void {
-  incrementCounter("scratchpad.trailing_text_dropped");
-  incrementCounter(
-    outcome === "retried"
-      ? "scratchpad.flow_violation_retried"
-      : "scratchpad.flow_violation_cap_exhausted",
-  );
+  recordSessionMetricEvent(chatId, {
+    trailingTextDropped: 1,
+    flowViolationRetries: outcome === "retried" ? 1 : 0,
+    flowViolationCapExhausted: outcome === "cap_exhausted" ? 1 : 0,
+  });
 }

--- a/src/frontend/discord/commands/admin.ts
+++ b/src/frontend/discord/commands/admin.ts
@@ -9,7 +9,7 @@ import type { Gateway } from "../../../core/engine/gateway.js";
 import { respawnSelf } from "../../../util/respawn.js";
 import { forceDream } from "../../../core/background/dream.js";
 import { formatDuration, renderMetricsMessages } from "../helpers.js";
-import { getMetrics } from "../../../util/metrics.js";
+import { getMetrics, getTodayMetrics } from "../../../util/metrics.js";
 import { handleAdminSubcommand } from "../admin.js";
 import { isAdmin } from "../handlers/index.js";
 import { suppressMentions, DISCORD_MAX_TEXT } from "../formatting.js";
@@ -35,7 +35,14 @@ export async function handleMetrics(
   }
   // Ephemeral — admin counters (token usage, latencies, errors) shouldn't leak
   // into a public channel where non-admins can read them.
-  const messages = renderMetricsMessages(getMetrics());
+  const messages = [
+    ...renderMetricsMessages(getMetrics()),
+    ...renderMetricsMessages(
+      getTodayMetrics(),
+      undefined,
+      "📊 Metrics — today (UTC)",
+    ),
+  ];
   for (const m of messages) {
     await reply(i, m, true);
   }

--- a/src/frontend/discord/helpers.ts
+++ b/src/frontend/discord/helpers.ts
@@ -35,7 +35,7 @@ type MetricsSnapshot = {
   counters: Record<string, number>;
   histograms: Record<
     string,
-    { count: number; p50: number; p95: number; p99: number; avg: number }
+    { count: number; avg: number; min: number; max: number }
   >;
 };
 
@@ -57,7 +57,7 @@ export function renderMetricsMessages(
 
   // Histograms come in two flavours: durations (keys ending in `_ms`,
   // rendered as human times) and plain counts like `tool_calls_per_turn`
-  // (rendered as bare numbers — "p50=1ms" for a count is nonsense).
+  // (rendered as bare numbers — "min=1ms" for a count is nonsense).
   const histKeys = Object.keys(metrics.histograms).sort();
   const durationKeys = histKeys.filter((key) => key.endsWith("_ms"));
   const countKeys = histKeys.filter((key) => !key.endsWith("_ms"));
@@ -65,8 +65,8 @@ export function renderMetricsMessages(
     const h = metrics.histograms[key];
     return (
       `  \`${truncateMetricLabel(key)}\`  n=${h.count} ` +
-      `p50=${fmt(h.p50)}  p95=${fmt(h.p95)} ` +
-      `p99=${fmt(h.p99)}  avg=${fmt(h.avg)}`
+      `avg=${fmt(h.avg)}  min=${fmt(h.min)} ` +
+      `max=${fmt(h.max)}`
     );
   };
   if (durationKeys.length > 0) {

--- a/src/frontend/discord/helpers.ts
+++ b/src/frontend/discord/helpers.ts
@@ -50,9 +50,10 @@ function truncateMetricLabel(label: string, max = 60): string {
 export function renderMetricsMessages(
   metrics: MetricsSnapshot,
   maxLen = DEFAULT_METRICS_MESSAGE_MAX,
+  title = "📊 Metrics",
 ): string[] {
-  const firstHeader = "**📊 Metrics**";
-  const continuationHeader = "**📊 Metrics (cont.)**";
+  const firstHeader = `**${title}**`;
+  const continuationHeader = `**${title} (cont.)**`;
   const sections: string[][] = [];
 
   // Histograms come in two flavours: durations (keys ending in `_ms`,

--- a/src/frontend/native/chats.ts
+++ b/src/frontend/native/chats.ts
@@ -15,7 +15,7 @@ import {
 import {
   getAllSessions,
   setSessionName,
-  resetSession,
+  deleteSession,
 } from "../../storage/sessions.js";
 import { getRecentHistory, clearHistory } from "../../storage/history.js";
 import { previewOf } from "./protocol.js";
@@ -125,7 +125,7 @@ export class NativeChats {
     if (!entry) return false;
     this.byId.delete(id);
     this.byNum.delete(entry.numericId);
-    resetSession(id);
+    deleteSession(id);
     clearHistory(id);
     return true;
   }

--- a/src/frontend/telegram/commands/admin.ts
+++ b/src/frontend/telegram/commands/admin.ts
@@ -23,7 +23,7 @@ import {
 } from "../helpers/index.js";
 import { collectDoctorReport } from "../../../core/doctor.js";
 import { handleAdminCommand } from "../admin.js";
-import { getMetrics } from "../../../util/metrics.js";
+import { getMetrics, getTodayMetrics } from "../../../util/metrics.js";
 import { isAuthorizedAdmin, type RegisterDeps } from "./state.js";
 import { telegramCommandMenu } from "./definitions.js";
 
@@ -44,7 +44,15 @@ export function registerAdminCommands(
       await ctx.reply("Not authorized.");
       return;
     }
-    for (const message of renderMetricsMessages(getMetrics())) {
+    const messages = [
+      ...renderMetricsMessages(getMetrics()),
+      ...renderMetricsMessages(
+        getTodayMetrics(),
+        undefined,
+        "📊 Metrics — today (UTC)",
+      ),
+    ];
+    for (const message of messages) {
       await ctx.reply(message, { parse_mode: "HTML" });
     }
   });

--- a/src/frontend/telegram/helpers/diagnostics.ts
+++ b/src/frontend/telegram/helpers/diagnostics.ts
@@ -23,9 +23,10 @@ function truncateMetricLabel(label: string, max = 80): string {
 export function renderMetricsMessages(
   metrics: MetricsSnapshot,
   maxLen = DEFAULT_METRICS_MESSAGE_MAX,
+  title = "📊 Metrics",
 ): string[] {
-  const firstHeader = "<b>📊 Metrics</b>";
-  const continuationHeader = "<b>📊 Metrics (cont.)</b>";
+  const firstHeader = `<b>${escapeHtml(title)}</b>`;
+  const continuationHeader = `<b>${escapeHtml(title)} (cont.)</b>`;
   const sections: string[][] = [];
 
   // Histograms come in two flavours: durations (keys ending in `_ms`,

--- a/src/frontend/telegram/helpers/diagnostics.ts
+++ b/src/frontend/telegram/helpers/diagnostics.ts
@@ -12,7 +12,7 @@ type MetricsSnapshot = {
   counters: Record<string, number>;
   histograms: Record<
     string,
-    { count: number; p50: number; p95: number; p99: number; avg: number }
+    { count: number; avg: number; min: number; max: number }
   >;
 };
 
@@ -30,7 +30,7 @@ export function renderMetricsMessages(
 
   // Histograms come in two flavours: durations (keys ending in `_ms`,
   // rendered as human times) and plain counts like `tool_calls_per_turn`
-  // (rendered as bare numbers — "p50=1ms" for a count is nonsense).
+  // (rendered as bare numbers — "min=1ms" for a count is nonsense).
   const histKeys = Object.keys(metrics.histograms).sort();
   const durationKeys = histKeys.filter((key) => key.endsWith("_ms"));
   const countKeys = histKeys.filter((key) => !key.endsWith("_ms"));
@@ -38,8 +38,8 @@ export function renderMetricsMessages(
     const h = metrics.histograms[key];
     return (
       `  <code>${escapeHtml(truncateMetricLabel(key))}</code>  n=${h.count} ` +
-      `p50=${fmt(h.p50)}  p95=${fmt(h.p95)} ` +
-      `p99=${fmt(h.p99)}  avg=${fmt(h.avg)}`
+      `avg=${fmt(h.avg)}  min=${fmt(h.min)} ` +
+      `max=${fmt(h.max)}`
     );
   };
   if (durationKeys.length > 0) {

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -68,7 +68,7 @@ let db: SqlDatabase | null = null;
  *
  * Column reconciliation runs first: `ALTER TABLE … ADD COLUMN` has no
  * IF NOT EXISTS form, so columns added to already-shipped tables
- * (media_index.content_hash) are ensured by attempting the ALTER and
+ * (media_index.content_hash, sessions.metrics) are ensured by attempting the ALTER and
  * swallowing the two expected failures — "duplicate column name"
  * (column already there) and "no such table" (fresh database; the
  * CREATE TABLE in schema.sql includes the column).
@@ -81,6 +81,11 @@ function ensureSchema(database: SqlDatabase): void {
     .get() as { tables: number };
   try {
     database.exec(dbSql.addMediaContentHashColumn);
+  } catch {
+    /* duplicate column or no such table — both mean nothing to do */
+  }
+  try {
+    database.exec(dbSql.addSessionsMetricsColumn);
   } catch {
     /* duplicate column or no such table — both mean nothing to do */
   }

--- a/src/storage/repositories/sessions-repo.ts
+++ b/src/storage/repositories/sessions-repo.ts
@@ -14,7 +14,11 @@
 
 import { getDatabase, inTransaction } from "../db.js";
 import { sessionsSql } from "../sql/statements.generated.js";
-import type { SessionState } from "../sessions.js";
+import {
+  emptyMetrics,
+  type SessionMetrics,
+  type SessionState,
+} from "../sessions.js";
 
 type Row = {
   chat_id: string;
@@ -37,7 +41,17 @@ type Row = {
   total_response_ms: number;
   last_response_ms: number;
   fastest_response_ms: number | null;
+  metrics: string | null;
 };
+
+function parseMetrics(raw: string | null): SessionMetrics {
+  if (!raw) return emptyMetrics();
+  try {
+    return JSON.parse(raw) as SessionMetrics;
+  } catch {
+    return emptyMetrics();
+  }
+}
 
 function rowToSession(row: Row): SessionState {
   return {
@@ -60,6 +74,7 @@ function rowToSession(row: Row): SessionState {
       // NULL = no timed turn yet — the domain sentinel is Infinity.
       fastestResponseMs: row.fastest_response_ms ?? Infinity,
     },
+    metrics: parseMetrics(row.metrics),
     lastBotMessageId: row.last_bot_message_id ?? undefined,
     sessionName: row.session_name ?? undefined,
     lastModel: row.last_model ?? undefined,
@@ -102,6 +117,7 @@ export function upsert(chatId: string, session: SessionState): void {
       num(usage?.totalResponseMs),
       num(usage?.lastResponseMs),
       typeof fastest === "number" && Number.isFinite(fastest) ? fastest : null,
+      JSON.stringify(session.metrics ?? emptyMetrics()),
     );
 }
 

--- a/src/storage/repositories/sessions-repo.ts
+++ b/src/storage/repositories/sessions-repo.ts
@@ -16,6 +16,7 @@ import { getDatabase, inTransaction } from "../db.js";
 import { sessionsSql } from "../sql/statements.generated.js";
 import {
   emptyMetrics,
+  normaliseMetrics,
   type SessionMetrics,
   type SessionState,
 } from "../sessions.js";
@@ -47,7 +48,9 @@ type Row = {
 function parseMetrics(raw: string | null): SessionMetrics {
   if (!raw) return emptyMetrics();
   try {
-    return JSON.parse(raw) as SessionMetrics;
+    // Normalise at the load boundary: backfills partial blobs and restores
+    // the Infinity minMs sentinel that JSON round-trips as null.
+    return normaliseMetrics(JSON.parse(raw));
   } catch {
     return emptyMetrics();
   }

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -380,7 +380,14 @@ function normaliseGrain(raw: unknown): MetricsGrain {
   return grain;
 }
 
-function normaliseMetrics(metrics: unknown): SessionMetrics {
+/**
+ * Coerce an untrusted/persisted metrics blob into a well-formed
+ * SessionMetrics: missing fields backfilled, non-finite numbers dropped,
+ * JSON's `minMs: null` (Infinity doesn't survive JSON.stringify) restored
+ * to the domain sentinel. Runs once at the load boundary (sessions-repo);
+ * in-memory metrics stay well-formed by construction after that.
+ */
+export function normaliseMetrics(metrics: unknown): SessionMetrics {
   const raw = metrics as Partial<SessionMetrics> | undefined;
   const result: SessionMetrics = {
     lifetime: normaliseGrain(raw?.lifetime),
@@ -437,7 +444,9 @@ function metricBucket(metrics: SessionMetrics, day: string): MetricsGrain {
  */
 function normaliseSession(session: SessionState): SessionState {
   if (!session.usage) session.usage = emptyUsage();
-  session.metrics = normaliseMetrics(session.metrics);
+  // Metrics blobs are normalised once when rows are hydrated
+  // (sessions-repo parseMetrics); here only backfill pre-metrics records.
+  if (!session.metrics) session.metrics = emptyMetrics();
   if (!session.createdAt) session.createdAt = session.lastActive;
   if (session.usage.totalResponseMs === undefined)
     session.usage.totalResponseMs = 0;

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -415,7 +415,8 @@ function addCounters(
   }
 }
 
-function todayUtc(now = Date.now()): string {
+/** UTC day key (`YYYY-MM-DD`) used for daily metric buckets. */
+export function todayUtc(now = Date.now()): string {
   return new Date(now).toISOString().slice(0, 10);
 }
 

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -575,6 +575,13 @@ export function recordSessionMetricEvent(
   persist(chatId, session);
 }
 
+export function resetAllSessionMetrics(): void {
+  for (const [chatId, session] of cache.entries()) {
+    session.metrics = emptyMetrics();
+    persist(chatId, session);
+  }
+}
+
 export function setSessionId(chatId: string, sessionId: string): void {
   const session = getSession(chatId);
   session.sessionId = sessionId;

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -47,6 +47,43 @@ export type SessionUsage = {
   fastestResponseMs: number;
 };
 
+export type MetricsCounterSet = {
+  queries: number;
+  toolCalls: number;
+  turnsWithTools: number;
+  apiCalls: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  failedTurns: number;
+  flowViolationRetries: number;
+  flowViolationCapExhausted: number;
+  trailingTextDropped: number;
+};
+
+export type MetricsLatencyAgg = {
+  count: number;
+  sumMs: number;
+  minMs: number;
+  maxMs: number;
+};
+
+export type MetricsGrain = {
+  counters: MetricsCounterSet;
+  latency: MetricsLatencyAgg;
+  toolCallsByName: Record<string, number>;
+  backend: Record<string, MetricsCounterSet & { latency: MetricsLatencyAgg }>;
+  cacheHitPercent: MetricsLatencyAgg;
+  toolCallsPerTurn: MetricsLatencyAgg;
+  apiCallsPerTurn: MetricsLatencyAgg;
+};
+
+export type SessionMetrics = {
+  lifetime: MetricsGrain;
+  buckets: Record<string, MetricsGrain>;
+};
+
 export type SessionState = {
   /** Backend server-side session ID. */
   sessionId: string | undefined;
@@ -58,6 +95,8 @@ export type SessionState = {
   createdAt: number;
   /** Cumulative usage stats. */
   usage: SessionUsage;
+  /** Persistent per-session metrics, bucketed by UTC day. */
+  metrics: SessionMetrics;
   /** ID of the last message sent by the bot in this chat. */
   lastBotMessageId?: number;
   /** Descriptive session name derived from first message. */
@@ -249,6 +288,147 @@ const emptyUsage = (): SessionUsage => ({
   fastestResponseMs: Infinity,
 });
 
+const emptyCounters = (): MetricsCounterSet => ({
+  queries: 0,
+  toolCalls: 0,
+  turnsWithTools: 0,
+  apiCalls: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  failedTurns: 0,
+  flowViolationRetries: 0,
+  flowViolationCapExhausted: 0,
+  trailingTextDropped: 0,
+});
+
+const emptyLatency = (): MetricsLatencyAgg => ({
+  count: 0,
+  sumMs: 0,
+  minMs: Infinity,
+  maxMs: 0,
+});
+
+const emptyGrain = (): MetricsGrain => ({
+  counters: emptyCounters(),
+  latency: emptyLatency(),
+  toolCallsByName: {},
+  backend: {},
+  cacheHitPercent: emptyLatency(),
+  toolCallsPerTurn: emptyLatency(),
+  apiCallsPerTurn: emptyLatency(),
+});
+
+export const emptyMetrics = (): SessionMetrics => ({
+  lifetime: emptyGrain(),
+  buckets: {},
+});
+
+function normaliseLatency(raw: unknown): MetricsLatencyAgg {
+  const r = raw as Partial<MetricsLatencyAgg> | undefined;
+  const count =
+    typeof r?.count === "number" && Number.isFinite(r.count) ? r.count : 0;
+  return {
+    count,
+    sumMs:
+      typeof r?.sumMs === "number" && Number.isFinite(r.sumMs) ? r.sumMs : 0,
+    minMs:
+      typeof r?.minMs === "number" && Number.isFinite(r.minMs)
+        ? r.minMs
+        : count > 0
+          ? 0
+          : Infinity,
+    maxMs:
+      typeof r?.maxMs === "number" && Number.isFinite(r.maxMs) ? r.maxMs : 0,
+  };
+}
+
+function normaliseCounters(raw: unknown): MetricsCounterSet {
+  const base = emptyCounters();
+  const r = raw as Partial<MetricsCounterSet> | undefined;
+  for (const key of Object.keys(base) as Array<keyof MetricsCounterSet>) {
+    const value = r?.[key];
+    if (typeof value === "number" && Number.isFinite(value)) base[key] = value;
+  }
+  return base;
+}
+
+function normaliseGrain(raw: unknown): MetricsGrain {
+  const r = raw as Partial<MetricsGrain> | undefined;
+  const grain = emptyGrain();
+  grain.counters = normaliseCounters(r?.counters);
+  grain.latency = normaliseLatency(r?.latency);
+  grain.cacheHitPercent = normaliseLatency(r?.cacheHitPercent);
+  grain.toolCallsPerTurn = normaliseLatency(r?.toolCallsPerTurn);
+  grain.apiCallsPerTurn = normaliseLatency(r?.apiCallsPerTurn);
+  if (r?.toolCallsByName && typeof r.toolCallsByName === "object") {
+    for (const [key, value] of Object.entries(r.toolCallsByName)) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        grain.toolCallsByName[key] = value;
+      }
+    }
+  }
+  if (r?.backend && typeof r.backend === "object") {
+    for (const [key, value] of Object.entries(r.backend)) {
+      grain.backend[key] = {
+        ...normaliseCounters(value),
+        latency: normaliseLatency((value as { latency?: unknown }).latency),
+      };
+    }
+  }
+  return grain;
+}
+
+function normaliseMetrics(metrics: unknown): SessionMetrics {
+  const raw = metrics as Partial<SessionMetrics> | undefined;
+  const result: SessionMetrics = {
+    lifetime: normaliseGrain(raw?.lifetime),
+    buckets: {},
+  };
+  if (raw?.buckets && typeof raw.buckets === "object") {
+    for (const [day, grain] of Object.entries(raw.buckets)) {
+      if (/^\d{4}-\d{2}-\d{2}$/.test(day))
+        result.buckets[day] = normaliseGrain(grain);
+    }
+  }
+  return result;
+}
+
+function addLatency(agg: MetricsLatencyAgg, value: number): void {
+  if (!Number.isFinite(value)) return;
+  agg.count += 1;
+  agg.sumMs += value;
+  agg.minMs = Math.min(agg.minMs, value);
+  agg.maxMs = Math.max(agg.maxMs, value);
+}
+
+function addCounters(
+  target: MetricsCounterSet,
+  delta: Partial<MetricsCounterSet>,
+): void {
+  for (const [key, value] of Object.entries(delta) as Array<
+    [keyof MetricsCounterSet, number | undefined]
+  >) {
+    if (typeof value === "number" && Number.isFinite(value))
+      target[key] += value;
+  }
+}
+
+function todayUtc(now = Date.now()): string {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+function metricBucket(metrics: SessionMetrics, day: string): MetricsGrain {
+  metrics.buckets[day] ??= emptyGrain();
+  const days = Object.keys(metrics.buckets).sort();
+  while (days.length > 30) {
+    const oldest = days.shift();
+    if (oldest) delete metrics.buckets[oldest];
+  }
+  return metrics.buckets[day]!;
+}
+
 /**
  * Normalise a session state object in-place. Migrates fields that
  * pre-date later schema additions (response timing, context fill,
@@ -256,6 +436,7 @@ const emptyUsage = (): SessionUsage => ({
  */
 function normaliseSession(session: SessionState): SessionState {
   if (!session.usage) session.usage = emptyUsage();
+  session.metrics = normaliseMetrics(session.metrics);
   if (!session.createdAt) session.createdAt = session.lastActive;
   if (session.usage.totalResponseMs === undefined)
     session.usage.totalResponseMs = 0;
@@ -285,11 +466,113 @@ export function getSession(chatId: string): SessionState {
       lastActive: now,
       createdAt: now,
       usage: emptyUsage(),
+      metrics: emptyMetrics(),
     };
     cache.set(chatId, session);
     persist(chatId, session);
   }
   return normaliseSession(session);
+}
+
+export type SessionMetricTurn = {
+  backend: string;
+  durationMs: number;
+  toolCalls?: number;
+  toolCallsByName?: Record<string, number>;
+  apiCalls?: number;
+  failed?: boolean;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+};
+
+function foldMetricTurn(grain: MetricsGrain, turn: SessionMetricTurn): void {
+  addCounters(grain.counters, {
+    queries: 1,
+    turnsWithTools: turn.toolCalls && turn.toolCalls > 0 ? 1 : 0,
+    apiCalls: turn.apiCalls ?? 0,
+    failedTurns: turn.failed ? 1 : 0,
+    inputTokens: turn.usage?.inputTokens ?? 0,
+    outputTokens: turn.usage?.outputTokens ?? 0,
+    cacheReadTokens: turn.usage?.cacheRead ?? 0,
+    cacheWriteTokens: turn.usage?.cacheWrite ?? 0,
+  });
+  addLatency(grain.latency, turn.durationMs);
+  if (turn.toolCalls !== undefined)
+    addLatency(grain.toolCallsPerTurn, turn.toolCalls);
+  if (turn.apiCalls !== undefined && turn.apiCalls > 0)
+    addLatency(grain.apiCallsPerTurn, turn.apiCalls);
+  if (turn.usage && turn.usage.inputTokens + turn.usage.cacheRead > 0) {
+    addLatency(
+      grain.cacheHitPercent,
+      Math.round(
+        (turn.usage.cacheRead /
+          (turn.usage.inputTokens + turn.usage.cacheRead)) *
+          100,
+      ),
+    );
+  }
+  for (const [name, count] of Object.entries(turn.toolCallsByName ?? {})) {
+    if (Number.isFinite(count))
+      grain.toolCallsByName[name] = (grain.toolCallsByName[name] ?? 0) + count;
+  }
+  const backend = (grain.backend[turn.backend] ??= {
+    ...emptyCounters(),
+    latency: emptyLatency(),
+  });
+  addCounters(backend, {
+    queries: 1,
+    apiCalls: turn.apiCalls ?? 0,
+    failedTurns: turn.failed ? 1 : 0,
+    inputTokens: turn.usage?.inputTokens ?? 0,
+    outputTokens: turn.usage?.outputTokens ?? 0,
+    cacheReadTokens: turn.usage?.cacheRead ?? 0,
+    cacheWriteTokens: turn.usage?.cacheWrite ?? 0,
+  });
+  addLatency(backend.latency, turn.durationMs);
+}
+
+export function recordSessionMetrics(
+  chatId: string,
+  turn: SessionMetricTurn,
+  day = todayUtc(),
+): void {
+  const session = getSession(chatId);
+  foldMetricTurn(session.metrics.lifetime, turn);
+  foldMetricTurn(metricBucket(session.metrics, day), turn);
+  persist(chatId, session);
+}
+
+export function recordSessionMetricEvent(
+  chatId: string,
+  event: Partial<MetricsCounterSet> & {
+    toolName?: string;
+    backend?: string;
+  },
+  day = todayUtc(),
+): void {
+  const session = getSession(chatId);
+  for (const grain of [
+    session.metrics.lifetime,
+    metricBucket(session.metrics, day),
+  ]) {
+    addCounters(grain.counters, event);
+    if (event.toolName && event.toolCalls) {
+      grain.toolCallsByName[event.toolName] =
+        (grain.toolCallsByName[event.toolName] ?? 0) + event.toolCalls;
+    }
+    if (event.backend) {
+      const backend = (grain.backend[event.backend] ??= {
+        ...emptyCounters(),
+        latency: emptyLatency(),
+      });
+      addCounters(backend, event);
+    }
+  }
+  persist(chatId, session);
 }
 
 export function setSessionId(chatId: string, sessionId: string): void {
@@ -401,6 +684,7 @@ export type SessionInfo = {
   lastActive: number;
   createdAt: number;
   usage: SessionUsage;
+  metrics: SessionMetrics;
   sessionName?: string;
   lastModel?: string;
   /** True when a turn is currently streaming and `usage` includes its live so-far counts. */
@@ -415,6 +699,7 @@ export function getSessionInfo(chatId: string): SessionInfo {
     lastActive: session?.lastActive ?? 0,
     createdAt: session?.createdAt ?? 0,
     usage: withLiveTurn(chatId, session?.usage ?? emptyUsage()),
+    metrics: session?.metrics ?? emptyMetrics(),
     sessionName: session?.sessionName,
     lastModel: session?.lastModel,
     turnInProgress: liveTurns.has(chatId),
@@ -435,6 +720,7 @@ export function getAllSessions(): Array<{ chatId: string; info: SessionInfo }> {
       lastActive: session.lastActive,
       createdAt: session.createdAt,
       usage: withLiveTurn(chatId, session.usage ?? emptyUsage()),
+      metrics: session.metrics ?? emptyMetrics(),
       sessionName: session.sessionName,
       lastModel: session.lastModel,
       turnInProgress: liveTurns.has(chatId),

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -675,10 +675,7 @@ export function getLastBotMessageId(chatId: string): number | undefined {
   return cache.get(chatId)?.lastBotMessageId;
 }
 
-export function resetSession(chatId: string): void {
-  const session = cache.get(chatId);
-  const turns = session?.turns ?? 0;
-  const name = session?.sessionName;
+function removeSessionRow(chatId: string): void {
   cache.delete(chatId);
   clearLiveTurn(chatId);
   try {
@@ -689,9 +686,53 @@ export function resetSession(chatId: string): void {
       `Session delete failed: ${err instanceof Error ? err.message : err}`,
     );
   }
+}
+
+/**
+ * Reset the chat's conversation state (backend session id, turns, usage)
+ * while carrying its metrics forward. Resets fire on /new, model switches
+ * and error recovery — none of which should erase the chat's accounting
+ * history (that's what makes per-session metrics survive anything short
+ * of deleting the chat). Use deleteSession() to drop the chat entirely.
+ */
+export function resetSession(chatId: string): void {
+  const session = cache.get(chatId);
+  const turns = session?.turns ?? 0;
+  const name = session?.sessionName;
+  const metrics = session?.metrics;
+  removeSessionRow(chatId);
+  const hasHistory =
+    metrics &&
+    (metrics.lifetime.counters.queries > 0 ||
+      metrics.lifetime.counters.toolCalls > 0);
+  if (hasHistory) {
+    const now = Date.now();
+    const fresh: SessionState = {
+      sessionId: undefined,
+      turns: 0,
+      lastActive: now,
+      createdAt: now,
+      usage: emptyUsage(),
+      metrics,
+    };
+    cache.set(chatId, fresh);
+    persist(chatId, fresh);
+  }
   log(
     "sessions",
     `[${chatId}] Reset${name ? ` "${name}"` : ""} (${turns} turns)`,
+  );
+}
+
+/** Drop the chat entirely — row, cache, live overlay and metrics. */
+export function deleteSession(chatId: string): void {
+  const session = cache.get(chatId);
+  const turns = session?.turns ?? 0;
+  const name = session?.sessionName;
+  removeSessionRow(chatId);
+  log(
+    "sessions",
+    `[${chatId}] Deleted${name ? ` "${name}"` : ""} (${turns} turns)`,
   );
 }
 

--- a/src/storage/sql/db.sql
+++ b/src/storage/sql/db.sql
@@ -9,3 +9,8 @@ PRAGMA wal_checkpoint(TRUNCATE)
 -- attempts this on every open and swallows "duplicate column name" /
 -- "no such table" (fresh databases get the column via schema.sql).
 ALTER TABLE media_index ADD COLUMN content_hash TEXT
+
+-- name: addSessionsMetricsColumn
+-- Column reconciliation for databases that shipped before per-session
+-- metrics existed. Fresh databases get the column via schema.sql.
+ALTER TABLE sessions ADD COLUMN metrics TEXT NOT NULL DEFAULT '{"lifetime":{"counters":{"queries":0,"toolCalls":0,"turnsWithTools":0,"apiCalls":0,"inputTokens":0,"outputTokens":0,"cacheReadTokens":0,"cacheWriteTokens":0,"failedTurns":0,"flowViolationRetries":0,"flowViolationCapExhausted":0,"trailingTextDropped":0},"latency":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"toolCallsByName":{},"backend":{},"cacheHitPercent":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"toolCallsPerTurn":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"apiCallsPerTurn":{"count":0,"sumMs":0,"minMs":null,"maxMs":0}},"buckets":{}}'

--- a/src/storage/sql/schema.sql
+++ b/src/storage/sql/schema.sql
@@ -70,7 +70,8 @@ CREATE TABLE IF NOT EXISTS sessions (
   estimated_cost_usd  REAL    NOT NULL DEFAULT 0,
   total_response_ms   REAL    NOT NULL DEFAULT 0,
   last_response_ms    REAL    NOT NULL DEFAULT 0,
-  fastest_response_ms REAL
+  fastest_response_ms REAL,
+  metrics             TEXT    NOT NULL DEFAULT '{"lifetime":{"counters":{"queries":0,"toolCalls":0,"turnsWithTools":0,"apiCalls":0,"inputTokens":0,"outputTokens":0,"cacheReadTokens":0,"cacheWriteTokens":0,"failedTurns":0,"flowViolationRetries":0,"flowViolationCapExhausted":0,"trailingTextDropped":0},"latency":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"toolCallsByName":{},"backend":{},"cacheHitPercent":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"toolCallsPerTurn":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"apiCallsPerTurn":{"count":0,"sumMs":0,"minMs":null,"maxMs":0}},"buckets":{}}'
 );
 
 -- Chat settings: one JSON document per chat. The access pattern is

--- a/src/storage/sql/sessions.sql
+++ b/src/storage/sql/sessions.sql
@@ -7,15 +7,15 @@ INSERT OR REPLACE INTO sessions
    created_at, last_bot_message_id, total_input_tokens, total_output_tokens,
    total_cache_read, total_cache_write, last_prompt_tokens, context_tokens,
    context_window, num_api_calls, estimated_cost_usd, total_response_ms,
-   last_response_ms, fastest_response_ms)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+   last_response_ms, fastest_response_ms, metrics)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 
 -- name: all
 SELECT chat_id, session_id, session_name, last_model, turns, last_active,
        created_at, last_bot_message_id, total_input_tokens, total_output_tokens,
        total_cache_read, total_cache_write, last_prompt_tokens, context_tokens,
        context_window, num_api_calls, estimated_cost_usd, total_response_ms,
-       last_response_ms, fastest_response_ms
+       last_response_ms, fastest_response_ms, metrics
 FROM sessions
 
 -- name: remove

--- a/src/storage/sql/statements.generated.ts
+++ b/src/storage/sql/statements.generated.ts
@@ -75,7 +75,8 @@ CREATE TABLE IF NOT EXISTS sessions (
   estimated_cost_usd  REAL    NOT NULL DEFAULT 0,
   total_response_ms   REAL    NOT NULL DEFAULT 0,
   last_response_ms    REAL    NOT NULL DEFAULT 0,
-  fastest_response_ms REAL
+  fastest_response_ms REAL,
+  metrics             TEXT    NOT NULL DEFAULT '{"lifetime":{"counters":{"queries":0,"toolCalls":0,"turnsWithTools":0,"apiCalls":0,"inputTokens":0,"outputTokens":0,"cacheReadTokens":0,"cacheWriteTokens":0,"failedTurns":0,"flowViolationRetries":0,"flowViolationCapExhausted":0,"trailingTextDropped":0},"latency":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"toolCallsByName":{},"backend":{},"cacheHitPercent":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"toolCallsPerTurn":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"apiCallsPerTurn":{"count":0,"sumMs":0,"minMs":null,"maxMs":0}},"buckets":{}}'
 );
 
 -- Chat settings: one JSON document per chat. The access pattern is
@@ -277,6 +278,9 @@ export const dbSql = {
 -- attempts this on every open and swallows "duplicate column name" /
 -- "no such table" (fresh databases get the column via schema.sql).
 ALTER TABLE media_index ADD COLUMN content_hash TEXT`,
+  addSessionsMetricsColumn: `-- Column reconciliation for databases that shipped before per-session
+-- metrics existed. Fresh databases get the column via schema.sql.
+ALTER TABLE sessions ADD COLUMN metrics TEXT NOT NULL DEFAULT '{"lifetime":{"counters":{"queries":0,"toolCalls":0,"turnsWithTools":0,"apiCalls":0,"inputTokens":0,"outputTokens":0,"cacheReadTokens":0,"cacheWriteTokens":0,"failedTurns":0,"flowViolationRetries":0,"flowViolationCapExhausted":0,"trailingTextDropped":0},"latency":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"toolCallsByName":{},"backend":{},"cacheHitPercent":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"toolCallsPerTurn":{"count":0,"sumMs":0,"minMs":null,"maxMs":0},"apiCallsPerTurn":{"count":0,"sumMs":0,"minMs":null,"maxMs":0}},"buckets":{}}'`,
 } as const;
 
 export const goalsSql = {
@@ -420,13 +424,13 @@ export const sessionsSql = {
    created_at, last_bot_message_id, total_input_tokens, total_output_tokens,
    total_cache_read, total_cache_write, last_prompt_tokens, context_tokens,
    context_window, num_api_calls, estimated_cost_usd, total_response_ms,
-   last_response_ms, fastest_response_ms)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+   last_response_ms, fastest_response_ms, metrics)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   all: `SELECT chat_id, session_id, session_name, last_model, turns, last_active,
        created_at, last_bot_message_id, total_input_tokens, total_output_tokens,
        total_cache_read, total_cache_write, last_prompt_tokens, context_tokens,
        context_window, num_api_calls, estimated_cost_usd, total_response_ms,
-       last_response_ms, fastest_response_ms
+       last_response_ms, fastest_response_ms, metrics
 FROM sessions`,
   remove: `DELETE FROM sessions WHERE chat_id = ?`,
 } as const;

--- a/src/util/metrics.ts
+++ b/src/util/metrics.ts
@@ -2,7 +2,11 @@
 // storage/sessions.ts; this module keeps the public read shape used by
 // /metrics and a small compatibility sink for non-chat legacy counters.
 
-import { getAllSessions, type MetricsLatencyAgg } from "../storage/sessions.js";
+import {
+  getAllSessions,
+  resetAllSessionMetrics,
+  type MetricsLatencyAgg,
+} from "../storage/sessions.js";
 
 const legacyCounters = new Map<string, number>();
 
@@ -137,4 +141,5 @@ export function getMetrics(): MetricsSnapshot {
 
 export function resetMetrics(): void {
   legacyCounters.clear();
+  resetAllSessionMetrics();
 }

--- a/src/util/metrics.ts
+++ b/src/util/metrics.ts
@@ -1,80 +1,140 @@
-// src/util/metrics.ts — lightweight in-process metrics
+// Session-backed metrics aggregation. Writes for chat turns live on
+// storage/sessions.ts; this module keeps the public read shape used by
+// /metrics and a small compatibility sink for non-chat legacy counters.
 
-const counters = new Map<string, number>();
-const MAX_METRIC_KEYS = 500; // cap to prevent unbounded growth from high-cardinality names
+import { getAllSessions, type MetricsLatencyAgg } from "../storage/sessions.js";
 
-// Ring buffer for histograms — O(1) insert, avoids splice overhead
-interface RingBuffer {
-  data: number[];
-  head: number; // next write position
-  size: number; // current number of valid entries (≤ capacity)
-}
+const legacyCounters = new Map<string, number>();
 
-const histograms = new Map<string, RingBuffer>();
-const MAX_HISTOGRAM_SIZE = 1000;
-
-function createRingBuffer(capacity: number): RingBuffer {
-  return { data: new Array<number>(capacity), head: 0, size: 0 };
-}
-
-function ringPush(buf: RingBuffer, value: number): void {
-  buf.data[buf.head] = value;
-  buf.head = (buf.head + 1) % buf.data.length;
-  if (buf.size < buf.data.length) buf.size++;
-}
-
-function ringValues(buf: RingBuffer): number[] {
-  if (buf.size < buf.data.length) return buf.data.slice(0, buf.size);
-  // Full ring — read from head (oldest) wrapping around
-  return [...buf.data.slice(buf.head), ...buf.data.slice(0, buf.head)];
-}
-
-export function incrementCounter(name: string, amount = 1): void {
-  // Only allow new keys up to the cap — existing keys always pass
-  if (!counters.has(name) && counters.size >= MAX_METRIC_KEYS) return;
-  counters.set(name, (counters.get(name) ?? 0) + amount);
-}
-
-export function recordHistogram(name: string, value: number): void {
-  if (!Number.isFinite(value)) return; // drop NaN/Infinity/invalid samples
-  let buf = histograms.get(name);
-  if (!buf) {
-    if (histograms.size >= MAX_METRIC_KEYS) return; // cap key count
-    buf = createRingBuffer(MAX_HISTOGRAM_SIZE);
-    histograms.set(name, buf);
-  }
-  ringPush(buf, value);
-}
-
-export function getMetrics(): {
+export type MetricsSnapshot = {
   counters: Record<string, number>;
   histograms: Record<
     string,
-    { count: number; p50: number; p95: number; p99: number; avg: number }
+    { count: number; avg: number; min: number; max: number }
   >;
-} {
-  const result: ReturnType<typeof getMetrics> = {
-    counters: {},
-    histograms: {},
-  };
-  for (const [k, v] of counters) result.counters[k] = v;
-  for (const [k, buf] of histograms) {
-    if (buf.size === 0) continue;
-    const values = ringValues(buf);
-    const sorted = [...values].sort((a, b) => a - b);
-    const len = sorted.length;
-    result.histograms[k] = {
-      count: len,
-      p50: sorted[Math.floor(len * 0.5)],
-      p95: sorted[Math.floor(len * 0.95)],
-      p99: sorted[Math.floor(len * 0.99)],
-      avg: Math.round(values.reduce((a, b) => a + b, 0) / len),
-    };
+};
+
+export function incrementCounter(name: string, amount = 1): void {
+  legacyCounters.set(name, (legacyCounters.get(name) ?? 0) + amount);
+}
+
+export function recordHistogram(_name: string, _value: number): void {
+  // The old global histogram ring is intentionally gone. Chat-turn
+  // histograms are now latency aggregates on SessionMetrics.
+}
+
+function addCounter(
+  counters: Record<string, number>,
+  name: string,
+  amount: number | undefined,
+): void {
+  if (typeof amount === "number" && Number.isFinite(amount) && amount !== 0) {
+    counters[name] = (counters[name] ?? 0) + amount;
   }
-  return result;
+}
+
+function mergeAgg(target: MetricsLatencyAgg, source: MetricsLatencyAgg): void {
+  if (!source.count) return;
+  target.count += source.count;
+  target.sumMs += source.sumMs;
+  target.minMs = Math.min(target.minMs, source.minMs);
+  target.maxMs = Math.max(target.maxMs, source.maxMs);
+}
+
+function emptyAgg(): MetricsLatencyAgg {
+  return { count: 0, sumMs: 0, minMs: Infinity, maxMs: 0 };
+}
+
+function snapshotAgg(agg: MetricsLatencyAgg) {
+  return {
+    count: agg.count,
+    avg: Math.round(agg.sumMs / agg.count),
+    min: agg.minMs,
+    max: agg.maxMs,
+  };
+}
+
+export function getMetrics(): MetricsSnapshot {
+  const counters: Record<string, number> = {};
+  const responseLatency = emptyAgg();
+  const toolCallsPerTurn = emptyAgg();
+  const apiCallsPerTurn = emptyAgg();
+  const cacheHitPercent = emptyAgg();
+  const backendLatency = new Map<string, MetricsLatencyAgg>();
+
+  for (const [key, value] of legacyCounters) addCounter(counters, key, value);
+
+  for (const { info } of getAllSessions()) {
+    const grain = info.metrics.lifetime;
+    const c = grain.counters;
+    addCounter(counters, "queries_total", c.queries);
+    addCounter(counters, "turns_with_tools_total", c.turnsWithTools);
+    addCounter(counters, "api_calls_total", c.apiCalls);
+    addCounter(counters, "tokens.input_total", c.inputTokens);
+    addCounter(counters, "tokens.output_total", c.outputTokens);
+    addCounter(counters, "tokens.cache_read_total", c.cacheReadTokens);
+    addCounter(counters, "tokens.cache_write_total", c.cacheWriteTokens);
+    addCounter(
+      counters,
+      "scratchpad.trailing_text_dropped",
+      c.trailingTextDropped,
+    );
+    addCounter(
+      counters,
+      "scratchpad.flow_violation_retried",
+      c.flowViolationRetries,
+    );
+    addCounter(
+      counters,
+      "scratchpad.flow_violation_cap_exhausted",
+      c.flowViolationCapExhausted,
+    );
+    for (const [name, count] of Object.entries(grain.toolCallsByName)) {
+      addCounter(counters, `tool_calls.${name}`, count);
+    }
+    for (const [backend, bc] of Object.entries(grain.backend)) {
+      addCounter(counters, `backend.${backend}.queries`, bc.queries);
+      addCounter(counters, `backend.${backend}.tool_calls`, bc.toolCalls);
+      addCounter(counters, `backend.${backend}.turn_failed`, bc.failedTurns);
+      addCounter(counters, `backend.${backend}.tokens.input`, bc.inputTokens);
+      addCounter(counters, `backend.${backend}.tokens.output`, bc.outputTokens);
+      addCounter(
+        counters,
+        `backend.${backend}.tokens.cache_read`,
+        bc.cacheReadTokens,
+      );
+      addCounter(
+        counters,
+        `backend.${backend}.tokens.cache_write`,
+        bc.cacheWriteTokens,
+      );
+      const agg = backendLatency.get(backend) ?? emptyAgg();
+      mergeAgg(agg, bc.latency);
+      backendLatency.set(backend, agg);
+    }
+    mergeAgg(responseLatency, grain.latency);
+    mergeAgg(toolCallsPerTurn, grain.toolCallsPerTurn);
+    mergeAgg(apiCallsPerTurn, grain.apiCallsPerTurn);
+    mergeAgg(cacheHitPercent, grain.cacheHitPercent);
+  }
+
+  const histograms: MetricsSnapshot["histograms"] = {};
+  if (responseLatency.count)
+    histograms.response_latency_ms = snapshotAgg(responseLatency);
+  if (toolCallsPerTurn.count)
+    histograms.tool_calls_per_turn = snapshotAgg(toolCallsPerTurn);
+  if (apiCallsPerTurn.count)
+    histograms.api_calls_per_turn = snapshotAgg(apiCallsPerTurn);
+  if (cacheHitPercent.count)
+    histograms.cache_hit_percent = snapshotAgg(cacheHitPercent);
+  for (const [backend, agg] of backendLatency) {
+    if (agg.count)
+      histograms[`backend.${backend}.response_latency_ms`] = snapshotAgg(agg);
+  }
+
+  return { counters, histograms };
 }
 
 export function resetMetrics(): void {
-  counters.clear();
-  histograms.clear();
+  legacyCounters.clear();
 }

--- a/src/util/metrics.ts
+++ b/src/util/metrics.ts
@@ -5,6 +5,8 @@
 import {
   getAllSessions,
   resetAllSessionMetrics,
+  todayUtc,
+  type MetricsGrain,
   type MetricsLatencyAgg,
 } from "../storage/sessions.js";
 
@@ -58,18 +60,17 @@ function snapshotAgg(agg: MetricsLatencyAgg) {
   };
 }
 
-export function getMetrics(): MetricsSnapshot {
-  const counters: Record<string, number> = {};
+function buildSnapshot(
+  grains: MetricsGrain[],
+  counters: Record<string, number>,
+): MetricsSnapshot {
   const responseLatency = emptyAgg();
   const toolCallsPerTurn = emptyAgg();
   const apiCallsPerTurn = emptyAgg();
   const cacheHitPercent = emptyAgg();
   const backendLatency = new Map<string, MetricsLatencyAgg>();
 
-  for (const [key, value] of legacyCounters) addCounter(counters, key, value);
-
-  for (const { info } of getAllSessions()) {
-    const grain = info.metrics.lifetime;
+  for (const grain of grains) {
     const c = grain.counters;
     addCounter(counters, "queries_total", c.queries);
     addCounter(counters, "turns_with_tools_total", c.turnsWithTools);
@@ -137,6 +138,28 @@ export function getMetrics(): MetricsSnapshot {
   }
 
   return { counters, histograms };
+}
+
+/** Lifetime fleet snapshot: all sessions' cumulative metrics plus the
+ * in-process legacy counters. */
+export function getMetrics(): MetricsSnapshot {
+  const counters: Record<string, number> = {};
+  for (const [key, value] of legacyCounters) addCounter(counters, key, value);
+  return buildSnapshot(
+    getAllSessions().map(({ info }) => info.metrics.lifetime),
+    counters,
+  );
+}
+
+/** Today's (UTC) fleet snapshot, aggregated from the sessions' daily
+ * rollup buckets. Legacy counters are process-lifetime, not daily, so
+ * they are excluded here. */
+export function getTodayMetrics(): MetricsSnapshot {
+  const day = todayUtc();
+  return buildSnapshot(
+    getAllSessions().flatMap(({ info }) => info.metrics.buckets[day] ?? []),
+    {},
+  );
 }
 
 export function resetMetrics(): void {


### PR DESCRIPTION
## What & why

Metrics used to live in a **global, in-process** store (`src/util/metrics.ts`) — they **vanished on restart** and were **fleet-wide, not per-chat**. This PR moves metrics onto the **chat session**, persisted in SQLite alongside the rest of session state.

Result: metrics **persist across restart**, are **bound to the chat session**, and **roll up per UTC day** with retained history (30-day ring), so "today" resets emergently at the day boundary — no cron.

## Design

Design of record in **`docs/per-session-metrics.md`** (updated with the as-built notes).

1. **Data model** — `SessionMetrics { lifetime, buckets: Record<YYYY-MM-DD, MetricsGrain> }`; each grain holds a `MetricsCounterSet` (queries, tool calls, api calls, tokens, failures, flow violations), latency aggregates (count/sum/min/max), per-tool and per-backend dimensions.
2. **Persistence** — a `metrics TEXT` JSON blob column on `sessions`, reconciled on open for existing databases (schema.sql → sql/*.sql → `npm run build:sql` → repo → store layering). `normaliseSession()` backfills/validates on read.
3. **Collection** — instead of the planned Weaver collaborator, the existing `backend/shared/metrics.ts` entry points (`recordTurnMetrics`, `recordToolCall`, `recordFlowViolation`, `recordFailedTurnAccounting`) became thin shims over the session store, each threading `chatId`. Every backend already calls them on success **and** failure paths, so no new hook or bootstrap wiring was needed. `EventProcessingContext.chatId` is required, so a missing chat id is a compile error rather than a phantom session.
4. **Writer** — `recordSessionMetrics(chatId, turn, day = todayUtc())` and `recordSessionMetricEvent(...)` on `storage/sessions.ts`; the day key is injectable for deterministic tests. Blobs are normalised once at hydration (`sessions-repo`), not on every `getSession`.
5. **Reset vs delete** — conversation resets (`resetSession`: /new, model switches, error recovery) carry metrics into the fresh row, so error recovery can't erase the failure counters that recorded it; the new `deleteSession` (used by chat deletion) drops everything.
6. **Read side** — `getMetrics()` aggregates lifetime grains across `getAllSessions()` (plus a small in-process legacy-counter sink for non-chat instrumentation); `getTodayMetrics()` aggregates today's UTC buckets. `/metrics` on Telegram and Discord renders both, and the renderers show avg/min/max (the global percentile ring is gone — the accepted trade).
7. **Removal** — the global counter/histogram store is deleted; `src/util/metrics.ts` is now the aggregation read layer + legacy sink.

## Task checklist

- [x] Design doc (`docs/per-session-metrics.md`), updated to as-built
- [x] `SessionMetrics` type + `emptyMetrics()` + `normaliseSession()` backfill
- [x] Schema: `metrics` column on `sessions` + `build:sql` + repo mapping
- [x] `recordSessionMetrics` / `recordSessionMetricEvent` domain API
- [x] Backend collection threads `chatId` on success + failure paths (all five backends)
- [x] Fleet aggregator: `getMetrics()` lifetime + `getTodayMetrics()` daily read side in `/metrics`
- [x] Renderers (telegram `diagnostics.ts`, discord `helpers.ts`) → avg/min/max + titled today section
- [x] Global store removed; `backend/shared/metrics.ts` re-pointed to the session store
- [x] Tests updated (`metrics.test.ts`, `backend-metrics-usage.test.ts`, `codex-handler.test.ts`, `telegram-helpers.test.ts`, `sessions.test.ts` reset/delete semantics, conformance/kilo event fixtures)
- [x] Discord validated via CI (`gh pr checks`)

## Resolved decisions

- Blob column (not a dedicated table) — matches `SessionUsage`'s home; migrate only if query needs demand it.
- 30-day bucket retention, evicted oldest-first; not configurable yet.
- Per-backend dimension kept per-session, aggregated at read time.
- Day boundary is **UTC**; `/metrics` labels the section "today (UTC)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
