### PR TITLE
Fix native teleport chat scoping

### DIFF
--- a/src/__tests__/native-tools.test.ts
+++ b/src/__tests__/native-tools.test.ts
@@ -273,6 +273,59 @@ describe("native tools — teleport routing", () => {
     expect(sentCmds[1]).toContain("cd '/sdcard/Download'");
   });
 
+  it("scopes teleport routing to the current chat", async () => {
+    const service = freshMesh();
+    setMeshService(service);
+    await service.register({
+      id: "phone",
+      name: "Pixel 9",
+      platform: "android",
+      appVersion: "1.0.0",
+      capabilities: ["exec"],
+    });
+    const sentCmds: string[] = [];
+    service.registerTransport({
+      locate: () => {},
+      command: (cmd) =>
+        queueMicrotask(() => {
+          sentCmds.push(String(cmd.params.cmd));
+          service.completeCommand({
+            commandId: cmd.id,
+            deviceId: cmd.deviceId,
+            ok: true,
+            data: {
+              stdout: "remote\n__TALON_CWD__/sdcard__TALON_CWD_END__",
+              stderr: "",
+              exitCode: 0,
+            },
+          });
+        }),
+    });
+
+    const tp = await nativeHandlers.teleport(
+      { action: "teleport", device: "phone" },
+      1,
+    );
+    expect(tp.ok).toBe(true);
+
+    const local = await nativeHandlers.native_bash(
+      { action: "native_bash", command: "echo local-chat" },
+      2,
+    );
+    expect(local.ok).toBe(true);
+    expect(local.text).toContain("[local] exit 0");
+    expect(local.text).toContain("local-chat");
+    expect(sentCmds).toHaveLength(0);
+
+    const remote = await nativeHandlers.native_bash(
+      { action: "native_bash", command: "echo remote-chat" },
+      1,
+    );
+    expect(remote.ok).toBe(true);
+    expect(remote.text).toContain("[Pixel 9] exit 0");
+    expect(sentCmds).toHaveLength(1);
+  });
+
   it("refuses to teleport onto a device that lacks exec", async () => {
     const service = freshMesh();
     setMeshService(service);

--- a/src/core/engine/gateway-actions/native.ts
+++ b/src/core/engine/gateway-actions/native.ts
@@ -2,11 +2,11 @@
  * Native tools — Talon's own shell/filesystem tools, replacing the SDK's
  * built-in Bash/Read/Write/Edit/Glob/Grep when `config.nativeTools` is on.
  *
- * Their defining feature: every one checks the active `teleport` target. With
- * no teleport, they run on the daemon host (local spawn / local fs / local
- * ripgrep). With a teleport engaged, they run ON the companion device via the
- * mesh exec/fs channel — so `bash`/`read`/`write`/… transparently operate on
- * the phone. Talon acts as if it were running on whichever node is active.
+ * Their defining feature: every one checks the current chat's active
+ * `teleport` target. With no teleport for that chat, they run on the daemon
+ * host (local spawn / local fs / local ripgrep). With a teleport engaged, they
+ * run ON the companion device via the mesh exec/fs channel — so
+ * `bash`/`read`/`write`/… transparently operate on the phone for that chat.
  *
  *   teleport(device)  → native tools target that device
  *   teleport_back()   → native tools run locally again
@@ -56,21 +56,23 @@ const CWD_OPEN = "__TALON_CWD__";
 const CWD_CLOSE = "__TALON_CWD_END__";
 
 export const nativeHandlers: SharedActionHandlers = {
-  teleport: (body) => teleport(body.device),
-  teleport_back: () => teleportBack(),
-  native_bash: (body) => bash(body.command, body.cwd, body.timeout_sec),
-  native_read: (body) => read(body.path, body.offset, body.limit),
-  native_write: (body) => write(body.path, body.content),
-  native_edit: (body) =>
-    edit(body.path, body.old_string, body.new_string, body.replace_all),
-  native_glob: (body) => glob(body.pattern, body.path),
-  native_search: (body) =>
-    search(body.pattern, body.path, body.glob, body.case_insensitive),
+  teleport: (body, chatId) => teleport(chatId, body.device),
+  teleport_back: (_body, chatId) => teleportBack(chatId),
+  native_bash: (body, chatId) =>
+    bash(chatId, body.command, body.cwd, body.timeout_sec),
+  native_read: (body, chatId) =>
+    read(chatId, body.path, body.offset, body.limit),
+  native_write: (body, chatId) => write(chatId, body.path, body.content),
+  native_edit: (body, chatId) =>
+    edit(chatId, body.path, body.old_string, body.new_string, body.replace_all),
+  native_glob: (body, chatId) => glob(chatId, body.pattern, body.path),
+  native_search: (body, chatId) =>
+    search(chatId, body.pattern, body.path, body.glob, body.case_insensitive),
 };
 
 // ── Teleport control ────────────────────────────────────────────────────────
 
-async function teleport(query: unknown): Promise<Result> {
+async function teleport(chatId: number, query: unknown): Promise<Result> {
   const svc = getMeshService();
   await svc.list();
   const target = svc.chooseDevice(query);
@@ -95,7 +97,7 @@ async function teleport(query: unknown): Promise<Result> {
       text: `${target.name} does not advertise the "exec" capability, so teleport can't run commands on it.`,
     };
   }
-  await setTeleport(target.id, target.name);
+  await setTeleport(chatId, target.id, target.name);
   return {
     ok: true,
     text: [
@@ -106,8 +108,8 @@ async function teleport(query: unknown): Promise<Result> {
   };
 }
 
-async function teleportBack(): Promise<Result> {
-  const prior = await clearTeleport();
+async function teleportBack(chatId: number): Promise<Result> {
+  const prior = await clearTeleport(chatId);
   return {
     ok: true,
     text: prior
@@ -119,6 +121,7 @@ async function teleportBack(): Promise<Result> {
 // ── bash ────────────────────────────────────────────────────────────────────
 
 async function bash(
+  chatId: number,
   command: unknown,
   cwd: unknown,
   timeoutSec: unknown,
@@ -126,8 +129,8 @@ async function bash(
   const cmd = typeof command === "string" ? command : "";
   if (!cmd.trim()) return { ok: false, text: "No command given." };
   const timeoutMs = clampTimeout(timeoutSec);
-  const active = await getTeleport();
-  if (active) return bashTeleported(active.deviceId, cmd, timeoutMs);
+  const active = await getTeleport(chatId);
+  if (active) return bashTeleported(chatId, active.deviceId, cmd, timeoutMs);
   return bashLocal(cmd, typeof cwd === "string" ? cwd : undefined, timeoutMs);
 }
 
@@ -180,11 +183,12 @@ function bashLocal(
 }
 
 async function bashTeleported(
+  chatId: number,
   deviceId: string,
   cmd: string,
   timeoutMs: number,
 ): Promise<Result> {
-  const active = await getTeleport();
+  const active = await getTeleport(chatId);
   const cwd = active?.cwd;
   // Wrap so the resulting working dir is reported back and persists across
   // calls (a `cd` in `cmd` carries forward), while the real exit code is
@@ -213,7 +217,7 @@ async function bashTeleported(
     if (close !== -1) {
       const newCwd = stdout.slice(open + CWD_OPEN.length, close).trim();
       stdout = stdout.slice(0, open);
-      if (newCwd) await setTeleportCwd(newCwd);
+      if (newCwd) await setTeleportCwd(chatId, newCwd);
     }
   }
   if (!result.ok && exitCode === undefined) {
@@ -231,6 +235,7 @@ async function bashTeleported(
 // ── read / write / edit ─────────────────────────────────────────────────────
 
 async function read(
+  chatId: number,
   path: unknown,
   offset: unknown,
   limit: unknown,
@@ -239,7 +244,7 @@ async function read(
   if (!p) return { ok: false, text: "A file path is required." };
   const start = num(offset) ?? 0;
   const max = Math.min(num(limit) ?? MAX_READ_LINES, MAX_READ_LINES);
-  const active = await getTeleport();
+  const active = await getTeleport(chatId);
   let content: string;
   let where: string;
   if (active) {
@@ -270,11 +275,15 @@ async function read(
   };
 }
 
-async function write(path: unknown, content: unknown): Promise<Result> {
+async function write(
+  chatId: number,
+  path: unknown,
+  content: unknown,
+): Promise<Result> {
   const p = str(path);
   if (!p) return { ok: false, text: "A file path is required." };
   const body = typeof content === "string" ? content : "";
-  const active = await getTeleport();
+  const active = await getTeleport(chatId);
   if (active) {
     return getMeshService().writeFileToDevice(active.deviceId, p, body);
   }
@@ -288,6 +297,7 @@ async function write(path: unknown, content: unknown): Promise<Result> {
 }
 
 async function edit(
+  chatId: number,
   path: unknown,
   oldString: unknown,
   newString: unknown,
@@ -299,7 +309,7 @@ async function edit(
   const to = typeof newString === "string" ? newString : "";
   if (from === to)
     return { ok: false, text: "old_string and new_string are identical." };
-  const active = await getTeleport();
+  const active = await getTeleport(chatId);
   const svc = getMeshService();
 
   let content: string;
@@ -350,11 +360,15 @@ async function edit(
 
 // ── glob / search ───────────────────────────────────────────────────────────
 
-async function glob(pattern: unknown, path: unknown): Promise<Result> {
+async function glob(
+  chatId: number,
+  pattern: unknown,
+  path: unknown,
+): Promise<Result> {
   const pat = str(pattern);
   if (!pat) return { ok: false, text: "A glob pattern is required." };
   const root = str(path) ?? ".";
-  const active = await getTeleport();
+  const active = await getTeleport(chatId);
   if (active) {
     // Prefer rg on the device; fall back to find (basename patterns via
     // -name, path patterns via -path). `command -v` gates the choice so a
@@ -366,7 +380,7 @@ async function glob(pattern: unknown, path: unknown): Promise<Result> {
       `if command -v rg >/dev/null 2>&1; ` +
       `then rg --files -g ${shellQuote(pat)} ${shellQuote(root)}; ` +
       `else find ${shellQuote(root)} ${findExpr} 2>/dev/null; fi`;
-    return bashTeleported(active.deviceId, cmd, 30_000);
+    return bashTeleported(chatId, active.deviceId, cmd, 30_000);
   }
   const res = await runLocal(rgBin(), ["--files", "-g", pat, root]);
   let files: string[];
@@ -392,6 +406,7 @@ async function glob(pattern: unknown, path: unknown): Promise<Result> {
 }
 
 async function search(
+  chatId: number,
   pattern: unknown,
   path: unknown,
   globPat: unknown,
@@ -410,7 +425,7 @@ async function search(
     ...(ci ? ["-i"] : []),
     ...(g ? ["-g", g] : []),
   ];
-  const active = await getTeleport();
+  const active = await getTeleport(chatId);
   if (active) {
     // Prefer rg on the device, fall back to grep (Android toybox has grep
     // but rarely rg). --include is grep's closest analogue of -g.
@@ -423,7 +438,7 @@ async function search(
       `if command -v rg >/dev/null 2>&1; ` +
       `then rg ${flags.map(shellQuote).join(" ")} -e ${shellQuote(pat)} ${shellQuote(root)}; ` +
       `else grep ${grepFlags.map(shellQuote).join(" ")} -e ${shellQuote(pat)} ${shellQuote(root)} 2>/dev/null; fi`;
-    return bashTeleported(active.deviceId, cmd, 30_000);
+    return bashTeleported(chatId, active.deviceId, cmd, 30_000);
   }
   const res = await runLocal(rgBin(), [...flags, "-e", pat, root]);
   let lines: string[];

--- a/src/core/mesh/teleport.ts
+++ b/src/core/mesh/teleport.ts
@@ -1,15 +1,14 @@
 /**
- * Teleport state — the single "active node" the native tools route through.
+ * Teleport state — the active node each chat's native tools route through.
  *
  * When a node is active, Talon's native shell/file tools (bash/read/write/
  * edit/glob/search) execute ON that companion device via the mesh exec/fs
  * channel instead of on the daemon host — Talon acts as if it were running
  * on the phone. `teleport_back` clears it and everything runs locally again.
  *
- * State is a tiny JSON sidecar under the Talon root so it survives restarts
- * and is shared across the process (the native gateway actions read it on
- * every call). Deliberately global, not per-chat: teleport is an operator
- * mode for the whole daemon, matching how Dylan drives a single bot.
+ * State is a tiny JSON sidecar under the Talon root so it survives restarts.
+ * The sidecar is keyed by chat id: teleporting in one chat must not redirect
+ * native tools in another chat.
  */
 
 import { readFile } from "node:fs/promises";
@@ -32,6 +31,10 @@ export type TeleportState = {
   since: number;
 };
 
+type TeleportStore = {
+  chats: Record<string, TeleportState>;
+};
+
 /** Resolved lazily so a test can point it at a tmp file via env. */
 function stateFile(): string {
   return (
@@ -40,34 +43,73 @@ function stateFile(): string {
   );
 }
 
-let cache: TeleportState | null | undefined;
+let cache: TeleportStore | undefined;
 
-/** The active teleport target, or null when operating locally. */
-export async function getTeleport(): Promise<TeleportState | null> {
+function emptyStore(): TeleportStore {
+  return { chats: Object.create(null) as Record<string, TeleportState> };
+}
+
+function normalizeChatId(chatId: number | string): string {
+  return String(chatId);
+}
+
+function parseState(value: unknown): TeleportState | null {
+  const parsed = value as Partial<TeleportState> | null;
+  if (!parsed || typeof parsed.deviceId !== "string" || !parsed.deviceId) {
+    return null;
+  }
+  return {
+    deviceId: parsed.deviceId,
+    deviceName:
+      typeof parsed.deviceName === "string" && parsed.deviceName
+        ? parsed.deviceName
+        : parsed.deviceId,
+    ...(typeof parsed.cwd === "string" ? { cwd: parsed.cwd } : {}),
+    since: typeof parsed.since === "number" ? parsed.since : Date.now(),
+  };
+}
+
+async function readStore(): Promise<TeleportStore> {
   if (cache !== undefined) return cache;
   try {
     const raw = await readFile(stateFile(), "utf8");
-    const parsed = JSON.parse(raw) as Partial<TeleportState>;
-    cache =
-      parsed && typeof parsed.deviceId === "string" && parsed.deviceId
-        ? {
-            deviceId: parsed.deviceId,
-            deviceName:
-              typeof parsed.deviceName === "string" && parsed.deviceName
-                ? parsed.deviceName
-                : parsed.deviceId,
-            ...(typeof parsed.cwd === "string" ? { cwd: parsed.cwd } : {}),
-            since: typeof parsed.since === "number" ? parsed.since : Date.now(),
-          }
-        : null;
+    const parsed = JSON.parse(raw) as unknown;
+    const store = emptyStore();
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "chats" in parsed &&
+      parsed.chats &&
+      typeof parsed.chats === "object"
+    ) {
+      for (const [chatId, state] of Object.entries(
+        parsed.chats as Record<string, unknown>,
+      )) {
+        const normalized = parseState(state);
+        if (normalized) store.chats[chatId] = normalized;
+      }
+    } else {
+      // Legacy singleton file from pre-chat-scoped teleport. Keep reading it
+      // harmlessly, but do not bind it to any chat.
+    }
+    cache = store;
   } catch {
-    cache = null;
+    cache = emptyStore();
   }
   return cache;
 }
 
+/** The active teleport target, or null when operating locally. */
+export async function getTeleport(
+  chatId: number | string,
+): Promise<TeleportState | null> {
+  const store = await readStore();
+  return store.chats[normalizeChatId(chatId)] ?? null;
+}
+
 /** Engage teleport onto a device. */
 export async function setTeleport(
+  chatId: number | string,
   deviceId: string,
   deviceName: string,
 ): Promise<TeleportState> {
@@ -76,25 +118,37 @@ export async function setTeleport(
     deviceName,
     since: Date.now(),
   };
-  cache = state;
-  await writePrivateJson(stateFile(), state);
+  const store = await readStore();
+  store.chats[normalizeChatId(chatId)] = state;
+  cache = store;
+  await writePrivateJson(stateFile(), store);
   return state;
 }
 
 /** Persist an updated working directory for the active teleport. */
-export async function setTeleportCwd(cwd: string): Promise<void> {
-  const current = await getTeleport();
+export async function setTeleportCwd(
+  chatId: number | string,
+  cwd: string,
+): Promise<void> {
+  const current = await getTeleport(chatId);
   if (!current) return;
   const next: TeleportState = { ...current, cwd };
-  cache = next;
-  await writePrivateJson(stateFile(), next);
+  const store = await readStore();
+  store.chats[normalizeChatId(chatId)] = next;
+  cache = store;
+  await writePrivateJson(stateFile(), store);
 }
 
 /** Return to local operation. Returns the prior target (for the message). */
-export async function clearTeleport(): Promise<TeleportState | null> {
-  const prior = await getTeleport();
-  cache = null;
-  await writePrivateJson(stateFile(), null);
+export async function clearTeleport(
+  chatId: number | string,
+): Promise<TeleportState | null> {
+  const store = await readStore();
+  const key = normalizeChatId(chatId);
+  const prior = store.chats[key] ?? null;
+  delete store.chats[key];
+  cache = store;
+  await writePrivateJson(stateFile(), store);
   return prior;
 }
 


### PR DESCRIPTION
## Summary

- Store native teleport state by chat id instead of one daemon-wide singleton.
- Thread `chatId` through native `teleport`, `teleport_back`, shell, file, glob, and search handlers.
- Add a regression test proving one chat can be teleported while another chat continues to run local native commands.

## Why

`teleport` was implemented as global daemon state, so engaging a phone session in one chat redirected native tools for every chat. That made cross-chat shell/file routing possible and surprising.

## Validation

- `npm test -- src/__tests__/native-tools.test.ts`
- `npm run typecheck`