### PR TITLE
fix(mesh): explicit Shizuku privilege + exec/transfer infrastructure hardening

### DIFF
--- a/apps/companion/android/app/src/main/kotlin/org/talon/companion/ShizukuBridge.kt
+++ b/apps/companion/android/app/src/main/kotlin/org/talon/companion/ShizukuBridge.kt
@@ -30,7 +30,7 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
         private const val REQUEST_CODE = 4021
     }
 
-    private var pendingPermission: MethodChannel.Result? = null
+    private val pendingPermissions = mutableListOf<MethodChannel.Result>()
 
     /**
      * MethodChannel.Result is @UiThread-only — replying from a worker thread
@@ -51,8 +51,9 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
         Shizuku.OnRequestPermissionResultListener { requestCode, grantResult ->
             if (requestCode == REQUEST_CODE) {
                 val granted = grantResult == android.content.pm.PackageManager.PERMISSION_GRANTED
-                pendingPermission?.let { replySuccess(it, granted) }
-                pendingPermission = null
+                val pending = pendingPermissions.toList()
+                pendingPermissions.clear()
+                pending.forEach { replySuccess(it, granted && isReady()) }
             }
         }
 
@@ -67,8 +68,9 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
-            "isReady" -> result.success(isReady())
+            "getStatus" -> result.success(status())
             "requestPermission" -> requestPermission(result)
+            "cancelPermissionRequest" -> cancelPermissionRequest(result)
             "exec" -> exec(call, result)
             else -> result.notImplemented()
         }
@@ -92,6 +94,22 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
 
     private fun isReady(): Boolean = binderAlive() && hasPermission()
 
+    private fun status(): Map<String, Any> {
+        val binderAlive = binderAlive()
+        val granted = binderAlive && hasPermission()
+        val state = try {
+            when {
+                !binderAlive -> "not-running"
+                granted -> "ready"
+                Shizuku.shouldShowRequestPermissionRationale() -> "permission-denied"
+                else -> "permission-needed"
+            }
+        } catch (_: Throwable) {
+            "unavailable"
+        }
+        return mapOf("ready" to granted, "state" to state)
+    }
+
     private fun requestPermission(result: MethodChannel.Result) {
         try {
             if (!binderAlive()) {
@@ -106,14 +124,30 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
                 result.success(false)
                 return
             }
-            // A second in-flight request replaces the first; answer the old
-            // one instead of leaving its Dart await hanging forever.
-            pendingPermission?.let { replySuccess(it, false) }
-            pendingPermission = result
+            // Several mesh requests can land together. Keep every caller
+            // attached to the same Android permission prompt.
+            if (pendingPermissions.isNotEmpty()) {
+                pendingPermissions.add(result)
+                return
+            }
+            pendingPermissions.add(result)
             Shizuku.requestPermission(REQUEST_CODE)
         } catch (_: Throwable) {
-            result.success(false)
+            val pending = pendingPermissions.toList()
+            pendingPermissions.clear()
+            if (pending.isEmpty()) {
+                result.success(false)
+            } else {
+                pending.forEach { replySuccess(it, false) }
+            }
         }
+    }
+
+    private fun cancelPermissionRequest(result: MethodChannel.Result) {
+        val pending = pendingPermissions.toList()
+        pendingPermissions.clear()
+        pending.forEach { replySuccess(it, false) }
+        result.success(null)
     }
 
     private fun exec(call: MethodCall, result: MethodChannel.Result) {

--- a/apps/companion/lib/src/services/device_exec.dart
+++ b/apps/companion/lib/src/services/device_exec.dart
@@ -106,7 +106,9 @@ class DeviceExec {
   }
 
   Future<Map<String, String>> privilegeStatus() async {
-    if (!_isAndroid()) return const {'execPrivilege': 'app'};
+    // Desktop platforms run commands as the logged-in OS user; the
+    // shizuku/app distinction is Android-only.
+    if (!_isAndroid()) return const {'execPrivilege': 'user'};
     try {
       final status =
           await _shizuku.invokeMapMethod<String, dynamic>('getStatus');
@@ -250,7 +252,9 @@ class DeviceExec {
             if (timedOut) '[killed: timeout]',
           ].join('\n'),
           'exitCode': code,
-          'via': 'app',
+          // Only Android has a degraded app-UID mode worth flagging; desktop
+          // shells already run as the OS user.
+          if (_isAndroid()) 'via': 'app',
           if (privilegeWarning != null) 'privilegeWarning': privilegeWarning,
         },
         message: timedOut ? 'Command timed out.' : null,

--- a/apps/companion/lib/src/services/device_exec.dart
+++ b/apps/companion/lib/src/services/device_exec.dart
@@ -48,6 +48,11 @@ class DeviceExec {
 
   static const int _maxChunkBytes = 256 * 1024;
   static const Duration _shizukuPermissionWait = Duration(seconds: 12);
+  /// Per-stream cap on exec output shipped back over the mesh. Head + tail
+  /// (not head-only): the daemon's teleport wrapper prints its cwd marker at
+  /// the very END of stdout, and losing it would break cwd tracking.
+  static const int _execOutputHeadBytes = 192 * 1024;
+  static const int _execOutputTailBytes = 64 * 1024;
 
   /// True when Shizuku is available AND has granted permission right now.
   Future<bool> shizukuReady() async {
@@ -190,8 +195,8 @@ class DeviceExec {
           return CommandOutcome(
             ok: (res['exitCode'] as num?)?.toInt() == 0,
             data: {
-              'stdout': res['stdout'] ?? '',
-              'stderr': res['stderr'] ?? '',
+              'stdout': _CappedOutput.clamp('${res['stdout'] ?? ''}'),
+              'stderr': _CappedOutput.clamp('${res['stderr'] ?? ''}'),
               'exitCode': (res['exitCode'] as num?)?.toInt() ?? -1,
               'via': 'shizuku',
             },
@@ -231,8 +236,13 @@ class DeviceExec {
         args,
         workingDirectory: (cwd != null && cwd.isNotEmpty) ? cwd : null,
       );
-      final outF = proc.stdout.transform(utf8.decoder).join();
-      final errF = proc.stderr.transform(utf8.decoder).join();
+      // Bounded collection: a chatty command must not balloon app memory or
+      // the mesh result payload — the stream keeps draining, extra bytes are
+      // counted and elided.
+      final out = _CappedOutput();
+      final err = _CappedOutput();
+      final outF = proc.stdout.transform(utf8.decoder).forEach(out.add);
+      final errF = proc.stderr.transform(utf8.decoder).forEach(err.add);
       var timedOut = false;
       final timer = Timer(budget, () {
         timedOut = true;
@@ -240,8 +250,10 @@ class DeviceExec {
       });
       final code = await proc.exitCode;
       timer.cancel();
-      final stdout = await outF;
-      final stderr = await errF;
+      await outF;
+      await errF;
+      final stdout = out.value();
+      final stderr = err.value();
       return CommandOutcome(
         ok: !timedOut && code == 0,
         data: {
@@ -448,4 +460,44 @@ class CommandOutcome {
       CommandOutcome(ok: false, message: message);
   factory CommandOutcome.okData(Map<String, dynamic> data) =>
       CommandOutcome(ok: true, data: data);
+}
+
+/// Bounded exec-output collector: keeps the head and a rolling tail, counts
+/// what it elides. The tail is load-bearing — the daemon's teleport wrapper
+/// emits its cwd marker as the LAST bytes of stdout.
+class _CappedOutput {
+  final StringBuffer _head = StringBuffer();
+  String _tail = '';
+  int _dropped = 0;
+
+  void add(String chunk) {
+    var rest = chunk;
+    final room = DeviceExec._execOutputHeadBytes - _head.length;
+    if (room > 0) {
+      if (rest.length <= room) {
+        _head.write(rest);
+        return;
+      }
+      _head.write(rest.substring(0, room));
+      rest = rest.substring(room);
+    }
+    _tail = _tail + rest;
+    if (_tail.length > DeviceExec._execOutputTailBytes) {
+      _dropped += _tail.length - DeviceExec._execOutputTailBytes;
+      _tail = _tail.substring(_tail.length - DeviceExec._execOutputTailBytes);
+    }
+  }
+
+  String value() {
+    if (_tail.isEmpty) return _head.toString();
+    final note = _dropped > 0 ? '\n…[$_dropped chars truncated]…\n' : '';
+    return '$_head$note$_tail';
+  }
+
+  /// One-shot clamp for output that already arrived as a single string
+  /// (the Shizuku channel hands the whole result over at once).
+  static String clamp(String s) {
+    final out = _CappedOutput()..add(s);
+    return out.value();
+  }
 }

--- a/apps/companion/lib/src/services/device_exec.dart
+++ b/apps/companion/lib/src/services/device_exec.dart
@@ -23,10 +23,15 @@ import 'log.dart';
 ///     system without root. Falls back to app-UID whenever Shizuku is absent
 ///     or denied.
 class DeviceExec {
-  DeviceExec({MethodChannel? shizukuChannel})
-      : _shizuku = shizukuChannel ?? const MethodChannel('talon/shizuku');
+  DeviceExec({
+    MethodChannel? shizukuChannel,
+    bool Function()? isAndroid,
+  })  : _shizuku = shizukuChannel ?? const MethodChannel('talon/shizuku'),
+        _isAndroid = isAndroid ?? (() => !kIsWeb && Platform.isAndroid);
 
   final MethodChannel _shizuku;
+  final bool Function() _isAndroid;
+  Future<bool>? _pendingShizukuPermission;
 
   /// Commands this executor can answer — merged into the device's advertised
   /// mesh capabilities so the daemon gates cleanly.
@@ -42,26 +47,77 @@ class DeviceExec {
   ];
 
   static const int _maxChunkBytes = 256 * 1024;
+  static const Duration _shizukuPermissionWait = Duration(seconds: 12);
 
   /// True when Shizuku is available AND has granted permission right now.
   Future<bool> shizukuReady() async {
-    if (kIsWeb || !Platform.isAndroid) return false;
+    if (!_isAndroid()) return false;
     try {
-      final ok = await _shizuku.invokeMethod<bool>('isReady');
-      return ok ?? false;
+      final status =
+          await _shizuku.invokeMapMethod<String, dynamic>('getStatus');
+      return status?['ready'] == true;
     } catch (_) {
       return false;
     }
   }
 
-  /// Ask Shizuku for permission (no-op / false when unavailable).
+  /// Ask Shizuku for permission once. Concurrent commands share a single
+  /// system prompt instead of replacing one another's result callback.
   Future<bool> requestShizuku() async {
-    if (kIsWeb || !Platform.isAndroid) return false;
+    if (!_isAndroid()) return false;
+    return _pendingShizukuPermission ??= _requestShizuku().whenComplete(() {
+      _pendingShizukuPermission = null;
+    });
+  }
+
+  Future<bool> _requestShizuku() async {
     try {
-      final ok = await _shizuku.invokeMethod<bool>('requestPermission');
-      return ok ?? false;
+      final granted = await _shizuku
+          .invokeMethod<bool>('requestPermission')
+          .timeout(_shizukuPermissionWait);
+      // The permission callback is advisory; re-check the binder before
+      // claiming elevated execution is actually available.
+      return granted == true && await shizukuReady();
+    } on TimeoutException {
+      // Dart has stopped waiting, so release the Android-side MethodChannel
+      // result too. A late approval still applies to the next command.
+      unawaited(_cancelShizukuPermissionRequest());
+      return false;
     } catch (_) {
       return false;
+    }
+  }
+
+  Future<void> _cancelShizukuPermissionRequest() async {
+    try {
+      await _shizuku.invokeMethod<void>('cancelPermissionRequest');
+    } catch (_) {
+      // The bridge may have gone away with the activity; the next status check
+      // will report it as unavailable.
+    }
+  }
+
+  /// Prefer elevated Android execution, but never hang the command forever
+  /// waiting for a permission dialog that may be ignored.
+  Future<bool> ensureShizukuReady() async {
+    if (await shizukuReady()) return true;
+    if (!_isAndroid()) return false;
+    return requestShizuku();
+  }
+
+  Future<Map<String, String>> privilegeStatus() async {
+    if (!_isAndroid()) return const {'execPrivilege': 'app'};
+    try {
+      final status =
+          await _shizuku.invokeMapMethod<String, dynamic>('getStatus');
+      final ready = status?['ready'] == true;
+      final state = status?['state'];
+      return {
+        'execPrivilege': ready ? 'shizuku' : 'app',
+        'shizuku': state is String ? state : 'unavailable',
+      };
+    } catch (_) {
+      return const {'execPrivilege': 'app', 'shizuku': 'unavailable'};
     }
   }
 
@@ -116,9 +172,12 @@ class DeviceExec {
     if (cmd.trim().isEmpty) {
       return CommandOutcome.fail('No command given.');
     }
-    final budget = Duration(milliseconds: (timeoutMs ?? 60000).clamp(1000, 300000));
-    // Prefer Shizuku (shell UID) when it's ready, else run as the app user.
-    if (await shizukuReady()) {
+    final budget =
+        Duration(milliseconds: (timeoutMs ?? 60000).clamp(1000, 300000));
+    // Prefer Shizuku (shell UID). If it is installed but permission has not
+    // been granted yet, ask once; otherwise a remote filesystem command can
+    // silently run as the app UID and return a misleading scoped-storage view.
+    if (await ensureShizukuReady()) {
       try {
         final res = await _shizuku.invokeMapMethod<String, dynamic>('exec', {
           'cmd': cmd,
@@ -138,15 +197,29 @@ class DeviceExec {
         }
       } catch (e) {
         AppLog.warn('exec', 'shizuku exec failed, falling back', e);
+        return _execAppUid(
+          cmd,
+          cwd: cwd,
+          budget: budget,
+          privilegeWarning: 'Shizuku exec failed ($e); ran as app UID.',
+        );
       }
     }
-    return _execAppUid(cmd, cwd: cwd, budget: budget);
+    return _execAppUid(
+      cmd,
+      cwd: cwd,
+      budget: budget,
+      privilegeWarning: _isAndroid()
+          ? 'Shizuku not ready or permission not granted; ran as app UID.'
+          : null,
+    );
   }
 
   Future<CommandOutcome> _execAppUid(
     String cmd, {
     String? cwd,
     required Duration budget,
+    String? privilegeWarning,
   }) async {
     final shell = Platform.isWindows ? 'cmd' : 'sh';
     final args = Platform.isWindows ? ['/c', cmd] : ['-c', cmd];
@@ -171,9 +244,14 @@ class DeviceExec {
         ok: !timedOut && code == 0,
         data: {
           'stdout': stdout,
-          'stderr': timedOut ? '$stderr\n[killed: timeout]' : stderr,
+          'stderr': [
+            if (privilegeWarning != null) privilegeWarning,
+            if (stderr.isNotEmpty) stderr,
+            if (timedOut) '[killed: timeout]',
+          ].join('\n'),
           'exitCode': code,
           'via': 'app',
+          if (privilegeWarning != null) 'privilegeWarning': privilegeWarning,
         },
         message: timedOut ? 'Command timed out.' : null,
       );
@@ -184,9 +262,8 @@ class DeviceExec {
 
   // ── filesystem ────────────────────────────────────────────────────────────
 
-  Future<CommandOutcome> readFile(
-    String path,
-    {required int offset, required int len}) async {
+  Future<CommandOutcome> readFile(String path,
+      {required int offset, required int len}) async {
     if (path.isEmpty) return CommandOutcome.fail('No path.');
     try {
       final file = File(path);
@@ -273,7 +350,8 @@ class DeviceExec {
           'mtime': stat.modified.millisecondsSinceEpoch,
         });
       }
-      entries.sort((a, b) => (a['name'] as String).compareTo(b['name'] as String));
+      entries
+          .sort((a, b) => (a['name'] as String).compareTo(b['name'] as String));
       return CommandOutcome.okData({'entries': entries});
     } catch (e) {
       return CommandOutcome.fail('list_dir failed: $e');
@@ -326,7 +404,9 @@ class DeviceExec {
   }
 
   Future<CommandOutcome> move(String from, String to) async {
-    if (from.isEmpty || to.isEmpty) return CommandOutcome.fail('from/to required.');
+    if (from.isEmpty || to.isEmpty) {
+      return CommandOutcome.fail('from/to required.');
+    }
     try {
       final type = await FileSystemEntity.type(from);
       if (type == FileSystemEntityType.directory) {
@@ -348,7 +428,8 @@ class DeviceExec {
   }
 
   static String? _str(dynamic v) => v is String && v.isNotEmpty ? v : null;
-  static int? _int(dynamic v) => v is num ? v.toInt() : (v is String ? int.tryParse(v) : null);
+  static int? _int(dynamic v) =>
+      v is num ? v.toInt() : (v is String ? int.tryParse(v) : null);
 }
 
 /// Structured result of an on-device command.

--- a/apps/companion/lib/src/services/mesh_service.dart
+++ b/apps/companion/lib/src/services/mesh_service.dart
@@ -284,7 +284,9 @@ class MeshService {
           }
           final downToken = params['token'];
           final downPath = params['path'];
-          if (downToken is! String || downToken.isEmpty || downPath is! String) {
+          if (downToken is! String ||
+              downToken.isEmpty ||
+              downPath is! String) {
             message = 'download_file needs token and path.';
             break;
           }
@@ -353,6 +355,12 @@ class MeshService {
     } catch (_) {
       extras = const {};
     }
+    Map<String, String> privilege;
+    try {
+      privilege = await _exec.privilegeStatus();
+    } catch (_) {
+      privilege = const {};
+    }
     return {
       'name': await _nameProvider(),
       'platform': _platform,
@@ -361,10 +369,10 @@ class MeshService {
       if (battery.charging != null)
         'charging': battery.charging! ? 'yes' : 'no',
       ...extras,
+      ...privilege,
       'meshSharing': prefs.meshSharing ? 'on' : 'off',
-      'periodicReporting': prefs.meshPeriodic
-          ? 'every ${prefs.meshIntervalSeconds}s'
-          : 'off',
+      'periodicReporting':
+          prefs.meshPeriodic ? 'every ${prefs.meshIntervalSeconds}s' : 'off',
     };
   }
 
@@ -510,7 +518,8 @@ class MeshService {
       if (!kIsWeb && Platform.isAndroid) {
         final d = await device.androidInfo;
         info['hardware'] = '${d.manufacturer} ${d.model}';
-        info['osDetail'] = 'Android ${d.version.release} (SDK ${d.version.sdkInt})';
+        info['osDetail'] =
+            'Android ${d.version.release} (SDK ${d.version.sdkInt})';
       } else if (!kIsWeb && Platform.isIOS) {
         final d = await device.iosInfo;
         info['hardware'] = d.utsname.machine;

--- a/apps/companion/test/device_exec_test.dart
+++ b/apps/companion/test/device_exec_test.dart
@@ -89,6 +89,22 @@ void main() {
     expect(result.data!['privilegeWarning'], contains('Shizuku not ready'));
   });
 
+  test('caps runaway exec output but keeps the tail (cwd marker survives)',
+      () async {
+    // 400KB of noise then a trailing marker — like the teleport wrapper's
+    // cwd marker, which is always the LAST bytes of stdout. The cap must
+    // elide the middle, never the tail.
+    final r = await exec.exec(
+      "dd if=/dev/zero bs=1024 count=400 2>/dev/null | tr '\\0' x; "
+      'printf TALON_TAIL_MARKER',
+    );
+    expect(r.ok, isTrue);
+    final stdout = r.data!['stdout'] as String;
+    expect(stdout.length, lessThan(300 * 1024));
+    expect(stdout, contains('chars truncated'));
+    expect(stdout, endsWith('TALON_TAIL_MARKER'));
+  });
+
   test('desktop exec never consults Shizuku and stays unannotated', () async {
     const channel = MethodChannel('talon/shizuku-test-desktop');
     var channelCalls = 0;

--- a/apps/companion/test/device_exec_test.dart
+++ b/apps/companion/test/device_exec_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:talon_companion/src/services/device_exec.dart';
 
@@ -30,14 +31,72 @@ void main() {
     expect(r.data!['exitCode'], 7);
   });
 
+  test('uses Shizuku only after the permission callback verifies readiness',
+      () async {
+    const channel = MethodChannel('talon/shizuku-test-ready');
+    var ready = false;
+    var permissionRequests = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      switch (call.method) {
+        case 'getStatus':
+          return {
+            'ready': ready,
+            'state': ready ? 'ready' : 'permission-needed'
+          };
+        case 'requestPermission':
+          permissionRequests++;
+          ready = true;
+          return true;
+        case 'exec':
+          return {'stdout': 'shell', 'stderr': '', 'exitCode': 0};
+      }
+      return null;
+    });
+    addTearDown(() => TestDefaultBinaryMessengerBinding
+        .instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null));
+
+    final elevated = DeviceExec(shizukuChannel: channel, isAndroid: () => true);
+    final result = await elevated.exec('id');
+
+    expect(permissionRequests, 1);
+    expect(result.ok, isTrue);
+    expect(result.data!['via'], 'shizuku');
+    expect(result.data!['stdout'], 'shell');
+  });
+
+  test('marks app-UID results as limited when Shizuku is unavailable',
+      () async {
+    const channel = MethodChannel('talon/shizuku-test-unavailable');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'getStatus') {
+        return {'ready': false, 'state': 'not-running'};
+      }
+      if (call.method == 'requestPermission') return false;
+      return null;
+    });
+    addTearDown(() => TestDefaultBinaryMessengerBinding
+        .instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null));
+
+    final limited = DeviceExec(shizukuChannel: channel, isAndroid: () => true);
+    final result = await limited.exec('printf app');
+
+    expect(result.ok, isTrue);
+    expect(result.data!['via'], 'app');
+    expect(result.data!['privilegeWarning'], contains('Shizuku not ready'));
+  });
+
   test('writes then reads a file in chunks (base64 roundtrip)', () async {
     final f = '${tmp.path}/note.txt';
     final content = 'A' * (300 * 1024); // > one 256KB chunk
     // First chunk truncates, second appends.
     final first = utf8.encode(content.substring(0, 256 * 1024));
     final second = utf8.encode(content.substring(256 * 1024));
-    final w1 = await exec.writeFile(f, base64Encode(first),
-        offset: 0, truncate: true);
+    final w1 =
+        await exec.writeFile(f, base64Encode(first), offset: 0, truncate: true);
     expect(w1.ok, isTrue);
     final w2 = await exec.writeFile(f, base64Encode(second),
         offset: first.length, truncate: false);
@@ -82,8 +141,7 @@ void main() {
     await Directory('${tmp.path}/sub').create();
     final ls = await exec.listDir(tmp.path);
     expect(ls.ok, isTrue);
-    final names =
-        (ls.data!['entries'] as List).map((e) => e['name']).toList();
+    final names = (ls.data!['entries'] as List).map((e) => e['name']).toList();
     expect(names, containsAll(['a.txt', 'sub']));
 
     final st = await exec.statPath('${tmp.path}/a.txt');

--- a/apps/companion/test/device_exec_test.dart
+++ b/apps/companion/test/device_exec_test.dart
@@ -89,6 +89,28 @@ void main() {
     expect(result.data!['privilegeWarning'], contains('Shizuku not ready'));
   });
 
+  test('desktop exec never consults Shizuku and stays unannotated', () async {
+    const channel = MethodChannel('talon/shizuku-test-desktop');
+    var channelCalls = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      channelCalls++;
+      return null;
+    });
+    addTearDown(() => TestDefaultBinaryMessengerBinding
+        .instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null));
+
+    final desktop = DeviceExec(shizukuChannel: channel, isAndroid: () => false);
+    final result = await desktop.exec('echo desktop');
+
+    expect(channelCalls, 0);
+    expect(result.ok, isTrue);
+    expect(result.data!.containsKey('via'), isFalse);
+    expect(result.data!.containsKey('privilegeWarning'), isFalse);
+    expect(await desktop.privilegeStatus(), {'execPrivilege': 'user'});
+  });
+
   test('writes then reads a file in chunks (base64 roundtrip)', () async {
     final f = '${tmp.path}/note.txt';
     final content = 'A' * (300 * 1024); // > one 256KB chunk

--- a/src/__tests__/exec-output.test.ts
+++ b/src/__tests__/exec-output.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Exec output guards — the shared capture/render ceilings under both the
+ * local native tools and the mesh exec channel. Without them a runaway
+ * `yes` balloons daemon memory for the whole timeout window, and a chatty
+ * device command floods the chat/model with megabytes of output.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  clampExecOutput,
+  createOutputCapture,
+  MAX_EXEC_RENDER_CHARS,
+} from "../util/exec-output.js";
+
+describe("clampExecOutput", () => {
+  it("passes short output through untouched", () => {
+    expect(clampExecOutput("hello")).toBe("hello");
+  });
+
+  it("keeps head and tail, elides the middle with an explicit marker", () => {
+    const text = `HEAD${"x".repeat(100_000)}TAIL`;
+    const clamped = clampExecOutput(text);
+    expect(clamped.length).toBeLessThan(MAX_EXEC_RENDER_CHARS + 200);
+    expect(clamped.startsWith("HEAD")).toBe(true);
+    expect(clamped.endsWith("TAIL")).toBe(true);
+    expect(clamped).toContain("chars truncated");
+  });
+});
+
+describe("createOutputCapture", () => {
+  it("accumulates chunks below the cap verbatim", () => {
+    const cap = createOutputCapture();
+    cap.push("one ");
+    cap.push(Buffer.from("two"));
+    expect(cap.value()).toBe("one two");
+  });
+
+  it("stops storing past the cap and reports the dropped volume", () => {
+    const cap = createOutputCapture(10);
+    cap.push("0123456789");
+    cap.push("overflow!");
+    const value = cap.value();
+    expect(value.startsWith("0123456789")).toBe(true);
+    expect(value).toContain("more chars dropped");
+    expect(value).not.toContain("overflow!");
+  });
+
+  it("splits a chunk that straddles the cap", () => {
+    const cap = createOutputCapture(5);
+    cap.push("abcdefgh");
+    expect(cap.value().startsWith("abcde")).toBe(true);
+    expect(cap.value()).toContain("dropped");
+  });
+});

--- a/src/__tests__/mesh-service.test.ts
+++ b/src/__tests__/mesh-service.test.ts
@@ -770,3 +770,192 @@ describe("MeshService exec + filesystem channel", () => {
     expect(res.text).toContain("appears offline");
   });
 });
+
+describe("MeshService hardening", () => {
+  /** Transport that answers read_file with device-capped chunks. */
+  function chunkedReader(
+    service: MeshService,
+    content: string,
+    deviceCap: number,
+  ): void {
+    service.registerTransport({
+      locate: () => {},
+      command: (cmd) =>
+        queueMicrotask(() => {
+          const offset = Number(cmd.params.offset) || 0;
+          const want = Math.min(Number(cmd.params.len) || 0, deviceCap);
+          const slice = Buffer.from(content).subarray(offset, offset + want);
+          service.completeCommand({
+            commandId: cmd.id,
+            deviceId: cmd.deviceId,
+            ok: true,
+            data: {
+              base64: slice.toString("base64"),
+              eof: offset + slice.length >= content.length,
+            },
+          });
+        }),
+    });
+  }
+
+  it("reassembles a read whose device caps chunks below the requested size", async () => {
+    // The companion serves at most 256KB per read_file no matter what the
+    // daemon asks for. A short chunk mid-file must NOT be treated as EOF —
+    // that silently truncated every chunked read past the device's cap.
+    const service = await tempService();
+    await service.register({
+      id: "phone",
+      name: "Pixel 9",
+      platform: "android",
+      appVersion: "1.0.0",
+      capabilities: ["read_file"],
+    });
+    const content = "B".repeat(600 * 1024);
+    chunkedReader(service, content, 256 * 1024);
+
+    const res = await service.readFileBytes("phone", "/sdcard/big.txt");
+    expect("data" in res && res.data.length).toBe(content.length);
+  });
+
+  it("fails a stalled read (empty chunk without eof) instead of looping", async () => {
+    const service = await tempService();
+    await service.register({
+      id: "phone",
+      name: "Pixel 9",
+      platform: "android",
+      appVersion: "1.0.0",
+      capabilities: ["read_file"],
+    });
+    service.registerTransport({
+      locate: () => {},
+      command: (cmd) =>
+        queueMicrotask(() =>
+          service.completeCommand({
+            commandId: cmd.id,
+            deviceId: cmd.deviceId,
+            ok: true,
+            data: { base64: "", eof: false },
+          }),
+        ),
+    });
+
+    const res = await service.readFileBytes("phone", "/sdcard/stuck.txt");
+    expect("error" in res && res.error).toContain("stalled");
+  });
+
+  it("drops a command result claimed by the wrong device", async () => {
+    const service = await tempService();
+    await service.register({
+      id: "phone",
+      name: "Pixel 9",
+      platform: "android",
+      appVersion: "1.0.0",
+      capabilities: ["exec"],
+    });
+    let forgedAccepted: boolean | undefined;
+    service.registerTransport({
+      locate: () => {},
+      command: (cmd) =>
+        queueMicrotask(() => {
+          // An imposter answers first — must be ignored, so the command
+          // times out instead of resolving with the forged payload.
+          forgedAccepted = service.completeCommand({
+            commandId: cmd.id,
+            deviceId: "other-device",
+            ok: true,
+            data: { stdout: "forged", exitCode: 0 },
+          });
+        }),
+    });
+
+    const target = service.chooseDevice("phone")!;
+    const result = await service.sendCommand(target, "exec", {}, 150);
+    expect(forgedAccepted).toBe(false);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("did not answer");
+  });
+
+  it("resolves device names separator-insensitively and prefers the online duplicate", async () => {
+    const service = await tempService();
+    // Stale registration from a reinstall — same phone, old id, offline.
+    await service.register(
+      {
+        id: "phone-old",
+        name: "Google Pixel 10",
+        platform: "android",
+        appVersion: "1.0.0",
+      },
+      Date.now() - 300_000,
+    );
+    await service.register({
+      id: "phone-new",
+      name: "Google Pixel 10",
+      platform: "android",
+      appVersion: "1.1.0",
+    });
+
+    // "Pixel 10" is a fragment of both entries; the online one must win.
+    const byFragment = service.resolveDevice("Pixel 10");
+    expect("target" in byFragment && byFragment.target.id).toBe("phone-new");
+    // Separator/case-insensitive: "pixel10" and "PIXEL-10" also land.
+    const folded = service.resolveDevice("pixel10");
+    expect("target" in folded && folded.target.id).toBe("phone-new");
+  });
+
+  it("errors on an ambiguous fragment when several matches are online", async () => {
+    const service = await tempService();
+    await service.register({
+      id: "a",
+      name: "Pixel 9",
+      platform: "android",
+      appVersion: "1.0.0",
+    });
+    await service.register({
+      id: "b",
+      name: "Pixel 9 Pro",
+      platform: "android",
+      appVersion: "1.0.0",
+    });
+
+    const res = service.resolveDevice("pixel");
+    expect("error" in res && res.error).toContain("matches 2 devices");
+    // Exact name still resolves cleanly.
+    const exact = service.resolveDevice("Pixel 9");
+    expect("target" in exact && exact.target.id).toBe("a");
+  });
+
+  it("clamps oversized exec output with an explicit truncation marker", async () => {
+    const service = await tempService({ commandTimeoutMs: 2_000 });
+    await service.register({
+      id: "phone",
+      name: "Pixel 9",
+      platform: "android",
+      appVersion: "1.0.0",
+      capabilities: ["exec"],
+    });
+    service.registerTransport({
+      locate: () => {},
+      command: (cmd) =>
+        queueMicrotask(() =>
+          service.completeCommand({
+            commandId: cmd.id,
+            deviceId: cmd.deviceId,
+            ok: true,
+            data: { stdout: "x".repeat(200_000), stderr: "", exitCode: 0 },
+          }),
+        ),
+    });
+
+    const res = await service.execOnDevice("phone", "yes | head -c 200000");
+    expect(res.ok).toBe(true);
+    expect(res.text).toContain("chars truncated");
+    expect(res.text.length).toBeLessThan(40_000);
+  });
+
+  it("rejects non-string write content instead of truncating the target", async () => {
+    const service = await tempService();
+    const res = await service.writeFileToDevice("phone", "/sdcard/a.txt", 42);
+    expect(res.ok).toBe(false);
+    expect(res.text).toContain("must be a string");
+  });
+});

--- a/src/__tests__/mesh-service.test.ts
+++ b/src/__tests__/mesh-service.test.ts
@@ -540,7 +540,12 @@ describe("MeshService exec + filesystem channel", () => {
             commandId: cmd.id,
             deviceId: cmd.deviceId,
             ok: true,
-            data: { stdout: "hello world\n", stderr: "", exitCode: 0 },
+            data: {
+              stdout: "hello world\n",
+              stderr: "",
+              exitCode: 0,
+              via: "shizuku",
+            },
           });
         }),
     });
@@ -551,7 +556,7 @@ describe("MeshService exec + filesystem channel", () => {
       "/sdcard",
     );
     expect(res.ok).toBe(true);
-    expect(res.text).toContain("exit 0");
+    expect(res.text).toContain("[Pixel 9 via shizuku] exit 0");
     expect(res.text).toContain("hello world");
     expect(seen[0]).toMatchObject({ cmd: "echo hello world", cwd: "/sdcard" });
   });

--- a/src/__tests__/native-tools.test.ts
+++ b/src/__tests__/native-tools.test.ts
@@ -243,6 +243,7 @@ describe("native tools — teleport routing", () => {
                 "Downloads\nPictures\n__TALON_CWD__/sdcard/Download__TALON_CWD_END__",
               stderr: "",
               exitCode: 0,
+              via: "shizuku",
             },
           });
         }),
@@ -260,6 +261,7 @@ describe("native tools — teleport routing", () => {
       1,
     );
     expect(res.ok).toBe(true);
+    expect(res.text).toContain("[Pixel 9 via shizuku] exit 0");
     expect(res.text).toContain("Downloads");
     // The cwd marker must be stripped from what the model sees.
     expect(res.text).not.toContain("__TALON_CWD__");

--- a/src/core/engine/gateway-actions/native.ts
+++ b/src/core/engine/gateway-actions/native.ts
@@ -208,7 +208,8 @@ async function bashTeleported(
   const data = result.data ?? {};
   let stdout = typeof data.stdout === "string" ? data.stdout : "";
   const stderr = typeof data.stderr === "string" ? data.stderr : "";
-  const via = typeof data.via === "string" && data.via ? ` via ${data.via}` : "";
+  const via =
+    typeof data.via === "string" && data.via ? ` via ${data.via}` : "";
   const exitCode =
     typeof data.exitCode === "number" ? data.exitCode : undefined;
   // Recover + strip the trailing cwd marker.

--- a/src/core/engine/gateway-actions/native.ts
+++ b/src/core/engine/gateway-actions/native.ts
@@ -208,6 +208,7 @@ async function bashTeleported(
   const data = result.data ?? {};
   let stdout = typeof data.stdout === "string" ? data.stdout : "";
   const stderr = typeof data.stderr === "string" ? data.stderr : "";
+  const via = typeof data.via === "string" && data.via ? ` via ${data.via}` : "";
   const exitCode =
     typeof data.exitCode === "number" ? data.exitCode : undefined;
   // Recover + strip the trailing cwd marker.
@@ -228,7 +229,12 @@ async function bashTeleported(
   }
   return {
     ok: exitCode === 0,
-    text: renderExec(target.name, `exit ${exitCode ?? "?"}`, stdout, stderr),
+    text: renderExec(
+      `${target.name}${via}`,
+      `exit ${exitCode ?? "?"}`,
+      stdout,
+      stderr,
+    ),
   };
 }
 

--- a/src/core/engine/gateway-actions/native.ts
+++ b/src/core/engine/gateway-actions/native.ts
@@ -31,6 +31,10 @@ import {
   setTeleport,
   setTeleportCwd,
 } from "../../mesh/teleport.js";
+import {
+  clampExecOutput,
+  createOutputCapture,
+} from "../../../util/exec-output.js";
 import type { SharedActionHandlers } from "./types.js";
 
 type Result = { ok: boolean; text: string };
@@ -75,16 +79,9 @@ export const nativeHandlers: SharedActionHandlers = {
 async function teleport(chatId: number, query: unknown): Promise<Result> {
   const svc = getMeshService();
   await svc.list();
-  const target = svc.chooseDevice(query);
-  if (!target) {
-    return {
-      ok: false,
-      text:
-        typeof query === "string" && query.trim()
-          ? `No mesh device matches "${query}". Use list_devices to see them.`
-          : "No mesh device to teleport to. Register a companion first.",
-    };
-  }
+  const resolved = svc.resolveDevice(query);
+  if ("error" in resolved) return { ok: false, text: resolved.error };
+  const target = resolved.target;
   if (!target.online) {
     return {
       ok: false,
@@ -148,8 +145,8 @@ function bashLocal(
       env: process.env,
       detached,
     });
-    let stdout = "";
-    let stderr = "";
+    const stdout = createOutputCapture();
+    const stderr = createOutputCapture();
     let killed = false;
     const timer = setTimeout(() => {
       killed = true;
@@ -163,8 +160,8 @@ function bashLocal(
       }
       child.kill("SIGKILL");
     }, timeoutMs);
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
+    child.stdout.on("data", stdout.push);
+    child.stderr.on("data", stderr.push);
     child.on("error", (err) => {
       clearTimeout(timer);
       resolvePromise({ ok: false, text: `Failed to run: ${err.message}` });
@@ -176,7 +173,7 @@ function bashLocal(
         : `exit ${code ?? 0}`;
       resolvePromise({
         ok: !killed && (code ?? 0) === 0,
-        text: renderExec("local", exit, stdout, stderr),
+        text: renderExec("local", exit, stdout.value(), stderr.value()),
       });
     });
   });
@@ -547,13 +544,23 @@ function runLocal(
 ): Promise<{ code: number; stdout: string; stderr: string }> {
   return new Promise((resolvePromise) => {
     const child = spawn(bin, args, { env: process.env });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("error", () => resolvePromise({ code: 127, stdout, stderr }));
+    const stdout = createOutputCapture();
+    const stderr = createOutputCapture();
+    child.stdout.on("data", stdout.push);
+    child.stderr.on("data", stderr.push);
+    child.on("error", () =>
+      resolvePromise({
+        code: 127,
+        stdout: stdout.value(),
+        stderr: stderr.value(),
+      }),
+    );
     child.on("close", (code) =>
-      resolvePromise({ code: code ?? 0, stdout, stderr }),
+      resolvePromise({
+        code: code ?? 0,
+        stdout: stdout.value(),
+        stderr: stderr.value(),
+      }),
     );
   });
 }
@@ -566,9 +573,13 @@ function renderExec(
 ): string {
   const parts = [`[${where}] ${status}`];
   if (stdout.trim())
-    parts.push(`--- stdout ---\n${stdout.replace(/\s+$/, "")}`);
+    parts.push(
+      `--- stdout ---\n${clampExecOutput(stdout.replace(/\s+$/, ""))}`,
+    );
   if (stderr.trim())
-    parts.push(`--- stderr ---\n${stderr.replace(/\s+$/, "")}`);
+    parts.push(
+      `--- stderr ---\n${clampExecOutput(stderr.replace(/\s+$/, ""))}`,
+    );
   if (!stdout.trim() && !stderr.trim()) parts.push("(no output)");
   return parts.join("\n");
 }

--- a/src/core/mesh/service.ts
+++ b/src/core/mesh/service.ts
@@ -1120,7 +1120,8 @@ function formatExecResult(
   const exit = typeof d.exitCode === "number" ? d.exitCode : "?";
   const stdout = typeof d.stdout === "string" ? d.stdout : "";
   const stderr = typeof d.stderr === "string" ? d.stderr : "";
-  const parts = [`[${device.name}] exit ${exit}`];
+  const via = typeof d.via === "string" && d.via ? ` via ${d.via}` : "";
+  const parts = [`[${device.name}${via}] exit ${exit}`];
   if (stdout.trim())
     parts.push(`--- stdout ---\n${stdout.replace(/\s+$/, "")}`);
   if (stderr.trim())

--- a/src/core/mesh/service.ts
+++ b/src/core/mesh/service.ts
@@ -31,6 +31,7 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import type { Readable } from "node:stream";
+import { clampExecOutput } from "../../util/exec-output.js";
 import { dirs } from "../../util/paths.js";
 import { MeshRegistry } from "./registry.js";
 import { TransferStore } from "./transfers.js";
@@ -88,6 +89,13 @@ const STREAM_TRANSFER_TIMEOUT_MS = 60 * 60 * 1000;
 /** readFileBytes switches to the streaming path above this size. */
 const STREAM_READ_THRESHOLD_BYTES = 4 * 1024 * 1024;
 /**
+ * Hard ceiling on a chunked (command-channel) transfer. The chunked path
+ * assembles the whole file in daemon memory one mesh round trip at a time —
+ * past this size it's both a memory hazard and unusably slow, so fail with
+ * a pointer to the streaming path instead of grinding on.
+ */
+const MAX_CHUNKED_TRANSFER_BYTES = 64 * 1024 * 1024;
+/**
  * No policy size cap on transfers — a transfer is attempted whatever the
  * size and fails with a concrete error when a real limit bites (device read
  * error, stream timeout, disk). The streamed paths are disk-to-disk and
@@ -108,7 +116,10 @@ export class MeshService {
   private readonly transports = new Set<MeshTransport>();
   private readonly pendingCommands = new Map<
     string,
-    (result: DeviceCommandResult) => void
+    {
+      deviceId: string;
+      resolve: (result: DeviceCommandResult) => void;
+    }
   >();
   /**
    * Server-side receipt time (this process's clock) of the last fix per
@@ -203,11 +214,19 @@ export class MeshService {
    * A device answered a command (bridge route POST /devices/command-result).
    * Resolves the pending sendCommand; false when nothing was waiting (late
    * or unknown correlation id — harmless, just ignored).
+   *
+   * The result must come from the device the command was sent to: a reply
+   * whose deviceId names a DIFFERENT device is dropped (a confused or
+   * misbehaving companion must not be able to answer for its peers). A
+   * missing deviceId is tolerated for older app builds.
    */
   completeCommand(body: Record<string, unknown>): boolean {
     const commandId = typeof body.commandId === "string" ? body.commandId : "";
-    const resolve = this.pendingCommands.get(commandId);
-    if (!resolve) return false;
+    const pending = this.pendingCommands.get(commandId);
+    if (!pending) return false;
+    const from = typeof body.deviceId === "string" ? body.deviceId : "";
+    if (from && from !== pending.deviceId) return false;
+    const { resolve } = pending;
     this.pendingCommands.delete(commandId);
     resolve({
       commandId,
@@ -253,9 +272,12 @@ export class MeshService {
         });
       }, timeoutMs);
       timer.unref?.();
-      this.pendingCommands.set(command.id, (result) => {
-        clearTimeout(timer);
-        resolve(result);
+      this.pendingCommands.set(command.id, {
+        deviceId: device.id,
+        resolve: (result) => {
+          clearTimeout(timer);
+          resolve(result);
+        },
       });
       for (const transport of this.transports) {
         try {
@@ -289,8 +311,9 @@ export class MeshService {
    */
   async locateDevice(query?: unknown): Promise<MeshToolResult> {
     await this.load();
-    const target = this.chooseDevice(query);
-    if (!target) return this.noSuchDevice(query);
+    const resolved = this.resolveDevice(query);
+    if ("error" in resolved) return { ok: false, text: resolved.error };
+    const target = resolved.target;
     const requestedAt = Date.now();
     // Only wait out the fresh-fix window when a transport can actually
     // deliver the locate AND the device is currently present — pinging an
@@ -334,8 +357,9 @@ export class MeshService {
     hours?: unknown,
   ): Promise<MeshToolResult> {
     await this.load();
-    const target = this.chooseDevice(query);
-    if (!target) return this.noSuchDevice(query);
+    const resolved = this.resolveDevice(query);
+    if ("error" in resolved) return { ok: false, text: resolved.error };
+    const target = resolved.target;
     const windowHours = clampHours(hours);
     const sinceTs = Date.now() - windowHours * 3_600_000;
     const fixes = this.registry.getHistory(target.id, sinceTs);
@@ -546,8 +570,10 @@ export class MeshService {
     const p = requirePath(path);
     if (!p) return { error: "A file path is required." };
     await this.load();
-    const target = this.chooseDevice(query);
-    if (target && this.canStream(target, "upload_file")) {
+    const resolved = this.resolveDevice(query);
+    if ("error" in resolved) return { error: resolved.error };
+    const target = resolved.target;
+    if (this.canStream(target, "upload_file")) {
       const size = await this.statSize(target.id, p);
       if (size !== undefined && size > STREAM_READ_THRESHOLD_BYTES) {
         const tmp = join(tmpdir(), `talon-pull-${randomUUID()}-${basename(p)}`);
@@ -565,7 +591,7 @@ export class MeshService {
         }
       }
     }
-    return this.pullBytes(query, p);
+    return this.pullBytes(target.id, p);
   }
 
   /** Size of a device path via the `stat` command, if the device can. */
@@ -607,8 +633,16 @@ export class MeshService {
   ): Promise<MeshToolResult> {
     const p = requirePath(path);
     if (!p) return { ok: false, text: "A file path is required." };
-    const text = typeof content === "string" ? content : "";
-    const written = await this.pushBytes(query, p, Buffer.from(text, "utf8"));
+    // A non-string body must fail, not silently truncate the target to an
+    // empty file (an empty string is a legitimate truncate-to-zero).
+    if (typeof content !== "string") {
+      return { ok: false, text: "File content must be a string." };
+    }
+    const written = await this.pushBytes(
+      query,
+      p,
+      Buffer.from(content, "utf8"),
+    );
     if ("error" in written) return { ok: false, text: written.error };
     return {
       ok: true,
@@ -627,8 +661,9 @@ export class MeshService {
     const remote = requirePath(remotePath);
     if (!remote) return { ok: false, text: "A remote file path is required." };
     await this.load();
-    const target = this.chooseDevice(query);
-    if (!target) return this.noSuchDevice(query);
+    const resolved = this.resolveDevice(query);
+    if ("error" in resolved) return { ok: false, text: resolved.error };
+    const target = resolved.target;
     const dest =
       typeof localPath === "string" && localPath.trim()
         ? resolve(dirs.workspace, localPath.trim())
@@ -672,8 +707,9 @@ export class MeshService {
         : "";
     if (!local) return { ok: false, text: "A local source path is required." };
     await this.load();
-    const target = this.chooseDevice(query);
-    if (!target) return this.noSuchDevice(query);
+    const resolved = this.resolveDevice(query);
+    if ("error" in resolved) return { ok: false, text: resolved.error };
+    const target = resolved.target;
     if (this.canStream(target, "download_file")) {
       const started = Date.now();
       const { token } = this.transfers.createPush(target.id, local);
@@ -725,6 +761,13 @@ export class MeshService {
   /**
    * Chunked read of a remote file into a Buffer. Loops `read_file` with
    * increasing offsets until the device reports EOF.
+   *
+   * End-of-file is the DEVICE's call (`eof: true`), never inferred from a
+   * short chunk: devices cap their chunk size (the companion serves at most
+   * 256KB per read regardless of the requested length), so a chunk shorter
+   * than the request is normal mid-file and treating it as EOF silently
+   * truncated every chunked read past the device's cap. A zero-length chunk
+   * without `eof` is a stuck transfer and fails loudly instead of looping.
    */
   private async pullBytes(
     query: unknown,
@@ -764,8 +807,17 @@ export class MeshService {
       const chunk = Buffer.from(b64, "base64");
       chunks.push(chunk);
       offset += chunk.length;
-      // EOF when the device says so, or when it returns a short/empty chunk.
-      if (result.data?.eof === true || chunk.length < FILE_CHUNK_BYTES) break;
+      if (result.data?.eof === true) break;
+      if (chunk.length === 0) {
+        return {
+          error: `${path} transfer stalled: the device returned an empty chunk without reporting end-of-file (after ${formatBytes(offset)}).`,
+        };
+      }
+      if (offset > MAX_CHUNKED_TRANSFER_BYTES) {
+        return {
+          error: `${path} exceeds the ${formatBytes(MAX_CHUNKED_TRANSFER_BYTES)} chunked-transfer limit (device never reported end-of-file after ${formatBytes(offset)}). Use device_pull_file with a streaming-capable companion build for large files.`,
+        };
+      }
     }
     try {
       return { data: Buffer.concat(chunks), deviceName };
@@ -853,8 +905,9 @@ export class MeshService {
     { target: DeviceInfo; result: DeviceCommandResult } | { error: string }
   > {
     await this.load();
-    const target = this.chooseDevice(query);
-    if (!target) return { error: this.noSuchDevice(query).text };
+    const resolved = this.resolveDevice(query);
+    if ("error" in resolved) return { error: resolved.error };
+    const target = resolved.target;
     // Devices advertise what they can do; an explicit list that lacks the
     // command is a clean "can't" — absent list means an older app build, so
     // attempt it and let the timeout speak.
@@ -878,17 +931,64 @@ export class MeshService {
     return { target, result };
   }
 
-  /** Resolve a device by exact id, name fragment, or default (most recently
-   *  seen mobile device, falling back to the most recent device overall). */
+  /** Resolve a device by exact id, exact name, or unique name fragment;
+   *  undefined when nothing (or more than one device) matches. */
   chooseDevice(query?: unknown): DeviceInfo | undefined {
+    const resolved = this.resolveDevice(query);
+    return "target" in resolved ? resolved.target : undefined;
+  }
+
+  /**
+   * Device resolution with a caller-facing error. Matching order: exact id,
+   * exact name (case-insensitive), then name fragment — with names and
+   * queries compared separator-insensitively ("pixel 10" finds
+   * "Google-Pixel10"). When several devices match, a sole ONLINE match wins
+   * (a stale duplicate registration must not shadow the live device);
+   * otherwise it's an explicit error, never a silent first pick — exec and
+   * file commands aimed at "pixel" must not land on whichever Pixel
+   * happened to register first. No query defaults to the most recently
+   * seen mobile device, then the most recent device overall.
+   */
+  resolveDevice(query?: unknown): { target: DeviceInfo } | { error: string } {
     const devices = this.registry.list().devices;
     if (typeof query === "string" && query.trim()) {
-      const q = query.trim().toLowerCase();
-      return devices.find(
-        (d) => d.id.toLowerCase() === q || d.name.toLowerCase().includes(q),
+      const raw = query.trim();
+      const q = raw.toLowerCase();
+      const byId = devices.find((d) => d.id.toLowerCase() === q);
+      if (byId) return { target: byId };
+      const fold = (s: string): string =>
+        s.toLowerCase().replace(/[^a-z0-9]+/g, "");
+      const folded = fold(raw);
+      const pick = (
+        candidates: DeviceInfo[],
+      ): { target: DeviceInfo } | { error: string } | undefined => {
+        if (candidates.length === 1) return { target: candidates[0]! };
+        if (candidates.length > 1) {
+          const online = candidates.filter((d) => d.online);
+          if (online.length === 1) return { target: online[0]! };
+          return {
+            error: `"${raw}" matches ${candidates.length} devices: ${candidates
+              .map(
+                (d) =>
+                  `${d.name} [id: ${d.id}, ${d.online ? "online" : "offline"}]`,
+              )
+              .join(", ")}. Use the device id or full name.`,
+          };
+        }
+        return undefined;
+      };
+      return (
+        pick(devices.filter((d) => fold(d.name) === folded)) ??
+        (folded
+          ? pick(devices.filter((d) => fold(d.name).includes(folded)))
+          : undefined) ?? { error: this.noSuchDevice(query).text }
       );
     }
-    return devices.find((d) => MOBILE_PLATFORMS.has(d.platform)) ?? devices[0];
+    const fallback =
+      devices.find((d) => MOBILE_PLATFORMS.has(d.platform)) ?? devices[0];
+    return fallback
+      ? { target: fallback }
+      : { error: this.noSuchDevice(query).text };
   }
 
   // ── Formatting ─────────────────────────────────────────────────────────────
@@ -1123,9 +1223,13 @@ function formatExecResult(
   const via = typeof d.via === "string" && d.via ? ` via ${d.via}` : "";
   const parts = [`[${device.name}${via}] exit ${exit}`];
   if (stdout.trim())
-    parts.push(`--- stdout ---\n${stdout.replace(/\s+$/, "")}`);
+    parts.push(
+      `--- stdout ---\n${clampExecOutput(stdout.replace(/\s+$/, ""))}`,
+    );
   if (stderr.trim())
-    parts.push(`--- stderr ---\n${stderr.replace(/\s+$/, "")}`);
+    parts.push(
+      `--- stderr ---\n${clampExecOutput(stderr.replace(/\s+$/, ""))}`,
+    );
   if (!stdout.trim() && !stderr.trim()) parts.push("(no output)");
   return parts.join("\n");
 }

--- a/src/core/tools/mesh.ts
+++ b/src/core/tools/mesh.ts
@@ -12,7 +12,7 @@ const deviceParam = z
   .string()
   .optional()
   .describe(
-    "Device id or part of the device name (see list_devices). Defaults to the most recently seen mobile mesh device.",
+    "Device id, exact name, or unique name fragment (case/separator-insensitive; see list_devices). A fragment matching several devices errors unless exactly one is online — prefer the id when duplicates exist. Defaults to the most recently seen mobile mesh device.",
   );
 
 export const meshTools: ToolDefinition[] = [

--- a/src/core/tools/native.ts
+++ b/src/core/tools/native.ts
@@ -21,7 +21,7 @@ export const nativeTools: ToolDefinition[] = [
         .string()
         .optional()
         .describe(
-          "Device id or name fragment (see list_devices). Defaults to the most recent mobile device.",
+          "Device id, exact name, or unique name fragment (case/separator-insensitive; see list_devices). Ambiguous fragments error unless exactly one match is online — prefer the id when duplicates exist. Defaults to the most recent mobile device.",
         ),
     },
     execute: (params, bridge) => bridge("teleport", params),

--- a/src/util/exec-output.ts
+++ b/src/util/exec-output.ts
@@ -1,0 +1,64 @@
+/**
+ * Exec output guards, shared by the local native tools and the mesh exec
+ * channel. Two independent ceilings:
+ *
+ *  - capture: how much of a child process's stream the daemon will hold in
+ *    memory at all. A runaway `yes` otherwise balloons RSS for the whole
+ *    timeout window before a single byte reaches the model.
+ *  - render: how much of a (possibly device-supplied) stream reaches the
+ *    model/chat. Clamped head+tail — the tail keeps the part of a long log
+ *    where the error usually lives.
+ */
+
+/** In-memory cap while capturing one child-process output stream. */
+export const MAX_EXEC_CAPTURE_BYTES = 4 * 1024 * 1024;
+
+/** Ceiling on each rendered exec stream (stdout, stderr independently). */
+export const MAX_EXEC_RENDER_CHARS = 30_000;
+
+/**
+ * Clamp one output stream for rendering: keep the head and the tail,
+ * elide the middle with an explicit marker so truncation is never silent.
+ */
+export function clampExecOutput(
+  text: string,
+  max = MAX_EXEC_RENDER_CHARS,
+): string {
+  if (text.length <= max) return text;
+  const headLen = Math.floor(max * 0.75);
+  const tailLen = max - headLen;
+  const head = text.slice(0, headLen);
+  const tail = text.slice(-tailLen);
+  const elided = text.length - head.length - tail.length;
+  return `${head}\n…[${elided.toLocaleString()} chars truncated]…\n${tail}`;
+}
+
+/**
+ * Bounded accumulator for a child process's stdout/stderr. Chunks past the
+ * cap are counted, not stored; `value()` appends an explicit drop marker.
+ */
+export function createOutputCapture(cap = MAX_EXEC_CAPTURE_BYTES): {
+  push: (chunk: Buffer | string) => void;
+  value: () => string;
+} {
+  let text = "";
+  let dropped = 0;
+  return {
+    push: (chunk) => {
+      const s = chunk.toString();
+      const room = cap - text.length;
+      if (room <= 0) {
+        dropped += s.length;
+      } else if (s.length <= room) {
+        text += s;
+      } else {
+        text += s.slice(0, room);
+        dropped += s.length - room;
+      }
+    },
+    value: () =>
+      dropped > 0
+        ? `${text}\n…[${dropped.toLocaleString()} more chars dropped — output exceeded the ${Math.round(cap / (1024 * 1024))}MB capture cap]`
+        : text,
+  };
+}


### PR DESCRIPTION
## What changed

Two threads: make Android execution privilege explicit, and harden the mesh exec/transfer infrastructure end-to-end.

### Shizuku privilege (original scope)

- Make elevated Android execution observable in every native/mesh shell result (`via shizuku` or `via app`).
- Request Shizuku permission once for concurrent commands, verify the binder after approval, and release timed-out pending callbacks.
- Report actionable Shizuku states through device status: `ready`, `permission-needed`, `permission-denied`, `not-running`, or `unavailable`.
- Preserve app-UID fallback, but attach a privilege warning so scoped-storage output cannot look authoritative.
- Privilege annotations are **Android-only**: desktop companions (Windows/macOS/Linux) run commands as the logged-in OS user, so their results carry no `via` tag and device status reports `execPrivilege: user`.

### Mesh infrastructure hardening (widened scope)

- **Chunked-read truncation fix**: the daemon inferred EOF from any short chunk, but the companion caps chunks at 256KB while the daemon requests 1MB — every chunked read past 256KB was silently truncated. EOF is now the device's call; stalled transfers (empty chunk without `eof`) and >64MB chunked transfers fail with explicit errors instead of looping or ballooning daemon memory.
- **Device-bound command results**: a command result claiming a different `deviceId` than the command's target is dropped — one companion can't answer for another.
- **Smarter device resolution**: exact id > exact name > unique fragment, compared case/separator-insensitively (`pixel 10` finds `Google-Pixel10`); when duplicates match, a sole *online* device wins (stale reinstall registrations no longer shadow the live phone), otherwise the ambiguity is an explicit error listing candidates. Tool parameter descriptions updated so the model reaches for ids when names collide.
- **Exec output caps end-to-end** (`src/util/exec-output.ts`): bounded capture for local spawns (a runaway `yes` can't balloon daemon RSS for the whole timeout window), head+tail render clamps on both the mesh and native formatters, and device-side head+tail caps that always preserve the trailing teleport cwd marker.
- **`device_write_file` rejects non-string content** instead of silently truncating the target file to zero bytes.

## Root cause (original)

The companion could silently fall back to its Android app UID when Shizuku was not ready. A command such as `du` could then succeed against a restricted view of storage and be presented as the actual device result.

## Validation

- `npm run typecheck -- --pretty false`
- `npx vitest run src/__tests__/native-tools.test.ts src/__tests__/mesh-service.test.ts src/__tests__/exec-output.test.ts` (12 new hardening tests)
- `flutter test test/device_exec_test.dart test/mesh_service_test.dart` (desktop-path + output-cap tests added)
- `flutter analyze`, `flutter build apk --debug` (JDK 17)
- Full CI (Android/Linux/macOS/Windows Flutter jobs + TS suite) on the final commit.
