### PR TITLE
fix(companion): wait for the Shizuku binder before exec + full diagnostics

### DIFF
--- a/apps/companion/android/app/src/main/kotlin/org/talon/companion/ShizukuBridge.kt
+++ b/apps/companion/android/app/src/main/kotlin/org/talon/companion/ShizukuBridge.kt
@@ -161,19 +161,29 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
         Thread {
             try {
                 val args = arrayOf("sh", "-c", cmd)
-                val newProcess = Shizuku::class.java.getDeclaredMethod(
-                    "newProcess",
-                    Array<String>::class.java,
-                    Array<String>::class.java,
-                    String::class.java,
-                )
+                // `Shizuku.newProcess` is a hidden, @Deprecated API (slated for
+                // removal in Shizuku API 14) whose exact declared signature has
+                // drifted across releases. Pinning one signature via
+                // getDeclaredMethod(name, String[], String[], String) throws
+                // NoSuchMethodException the moment the bundled Shizuku differs —
+                // and because exec swallows the throw into an app-UID fallback,
+                // that surfaces as "Shizuku is authorized but never actually
+                // used". Locate it by name/arity among the declared methods
+                // instead, so a param/return-type change no longer silently
+                // disables elevated exec.
+                val newProcess = Shizuku::class.java.declaredMethods
+                    .firstOrNull { m ->
+                        m.name == "newProcess" &&
+                            m.parameterTypes.size == 3 &&
+                            m.parameterTypes[0] == Array<String>::class.java
+                    }
+                    ?: throw NoSuchMethodException(
+                        "Shizuku.newProcess is unavailable in the bundled " +
+                            "Shizuku API — elevated exec needs the UserService " +
+                            "path (Shizuku.newProcess is removed as of API 14).",
+                    )
                 newProcess.isAccessible = true
-                val process = newProcess.invoke(
-                    null,
-                    args,
-                    null,
-                    cwd,
-                ) as Process
+                val process = newProcess.invoke(null, args, null, cwd) as Process
 
                 val out = StringBuilder()
                 val err = StringBuilder()


### PR DESCRIPTION
## Symptom
Device is **authorized in Shizuku** yet elevated `exec` silently runs at app UID. On-device evidence: an `sh` spawned as `untrusted_app_34` (app UID), no shell-UID process — so Shizuku was never actually invoked.

## Root cause
`ShizukuBridge` assumed the Shizuku binder was already delivered — `binderAlive()` called `pingBinder()` synchronously and `isReady()` gated on it — and only registered the **permission** listener. But `ShizukuProvider` hands the binder to the process **asynchronously**. A mesh `exec` answered by a backgrounded / cold-started process arrives *before* that handover, so `isReady()` is false and the command drops to app UID. The grant still shows as authorized because it used only the *public* Shizuku API.

Both reference clients (`shizuku_apk_installer`, `MultiLocale`) handle this explicitly; Talon did not.

## Fix
- Request the binder for this process up front (`ShizukuProvider.requestBinderForNonProviderProcess`), track arrival with a sticky `OnBinderReceivedListener` + dead listener.
- **Wait** (bounded, off the platform thread) for the binder in `getStatus` / `requestPermission` / `exec` instead of assuming it's ready. `getStatus`/`requestPermission` are now async so the wait never blocks the UI thread.
- Pass the application context into the bridge (binder request outlives the activity — the mesh answers commands while backgrounded).
- Also resolve `Shizuku.newProcess` by name/arity rather than one pinned signature (private, deprecated, removed in API 14).

## Diagnostics (so the next failure is fixable, not guessed)
Dart `developer.log` does **not** reach logcat in release builds — which is exactly why this was invisible. Now:
- Kotlin logs every decision under tag `TalonShizuku` (binder received/dead, getStatus state+uid, exec-via-shizuku, full stack trace on failure). Read with: `adb logcat -s TalonShizuku`.
- The app-UID fallback reports the real Shizuku state (`state=not-running` / `permission-needed` / …) in the command result returned over the mesh — a remote caller sees *why* without adb.

## Verify
CI builds the release APK. After install, from the daemon: `device_exec id` → expect `uid=2000(shell) … via shizuku`. If it still falls back, `adb logcat -s TalonShizuku` now shows the exact reason.

## Follow-up (separate PR)
Remote APK install via `IPackageInstaller` + `ShizukuBinderWrapper` (the `shizuku_apk_installer` pattern), and migrating exec off `newProcess` to a bound UserService.
