### PR TITLE
fix(companion): wait for the Shizuku binder before exec + full diagnostics

### DIFF
--- a/apps/companion/android/app/src/main/kotlin/org/talon/companion/MainActivity.kt
+++ b/apps/companion/android/app/src/main/kotlin/org/talon/companion/MainActivity.kt
@@ -14,7 +14,10 @@ class MainActivity : FlutterActivity() {
             ShizukuBridge.CHANNEL,
         )
         // Registers itself as the channel handler; harmless when the Shizuku
-        // app is not installed (all calls report not-ready).
-        shizuku = ShizukuBridge(channel)
+        // app is not installed (all calls report not-ready). Uses the
+        // application context so the Shizuku binder request isn't tied to this
+        // activity's lifecycle (the mesh answers exec commands while the app is
+        // backgrounded).
+        shizuku = ShizukuBridge(channel, applicationContext)
     }
 }

--- a/apps/companion/android/app/src/main/kotlin/org/talon/companion/ShizukuBridge.kt
+++ b/apps/companion/android/app/src/main/kotlin/org/talon/companion/ShizukuBridge.kt
@@ -1,10 +1,13 @@
 package org.talon.companion
 
+import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import rikka.shizuku.Shizuku
+import rikka.shizuku.ShizukuProvider
 import java.io.BufferedReader
 
 /**
@@ -19,18 +22,50 @@ import java.io.BufferedReader
  * Everything degrades gracefully: if the Shizuku app isn't installed/running
  * the calls report not-ready and Dart falls back to app-UID execution.
  *
- * `Shizuku.newProcess` is a hidden API, invoked reflectively (its signature is
- * stable across Shizuku 12/13). Any reflection/binding failure surfaces as a
- * FlutterError so the Dart side can fall back cleanly.
+ * The Shizuku binder is handed to this process *asynchronously* by
+ * `ShizukuProvider`. We must not assume `pingBinder()` is already true — a mesh
+ * exec that arrives before the handover (a backgrounded or cold-started
+ * process answering an SSE command) would otherwise read isReady()==false and
+ * silently run at app UID. So we request the binder for this process up front,
+ * track its arrival via a sticky listener, and briefly *wait* for it off the
+ * platform thread before reporting status / running exec — mirroring the
+ * reference Shizuku clients (shizuku_apk_installer, MultiLocale).
+ *
+ * `Shizuku.newProcess` is a hidden API, invoked reflectively. Any
+ * reflection/binding failure surfaces as a FlutterError so the Dart side can
+ * fall back cleanly.
  */
-class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
+class ShizukuBridge(
+    channel: MethodChannel,
+    private val context: Context,
+) : MethodChannel.MethodCallHandler {
 
     companion object {
         const val CHANNEL = "talon/shizuku"
         private const val REQUEST_CODE = 4021
+
+        /** How long a status/exec probe waits for the binder handover. */
+        private const val BINDER_WAIT_MS = 2_000L
+
+        /**
+         * Logcat tag for the whole Shizuku path. In release builds Dart's
+         * `developer.log` does NOT reach logcat, so when elevation silently
+         * fails there is nothing to read — every decision here is logged under
+         * this tag instead. Diagnose a future failure with:
+         *   adb logcat -s TalonShizuku
+         */
+        private const val TAG = "TalonShizuku"
     }
 
     private val pendingPermissions = mutableListOf<MethodChannel.Result>()
+
+    /**
+     * Set by Shizuku's sticky binder-received listener (fires immediately if
+     * the binder is already here). Lets a probe distinguish "binder not here
+     * *yet*" from "Shizuku genuinely absent" and wait accordingly.
+     */
+    @Volatile
+    private var binderReceived = false
 
     /**
      * MethodChannel.Result is @UiThread-only — replying from a worker thread
@@ -60,15 +95,41 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
     init {
         channel.setMethodCallHandler(this)
         try {
+            // Deliver the binder to THIS process (harmless if the provider
+            // already did) so a non-foreground process can reach Shizuku.
+            ShizukuProvider.requestBinderForNonProviderProcess(context)
+        } catch (t: Throwable) {
+            // Shizuku provider not present — no-op.
+            Log.d(TAG, "requestBinderForNonProviderProcess failed: ${t.message}")
+        }
+        try {
+            Shizuku.addBinderReceivedListenerSticky {
+                binderReceived = true
+                Log.i(TAG, "Shizuku binder received (uid=${shizukuUid()})")
+            }
+            Shizuku.addBinderDeadListener {
+                binderReceived = false
+                Log.w(TAG, "Shizuku binder died")
+            }
             Shizuku.addRequestPermissionResultListener(permissionListener)
-        } catch (_: Throwable) {
+            Log.i(TAG, "ShizukuBridge initialised; listeners registered")
+        } catch (t: Throwable) {
             // Shizuku not present — listener registration is a no-op path.
+            Log.d(TAG, "Shizuku listener registration failed: ${t.message}")
         }
     }
 
+    /** Best-effort Shizuku server UID for logs (2000=adb/shell, 0=root). */
+    private fun shizukuUid(): Int =
+        try {
+            Shizuku.getUid()
+        } catch (_: Throwable) {
+            -1
+        }
+
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
-            "getStatus" -> result.success(status())
+            "getStatus" -> status(result)
             "requestPermission" -> requestPermission(result)
             "cancelPermissionRequest" -> cancelPermissionRequest(result)
             "exec" -> exec(call, result)
@@ -83,6 +144,34 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
             false
         }
 
+    /**
+     * Block up to [timeoutMs] for the Shizuku binder to arrive in this process.
+     * MUST be called off the platform (UI) thread. Returns as soon as the
+     * binder is alive; returns false if it never arrives in the window (Shizuku
+     * genuinely absent / not running).
+     */
+    private fun awaitBinder(timeoutMs: Long): Boolean {
+        if (binderAlive()) return true
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (binderAlive()) return true
+            try {
+                Thread.sleep(50)
+            } catch (_: InterruptedException) {
+                break
+            }
+        }
+        val alive = binderAlive()
+        if (!alive) {
+            Log.w(
+                TAG,
+                "Shizuku binder not available after ${timeoutMs}ms " +
+                    "(received=$binderReceived) — is Shizuku running?",
+            )
+        }
+        return alive
+    }
+
     private fun hasPermission(): Boolean =
         try {
             !Shizuku.isPreV11() &&
@@ -94,53 +183,68 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
 
     private fun isReady(): Boolean = binderAlive() && hasPermission()
 
-    private fun status(): Map<String, Any> {
-        val binderAlive = binderAlive()
-        val granted = binderAlive && hasPermission()
-        val state = try {
-            when {
-                !binderAlive -> "not-running"
-                granted -> "ready"
-                Shizuku.shouldShowRequestPermissionRationale() -> "permission-denied"
-                else -> "permission-needed"
+    private fun status(result: MethodChannel.Result) {
+        Thread {
+            // Wait briefly for the binder handover so a status probe issued
+            // right before an exec (Dart's ensureShizukuReady) doesn't report
+            // "not-running" during the race and force an app-UID downgrade.
+            val binderAlive = awaitBinder(BINDER_WAIT_MS)
+            val granted = binderAlive && hasPermission()
+            val state = try {
+                when {
+                    !binderAlive -> "not-running"
+                    granted -> "ready"
+                    Shizuku.shouldShowRequestPermissionRationale() -> "permission-denied"
+                    else -> "permission-needed"
+                }
+            } catch (_: Throwable) {
+                "unavailable"
             }
-        } catch (_: Throwable) {
-            "unavailable"
-        }
-        return mapOf("ready" to granted, "state" to state)
+            Log.i(TAG, "getStatus -> ready=$granted state=$state uid=${shizukuUid()}")
+            replySuccess(result, mapOf("ready" to granted, "state" to state))
+        }.start()
     }
 
     private fun requestPermission(result: MethodChannel.Result) {
-        try {
-            if (!binderAlive()) {
-                result.success(false)
-                return
+        // Wait for the binder off the platform thread, then run the (binder-
+        // dependent) permission logic back on the main thread so the
+        // pendingPermissions list and the permission dialog stay single-
+        // threaded, matching the result listener.
+        Thread {
+            val alive = awaitBinder(BINDER_WAIT_MS)
+            mainHandler.post {
+                try {
+                    if (!alive) {
+                        result.success(false)
+                        return@post
+                    }
+                    if (hasPermission()) {
+                        result.success(true)
+                        return@post
+                    }
+                    if (Shizuku.shouldShowRequestPermissionRationale()) {
+                        result.success(false)
+                        return@post
+                    }
+                    // Several mesh requests can land together. Keep every caller
+                    // attached to the same Android permission prompt.
+                    if (pendingPermissions.isNotEmpty()) {
+                        pendingPermissions.add(result)
+                        return@post
+                    }
+                    pendingPermissions.add(result)
+                    Shizuku.requestPermission(REQUEST_CODE)
+                } catch (_: Throwable) {
+                    val pending = pendingPermissions.toList()
+                    pendingPermissions.clear()
+                    if (pending.isEmpty()) {
+                        result.success(false)
+                    } else {
+                        pending.forEach { replySuccess(it, false) }
+                    }
+                }
             }
-            if (hasPermission()) {
-                result.success(true)
-                return
-            }
-            if (Shizuku.shouldShowRequestPermissionRationale()) {
-                result.success(false)
-                return
-            }
-            // Several mesh requests can land together. Keep every caller
-            // attached to the same Android permission prompt.
-            if (pendingPermissions.isNotEmpty()) {
-                pendingPermissions.add(result)
-                return
-            }
-            pendingPermissions.add(result)
-            Shizuku.requestPermission(REQUEST_CODE)
-        } catch (_: Throwable) {
-            val pending = pendingPermissions.toList()
-            pendingPermissions.clear()
-            if (pending.isEmpty()) {
-                result.success(false)
-            } else {
-                pending.forEach { replySuccess(it, false) }
-            }
-        }
+        }.start()
     }
 
     private fun cancelPermissionRequest(result: MethodChannel.Result) {
@@ -151,14 +255,28 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
     }
 
     private fun exec(call: MethodCall, result: MethodChannel.Result) {
-        if (!isReady()) {
-            result.error("shizuku_unavailable", "Shizuku not ready", null)
-            return
-        }
         val cmd = call.argument<String>("cmd") ?: ""
         val cwd = call.argument<String>("cwd")
         val timeoutMs = (call.argument<Number>("timeoutMs")?.toLong()) ?: 60_000L
         Thread {
+            // Await the binder here (off the platform thread) rather than
+            // gating on a synchronous isReady() up front: the command may have
+            // arrived before the provider handed this process the binder.
+            val binderOk = awaitBinder(BINDER_WAIT_MS)
+            val permOk = binderOk && hasPermission()
+            if (!binderOk || !permOk) {
+                Log.w(
+                    TAG,
+                    "exec refused: binder=$binderOk permission=$permOk — " +
+                        "falling back to app UID for: ${cmd.take(120)}",
+                )
+                replyError(
+                    result,
+                    "shizuku_unavailable",
+                    "Shizuku not ready (binder=$binderOk permission=$permOk)",
+                )
+                return@Thread
+            }
             try {
                 val args = arrayOf("sh", "-c", cmd)
                 // `Shizuku.newProcess` is a hidden, @Deprecated API (slated for
@@ -184,6 +302,7 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
                     )
                 newProcess.isAccessible = true
                 val process = newProcess.invoke(null, args, null, cwd) as Process
+                Log.i(TAG, "exec via Shizuku (uid=${shizukuUid()}): ${cmd.take(120)}")
 
                 val out = StringBuilder()
                 val err = StringBuilder()
@@ -203,6 +322,7 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
                     process.destroy()
                     -1
                 }
+                Log.i(TAG, "exec via Shizuku done: exit=$exit finished=$finished")
                 replySuccess(
                     result,
                     mapOf(
@@ -213,6 +333,10 @@ class ShizukuBridge(channel: MethodChannel) : MethodChannel.MethodCallHandler {
                     ),
                 )
             } catch (t: Throwable) {
+                // Full stack trace to logcat: this is the exact failure we were
+                // blind to before (e.g. newProcess signature/removal, binder
+                // transaction error). The Dart side still degrades to app UID.
+                Log.e(TAG, "exec via Shizuku FAILED for: ${cmd.take(120)}", t)
                 replyError(result, "shizuku_exec_failed", t.message)
             }
         }.start()

--- a/apps/companion/lib/src/services/device_exec.dart
+++ b/apps/companion/lib/src/services/device_exec.dart
@@ -33,6 +33,12 @@ class DeviceExec {
   final bool Function() _isAndroid;
   Future<bool>? _pendingShizukuPermission;
 
+  /// Last Shizuku state string reported by the native bridge ("ready",
+  /// "permission-needed", "not-running", "unavailable", …). Captured on every
+  /// readiness probe so an app-UID fallback can say *why* Shizuku wasn't used,
+  /// in the command result that travels back over the mesh — no adb needed.
+  String? _lastShizukuState;
+
   /// Commands this executor can answer — merged into the device's advertised
   /// mesh capabilities so the daemon gates cleanly.
   static const List<String> capabilities = [
@@ -60,8 +66,14 @@ class DeviceExec {
     try {
       final status =
           await _shizuku.invokeMapMethod<String, dynamic>('getStatus');
-      return status?['ready'] == true;
-    } catch (_) {
+      final state = status?['state'];
+      if (state is String) _lastShizukuState = state;
+      final ready = status?['ready'] == true;
+      AppLog.info('shizuku', 'getStatus ready=$ready state=$_lastShizukuState');
+      return ready;
+    } catch (e) {
+      _lastShizukuState = 'error: $e';
+      AppLog.warn('shizuku', 'getStatus failed', e);
       return false;
     }
   }
@@ -217,7 +229,8 @@ class DeviceExec {
       cwd: cwd,
       budget: budget,
       privilegeWarning: _isAndroid()
-          ? 'Shizuku not ready or permission not granted; ran as app UID.'
+          ? 'Shizuku not used (state=${_lastShizukuState ?? 'unknown'}); '
+              'ran as app UID.'
           : null,
     );
   }

--- a/apps/companion/test/device_exec_test.dart
+++ b/apps/companion/test/device_exec_test.dart
@@ -86,7 +86,10 @@ void main() {
 
     expect(result.ok, isTrue);
     expect(result.data!['via'], 'app');
-    expect(result.data!['privilegeWarning'], contains('Shizuku not ready'));
+    // The fallback warning surfaces the actual Shizuku state (why it wasn't
+    // used) so a remote caller can diagnose without adb.
+    expect(result.data!['privilegeWarning'], contains('state=not-running'));
+    expect(result.data!['privilegeWarning'], contains('app UID'));
   });
 
   test('caps runaway exec output but keeps the tail (cwd marker survives)',


### PR DESCRIPTION
Follow-up to #492 (which merged only the `newProcess`-lookup commit — that alone didn't fix elevation). This is the actual fix + the diagnostics that were missing.

## Symptom
Device is **authorized in Shizuku** yet elevated `exec` silently runs at app UID. On-device evidence: an `sh` spawned as `untrusted_app_34` (app UID), no shell-UID process — Shizuku was never invoked.

## Root cause
`ShizukuBridge` assumed the binder was already delivered (`pingBinder()` synchronously; `isReady()` gated on it) and only registered the **permission** listener. But `ShizukuProvider` hands the binder to the process **asynchronously**. A mesh `exec` answered by a backgrounded / cold-started process arrives *before* that handover → `isReady()` false → drops to app UID. The grant still shows authorized because it used only the public Shizuku API. Both reference clients (`shizuku_apk_installer`, `MultiLocale`) handle this; Talon didn't.

## Fix
- `ShizukuProvider.requestBinderForNonProviderProcess()` up front + sticky `OnBinderReceivedListener` + dead listener.
- **Wait** (bounded, off the platform thread) for the binder in `getStatus`/`requestPermission`/`exec` instead of assuming it's ready. Those two are now async so the wait never blocks the UI thread.
- Pass application context into the bridge (binder request outlives the activity).

## Diagnostics (the part that was missing)
Dart `developer.log` doesn't reach logcat in release — which is exactly why this was invisible. Now:
- Kotlin logs every decision under tag `TalonShizuku`: `adb logcat -s TalonShizuku` (binder received/dead, getStatus state+uid, exec-via-shizuku, full stack trace on failure).
- App-UID fallback reports the real Shizuku state (`state=not-running` / `permission-needed` / …) in the mesh command result — remote caller sees *why* without adb.

## Verify
CI builds the APK. `device_exec id` → expect `uid=2000(shell) … via shizuku`. If it still falls back, `adb logcat -s TalonShizuku` now shows the exact reason.

## Follow-up (separate PR)
Remote APK install via `IPackageInstaller` + `ShizukuBinderWrapper` (`shizuku_apk_installer` pattern); migrate exec off `newProcess` to a UserService.
