### PR TITLE
fix(companion): keep Shizuku from R8 so reflective newProcess survives

### DIFF
--- a/apps/companion/android/app/build.gradle.kts
+++ b/apps/companion/android/app/build.gradle.kts
@@ -56,6 +56,16 @@ android {
             } else {
                 signingConfigs.getByName("debug")
             }
+            // AGP 9 shrinks release builds with R8. Shizuku's `newProcess` is
+            // reached only via reflection (a runtime string), which R8 can't
+            // see — so it strips/renames the method and elevated exec fails
+            // with NoSuchMethodException, silently downgrading to app UID.
+            // proguard-rules.pro keeps the Shizuku surface so that path works.
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
 }

--- a/apps/companion/android/app/proguard-rules.pro
+++ b/apps/companion/android/app/proguard-rules.pro
@@ -1,0 +1,18 @@
+# Talon reaches Shizuku's hidden `newProcess` reflectively (see
+# ShizukuBridge.kt). R8 — enabled by default for release builds under AGP 9 —
+# doesn't account for reflective use, so without these rules it strips or
+# renames the private `Shizuku.newProcess` method (and can rename the classes
+# it returns/depends on). At runtime the reflection then throws
+# NoSuchMethodException and every elevated exec silently downgrades to app UID
+# — exactly the failure seen in `adb logcat -s TalonShizuku`.
+#
+# Keep the whole Shizuku client + AIDL surface intact (names preserved, not
+# shrunk) so the reflective elevated-exec path survives minification.
+-keep class rikka.shizuku.** { *; }
+-keep interface rikka.shizuku.** { *; }
+-keep class moe.shizuku.** { *; }
+-keep interface moe.shizuku.** { *; }
+-keep class dev.rikka.** { *; }
+-dontwarn rikka.shizuku.**
+-dontwarn moe.shizuku.**
+-dontwarn dev.rikka.**


### PR DESCRIPTION
Follow-up to #494. That fix was based on the wrong theory (binder timing); the new `TalonShizuku` logging it added has now revealed the **actual** cause.

## Proof (from `adb logcat -s TalonShizuku` on 1.37.2)
```
Shizuku binder received (uid=2000)
getStatus -> ready=true state=ready uid=2000
exec via Shizuku FAILED:
  java.lang.NoSuchMethodException: Shizuku.newProcess is unavailable...
  at f4.f.run(r8-map-id-...)
```
Shizuku is bound, ready, uid=2000 (shell) — and reached. But `Shizuku.newProcess` isn't found at runtime.

## Root cause
The obfuscated `f4.f` / `r8-map-id` frames show **R8 is minifying the release build** (AGP 9.0.1 enables it by default; there was no explicit `minifyEnabled`). `Shizuku.newProcess` is a **private** method reached only through a reflection *string* (`getDeclaredMethod`/`declaredMethods`), which R8 can't see — so it strips/renames the method as dead code. The reflection then throws `NoSuchMethodException` and every elevated exec silently downgrades to app UID.

The method genuinely exists in `dev.rikka.shizuku:api:13.1.5` (`private static ShizukuRemoteProcess newProcess(String[], String[], String)`); it was just shrunk away.

## Fix
`proguard-rules.pro` keeps the Shizuku client + AIDL surface (`rikka.shizuku.*`, `moe.shizuku.*`, `dev.rikka.*`) with names intact, wired into the release buildType with an explicit `isMinifyEnabled = true` so the keep rules always apply. Nothing else changes — the existing reflective exec path now finds `newProcess`.

## Verify
After installing the APK from the resulting release: `device_exec id` → expect `uid=2000(shell) … via shizuku`. `adb logcat -s TalonShizuku` should now show `exec via Shizuku (uid=2000)` / `exec via Shizuku done: exit=0` instead of the NoSuchMethodException.
