### PR TITLE
fix(companion): wait on ShizukuRemoteProcess with waitFor(), not exitValue polling

### DIFF
--- a/apps/companion/android/app/src/main/kotlin/org/talon/companion/ShizukuBridge.kt
+++ b/apps/companion/android/app/src/main/kotlin/org/talon/companion/ShizukuBridge.kt
@@ -354,15 +354,25 @@ private fun BufferedReader.useDrain(sb: StringBuilder) {
     }
 }
 
+/**
+ * Wait up to [timeoutMs] for the process to exit; true if it did.
+ *
+ * NOT a poll on exitValue(): a `ShizukuRemoteProcess` is a remote (binder)
+ * process whose `exitValue()` throws `IllegalArgumentException("process hasn't
+ * exited")` while still running — unlike a local `java.lang.Process`, which
+ * throws `IllegalThreadStateException`. Polling exitValue() therefore blew up
+ * with an uncaught IllegalArgumentException on the very first tick and failed
+ * every elevated command. `waitFor()` works for both process kinds, so run it
+ * on a helper thread and bound it with join().
+ */
 private fun Process.waitForTimeout(timeoutMs: Long): Boolean {
-    val deadline = System.currentTimeMillis() + timeoutMs
-    while (System.currentTimeMillis() < deadline) {
+    val waiter = Thread {
         try {
-            exitValue()
-            return true
-        } catch (_: IllegalThreadStateException) {
-            Thread.sleep(50)
+            waitFor()
+        } catch (_: InterruptedException) {
         }
     }
-    return false
+    waiter.start()
+    waiter.join(timeoutMs)
+    return !waiter.isAlive
 }


### PR DESCRIPTION
Follow-up to #496. With R8 keeping `newProcess`, elevated exec now spawns at **uid=2000 (shell)** — confirmed in `adb logcat -s TalonShizuku`:
```
exec via Shizuku (uid=2000): { dumpsys package ... }
java.lang.IllegalArgumentException: process hasn't exited
  at rikka.shizuku.ShizukuRemoteProcess.exitValue(...)
```

## Root cause
`waitForTimeout` polled `Process.exitValue()`, catching `IllegalThreadStateException` (how a local `java.lang.Process` signals "still running"). But a `ShizukuRemoteProcess` is a remote binder process — its `exitValue()` throws `IllegalArgumentException("process hasn't exited")` while running. That wasn't caught, so exec threw on the first poll tick and fell back to app UID.

## Fix
Replace the exitValue poll with `waitFor()` (correct for both local and remote processes) on a helper thread, bounded by `join(timeoutMs)`. After it returns, `exitValue()` is safe.

## Verify
`device_exec id` → `uid=2000(shell) … via shizuku`, and `TalonShizuku` logs should show `exec via Shizuku done: exit=0`.
