### PR TITLE
feat(core): task table — live registry of agent work with talon ps / talon kill

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Multi-platform agentic AI harness. Runs on **Telegram**, **Discord**, **Microsof
 | **Goals**             | Persistent multi-day objectives the agent commits to in chat; every heartbeat run re-reads them, makes progress, and records what it did     |
 | **Skills**            | Agent-authored reusable scripts (bash/python/node) — procedures worked out once get saved and replayed locally at zero token cost            |
 | **Triggers**          | Self-authored watcher scripts (bash/python/node) that wake the bot when conditions are met                                                   |
+| **Task table**        | Every unit of agent work — chat turns, heartbeat, dream, isolated cron/trigger jobs — registered live; `talon ps` / `talon kill`             |
 | **Per-chat settings** | Model, effort level, and pulse toggle per conversation via inline keyboard                                                                   |
 | **Model registry**    | Models discovered from the active backend at startup — new models appear in all pickers automatically                                        |
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,59 @@
+# Task table
+
+> Status: **implemented** (`src/core/tasks/`). The daemon's registry of agent
+> work — the process-table analogue for the agent runtime, with tokens (not
+> CPU) as the accounted resource.
+
+## The model
+
+A **task** is one bounded run of agent work. Four kinds exist today, one per
+place the runtime actually starts an agent:
+
+| Kind        | Registered by                        | Killable | Usage captured |
+| ----------- | ------------------------------------ | -------- | -------------- |
+| `turn`      | `core/weaver` (every chat turn)      | no       | yes            |
+| `heartbeat` | `core/background/heartbeat/agent.ts` | yes      | no             |
+| `dream`     | `core/background/dream.ts`           | yes      | no             |
+| `cron` / `trigger` | `core/background/job-oneshot.ts` (isolated query jobs) | yes | no |
+
+Deliberately **not** tasks: trigger watcher scripts (long-lived OS processes
+the trigger store already tracks, pid and all), cron `message` jobs (a single
+send, no agent run), and the pulse ticker.
+
+Lifecycle: `queued → running → done | failed | killed`. Chat turns enter as
+`queued` while waiting in their chat's FIFO; everything else begins `running`.
+Settlement is idempotent — the first terminal state wins.
+
+## Kill semantics
+
+A task is killable when its owner registered an abort hook (in practice: the
+run is driven by an `AbortController`). `kill` delivers the abort and returns
+immediately; the task settles as `killed` when the owner's failure path lands.
+A run that completes despite the abort settles as `done` — a kill only
+"takes" when the run actually dies. Chat turns have no abort path today, so
+they are honestly reported as not killable rather than pretending.
+
+The table is observational: it never schedules, retries, or times out a run.
+Those disciplines stay with the owning module (weaver, heartbeat scheduler,
+dream, job-oneshot). It is also in-memory only — a task is a live run, and a
+daemon restart ends every run, so there is nothing truthful to persist. The
+settled history is a bounded ring (50 entries).
+
+## Token accounting
+
+`turn` tasks record `usage` (input/output/cache tokens) from the turn result.
+Isolated one-shots run through `runOneShotAgent`, which reports no usage, so
+their tasks settle without it. When the background capability grows usage
+reporting, the wiring point is already there (`TaskHandle.succeed(usage)`).
+
+## Surfaces
+
+- **HTTP (gateway, 127.0.0.1)** — `GET /tasks` returns
+  `{ ok, tasks: TaskRecord[] }`; `POST /tasks/kill` with `{ id }` returns a
+  `KillOutcome` (`ok` / `not-found` / `finished` / `not-killable`).
+- **CLI** — `talon ps` renders the table (live tasks first, then history
+  newest-first); `talon kill <id>` aborts a killable task.
+
+Labels are content-free by contract (`TaskSpec.label`): the turn source, the
+job/trigger name, or the heartbeat run number — never message text, so the
+listing can be shown anywhere the daemon's status can.

--- a/src/__tests__/gateway-http.test.ts
+++ b/src/__tests__/gateway-http.test.ts
@@ -56,6 +56,7 @@ vi.mock("write-file-atomic", () => ({
 }));
 
 import { Gateway } from "../core/engine/gateway.js";
+import { taskTable } from "../core/tasks/index.js";
 
 let gateway: Gateway;
 let port: number;
@@ -111,6 +112,70 @@ describe("gateway HTTP server", () => {
       expect(data.ok).toBeDefined();
       expect(data.uptime).toBeDefined();
       expect(data.memory).toBeDefined();
+    });
+  });
+
+  describe("task endpoints", () => {
+    it("GET /tasks lists the task table", async () => {
+      const task = taskTable.begin({ kind: "heartbeat", label: "#1" });
+      try {
+        const resp = await fetch(`http://127.0.0.1:${port}/tasks`);
+        expect(resp.status).toBe(200);
+        const data = (await resp.json()) as {
+          ok: boolean;
+          tasks: Array<Record<string, unknown>>;
+        };
+        expect(data.ok).toBe(true);
+        expect(data.tasks.find((t) => t.id === task.id)).toMatchObject({
+          kind: "heartbeat",
+          state: "running",
+        });
+      } finally {
+        task.succeed();
+      }
+    });
+
+    it("POST /tasks/kill aborts a killable task", async () => {
+      const abort = vi.fn();
+      const task = taskTable.begin({ kind: "dream", label: "test", abort });
+      try {
+        const resp = await fetch(`http://127.0.0.1:${port}/tasks/kill`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: task.id }),
+        });
+        expect(resp.status).toBe(200);
+        expect(await resp.json()).toEqual({ ok: true });
+        expect(abort).toHaveBeenCalledTimes(1);
+      } finally {
+        task.fail(new Error("aborted"));
+      }
+    });
+
+    it("POST /tasks/kill reports unknown ids", async () => {
+      const resp = await fetch(`http://127.0.0.1:${port}/tasks/kill`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: 999_999 }),
+      });
+      expect(resp.status).toBe(200);
+      expect(await resp.json()).toEqual({ ok: false, reason: "not-found" });
+    });
+
+    it("POST /tasks/kill rejects malformed bodies", async () => {
+      const invalidJson = await fetch(`http://127.0.0.1:${port}/tasks/kill`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json{{{",
+      });
+      expect(invalidJson.status).toBe(400);
+
+      const nonIntegerId = await fetch(`http://127.0.0.1:${port}/tasks/kill`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: "7" }),
+      });
+      expect(nonIntegerId.status).toBe(400);
     });
   });
 

--- a/src/__tests__/task-table.test.ts
+++ b/src/__tests__/task-table.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from "vitest";
+import { TaskTable } from "../core/tasks/index.js";
+
+describe("task table", () => {
+  it("begin registers a running task; enqueue registers a queued one", () => {
+    const table = new TaskTable();
+
+    const running = table.begin({ kind: "heartbeat", label: "#1" });
+    const queued = table.enqueue({
+      kind: "turn",
+      label: "message",
+      chatId: "42",
+    });
+
+    const records = table.list();
+    expect(records).toHaveLength(2);
+    const [first, second] = records;
+    expect(first).toMatchObject({
+      id: running.id,
+      kind: "heartbeat",
+      state: "running",
+      killable: false,
+    });
+    expect(first!.startedAt).toBeDefined();
+    expect(second).toMatchObject({
+      id: queued.id,
+      kind: "turn",
+      state: "queued",
+      chatId: "42",
+    });
+    expect(second!.startedAt).toBeUndefined();
+  });
+
+  it("ids are unique and monotonically increasing", () => {
+    const table = new TaskTable();
+    const ids = [
+      table.begin({ kind: "turn", label: "a" }).id,
+      table.begin({ kind: "turn", label: "b" }).id,
+      table.begin({ kind: "turn", label: "c" }).id,
+    ];
+    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("start moves queued → running exactly once", () => {
+    const table = new TaskTable();
+    const task = table.enqueue({ kind: "turn", label: "message" });
+
+    task.start();
+    const startedAt = table.list()[0]!.startedAt;
+    task.start();
+
+    expect(table.list()[0]!.state).toBe("running");
+    expect(table.list()[0]!.startedAt).toBe(startedAt);
+  });
+
+  it("bind records the resolved model/backend", () => {
+    const table = new TaskTable();
+    const task = table.begin({ kind: "turn", label: "message" });
+
+    task.bind({ model: "opus-4", backendId: "claude" });
+
+    expect(table.list()[0]).toMatchObject({
+      model: "opus-4",
+      backendId: "claude",
+    });
+  });
+
+  it("succeed settles as done and captures usage", () => {
+    const table = new TaskTable();
+    const task = table.begin({ kind: "turn", label: "message" });
+
+    task.succeed({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheRead: 5,
+      cacheWrite: 1,
+    });
+
+    expect(table.list()[0]).toMatchObject({
+      state: "done",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheRead: 5,
+        cacheWrite: 1,
+      },
+    });
+    expect(table.list()[0]!.endedAt).toBeDefined();
+  });
+
+  it("fail settles as failed and records the error message", () => {
+    const table = new TaskTable();
+    const task = table.begin({ kind: "cron", label: "digest" });
+
+    task.fail(new Error("backend unavailable"));
+
+    expect(table.list()[0]).toMatchObject({
+      state: "failed",
+      error: "backend unavailable",
+    });
+  });
+
+  it("settlement is idempotent — the first terminal state wins", () => {
+    const table = new TaskTable();
+    const task = table.begin({ kind: "turn", label: "message" });
+
+    task.succeed();
+    task.fail(new Error("late"));
+    task.succeed({
+      inputTokens: 1,
+      outputTokens: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+
+    const record = table.list()[0]!;
+    expect(record.state).toBe("done");
+    expect(record.error).toBeUndefined();
+    expect(record.usage).toBeUndefined();
+  });
+
+  describe("kill", () => {
+    it("aborts a live killable task and settles it as killed when it fails", () => {
+      const table = new TaskTable();
+      const abort = vi.fn();
+      const task = table.begin({ kind: "heartbeat", label: "#7", abort });
+
+      const outcome = table.kill(task.id);
+      expect(outcome).toEqual({ ok: true });
+      expect(abort).toHaveBeenCalledTimes(1);
+      expect(table.list()[0]!.state).toBe("running");
+
+      task.fail(new Error("aborted"));
+      expect(table.list()[0]).toMatchObject({
+        state: "killed",
+        error: "aborted",
+      });
+    });
+
+    it("a run that completes despite the abort settles as done", () => {
+      const table = new TaskTable();
+      const task = table.begin({
+        kind: "dream",
+        label: "consolidation",
+        abort: vi.fn(),
+      });
+
+      table.kill(task.id);
+      task.succeed();
+
+      expect(table.list()[0]!.state).toBe("done");
+    });
+
+    it("repeat kills report ok without re-firing the abort hook", () => {
+      const table = new TaskTable();
+      const abort = vi.fn();
+      const task = table.begin({ kind: "heartbeat", label: "#7", abort });
+
+      expect(table.kill(task.id)).toEqual({ ok: true });
+      expect(table.kill(task.id)).toEqual({ ok: true });
+      expect(abort).toHaveBeenCalledTimes(1);
+    });
+
+    it("a throwing abort hook does not break the kill path", () => {
+      const table = new TaskTable();
+      const task = table.begin({
+        kind: "heartbeat",
+        label: "#7",
+        abort: () => {
+          throw new Error("contract violation");
+        },
+      });
+
+      expect(table.kill(task.id)).toEqual({ ok: true });
+    });
+
+    it("refuses tasks without an abort hook", () => {
+      const table = new TaskTable();
+      const task = table.begin({ kind: "turn", label: "message" });
+
+      expect(table.kill(task.id)).toEqual({
+        ok: false,
+        reason: "not-killable",
+      });
+    });
+
+    it("distinguishes finished tasks from unknown ids", () => {
+      const table = new TaskTable();
+      const task = table.begin({ kind: "turn", label: "message" });
+      task.succeed();
+
+      expect(table.kill(task.id)).toEqual({ ok: false, reason: "finished" });
+      expect(table.kill(9999)).toEqual({ ok: false, reason: "not-found" });
+    });
+  });
+
+  it("keeps settled history bounded while live tasks are never evicted", () => {
+    const table = new TaskTable(3);
+
+    const live = table.begin({ kind: "turn", label: "live" });
+    for (let i = 0; i < 5; i++) {
+      table.begin({ kind: "turn", label: `settled-${i}` }).succeed();
+    }
+
+    const records = table.list();
+    // 3 retained settled tasks + the live one.
+    expect(records).toHaveLength(4);
+    expect(records.map((r) => r.label)).toEqual([
+      "live",
+      "settled-2",
+      "settled-3",
+      "settled-4",
+    ]);
+    expect(records.find((r) => r.id === live.id)!.state).toBe("running");
+  });
+
+  it("list returns id-ascending snapshots that do not mutate the table", () => {
+    const table = new TaskTable();
+    table.begin({ kind: "turn", label: "a" });
+    const task = table.begin({ kind: "cron", label: "b" });
+    task.succeed();
+
+    const records = table.list();
+    expect(records.map((r) => r.id)).toEqual(
+      [...records.map((r) => r.id)].sort((a, b) => a - b),
+    );
+
+    (records[0] as { label: string }).label = "tampered";
+    (records[1] as { label: string }).label = "tampered";
+    expect(table.list().map((r) => r.label)).toEqual(["a", "b"]);
+  });
+});

--- a/src/__tests__/weaver.test.ts
+++ b/src/__tests__/weaver.test.ts
@@ -3,6 +3,7 @@ import type { RetrievedMemory } from "../core/agent-runtime/capabilities.js";
 import type { MemoryRetriever } from "../core/memory/retrieval.js";
 import type { QueryParams } from "../backend/shared/handler-types.js";
 import { Loom, Thread, Weaver } from "../core/weaver/index.js";
+import { taskTable, type TaskRecord } from "../core/tasks/index.js";
 import type { ExecuteParams } from "../core/types.js";
 import { stubBackend, stubResolveActiveModel } from "./helpers/stub-backend.js";
 
@@ -154,6 +155,126 @@ describe("weaver", () => {
     b.resolve();
     await Promise.all([p1, p2]);
     expect(order).toEqual(["start:a", "start:b", "end:a", "end:b"]);
+  });
+});
+
+describe("weaver task registration", () => {
+  // The weaver reports to the daemon-wide task table; tests share it, so
+  // every case isolates by a chatId unique to this file.
+  const turnTask = (chatId: string): TaskRecord | undefined =>
+    taskTable
+      .list()
+      .filter((t) => t.kind === "turn" && t.chatId === chatId)
+      .at(-1);
+
+  function makeWeaver(backend = stubBackend()) {
+    return new Weaver({
+      getBackend: () => backend,
+      resolveActiveModel: stubResolveActiveModel(),
+      context: { acquire: vi.fn(), release: vi.fn(), getMessageCount: () => 0 },
+      sendTyping: vi.fn(async () => {}),
+      onActivity: vi.fn(),
+    });
+  }
+
+  it("settles a completed turn as done with its warp binding and usage", async () => {
+    const backend = stubBackend({
+      query: async () => ({
+        text: "ok",
+        durationMs: 1,
+        inputTokens: 11,
+        outputTokens: 7,
+        cacheRead: 3,
+        cacheWrite: 2,
+      }),
+    });
+
+    await makeWeaver(backend).runTurn(params({ chatId: "task-ok" }));
+
+    expect(turnTask("task-ok")).toMatchObject({
+      state: "done",
+      label: "message",
+      killable: false,
+      model: "stub-model",
+      backendId: "claude",
+      usage: { inputTokens: 11, outputTokens: 7, cacheRead: 3, cacheWrite: 2 },
+    });
+  });
+
+  it("settles a throwing turn as failed", async () => {
+    const backend = stubBackend({
+      query: async () => {
+        throw new Error("backend exploded");
+      },
+    });
+
+    await expect(
+      makeWeaver(backend).runTurn(params({ chatId: "task-boom" })),
+    ).rejects.toThrow("backend exploded");
+
+    expect(turnTask("task-boom")).toMatchObject({
+      state: "failed",
+      error: expect.stringContaining("backend exploded"),
+    });
+  });
+
+  it("settles a no-model refusal as done without a binding", async () => {
+    const weaver = new Weaver({
+      getBackend: () => stubBackend(),
+      resolveActiveModel: async () => ({
+        model: null,
+        ref: null,
+        backendId: "claude",
+      }),
+      context: { acquire: vi.fn(), release: vi.fn(), getMessageCount: () => 0 },
+      sendTyping: vi.fn(async () => {}),
+      onActivity: vi.fn(),
+    });
+
+    await weaver.runTurn(params({ chatId: "task-refused" }));
+
+    const record = turnTask("task-refused");
+    expect(record).toMatchObject({ state: "done" });
+    expect(record!.model).toBeUndefined();
+  });
+
+  it("shows a turn waiting in its chat's FIFO as queued", async () => {
+    const gate = deferred();
+    const backend = stubBackend({
+      query: async (queryParams) => {
+        if (queryParams.text === "first") await gate.promise;
+        return {
+          text: queryParams.text,
+          durationMs: 1,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        };
+      },
+    });
+    const weaver = makeWeaver(backend);
+
+    const p1 = weaver.runTurn(params({ chatId: "task-fifo", prompt: "first" }));
+    const p2 = weaver.runTurn(
+      params({ chatId: "task-fifo", prompt: "second" }),
+    );
+
+    await vi.waitFor(() => {
+      const states = taskTable
+        .list()
+        .filter((t) => t.chatId === "task-fifo")
+        .map((t) => t.state);
+      expect(states).toEqual(["running", "queued"]);
+    });
+
+    gate.resolve();
+    await Promise.all([p1, p2]);
+    const states = taskTable
+      .list()
+      .filter((t) => t.chatId === "task-fifo")
+      .map((t) => t.state);
+    expect(states).toEqual(["done", "done"]);
   });
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ import { tailLogs } from "./logs.js";
 import { runDoctor } from "./doctor.js";
 import { startChat } from "./chat.js";
 import { daemonStart, daemonStop, daemonRestart } from "./daemon.js";
+import { showTasks, killTask } from "./tasks.js";
 import { mainMenu } from "./menu.js";
 
 export * from "./context.js";
@@ -55,6 +56,8 @@ const CLI_COMMANDS = [
   "run",
   "chat",
   "doctor",
+  "ps",
+  "kill",
 ];
 
 /** Route a `talon <command>` invocation. Called by the entry point. */
@@ -96,6 +99,12 @@ export async function runCli(): Promise<void> {
     case "doctor":
       runDoctor();
       break;
+    case "ps":
+      await showTasks();
+      break;
+    case "kill":
+      await killTask(process.argv[3]);
+      break;
     case "--version":
     case "-v": {
       console.log(pkg.version);
@@ -113,6 +122,8 @@ export async function runCli(): Promise<void> {
       console.log(`    ${pc.cyan("run")}        Run in foreground (attached)`);
       console.log(`    ${pc.cyan("chat")}       Terminal chat mode`);
       console.log(`    ${pc.cyan("status")}     Show bot health`);
+      console.log(`    ${pc.cyan("ps")}         List agent tasks (task table)`);
+      console.log(`    ${pc.cyan("kill")}       Abort a killable task by id`);
       console.log(`    ${pc.cyan("config")}     View/edit configuration`);
       console.log(`    ${pc.cyan("logs")}       Tail log file`);
       console.log(`    ${pc.cyan("doctor")}     Validate environment`);

--- a/src/cli/tasks.ts
+++ b/src/cli/tasks.ts
@@ -1,0 +1,212 @@
+/**
+ * `talon ps` / `talon kill` — the task table from the outside.
+ *
+ * Data comes from the running daemon's gateway (`GET /tasks`,
+ * `POST /tasks/kill`); discovery finds the instance the same way
+ * `talon status` does. This module only renders — the table itself
+ * lives in core/tasks/.
+ */
+
+import pc from "picocolors";
+import { findRunningInstance } from "../core/daemon/discovery.js";
+import type {
+  KillOutcome,
+  TaskRecord,
+  TaskState,
+} from "../core/tasks/index.js";
+
+const REQUEST_TIMEOUT_MS = 3_000;
+
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+}
+
+function formatTokenCount(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+function formatTokens(task: TaskRecord): string {
+  if (!task.usage) return "—";
+  return `${formatTokenCount(task.usage.inputTokens)}→${formatTokenCount(task.usage.outputTokens)}`;
+}
+
+/** Queued: wait so far. Running: runtime so far. Settled: total runtime. */
+function formatTime(task: TaskRecord, now: number): string {
+  if (task.state === "queued") return formatDuration(now - task.queuedAt);
+  const start = task.startedAt ?? task.queuedAt;
+  return formatDuration((task.endedAt ?? now) - start);
+}
+
+function colorState(state: TaskState): string {
+  switch (state) {
+    case "running":
+      return pc.green(state);
+    case "queued":
+      return pc.yellow(state);
+    case "done":
+      return pc.dim(state);
+    case "failed":
+      return pc.red(state);
+    case "killed":
+      return pc.magenta(state);
+  }
+}
+
+/** Live tasks first (oldest running at the top), then history newest-first. */
+function displayOrder(tasks: TaskRecord[]): TaskRecord[] {
+  const live = tasks.filter(
+    (t) => t.state === "running" || t.state === "queued",
+  );
+  const settled = tasks.filter(
+    (t) => t.state !== "running" && t.state !== "queued",
+  );
+  live.sort((a, b) => a.id - b.id);
+  settled.sort((a, b) => b.id - a.id);
+  return [...live, ...settled];
+}
+
+type Row = readonly string[];
+
+const HEADER: Row = ["ID", "STATE", "KIND", "TIME", "TOKENS", "LABEL", "CHAT"];
+
+function toRow(task: TaskRecord, now: number): Row {
+  return [
+    String(task.id),
+    task.state,
+    task.kind,
+    formatTime(task, now),
+    formatTokens(task),
+    task.label,
+    task.chatId ?? "—",
+  ];
+}
+
+/**
+ * Pad every column to its widest cell. Colors are applied after padding
+ * (the state cell) so ANSI escapes never skew the width math.
+ */
+function renderTable(tasks: TaskRecord[], now: number): void {
+  const rows = tasks.map((t) => toRow(t, now));
+  const widths = HEADER.map((h, col) =>
+    Math.max(h.length, ...rows.map((r) => r[col]!.length)),
+  );
+  const pad = (row: Row) => row.map((cell, col) => cell.padEnd(widths[col]!));
+
+  console.log(`  ${pc.dim(pad(HEADER).join("  "))}`);
+  tasks.forEach((task, i) => {
+    const cells = pad(rows[i]!);
+    cells[1] =
+      colorState(task.state) + " ".repeat(widths[1]! - task.state.length);
+    console.log(`  ${cells.join("  ")}`);
+  });
+  console.log();
+}
+
+async function fetchGateway(
+  port: number,
+  path: string,
+  init?: RequestInit,
+): Promise<unknown> {
+  const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+    ...init,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`gateway answered ${response.status}`);
+  return response.json();
+}
+
+/** Find the daemon and return its gateway port, or render why not. */
+async function requireGatewayPort(): Promise<number | null> {
+  const instance = await findRunningInstance();
+  if (!instance) {
+    console.log(`  ${pc.red("●")} Talon is not running\n`);
+    return null;
+  }
+  if (!instance.port) {
+    console.log(
+      `  ${pc.yellow("●")} Talon is running (PID ${instance.pid}) but its gateway port is unknown — possibly still starting.\n`,
+    );
+    return null;
+  }
+  return instance.port;
+}
+
+export async function showTasks(): Promise<void> {
+  console.log();
+  const port = await requireGatewayPort();
+  if (port === null) return;
+
+  let tasks: TaskRecord[];
+  try {
+    const body = (await fetchGateway(port, "/tasks")) as {
+      tasks?: TaskRecord[];
+    };
+    tasks = body.tasks ?? [];
+  } catch (err) {
+    console.log(
+      `  ${pc.red("✖")} Could not read the task table: ${err instanceof Error ? err.message : err}\n`,
+    );
+    return;
+  }
+
+  if (tasks.length === 0) {
+    console.log(
+      `  ${pc.dim("No tasks — the table starts empty on each daemon start.")}\n`,
+    );
+    return;
+  }
+  renderTable(displayOrder(tasks), Date.now());
+}
+
+export async function killTask(rawId: string | undefined): Promise<void> {
+  console.log();
+  const id = Number(rawId);
+  if (rawId === undefined || !Number.isInteger(id)) {
+    console.log(
+      `  ${pc.red("✖")} Usage: ${pc.cyan("talon kill <id>")} — ids come from ${pc.cyan("talon ps")}\n`,
+    );
+    return;
+  }
+
+  const port = await requireGatewayPort();
+  if (port === null) return;
+
+  let outcome: KillOutcome;
+  try {
+    outcome = (await fetchGateway(port, "/tasks/kill", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    })) as KillOutcome;
+  } catch (err) {
+    console.log(
+      `  ${pc.red("✖")} Kill request failed: ${err instanceof Error ? err.message : err}\n`,
+    );
+    return;
+  }
+
+  if (outcome.ok) {
+    console.log(
+      `  ${pc.green("●")} Task ${id} aborted — it settles as ${pc.magenta("killed")} once the backend honours the abort.\n`,
+    );
+    return;
+  }
+  switch (outcome.reason) {
+    case "not-found":
+      console.log(`  ${pc.red("✖")} No task ${id} in the table.\n`);
+      return;
+    case "finished":
+      console.log(`  ${pc.dim("●")} Task ${id} already finished.\n`);
+      return;
+    case "not-killable":
+      console.log(
+        `  ${pc.yellow("!")} Task ${id} has no abort hook (chat turns run to completion) — it cannot be killed.\n`,
+      );
+      return;
+  }
+}

--- a/src/core/background/dream.ts
+++ b/src/core/background/dream.ts
@@ -22,6 +22,7 @@ import { getDefaultModel } from "../models/catalog.js";
 import type { OneShotAgentParams } from "../types.js";
 import type { Backend } from "../agent-runtime/capabilities.js";
 import { getSoul } from "../soul/service.js";
+import { taskTable } from "../tasks/index.js";
 import { FailureBackoff } from "./failure-backoff.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -259,6 +260,13 @@ If commands fail, log the error and continue — this stage is optional.`
 
   const abortController = new AbortController();
 
+  const task = taskTable.begin({
+    kind: "dream",
+    label: "consolidation",
+    abort: () => abortController.abort(),
+  });
+  task.bind({ model });
+
   const oneShotParams: OneShotAgentParams = {
     prompt,
     systemPrompt,
@@ -298,6 +306,7 @@ If commands fail, log the error and continue — this stage is optional.`
   try {
     await Promise.race([agentPromise, timeoutPromise]);
   } catch (err) {
+    task.fail(err);
     appendDreamLog(
       dreamLogFile,
       `\n---\n**Dream FAILED at ${new Date().toISOString()}:** ${err}\n`,
@@ -323,6 +332,7 @@ If commands fail, log the error and continue — this stage is optional.`
     if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
+  task.succeed();
   return dreamLogFile;
 }
 

--- a/src/core/background/heartbeat/agent.ts
+++ b/src/core/background/heartbeat/agent.ts
@@ -12,6 +12,7 @@ import { toYMD } from "../../../util/time.js";
 import { getDefaultModel } from "../../models/catalog.js";
 import { loadSystemTemplate } from "../../prompt/templates.js";
 import { formatGoal, getOpenGoals } from "../../../storage/goal-store.js";
+import { taskTable } from "../../tasks/index.js";
 import type { OneShotAgentParams } from "../../types.js";
 import { hb } from "./state.js";
 
@@ -184,6 +185,13 @@ export async function runHeartbeatAgent(
   // heartbeatAbortGraceMs below.
   const abortController = new AbortController();
 
+  const task = taskTable.begin({
+    kind: "heartbeat",
+    label: `#${runCount}`,
+    abort: () => abortController.abort(),
+  });
+  task.bind({ model });
+
   const oneShotParams: OneShotAgentParams = {
     prompt,
     systemPrompt: buildHeartbeatSystemPrompt(),
@@ -231,6 +239,7 @@ export async function runHeartbeatAgent(
       clearTimeout(timeoutHandle);
       timeoutHandle = null;
     }
+    task.fail(err);
     await appendHeartbeatLog(
       heartbeatLogFile,
       `\n---\n**Heartbeat #${runCount} FAILED at ${new Date().toISOString()}:** ${err}\n`,
@@ -269,6 +278,7 @@ export async function runHeartbeatAgent(
     if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
+  task.succeed();
   return heartbeatLogFile;
 }
 

--- a/src/core/background/job-oneshot.ts
+++ b/src/core/background/job-oneshot.ts
@@ -20,6 +20,7 @@ import {
   acquireBackendInstance,
   isModelValidForBackend,
 } from "../engine/backend-controller/index.js";
+import { taskTable } from "../tasks/index.js";
 import type { OneShotAgentParams } from "../types.js";
 import { runIsolatedAgent } from "./isolated-agent.js";
 import {
@@ -132,6 +133,15 @@ export async function runJobOneShot(
       params.model,
     );
 
+    const abortController = new AbortController();
+    const task = taskTable.begin({
+      kind: params.kind,
+      label: params.label,
+      chatId: params.chatId,
+      abort: () => abortController.abort(),
+    });
+    task.bind({ model: params.model, backendId: params.backendId });
+
     const oneShot: OneShotAgentParams = {
       prompt: params.payload,
       systemPrompt: buildJobSystemPrompt(
@@ -142,18 +152,24 @@ export async function runJobOneShot(
       contextLabel: JOB_CONTEXT_LABEL,
       workspace: dirs.workspace,
       model: params.model,
-      abortController: new AbortController(),
+      abortController,
       appendLog,
     };
 
-    await runIsolatedAgent({
-      background,
-      params: oneShot,
-      timeoutMs: params.timeoutMs ?? DEFAULT_JOB_TIMEOUT_MS,
-      // No evictLabel: the job context label is shared with heartbeat, so a
-      // sweep here could kill a concurrent heartbeat's subprocess. Bounded
-      // abort-grace is enough.
-    });
+    try {
+      await runIsolatedAgent({
+        background,
+        params: oneShot,
+        timeoutMs: params.timeoutMs ?? DEFAULT_JOB_TIMEOUT_MS,
+        // No evictLabel: the job context label is shared with heartbeat, so a
+        // sweep here could kill a concurrent heartbeat's subprocess. Bounded
+        // abort-grace is enough.
+      });
+      task.succeed();
+    } catch (err) {
+      task.fail(err);
+      throw err;
+    }
     log(
       params.kind === "cron" ? "cron" : "triggers",
       `isolated job "${params.label}" ran on ${params.backendId}/${params.model}`,

--- a/src/core/engine/gateway.ts
+++ b/src/core/engine/gateway.ts
@@ -27,6 +27,7 @@ import {
   HUB_PATH_PREFIX,
 } from "../mcp-hub/index.js";
 import { handlePluginAction } from "../plugin/index.js";
+import { taskTable } from "../tasks/index.js";
 import type { FrontendActionHandler } from "../types.js";
 import { BOT_MESSAGE_ACTIONS, noteBotMessage } from "../soul/taps.js";
 import type { Backend } from "../agent-runtime/capabilities.js";
@@ -392,6 +393,39 @@ export class Gateway {
           res.end(JSON.stringify({ ok: true }));
           const handler = this.shutdownHandler;
           setImmediate(() => handler("gateway /shutdown"));
+          return;
+        }
+
+        if (req.method === "GET" && req.url === "/tasks") {
+          // The task table — every live/recent unit of agent work. Read by
+          // `talon ps`. Same 127.0.0.1 trust boundary as /action.
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true, tasks: taskTable.list() }));
+          return;
+        }
+
+        if (req.method === "POST" && req.url === "/tasks/kill") {
+          // Abort one killable task by id — the transport for `talon kill`.
+          const chunks: Buffer[] = [];
+          for await (const chunk of req) chunks.push(chunk as Buffer);
+          let id: unknown;
+          try {
+            const body = JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+            id = (body as { id?: unknown }).id;
+          } catch {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "Invalid JSON" }));
+            return;
+          }
+          if (typeof id !== "number" || !Number.isInteger(id)) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({ ok: false, error: "id must be an integer" }),
+            );
+            return;
+          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(taskTable.kill(id)));
           return;
         }
 

--- a/src/core/tasks/index.ts
+++ b/src/core/tasks/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Task table — public surface.
+ *
+ * See table.ts for the registry and types.ts for the vocabulary. Wiring
+ * points: weaver (turns), heartbeat/agent, dream, background/job-oneshot
+ * (isolated cron/trigger jobs); read surfaces: gateway `GET /tasks` +
+ * `POST /tasks/kill`, CLI `talon ps` / `talon kill`.
+ */
+
+export { TaskTable, taskTable } from "./table.js";
+export type {
+  KillOutcome,
+  TaskBinding,
+  TaskHandle,
+  TaskKind,
+  TaskRecord,
+  TaskSpec,
+  TaskState,
+  TaskUsage,
+} from "./types.js";

--- a/src/core/tasks/table.ts
+++ b/src/core/tasks/table.ts
@@ -1,0 +1,161 @@
+/**
+ * TaskTable — live registry plus bounded history of agent-work runs.
+ *
+ * One instance (`taskTable`) serves the whole daemon. Call sites register a
+ * run with `begin`/`enqueue` and settle it through the returned TaskHandle;
+ * the gateway serves `list()` over HTTP and routes `talon kill` to `kill()`.
+ *
+ * The table is observational: it never schedules, retries, or times out a
+ * run — those disciplines stay with the owning module (weaver, heartbeat,
+ * dream, job-oneshot). In-memory only by design: a task is a live run, and
+ * a daemon restart ends every run, so persisted rows could only describe
+ * work that no longer exists.
+ */
+
+import type {
+  KillOutcome,
+  TaskBinding,
+  TaskHandle,
+  TaskRecord,
+  TaskSpec,
+  TaskState,
+  TaskUsage,
+} from "./types.js";
+
+/** Settled tasks kept for `list()` after they leave the live map. */
+const DEFAULT_HISTORY_LIMIT = 50;
+
+type MutableTaskRecord = {
+  -readonly [K in keyof TaskRecord]: TaskRecord[K];
+};
+
+interface LiveTask {
+  readonly record: MutableTaskRecord;
+  readonly abort?: () => void;
+  killRequested: boolean;
+}
+
+export class TaskTable {
+  private readonly live = new Map<number, LiveTask>();
+  private readonly history: TaskRecord[] = [];
+  private readonly historyLimit: number;
+  private nextId = 1;
+
+  constructor(historyLimit = DEFAULT_HISTORY_LIMIT) {
+    this.historyLimit = historyLimit;
+  }
+
+  /** Register a run that starts immediately. */
+  begin(spec: TaskSpec): TaskHandle {
+    const handle = this.enqueue(spec);
+    handle.start();
+    return handle;
+  }
+
+  /** Register a run that is waiting its turn (e.g. a chat's FIFO queue). */
+  enqueue(spec: TaskSpec): TaskHandle {
+    const id = this.nextId++;
+    const record: MutableTaskRecord = {
+      id,
+      kind: spec.kind,
+      label: spec.label,
+      state: "queued",
+      killable: spec.abort !== undefined,
+      queuedAt: Date.now(),
+    };
+    if (spec.chatId !== undefined) record.chatId = spec.chatId;
+    const task: LiveTask = {
+      record,
+      killRequested: false,
+      ...(spec.abort !== undefined ? { abort: spec.abort } : {}),
+    };
+    this.live.set(id, task);
+    return {
+      id,
+      start: () => this.start(id),
+      bind: (binding) => this.bind(id, binding),
+      succeed: (usage) => this.settle(id, "done", undefined, usage),
+      fail: (error) => this.settle(id, "failed", error),
+    };
+  }
+
+  /**
+   * Request an abort of a live killable task. Returns immediately — the
+   * task stays `running` until its owner's failure path lands, at which
+   * point it settles as `killed`. Repeat kills are no-ops that still
+   * report `ok` (the request stands); the abort hook fires only once.
+   */
+  kill(id: number): KillOutcome {
+    const task = this.live.get(id);
+    if (!task) {
+      return this.history.some((record) => record.id === id)
+        ? { ok: false, reason: "finished" }
+        : { ok: false, reason: "not-found" };
+    }
+    if (!task.abort) return { ok: false, reason: "not-killable" };
+    if (!task.killRequested) {
+      task.killRequested = true;
+      try {
+        task.abort();
+      } catch {
+        // The abort hook contract is "must not throw" — a violation must
+        // not break the kill path for the caller.
+      }
+    }
+    return { ok: true };
+  }
+
+  /**
+   * Every live task plus the bounded settled history, id-ascending.
+   * Snapshots are copies — callers can never mutate table state.
+   */
+  list(): TaskRecord[] {
+    const records: TaskRecord[] = this.history.map((record) => ({
+      ...record,
+    }));
+    for (const task of this.live.values()) records.push({ ...task.record });
+    return records.sort((a, b) => a.id - b.id);
+  }
+
+  private start(id: number): void {
+    const task = this.live.get(id);
+    if (!task || task.record.state !== "queued") return;
+    task.record.state = "running";
+    task.record.startedAt = Date.now();
+  }
+
+  private bind(id: number, binding: TaskBinding): void {
+    const task = this.live.get(id);
+    if (!task) return;
+    if (binding.model !== undefined) task.record.model = binding.model;
+    if (binding.backendId !== undefined)
+      task.record.backendId = binding.backendId;
+  }
+
+  private settle(
+    id: number,
+    state: Extract<TaskState, "done" | "failed">,
+    error?: unknown,
+    usage?: TaskUsage,
+  ): void {
+    const task = this.live.get(id);
+    if (!task) return;
+    const { record } = task;
+    // A kill only "takes" when the run actually dies: a run that completes
+    // despite the abort settles as done, one that unwinds settles as killed.
+    record.state = state === "failed" && task.killRequested ? "killed" : state;
+    record.endedAt = Date.now();
+    if (error !== undefined) {
+      record.error = error instanceof Error ? error.message : String(error);
+    }
+    if (usage !== undefined) record.usage = usage;
+    this.live.delete(id);
+    this.history.push(record);
+    if (this.history.length > this.historyLimit) {
+      this.history.splice(0, this.history.length - this.historyLimit);
+    }
+  }
+}
+
+/** The daemon-wide table. Tests needing isolation construct their own. */
+export const taskTable = new TaskTable();

--- a/src/core/tasks/types.ts
+++ b/src/core/tasks/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Task table vocabulary — the daemon's registry of agent work.
+ *
+ * A task is one bounded run of agent work: a chat turn, a heartbeat pass, a
+ * dream consolidation, or an isolated cron/trigger job. The table gives every
+ * such run an id, a lifecycle, an owner chat, and — where the run can be
+ * aborted — a kill switch. It is the process-table analogue for the agent
+ * runtime, with tokens (not CPU) as the accounted resource.
+ *
+ * Deliberately NOT tasks: trigger watcher scripts (long-lived OS processes
+ * owned by the trigger store, which already tracks their pid/status), cron
+ * "message" jobs (a single send, no agent run), and the pulse ticker.
+ */
+
+/** Which unit of agent work a task represents. */
+export type TaskKind = "turn" | "heartbeat" | "dream" | "cron" | "trigger";
+
+/** Task lifecycle. `done`, `failed`, and `killed` are terminal. */
+export type TaskState = "queued" | "running" | "done" | "failed" | "killed";
+
+/**
+ * Token spend for the run, captured at settlement when the runner reports
+ * it. Chat turns report usage today; isolated one-shots run through
+ * `runOneShotAgent`, which returns no usage, so their tasks settle without.
+ */
+export interface TaskUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheRead: number;
+  readonly cacheWrite: number;
+}
+
+/** What a call site declares when it registers a run with the table. */
+export interface TaskSpec {
+  readonly kind: TaskKind;
+  /**
+   * Short human label shown in `talon ps`: the turn source ("message",
+   * "trigger", …), the cron job or trigger name, or the heartbeat run
+   * number. Never message content — the listing must not leak chat text.
+   */
+  readonly label: string;
+  /** Chat the work belongs to, when it belongs to one. */
+  readonly chatId?: string;
+  /**
+   * Abort the run mid-flight (typically `AbortController.abort`). Present ⇒
+   * the task is killable via `TaskTable.kill`. Must not throw; the table
+   * swallows a throwing abort so a broken hook cannot break the kill path.
+   */
+  readonly abort?: () => void;
+}
+
+/** The model/backend a task actually resolved to, once known. */
+export interface TaskBinding {
+  readonly model?: string;
+  readonly backendId?: string;
+}
+
+/** Immutable snapshot of one task, as returned by `TaskTable.list()`. */
+export interface TaskRecord {
+  readonly id: number;
+  readonly kind: TaskKind;
+  readonly label: string;
+  readonly chatId?: string;
+  readonly state: TaskState;
+  readonly killable: boolean;
+  /** When the task entered the table (equal to `startedAt` unless queued). */
+  readonly queuedAt: number;
+  readonly startedAt?: number;
+  readonly endedAt?: number;
+  readonly model?: string;
+  readonly backendId?: string;
+  /** Failure detail. Also set for killed tasks (the abort's error). */
+  readonly error?: string;
+  readonly usage?: TaskUsage;
+}
+
+/**
+ * Mutator handed to the owning call site. Every transition is idempotent:
+ * once a task settles, later calls (including a duplicate settle) no-op, so
+ * error paths never need to guard against double settlement.
+ */
+export interface TaskHandle {
+  readonly id: number;
+  /** Move a queued task to running. No-op unless queued. */
+  start(): void;
+  /** Record the model/backend the run resolved to. No-op once settled. */
+  bind(binding: TaskBinding): void;
+  /** Settle as `done`, optionally recording token usage. */
+  succeed(usage?: TaskUsage): void;
+  /** Settle as `failed` — or `killed` when a kill was requested first. */
+  fail(error: unknown): void;
+}
+
+/** Result of `TaskTable.kill`. */
+export type KillOutcome =
+  | { readonly ok: true }
+  | {
+      readonly ok: false;
+      readonly reason: "not-found" | "finished" | "not-killable";
+    };

--- a/src/core/weaver/weaver.ts
+++ b/src/core/weaver/weaver.ts
@@ -24,6 +24,7 @@ import type { AgentResult } from "../agent-runtime/events.js";
 import type { ModelRef } from "../agent-runtime/model-ref.js";
 import type { MemoryRetriever } from "../memory/retrieval.js";
 import type { ContextManager, ExecuteParams, ExecuteResult } from "../types.js";
+import { taskTable, type TaskHandle } from "../tasks/index.js";
 import { log, logDebug, logWarn } from "../../util/log.js";
 import { Loom } from "./loom.js";
 import { prefetchMemory } from "./memory-prefetch.js";
@@ -80,7 +81,14 @@ export class Weaver {
 
   runTurn(params: ExecuteParams): Promise<ExecuteResult> {
     const thread = this.loom.thread(params.chatId);
-    return thread.enqueue(() => this.run(thread, params));
+    // Registered before enqueueing so a turn waiting in its chat's FIFO is
+    // visible as `queued` in the task table, not invisible until it runs.
+    const task = taskTable.enqueue({
+      kind: "turn",
+      label: params.source,
+      chatId: params.chatId,
+    });
+    return thread.enqueue(() => this.run(thread, params, task));
   }
 
   /** Number of turns currently running (not queued) across all chats. */
@@ -100,10 +108,22 @@ export class Weaver {
   private async run(
     thread: Thread,
     params: ExecuteParams,
+    task: TaskHandle,
   ): Promise<ExecuteResult> {
     this.activeCount++;
+    task.start();
     try {
-      return await this.executeInner(thread, params);
+      const result = await this.executeInner(thread, params, task);
+      task.succeed({
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+        cacheRead: result.cacheRead,
+        cacheWrite: result.cacheWrite,
+      });
+      return result;
+    } catch (err) {
+      task.fail(err);
+      throw err;
     } finally {
       this.activeCount--;
     }
@@ -112,6 +132,7 @@ export class Weaver {
   private async executeInner(
     thread: Thread,
     params: ExecuteParams,
+    task: TaskHandle,
   ): Promise<ExecuteResult> {
     const { context, onActivity, retrieveMemory } = this.deps;
     const backend = this.deps.getBackend(params.chatId);
@@ -151,6 +172,7 @@ export class Weaver {
       overridden: warp.overridden,
       boundAt: Date.now(),
     });
+    task.bind({ model: warp.ref.id, backendId: warp.backendId });
     if (drifted && previous) {
       logDebug(
         "dispatcher",


### PR DESCRIPTION
## What

First step of the "Talon as an OS" direction: a unified **task table** — the process-table analogue for the agent runtime, with tokens (not CPU) as the accounted resource.

Every unit of agent work now registers in one in-memory registry (`src/core/tasks/`):

| Kind | Registered by | Killable | Usage |
| --- | --- | --- | --- |
| `turn` | `core/weaver` (every chat turn; visible as `queued` while waiting in its chat's FIFO) | no | yes |
| `heartbeat` | `heartbeat/agent.ts` | yes | no |
| `dream` | `dream.ts` | yes | no |
| `cron` / `trigger` | `job-oneshot.ts` (isolated query jobs) | yes | no |

Lifecycle `queued → running → done | failed | killed`, idempotent settlement, resolved model/backend recorded at warp-bind time, bounded settled history (50).

## Kill semantics

Runs driven by an `AbortController` are killable: `kill` delivers the abort and the task settles as `killed` when the owner's failure path lands. A run that completes despite the abort settles as `done` — a kill only "takes" when the run actually dies. Chat turns have no abort path today and are honestly reported `not-killable`.

The table is **observational** — scheduling, retries, and timeouts stay with the owning modules. Deliberately not tasks: trigger watcher scripts (the trigger store already owns their pid/status), cron `message` jobs, the pulse ticker.

## Surfaces

- Gateway: `GET /tasks`, `POST /tasks/kill` (127.0.0.1, same trust boundary as `/action`)
- CLI: `talon ps` (live first, then history newest-first), `talon kill <id>`
- Labels are content-free by contract — never message text

## Tests

- `task-table.test.ts` — lifecycle, kill semantics, history bound, snapshot isolation
- `weaver.test.ts` — turn registration: done+usage+binding, failed, refusal, queued visibility
- `gateway-http.test.ts` — both endpoints incl. malformed bodies

Docs: `docs/tasks.md`; README features row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)