### PR TITLE
feat(cli): plugin & skill managers — install/enable/disable from npm, git, and local sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Multi-platform agentic AI harness. Runs on **Telegram**, **Discord**, **Microsof
 | **Multi-frontend**    | Telegram (Grammy + GramJS userbot), Discord (discord.js), Microsoft Teams (Bot Framework), Terminal with live tool visibility, and a **Desktop/Mobile app** (Flutter) over a local/remote bridge |
 | **Pluggable backend** | Claude Agent SDK, Kilo, OpenCode, Codex, OpenAI Agents — selectable per-process via `backend` config. Streaming, model fallback, context-overflow recovery. |
 | **MCP tools**         | Messaging, media, history, search, web fetch, cron jobs, triggers, goals, stickers, file system, admin controls                              |
-| **Plugins**           | Hot-reloadable plugin system. Built-in: GitHub, MemPalace, Playwright, Brave Search                                                          |
+| **Plugins**           | Hot-reloadable plugin system with `talon plugin install/enable/disable` (npm, git, or local sources). Built-in: GitHub, MemPalace, Playwright, Brave Search |
 | **Background agents** | Heartbeat (hourly by default — advances goals, proactively messages when something matters) and Dream (memory consolidation + diary)         |
 | **Goals**             | Persistent multi-day objectives the agent commits to in chat; every heartbeat run re-reads them, makes progress, and records what it did     |
-| **Skills**            | Agent-authored reusable scripts (bash/python/node) — procedures worked out once get saved and replayed locally at zero token cost            |
+| **Skills**            | SKILL.md workflow bundles the agent authors and reuses, with `talon skill install/enable/disable` (local folders, git, or `owner/repo` — the Anthropic skills ecosystem installs directly) |
 | **Triggers**          | Self-authored watcher scripts (bash/python/node) that wake the bot when conditions are met                                                   |
 | **Task table**        | Every unit of agent work — chat turns, heartbeat, dream, isolated cron/trigger jobs — registered live; `talon ps` / `talon kill`             |
 | **Event bus**         | Typed internal pub-sub spine (task + turn lifecycle events); subsystems subscribe instead of importing each other; `talon events -f`         |
@@ -168,6 +168,32 @@ The `desktop` frontend turns the daemon into a **client bridge** — a versioned
 The app provides multi-chat history, live streaming with reasoning + tool-call visibility, per-chat model/effort/pulse/reset, and **settings sync** — read and change the daemon's own config (default model, display name, timezone, pulse/heartbeat/dream) and restart it. See [apps/companion/README.md](apps/companion/README.md).
 
 ---
+
+## Managing plugins & skills
+
+Both stores are managed from the CLI; changes hot-reload into a running
+daemon (plugins) or apply on the next session (skills):
+
+```bash
+# Plugins — npm specs, git repos, or local paths
+talon plugin install @scope/my-talon-plugin        # npm → module plugin
+talon plugin install some-mcp-server --mcp         # npm → standalone MCP server (npx)
+talon plugin install owner/repo                    # git → module plugin
+talon plugin list                                  # built-ins + configured entries
+talon plugin disable github                        # also toggles built-ins
+talon plugin remove my-talon-plugin
+
+# Skills — SKILL.md folders from local paths, git URLs, or owner/repo[/subpath]
+talon skill install anthropics/skills/document-skills/pdf
+talon skill install ./my-skill --force
+talon skill list
+talon skill disable pdf                            # hidden from the prompt index, still readable
+talon skill remove pdf
+```
+
+Module plugins install under `~/.talon/plugins/`; standalone MCP servers are
+registered as `npx` entries in `config.json`. Disabling keeps the entry (or a
+`.disabled` marker in the skill folder) so enabling restores it unchanged.
 
 ## Built-in Plugins
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -47,6 +47,29 @@ templates, references) alongside `SKILL.md`. `save_skill` overwrites only
 resources. `read_skill` enumerates them and tells the agent to open them with
 the normal Read tool. Deleting a skill removes the whole folder.
 
+## CLI management
+
+`talon skill` manages the store from the outside — the agent-facing tools
+(`save_skill`, `find_skills`, `read_skill`) are unchanged:
+
+- `talon skill install <source>` — install from a local folder, a git URL, or
+  `owner/repo[/subpath]` GitHub shorthand (so
+  `talon skill install anthropics/skills/document-skills/pdf` works). The
+  source either **is** a skill (has `SKILL.md`) or is a collection whose
+  immediate children are skills — collections install every child. The target
+  folder name is the frontmatter `name`; existing skills are only replaced
+  with `--force`.
+- `talon skill list` — every skill with its enabled state.
+- `talon skill enable/disable <name>` — toggle via a `.disabled` marker file
+  in the skill folder. The marker survives `save_skill` updates (which only
+  rewrite `SKILL.md`). Disabled skills drop out of the prompt index and
+  `find_skills`, but stay listable via `list_skills` (shown `[disabled]`) and
+  readable via `read_skill` — the toggle hides, it never restricts.
+- `talon skill remove <name>` — delete the skill folder.
+
+Installs and toggles need no daemon restart: the prompt index re-reads the
+store on the next prompt assembly.
+
 ## Loading Policy
 
 The system prompt injects only a capped skill index: name, description, and

--- a/src/__tests__/cli-plugin-entries.test.ts
+++ b/src/__tests__/cli-plugin-entries.test.ts
@@ -1,0 +1,162 @@
+/**
+ * `talon plugin` pure helpers — entry naming/matching, enable toggling,
+ * npm spec parsing, install-source grammar.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  entryDisplayName,
+  entryMatches,
+  findConflictIndex,
+  isBuiltinPlugin,
+  npmSpecName,
+  withEnabled,
+  type PluginEntryJson,
+} from "../cli/plugin-entries.js";
+import { resolveSource } from "../cli/install-sources.js";
+
+describe("entryDisplayName", () => {
+  it("uses the MCP name when present", () => {
+    expect(
+      entryDisplayName({ name: "fetch", command: "npx", args: ["-y", "x"] }),
+    ).toBe("fetch");
+  });
+
+  it("uses the folder basename for plain path entries", () => {
+    expect(entryDisplayName({ path: "/home/u/.talon/plugins/my-tool" })).toBe(
+      "my-tool",
+    );
+  });
+
+  it("preserves the scoped package name under node_modules", () => {
+    expect(
+      entryDisplayName({
+        path: "/home/u/.talon/plugins/node_modules/@scope/pkg",
+      }),
+    ).toBe("@scope/pkg");
+  });
+
+  it("handles Windows separators", () => {
+    expect(
+      entryDisplayName({
+        path: "C:\\Users\\u\\.talon\\plugins\\node_modules\\pkg",
+      }),
+    ).toBe("pkg");
+  });
+});
+
+describe("entryMatches", () => {
+  const entry: PluginEntryJson = {
+    path: "/home/u/.talon/plugins/node_modules/@scope/pkg",
+  };
+
+  it("matches display name, basename, and full path", () => {
+    expect(entryMatches(entry, "@scope/pkg")).toBe(true);
+    expect(entryMatches(entry, "pkg")).toBe(true);
+    expect(
+      entryMatches(entry, "/home/u/.talon/plugins/node_modules/@scope/pkg"),
+    ).toBe(true);
+  });
+
+  it("rejects other tokens", () => {
+    expect(entryMatches(entry, "scope")).toBe(false);
+    expect(entryMatches(entry, "other")).toBe(false);
+  });
+});
+
+describe("findConflictIndex", () => {
+  it("finds a same-path module entry but not a same-name coincidence", () => {
+    const entries: PluginEntryJson[] = [
+      { path: "/a/tool" },
+      { name: "fetch", command: "npx" },
+    ];
+    expect(findConflictIndex(entries, { path: "/a/tool" })).toBe(0);
+    expect(findConflictIndex(entries, { path: "/b/tool" })).toBe(-1);
+    expect(findConflictIndex(entries, { name: "fetch", command: "uvx" })).toBe(
+      1,
+    );
+    expect(findConflictIndex(entries, { name: "other", command: "npx" })).toBe(
+      -1,
+    );
+  });
+});
+
+describe("withEnabled", () => {
+  it("removes the key when enabling (enabled is the default)", () => {
+    expect(withEnabled({ path: "/a", enabled: false }, true)).toEqual({
+      path: "/a",
+    });
+  });
+
+  it("writes enabled: false when disabling", () => {
+    expect(withEnabled({ path: "/a" }, false)).toEqual({
+      path: "/a",
+      enabled: false,
+    });
+  });
+});
+
+describe("npmSpecName", () => {
+  it("strips versions and keeps scopes", () => {
+    expect(npmSpecName("pkg")).toBe("pkg");
+    expect(npmSpecName("pkg@1.2.3")).toBe("pkg");
+    expect(npmSpecName("@scope/pkg")).toBe("@scope/pkg");
+    expect(npmSpecName("@scope/pkg@^2")).toBe("@scope/pkg");
+  });
+});
+
+describe("isBuiltinPlugin", () => {
+  it("recognises the built-in config sections", () => {
+    expect(isBuiltinPlugin("github")).toBe(true);
+    expect(isBuiltinPlugin("playwright")).toBe(true);
+    expect(isBuiltinPlugin("my-plugin")).toBe(false);
+  });
+});
+
+describe("resolveSource", () => {
+  it("resolves an existing path to local", () => {
+    const dir = mkdtempSync(join(tmpdir(), "talon-src-"));
+    try {
+      expect(resolveSource(dir)).toEqual({ kind: "local", dir });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("recognises git URLs", () => {
+    expect(resolveSource("https://github.com/o/r.git")).toEqual({
+      kind: "git",
+      url: "https://github.com/o/r.git",
+    });
+    expect(resolveSource("git@github.com:o/r.git")).toEqual({
+      kind: "git",
+      url: "git@github.com:o/r.git",
+    });
+  });
+
+  it("expands owner/repo shorthand, with and without subpath", () => {
+    expect(resolveSource("anthropics/skills")).toEqual({
+      kind: "git",
+      url: "https://github.com/anthropics/skills.git",
+    });
+    expect(resolveSource("anthropics/skills/document-skills/pdf")).toEqual({
+      kind: "git",
+      url: "https://github.com/anthropics/skills.git",
+      subpath: "document-skills/pdf",
+    });
+  });
+
+  it("treats npm specs as other — scoped names are not shorthand", () => {
+    expect(resolveSource("@scope/pkg")).toEqual({
+      kind: "other",
+      raw: "@scope/pkg",
+    });
+    expect(resolveSource("plain-package")).toEqual({
+      kind: "other",
+      raw: "plain-package",
+    });
+  });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -273,6 +273,24 @@ describe("config", () => {
       ]);
     });
 
+    it("parses the enabled flag on both plugin entry formats", async () => {
+      // Regression: `talon plugin disable` writes `enabled: false`; the
+      // strict piped schemas must accept the key or the daemon refuses to
+      // boot on a config the CLI itself wrote.
+      mockFs({
+        frontend: "terminal",
+        plugins: [
+          { path: "./plugins/my-plugin", enabled: false },
+          { name: "polymarket", command: "node", enabled: false },
+        ],
+      });
+
+      const { loadConfig } = await import("../util/config.js");
+      const config = loadConfig();
+      expect(config.plugins).toHaveLength(2);
+      expect(config.plugins.map((p) => p.enabled)).toEqual([false, false]);
+    });
+
     it("rejects plugin entries that mix path and standalone MCP fields", async () => {
       mockFs({
         frontend: "terminal",

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -200,6 +200,37 @@ describe("plugin system", () => {
     });
   });
 
+  describe("disabled entries", () => {
+    it("skips a disabled path plugin", async () => {
+      const plugin = createMockPlugin();
+      const { loadPlugins, getPluginCount } = await setup(plugin);
+      await loadPlugins([{ path: "/fake/plugin", enabled: false }]);
+      expect(getPluginCount()).toBe(0);
+    });
+
+    it("loads a path plugin with explicit enabled: true", async () => {
+      const plugin = createMockPlugin();
+      const { loadPlugins, getPluginCount } = await setup(plugin);
+      await loadPlugins([{ path: "/fake/plugin", enabled: true }]);
+      expect(getPluginCount()).toBe(1);
+    });
+
+    it("skips a disabled standalone MCP entry", async () => {
+      const plugin = createMockPlugin();
+      const { loadPlugins, getPluginMcpServers } = await setup(plugin);
+      await loadPlugins([
+        {
+          name: "srv",
+          command: "npx",
+          args: ["-y", "some-server"],
+          enabled: false,
+        },
+      ]);
+      const servers = getPluginMcpServers("http://localhost:19876", "chat1");
+      expect(Object.keys(servers)).toHaveLength(0);
+    });
+  });
+
   describe("MCP server config", () => {
     it("builds MCP server entries for plugins with mcpServerPath", async () => {
       const plugin = createMockPlugin({

--- a/src/__tests__/skill-lifecycle.test.ts
+++ b/src/__tests__/skill-lifecycle.test.ts
@@ -4,7 +4,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 

--- a/src/__tests__/skill-lifecycle.test.ts
+++ b/src/__tests__/skill-lifecycle.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Skill store — enable/disable marker + folder install
+ * (`talon skill enable/disable/install`).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+let workspaceDir: string;
+vi.mock("../util/paths.js", async () => {
+  const real =
+    await vi.importActual<typeof import("../util/paths.js")>(
+      "../util/paths.js",
+    );
+  return {
+    ...real,
+    dirs: new Proxy(real.dirs, {
+      get(target, prop: string) {
+        if (prop === "workspace") return workspaceDir;
+        if (prop === "skills") return join(workspaceDir, "skills");
+        return target[prop as keyof typeof target];
+      },
+    }),
+  };
+});
+
+import {
+  installSkillFromDir,
+  listSkills,
+  readSkill,
+  renderSkillsPrompt,
+  saveSkill,
+  searchSkills,
+  setSkillEnabled,
+} from "../storage/skill-store.js";
+
+function writeSkillFolder(
+  dir: string,
+  frontmatter: string,
+  body = "## Steps\n\n1. Do the thing.",
+): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "SKILL.md"), `---\n${frontmatter}\n---\n\n${body}\n`);
+}
+
+let sourceRoot: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "talon-skill-ws-"));
+  sourceRoot = mkdtempSync(join(tmpdir(), "talon-skill-src-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+  rmSync(sourceRoot, { recursive: true, force: true });
+});
+
+describe("setSkillEnabled", () => {
+  it("toggles the enabled flag via the .disabled marker", () => {
+    saveSkill({ name: "demo", description: "a demo", body: "steps" });
+    expect(readSkill("demo")!.enabled).toBe(true);
+
+    expect(setSkillEnabled("demo", false)).toBe(true);
+    expect(readSkill("demo")!.enabled).toBe(false);
+    expect(existsSync(join(workspaceDir, "skills", "demo", ".disabled"))).toBe(
+      true,
+    );
+
+    expect(setSkillEnabled("demo", true)).toBe(true);
+    expect(readSkill("demo")!.enabled).toBe(true);
+  });
+
+  it("is idempotent in both directions", () => {
+    saveSkill({ name: "demo", description: "a demo", body: "steps" });
+    expect(setSkillEnabled("demo", false)).toBe(true);
+    expect(setSkillEnabled("demo", false)).toBe(true);
+    expect(setSkillEnabled("demo", true)).toBe(true);
+    expect(setSkillEnabled("demo", true)).toBe(true);
+    expect(readSkill("demo")!.enabled).toBe(true);
+  });
+
+  it("returns false for missing skills and invalid names", () => {
+    expect(setSkillEnabled("missing", false)).toBe(false);
+    expect(setSkillEnabled("../escape", false)).toBe(false);
+  });
+
+  it("does not list the marker as a bundled resource", () => {
+    saveSkill({ name: "demo", description: "a demo", body: "steps" });
+    setSkillEnabled("demo", false);
+    expect(readSkill("demo")!.resources).toEqual([]);
+  });
+
+  it("survives a save_skill update (marker lives beside SKILL.md)", () => {
+    saveSkill({ name: "demo", description: "a demo", body: "steps" });
+    setSkillEnabled("demo", false);
+    saveSkill({ name: "demo", description: "updated", body: "new steps" });
+    expect(readSkill("demo")!.enabled).toBe(false);
+  });
+});
+
+describe("disabled skills in prompt and search", () => {
+  it("drops disabled skills from the prompt index but not list_skills", () => {
+    saveSkill({ name: "keep", description: "kept skill", body: "steps" });
+    saveSkill({ name: "hide", description: "hidden skill", body: "steps" });
+    setSkillEnabled("hide", false);
+
+    const prompt = renderSkillsPrompt();
+    expect(prompt).toContain("keep");
+    expect(prompt).not.toContain("hide");
+
+    const names = listSkills().map((skill) => skill.name);
+    expect(names).toEqual(["hide", "keep"]);
+  });
+
+  it("returns an empty prompt when every skill is disabled", () => {
+    saveSkill({ name: "only", description: "the only one", body: "steps" });
+    setSkillEnabled("only", false);
+    expect(renderSkillsPrompt()).toBe("");
+  });
+
+  it("excludes disabled skills from search", () => {
+    saveSkill({ name: "review-pr", description: "review PRs", body: "steps" });
+    setSkillEnabled("review-pr", false);
+    expect(searchSkills("review")).toEqual([]);
+  });
+});
+
+describe("installSkillFromDir", () => {
+  it("installs a folder under its frontmatter name, resources included", () => {
+    const src = join(sourceRoot, "checkout-dir-name");
+    writeSkillFolder(src, "name: pdf-tools\ndescription: work with PDFs");
+    writeFileSync(join(src, "helper.py"), "print('hi')\n");
+
+    const outcome = installSkillFromDir(src);
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.skill.name).toBe("pdf-tools");
+    expect(outcome.skill.enabled).toBe(true);
+    expect(outcome.skill.resources).toEqual(["helper.py"]);
+    // Frontmatter name wins over the checkout's folder name.
+    expect(readSkill("checkout-dir-name")).toBeUndefined();
+  });
+
+  it("rejects a folder without SKILL.md", () => {
+    const src = join(sourceRoot, "empty");
+    mkdirSync(src, { recursive: true });
+    const outcome = installSkillFromDir(src);
+    expect(outcome).toMatchObject({ ok: false });
+  });
+
+  it("rejects invalid frontmatter", () => {
+    const src = join(sourceRoot, "bad");
+    writeSkillFolder(src, "name: 'has spaces in it!'\ndescription: x");
+    const outcome = installSkillFromDir(src);
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) return;
+    expect(outcome.error).toContain("Invalid skill");
+  });
+
+  it("refuses to overwrite without force, replaces with force", () => {
+    saveSkill({ name: "demo", description: "original", body: "v1" });
+    setSkillEnabled("demo", false);
+
+    const src = join(sourceRoot, "demo-v2");
+    writeSkillFolder(src, "name: demo\ndescription: replacement");
+
+    const refused = installSkillFromDir(src);
+    expect(refused.ok).toBe(false);
+
+    const replaced = installSkillFromDir(src, { force: true });
+    expect(replaced.ok).toBe(true);
+    if (!replaced.ok) return;
+    expect(replaced.skill.description).toBe("replacement");
+    // A force reinstall is a fresh skill — the old disabled state goes too.
+    expect(replaced.skill.enabled).toBe(true);
+  });
+});

--- a/src/cli/daemon-api.ts
+++ b/src/cli/daemon-api.ts
@@ -13,10 +13,11 @@ export async function fetchGateway(
   port: number,
   path: string,
   init?: RequestInit,
+  timeoutMs: number = REQUEST_TIMEOUT_MS,
 ): Promise<unknown> {
   const response = await fetch(`http://127.0.0.1:${port}${path}`, {
     ...init,
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   if (!response.ok) throw new Error(`gateway answered ${response.status}`);
   return response.json();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,6 +33,8 @@ import { daemonStart, daemonStop, daemonRestart } from "./daemon.js";
 import { showTasks, killTask } from "./tasks.js";
 import { showEvents } from "./events.js";
 import { showLs, showCat } from "./fs.js";
+import { runPluginCommand } from "./plugin.js";
+import { runSkillCommand } from "./skill.js";
 import { mainMenu } from "./menu.js";
 
 export * from "./context.js";
@@ -63,6 +65,8 @@ const CLI_COMMANDS = [
   "events",
   "ls",
   "cat",
+  "plugin",
+  "skill",
 ];
 
 /** Route a `talon <command>` invocation. Called by the entry point. */
@@ -128,6 +132,12 @@ export async function runCli(): Promise<void> {
     case "cat":
       await showCat(process.argv[3]);
       break;
+    case "plugin":
+      await runPluginCommand(process.argv.slice(3));
+      break;
+    case "skill":
+      await runSkillCommand(process.argv.slice(3));
+      break;
     case "--version":
     case "-v": {
       console.log(pkg.version);
@@ -157,6 +167,12 @@ export async function runCli(): Promise<void> {
       );
       console.log(
         `    ${pc.cyan("cat")}        Read a talon:// file (cat proc/events)`,
+      );
+      console.log(
+        `    ${pc.cyan("plugin")}     Manage plugins (install/enable/disable)`,
+      );
+      console.log(
+        `    ${pc.cyan("skill")}      Manage skills (install/enable/disable)`,
       );
       console.log(`    ${pc.cyan("config")}     View/edit configuration`);
       console.log(`    ${pc.cyan("logs")}       Tail log file`);

--- a/src/cli/install-sources.ts
+++ b/src/cli/install-sources.ts
@@ -91,8 +91,7 @@ export function runTool(
 }
 
 export type CloneOutcome =
-  | { ok: true; dir: string; cleanup: () => void }
-  | { ok: false; error: string };
+  { ok: true; dir: string; cleanup: () => void } | { ok: false; error: string };
 
 /** Shallow-clone into a fresh temp directory. Caller must run `cleanup`. */
 export function cloneShallow(url: string): CloneOutcome {

--- a/src/cli/install-sources.ts
+++ b/src/cli/install-sources.ts
@@ -1,0 +1,107 @@
+/**
+ * Install-source resolution shared by `talon plugin install` and
+ * `talon skill install`.
+ *
+ * One grammar for both commands, checked in order:
+ *
+ *   1. an existing local path                → { kind: "local" }
+ *   2. a git URL (scheme, `git@`, or `.git`) → { kind: "git" }
+ *   3. `owner/repo[/subpath]` shorthand      → { kind: "git" } on github.com
+ *   4. anything else                         → { kind: "other" } — the caller
+ *      decides (plugins treat it as an npm spec, skills reject it)
+ *
+ * Cloning always uses `--depth=1` (installs never need history) and spawns
+ * `git`/`npm` via cross-spawn, which resolves the `.cmd`/`.exe` shims on
+ * Windows — never assume a POSIX shell here.
+ */
+
+import crossSpawn from "cross-spawn";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+export type ResolvedSource =
+  | { kind: "local"; dir: string }
+  | { kind: "git"; url: string; subpath?: string }
+  | { kind: "other"; raw: string };
+
+const GIT_URL_RE = /^(https?|git|ssh):\/\//;
+/** `owner/repo` or `owner/repo/sub/path` — never an npm scope (`@…`). */
+const GITHUB_SHORTHAND_RE =
+  /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)((?:\/[^\s/]+)*)$/;
+
+export function resolveSource(raw: string): ResolvedSource {
+  const trimmed = raw.trim();
+  if (existsSync(resolve(trimmed))) {
+    return { kind: "local", dir: resolve(trimmed) };
+  }
+  if (
+    GIT_URL_RE.test(trimmed) ||
+    trimmed.startsWith("git@") ||
+    trimmed.endsWith(".git")
+  ) {
+    return { kind: "git", url: trimmed };
+  }
+  if (!trimmed.startsWith("@")) {
+    const match = GITHUB_SHORTHAND_RE.exec(trimmed);
+    if (match) {
+      const [, owner, repo, rest] = match;
+      return {
+        kind: "git",
+        url: `https://github.com/${owner}/${repo}.git`,
+        ...(rest ? { subpath: rest.slice(1) } : {}),
+      };
+    }
+  }
+  return { kind: "other", raw: trimmed };
+}
+
+export type CommandOutcome = { ok: true } | { ok: false; error: string };
+
+/**
+ * Run a tool from PATH synchronously. `inherit` streams output to the
+ * terminal (npm installs); otherwise stderr is captured for the error.
+ */
+export function runTool(
+  tool: string,
+  args: string[],
+  options: { cwd?: string; inherit?: boolean } = {},
+): CommandOutcome {
+  const result = crossSpawn.sync(tool, args, {
+    cwd: options.cwd,
+    stdio: options.inherit ? "inherit" : ["ignore", "ignore", "pipe"],
+  });
+  if (result.error) {
+    const missing = (result.error as NodeJS.ErrnoException).code === "ENOENT";
+    return {
+      ok: false,
+      error: missing
+        ? `${tool} is not installed or not on PATH`
+        : result.error.message,
+    };
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString().trim();
+    return {
+      ok: false,
+      error: stderr || `${tool} ${args[0]} exited with ${result.status}`,
+    };
+  }
+  return { ok: true };
+}
+
+export type CloneOutcome =
+  | { ok: true; dir: string; cleanup: () => void }
+  | { ok: false; error: string };
+
+/** Shallow-clone into a fresh temp directory. Caller must run `cleanup`. */
+export function cloneShallow(url: string): CloneOutcome {
+  const dir = mkdtempSync(join(tmpdir(), "talon-install-"));
+  const cleanup = () => rmSync(dir, { recursive: true, force: true });
+  const outcome = runTool("git", ["clone", "--depth=1", url, dir]);
+  if (!outcome.ok) {
+    cleanup();
+    return { ok: false, error: `Clone failed: ${outcome.error}` };
+  }
+  return { ok: true, dir, cleanup };
+}

--- a/src/cli/plugin-entries.ts
+++ b/src/cli/plugin-entries.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure helpers over the config `plugins` array for the `talon plugin`
+ * command group. The CLI edits config.json as JSON — entries here are the
+ * on-disk shape (`core/plugin/types.ts` PluginEntry), not loaded plugins.
+ * No filesystem or process access — everything is testable data-in/data-out.
+ */
+
+/** On-disk plugin entry — path-based module or standalone MCP server. */
+export type PluginEntryJson = {
+  path?: string;
+  config?: Record<string, unknown>;
+  name?: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  enabled?: boolean;
+};
+
+/**
+ * Built-in plugins toggled by their own config sections (`github.enabled`,
+ * …) rather than `plugins[]` entries — see core/plugin/builtins.ts.
+ */
+export const BUILTIN_PLUGINS = [
+  "github",
+  "mempalace",
+  "mem0",
+  "playwright",
+] as const;
+
+export function isBuiltinPlugin(name: string): boolean {
+  return (BUILTIN_PLUGINS as readonly string[]).includes(name);
+}
+
+/** Split a config path on either separator — Windows configs carry `\`. */
+function pathSegments(path: string): string[] {
+  return path.split(/[\\/]+/).filter(Boolean);
+}
+
+/**
+ * Display name for an entry: the MCP name, or for path entries the package
+ * name — segments after the last `node_modules` (preserving `@scope/pkg`),
+ * else the folder basename.
+ */
+export function entryDisplayName(entry: PluginEntryJson): string {
+  if (entry.name) return entry.name;
+  if (!entry.path) return "(invalid entry)";
+  const segments = pathSegments(entry.path);
+  const nm = segments.lastIndexOf("node_modules");
+  if (nm >= 0 && nm < segments.length - 1) {
+    return segments.slice(nm + 1).join("/");
+  }
+  return segments[segments.length - 1] ?? entry.path;
+}
+
+/** Does `token` identify this entry? Display name, basename, or full path. */
+export function entryMatches(entry: PluginEntryJson, token: string): boolean {
+  if (entryDisplayName(entry) === token) return true;
+  if (!entry.path) return false;
+  const segments = pathSegments(entry.path);
+  return entry.path === token || segments[segments.length - 1] === token;
+}
+
+export function findEntryIndex(
+  entries: PluginEntryJson[],
+  token: string,
+): number {
+  return entries.findIndex((entry) => entryMatches(entry, token));
+}
+
+/**
+ * Index of an entry with the same identity as `candidate` (same module
+ * path or same MCP name) — the duplicate an install must replace.
+ */
+export function findConflictIndex(
+  entries: PluginEntryJson[],
+  candidate: PluginEntryJson,
+): number {
+  return entries.findIndex((entry) =>
+    candidate.path !== undefined
+      ? entry.path === candidate.path
+      : entry.name !== undefined && entry.name === candidate.name,
+  );
+}
+
+/**
+ * Copy of `entry` with the enabled state applied. Enabled is the default,
+ * so enabling removes the key rather than writing `enabled: true`.
+ */
+export function withEnabled(
+  entry: PluginEntryJson,
+  enabled: boolean,
+): PluginEntryJson {
+  const { enabled: _drop, ...rest } = entry;
+  return enabled ? rest : { ...rest, enabled: false };
+}
+
+/**
+ * Package name of an npm spec, version stripped: `pkg@1.2` → `pkg`,
+ * `@scope/pkg@^1` → `@scope/pkg`. A leading `@` is the scope, not a version.
+ */
+export function npmSpecName(spec: string): string {
+  const at = spec.lastIndexOf("@");
+  return at > 0 ? spec.slice(0, at) : spec;
+}

--- a/src/cli/plugin.ts
+++ b/src/cli/plugin.ts
@@ -145,7 +145,8 @@ function listRows(config: Config): Row[] {
   const builtins: Row[] = BUILTIN_PLUGINS.map((name) => ({
     name,
     kind: "built-in",
-    state: builtinSection(config, name)?.enabled === true ? "enabled" : "disabled",
+    state:
+      builtinSection(config, name)?.enabled === true ? "enabled" : "disabled",
     source: `config.${name}`,
   }));
   const configured: Row[] = entries(config).map((entry) => ({
@@ -202,8 +203,7 @@ function parseInstallArgs(
 }
 
 type EntryOutcome =
-  | { ok: true; entry: PluginEntryJson }
-  | { ok: false; error: string };
+  { ok: true; entry: PluginEntryJson } | { ok: false; error: string };
 
 function installFromLocalDir(dir: string): EntryOutcome {
   if (existsSync(resolve(dir, "SKILL.md"))) {
@@ -300,11 +300,9 @@ function installFromNpm(spec: string, flags: InstallFlags): EntryOutcome {
 
   mkdirSync(dirs.plugins, { recursive: true });
   console.log(`  ${pc.dim(`Installing ${spec} from npm…`)}`);
-  const install = runTool(
-    "npm",
-    ["install", "--prefix", dirs.plugins, spec],
-    { inherit: true },
-  );
+  const install = runTool("npm", ["install", "--prefix", dirs.plugins, spec], {
+    inherit: true,
+  });
   if (!install.ok) return { ok: false, error: install.error };
 
   const pkg = npmSpecName(spec);
@@ -407,9 +405,7 @@ async function cmdSetEnabled(
     const list = entries(config);
     const index = findEntryIndex(list, name);
     if (index < 0) {
-      fail(
-        `No plugin named "${name}" — see ${pc.cyan("talon plugin list")}.`,
-      );
+      fail(`No plugin named "${name}" — see ${pc.cyan("talon plugin list")}.`);
       process.exitCode = 1;
       return;
     }

--- a/src/cli/plugin.ts
+++ b/src/cli/plugin.ts
@@ -1,0 +1,498 @@
+/**
+ * `talon plugin` — install / list / enable / disable / remove plugins.
+ *
+ * Plugins live in two places, and this command manages both:
+ *   - built-ins toggled by their own config sections (`github.enabled`, …);
+ *   - the `plugins` array: path-based modules and standalone MCP servers.
+ *
+ * Every mutation edits config.json, then asks a running daemon to hot-reload
+ * via `POST /plugins/reload`; when the daemon is down the change simply
+ * applies on the next start.
+ *
+ * Install sources (see cli/install-sources.ts for the shared grammar):
+ * local path and git checkouts become module entries under ~/.talon/plugins;
+ * an npm spec installs there too, or registers an `npx` MCP entry with
+ * `--mcp`. Windows-safe throughout — tools are spawned via cross-spawn.
+ */
+
+import pc from "picocolors";
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
+import { dirs } from "../util/paths.js";
+import { ENTRY_CANDIDATES } from "../core/plugin/loader.js";
+import { findRunningInstance } from "../core/daemon/discovery.js";
+import { fetchGateway } from "./daemon-api.js";
+import { loadConfig, saveConfig, type Config } from "./config.js";
+import {
+  cloneShallow,
+  resolveSource,
+  runTool,
+  type ResolvedSource,
+} from "./install-sources.js";
+import {
+  BUILTIN_PLUGINS,
+  entryDisplayName,
+  findConflictIndex,
+  findEntryIndex,
+  isBuiltinPlugin,
+  npmSpecName,
+  withEnabled,
+  type PluginEntryJson,
+} from "./plugin-entries.js";
+
+/** Plugin init can legitimately take ~30s (MemPalace) — outlive it. */
+const RELOAD_TIMEOUT_MS = 60_000;
+
+const USAGE = [
+  `  Usage: ${pc.cyan("talon plugin <command>")}`,
+  "",
+  "  Commands:",
+  `    ${pc.cyan("list")}                       Show built-ins and configured plugins`,
+  `    ${pc.cyan("install <source>")}           Add a plugin (local path, git URL,`,
+  "                               owner/repo, or npm spec)",
+  `    ${pc.cyan("enable <name>")}              Enable a plugin`,
+  `    ${pc.cyan("disable <name>")}             Disable a plugin (kept in config)`,
+  `    ${pc.cyan("remove <name>")}              Remove a plugin entry (and its install)`,
+  "",
+  "  Install flags:",
+  `    ${pc.cyan("--mcp")}                      Register an npm spec as a standalone`,
+  "                               MCP server (npx) instead of a module",
+  `    ${pc.cyan("--name <name>")}              Override the derived plugin name`,
+  `    ${pc.cyan("--force")}                    Replace an existing install/entry`,
+  "",
+].join("\n");
+
+function entries(config: Config): PluginEntryJson[] {
+  if (!Array.isArray(config.plugins)) config.plugins = [];
+  return config.plugins as PluginEntryJson[];
+}
+
+function builtinSection(
+  config: Config,
+  name: string,
+): Record<string, unknown> | undefined {
+  const section = (config as unknown as Record<string, unknown>)[name];
+  return section && typeof section === "object"
+    ? (section as Record<string, unknown>)
+    : undefined;
+}
+
+function ok(message: string): void {
+  console.log(`  ${pc.green("●")} ${message}`);
+}
+
+function fail(message: string): void {
+  console.log(`  ${pc.red("✖")} ${message}`);
+}
+
+/**
+ * Ask a running daemon to hot-reload. Daemon down is not an error — the
+ * config change applies on next start.
+ */
+async function requestReload(): Promise<void> {
+  const instance = await findRunningInstance();
+  if (!instance?.port) {
+    console.log(
+      `  ${pc.dim("Talon is not running — the change applies on next start.")}`,
+    );
+    return;
+  }
+  try {
+    const body = (await fetchGateway(
+      instance.port,
+      "/plugins/reload",
+      { method: "POST" },
+      RELOAD_TIMEOUT_MS,
+    )) as { ok?: boolean; loaded?: string[]; error?: string };
+    if (body.ok) {
+      const loaded = body.loaded ?? [];
+      ok(
+        `Daemon reloaded plugins (${loaded.length} loaded${
+          loaded.length > 0 ? `: ${loaded.join(", ")}` : ""
+        }).`,
+      );
+    } else {
+      fail(`Daemon reload failed: ${body.error ?? "unknown error"}`);
+    }
+  } catch (err) {
+    fail(
+      `Could not reach the daemon to reload: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+function hasModuleEntryPoint(dir: string): boolean {
+  return ENTRY_CANDIDATES.some((candidate) =>
+    existsSync(resolve(dir, candidate)),
+  );
+}
+
+/**
+ * Is `path` inside the managed ~/.talon/plugins tree? Cross-drive Windows
+ * paths make `relative()` return an absolute path, hence the isAbsolute
+ * guard alongside the usual `..` escape check.
+ */
+function isManagedPath(path: string): boolean {
+  const rel = relative(dirs.plugins, resolve(path));
+  return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+}
+
+// ── list ────────────────────────────────────────────────────────────────────
+
+type Row = { name: string; kind: string; state: string; source: string };
+
+function listRows(config: Config): Row[] {
+  const builtins: Row[] = BUILTIN_PLUGINS.map((name) => ({
+    name,
+    kind: "built-in",
+    state: builtinSection(config, name)?.enabled === true ? "enabled" : "disabled",
+    source: `config.${name}`,
+  }));
+  const configured: Row[] = entries(config).map((entry) => ({
+    name: entryDisplayName(entry),
+    kind: entry.path !== undefined ? "module" : "mcp",
+    state: entry.enabled === false ? "disabled" : "enabled",
+    source:
+      entry.path ??
+      `${entry.command ?? "?"}${entry.args ? ` ${entry.args.join(" ")}` : ""}`,
+  }));
+  return [...builtins, ...configured];
+}
+
+function cmdList(): void {
+  const rows = listRows(loadConfig());
+  const header = ["NAME", "KIND", "STATE", "SOURCE"];
+  const cells = rows.map((r) => [r.name, r.kind, r.state, r.source]);
+  const widths = header.map((h, col) =>
+    Math.max(h.length, ...cells.map((r) => r[col]!.length)),
+  );
+  const pad = (row: string[]) =>
+    row.map((cell, col) => cell.padEnd(widths[col]!));
+
+  console.log(`  ${pc.dim(pad(header).join("  "))}`);
+  rows.forEach((row, i) => {
+    const padded = pad(cells[i]!);
+    padded[2] =
+      (row.state === "enabled" ? pc.green(row.state) : pc.dim(row.state)) +
+      " ".repeat(widths[2]! - row.state.length);
+    console.log(`  ${padded.join("  ")}`);
+  });
+  console.log();
+}
+
+// ── install ─────────────────────────────────────────────────────────────────
+
+type InstallFlags = { mcp: boolean; force: boolean; name?: string };
+
+function parseInstallArgs(
+  args: string[],
+): { source: string; flags: InstallFlags } | null {
+  const flags: InstallFlags = { mcp: false, force: false };
+  let source: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--mcp") flags.mcp = true;
+    else if (arg === "--force") flags.force = true;
+    else if (arg === "--name") flags.name = args[++i];
+    else if (!arg.startsWith("-") && source === undefined) source = arg;
+    else return null;
+  }
+  if (!source || (flags.name !== undefined && !flags.name)) return null;
+  return { source, flags };
+}
+
+type EntryOutcome =
+  | { ok: true; entry: PluginEntryJson }
+  | { ok: false; error: string };
+
+function installFromLocalDir(dir: string): EntryOutcome {
+  if (existsSync(resolve(dir, "SKILL.md"))) {
+    return {
+      ok: false,
+      error: `${dir} looks like a skill — use ${pc.cyan("talon skill install")}`,
+    };
+  }
+  if (!hasModuleEntryPoint(dir)) {
+    return {
+      ok: false,
+      error: `No plugin entry point in ${dir} (expected one of: ${ENTRY_CANDIDATES.join(", ")})`,
+    };
+  }
+  return { ok: true, entry: { path: dir } };
+}
+
+/**
+ * Clone (or copy a clone subpath) into ~/.talon/plugins/<name>. The
+ * checkout is staged and validated (deps installed, entry point present)
+ * entirely inside the temp clone; an existing install is only replaced
+ * once the staged copy is known-good, so a failed install never destroys
+ * a working one.
+ */
+function installFromGit(
+  source: Extract<ResolvedSource, { kind: "git" }>,
+  flags: InstallFlags,
+): EntryOutcome {
+  const derived = source.subpath
+    ? basename(source.subpath)
+    : basename(source.url, ".git");
+  const name = flags.name ?? derived;
+  const target = join(dirs.plugins, name);
+  if (existsSync(target) && !flags.force) {
+    return {
+      ok: false,
+      error: `${target} already exists (use --force to replace)`,
+    };
+  }
+
+  const clone = cloneShallow(source.url);
+  if (!clone.ok) return { ok: false, error: clone.error };
+  try {
+    const stage = source.subpath
+      ? resolve(clone.dir, source.subpath)
+      : clone.dir;
+    if (!existsSync(stage)) {
+      return {
+        ok: false,
+        error: `Path "${source.subpath}" not found in ${source.url}`,
+      };
+    }
+    // An install is a snapshot, not a checkout — updates go through
+    // `install --force`, so the clone's history has no business here.
+    rmSync(join(stage, ".git"), { recursive: true, force: true });
+
+    if (existsSync(join(stage, "package.json"))) {
+      console.log(`  ${pc.dim("Installing dependencies…")}`);
+      const deps = runTool("npm", ["install", "--omit=dev"], {
+        cwd: stage,
+        inherit: true,
+      });
+      if (!deps.ok) {
+        return { ok: false, error: `Dependency install failed: ${deps.error}` };
+      }
+    }
+    if (!hasModuleEntryPoint(stage)) {
+      return {
+        ok: false,
+        error: `No plugin entry point in the checkout (expected one of: ${ENTRY_CANDIDATES.join(", ")})`,
+      };
+    }
+
+    mkdirSync(dirs.plugins, { recursive: true });
+    rmSync(target, { recursive: true, force: true });
+    cpSync(stage, target, { recursive: true });
+    return { ok: true, entry: { path: target } };
+  } finally {
+    clone.cleanup();
+  }
+}
+
+function installFromNpm(spec: string, flags: InstallFlags): EntryOutcome {
+  if (flags.mcp) {
+    const pkg = npmSpecName(spec);
+    const name = flags.name ?? pkg.split("/").pop()!;
+    // npx resolves the package at daemon start; the mcp-launcher wraps the
+    // spawn, so `.cmd` shims work on Windows.
+    return {
+      ok: true,
+      entry: { name, command: "npx", args: ["-y", spec] },
+    };
+  }
+
+  mkdirSync(dirs.plugins, { recursive: true });
+  console.log(`  ${pc.dim(`Installing ${spec} from npm…`)}`);
+  const install = runTool(
+    "npm",
+    ["install", "--prefix", dirs.plugins, spec],
+    { inherit: true },
+  );
+  if (!install.ok) return { ok: false, error: install.error };
+
+  const pkg = npmSpecName(spec);
+  const moduleDir = join(dirs.plugins, "node_modules", ...pkg.split("/"));
+  if (!hasModuleEntryPoint(moduleDir)) {
+    runTool("npm", ["uninstall", "--prefix", dirs.plugins, pkg]);
+    return {
+      ok: false,
+      error:
+        `${pkg} has no Talon plugin entry point — if it is a standalone ` +
+        `MCP server, install it with ${pc.cyan(`talon plugin install ${spec} --mcp`)}`,
+    };
+  }
+  return { ok: true, entry: { path: moduleDir } };
+}
+
+async function cmdInstall(args: string[]): Promise<void> {
+  const parsed = parseInstallArgs(args);
+  if (!parsed) {
+    console.log(USAGE);
+    process.exitCode = 1;
+    return;
+  }
+  const { source, flags } = parsed;
+
+  const resolved = resolveSource(source);
+  let outcome: EntryOutcome;
+  switch (resolved.kind) {
+    case "local":
+      outcome = installFromLocalDir(resolved.dir);
+      break;
+    case "git":
+      outcome = installFromGit(resolved, flags);
+      break;
+    case "other":
+      outcome = installFromNpm(resolved.raw, flags);
+      break;
+  }
+  if (!outcome.ok) {
+    fail(outcome.error);
+    process.exitCode = 1;
+    return;
+  }
+
+  const config = loadConfig();
+  const list = entries(config);
+  const conflict = findConflictIndex(list, outcome.entry);
+  if (conflict >= 0) {
+    if (!flags.force) {
+      fail(
+        `"${entryDisplayName(outcome.entry)}" is already configured (use --force to replace).`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    list[conflict] = outcome.entry;
+  } else {
+    list.push(outcome.entry);
+  }
+  saveConfig(config);
+
+  const name = entryDisplayName(outcome.entry);
+  ok(
+    outcome.entry.path !== undefined
+      ? `Installed module plugin ${pc.bold(name)} (${outcome.entry.path}).`
+      : `Registered MCP server ${pc.bold(name)} (${outcome.entry.command} ${outcome.entry.args?.join(" ") ?? ""}).`,
+  );
+  await requestReload();
+  console.log();
+}
+
+// ── enable / disable ────────────────────────────────────────────────────────
+
+async function cmdSetEnabled(
+  name: string | undefined,
+  enabled: boolean,
+): Promise<void> {
+  const verb = enabled ? "enable" : "disable";
+  if (!name) {
+    fail(`Usage: ${pc.cyan(`talon plugin ${verb} <name>`)}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const config = loadConfig();
+  if (isBuiltinPlugin(name)) {
+    const section = builtinSection(config, name) ?? {};
+    (config as unknown as Record<string, unknown>)[name] = {
+      ...section,
+      enabled,
+    };
+    saveConfig(config);
+    ok(`Built-in ${pc.bold(name)} ${verb}d.`);
+    if (enabled && Object.keys(section).length === 0) {
+      console.log(
+        `  ${pc.dim(`${name} may need additional config — see the README's plugin section.`)}`,
+      );
+    }
+  } else {
+    const list = entries(config);
+    const index = findEntryIndex(list, name);
+    if (index < 0) {
+      fail(
+        `No plugin named "${name}" — see ${pc.cyan("talon plugin list")}.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    list[index] = withEnabled(list[index]!, enabled);
+    saveConfig(config);
+    ok(`Plugin ${pc.bold(entryDisplayName(list[index]!))} ${verb}d.`);
+  }
+  await requestReload();
+  console.log();
+}
+
+// ── remove ──────────────────────────────────────────────────────────────────
+
+async function cmdRemove(name: string | undefined): Promise<void> {
+  if (!name) {
+    fail(`Usage: ${pc.cyan("talon plugin remove <name>")}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (isBuiltinPlugin(name)) {
+    fail(
+      `${name} is built-in — use ${pc.cyan(`talon plugin disable ${name}`)} instead.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const config = loadConfig();
+  const list = entries(config);
+  const index = findEntryIndex(list, name);
+  if (index < 0) {
+    fail(`No plugin named "${name}" — see ${pc.cyan("talon plugin list")}.`);
+    process.exitCode = 1;
+    return;
+  }
+  const [removed] = list.splice(index, 1);
+  saveConfig(config);
+
+  // Clean up installs this CLI owns (~/.talon/plugins); never touch
+  // user-managed paths elsewhere on disk.
+  const path = removed!.path;
+  if (path && isManagedPath(path)) {
+    if (path.split(/[\\/]/).includes("node_modules")) {
+      runTool("npm", [
+        "uninstall",
+        "--prefix",
+        dirs.plugins,
+        entryDisplayName(removed!),
+      ]);
+    } else {
+      rmSync(path, { recursive: true, force: true });
+    }
+  }
+
+  ok(`Removed plugin ${pc.bold(entryDisplayName(removed!))}.`);
+  await requestReload();
+  console.log();
+}
+
+// ── dispatch ────────────────────────────────────────────────────────────────
+
+export async function runPluginCommand(args: string[]): Promise<void> {
+  console.log();
+  const [subcommand, ...rest] = args;
+  switch (subcommand) {
+    case "list":
+    case undefined:
+      cmdList();
+      break;
+    case "install":
+      await cmdInstall(rest);
+      break;
+    case "enable":
+      await cmdSetEnabled(rest[0], true);
+      break;
+    case "disable":
+      await cmdSetEnabled(rest[0], false);
+      break;
+    case "remove":
+      await cmdRemove(rest[0]);
+      break;
+    default:
+      console.log(USAGE);
+      process.exitCode = 1;
+  }
+}

--- a/src/cli/skill.ts
+++ b/src/cli/skill.ts
@@ -1,0 +1,250 @@
+/**
+ * `talon skill` — install / list / enable / disable / remove SKILL.md
+ * workflow bundles.
+ *
+ * All lifecycle logic lives in storage/skill-store.ts; this module only
+ * resolves install sources and renders outcomes. Installs accept a local
+ * folder, a git URL, or `owner/repo[/subpath]` (so `talon skill install
+ * anthropics/skills/skills/pdf` works). A source folder either IS a skill
+ * (has SKILL.md) or is a collection whose immediate children are skills —
+ * collections install every child.
+ *
+ * No daemon round-trip needed: the prompt index re-reads the store on the
+ * next prompt assembly, so changes apply to new sessions automatically.
+ */
+
+import pc from "picocolors";
+import { existsSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  deleteSkill,
+  installSkillFromDir,
+  listSkills,
+  setSkillEnabled,
+  type Skill,
+} from "../storage/skill-store.js";
+import { cloneShallow, resolveSource } from "./install-sources.js";
+
+const USAGE = [
+  `  Usage: ${pc.cyan("talon skill <command>")}`,
+  "",
+  "  Commands:",
+  `    ${pc.cyan("list")}                       Show installed skills`,
+  `    ${pc.cyan("install <source> [--force]")} Add skills from a local folder,`,
+  "                               git URL, or owner/repo[/subpath]",
+  `    ${pc.cyan("enable <name>")}              Restore a skill to the prompt index`,
+  `    ${pc.cyan("disable <name>")}             Hide a skill from the prompt index`,
+  `    ${pc.cyan("remove <name>")}              Delete a skill folder`,
+  "",
+].join("\n");
+
+function ok(message: string): void {
+  console.log(`  ${pc.green("●")} ${message}`);
+}
+
+function fail(message: string): void {
+  console.log(`  ${pc.red("✖")} ${message}`);
+}
+
+// ── list ────────────────────────────────────────────────────────────────────
+
+function cmdList(): void {
+  const skills = listSkills();
+  if (skills.length === 0) {
+    console.log(
+      `  ${pc.dim("No skills installed — try")} ${pc.cyan("talon skill install <source>")}\n`,
+    );
+    return;
+  }
+
+  const header = ["NAME", "STATE", "UPDATED", "DESCRIPTION"];
+  const cells = skills.map((skill) => [
+    skill.name,
+    skill.enabled ? "enabled" : "disabled",
+    skill.updatedAt
+      ? new Date(skill.updatedAt).toISOString().slice(0, 10)
+      : "unknown",
+    skill.description,
+  ]);
+  const widths = header.map((h, col) =>
+    Math.max(h.length, ...cells.map((r) => r[col]!.length)),
+  );
+  const pad = (row: string[]) =>
+    row.map((cell, col) => cell.padEnd(widths[col]!));
+
+  console.log(`  ${pc.dim(pad(header).join("  "))}`);
+  skills.forEach((skill, i) => {
+    const padded = pad(cells[i]!);
+    const state = cells[i]![1]!;
+    padded[1] =
+      (skill.enabled ? pc.green(state) : pc.dim(state)) +
+      " ".repeat(widths[1]! - state.length);
+    console.log(`  ${padded.join("  ")}`);
+  });
+  console.log();
+}
+
+// ── install ─────────────────────────────────────────────────────────────────
+
+/**
+ * The folders to install from a source dir: itself when it is a skill,
+ * else every immediate child that is one.
+ */
+function collectSkillDirs(dir: string): string[] {
+  if (existsSync(resolve(dir, "SKILL.md"))) return [dir];
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => resolve(dir, entry.name))
+      .filter((child) => existsSync(resolve(child, "SKILL.md")))
+      .sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+}
+
+function installAll(dirs: string[], force: boolean): Skill[] {
+  const installed: Skill[] = [];
+  for (const dir of dirs) {
+    const outcome = installSkillFromDir(dir, { force });
+    if (outcome.ok) {
+      installed.push(outcome.skill);
+      ok(`Installed ${pc.bold(outcome.skill.name)} — ${outcome.skill.description}`);
+    } else {
+      fail(outcome.error);
+    }
+  }
+  return installed;
+}
+
+async function cmdInstall(args: string[]): Promise<void> {
+  const force = args.includes("--force");
+  const source = args.find((arg) => !arg.startsWith("-"));
+  if (!source) {
+    console.log(USAGE);
+    process.exitCode = 1;
+    return;
+  }
+
+  const resolved = resolveSource(source);
+  if (resolved.kind === "other") {
+    fail(
+      `"${source}" is not a folder, git URL, or owner/repo — skills install from SKILL.md folders.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  let installed: Skill[];
+  if (resolved.kind === "local") {
+    const dirs = collectSkillDirs(resolved.dir);
+    if (dirs.length === 0) {
+      fail(`No SKILL.md found in ${resolved.dir} (or its immediate children).`);
+      process.exitCode = 1;
+      return;
+    }
+    installed = installAll(dirs, force);
+  } else {
+    const clone = cloneShallow(resolved.url);
+    if (!clone.ok) {
+      fail(clone.error);
+      process.exitCode = 1;
+      return;
+    }
+    try {
+      const root = resolved.subpath
+        ? resolve(clone.dir, resolved.subpath)
+        : clone.dir;
+      if (!existsSync(root)) {
+        fail(`Path "${resolved.subpath}" not found in ${resolved.url}`);
+        process.exitCode = 1;
+        return;
+      }
+      const dirs = collectSkillDirs(root);
+      if (dirs.length === 0) {
+        fail(
+          `No SKILL.md found under ${resolved.subpath ?? "the repository root"} (or its immediate children).`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+      installed = installAll(dirs, force);
+    } finally {
+      clone.cleanup();
+    }
+  }
+
+  if (installed.length === 0) {
+    process.exitCode = 1;
+  } else {
+    console.log(
+      `  ${pc.dim("Skills appear in the prompt index from the next session.")}`,
+    );
+  }
+  console.log();
+}
+
+// ── enable / disable / remove ───────────────────────────────────────────────
+
+function cmdSetEnabled(name: string | undefined, enabled: boolean): void {
+  const verb = enabled ? "enable" : "disable";
+  if (!name) {
+    fail(`Usage: ${pc.cyan(`talon skill ${verb} <name>`)}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!setSkillEnabled(name, enabled)) {
+    fail(`No skill named "${name}" — see ${pc.cyan("talon skill list")}.`);
+    process.exitCode = 1;
+    return;
+  }
+  ok(
+    enabled
+      ? `Skill ${pc.bold(name)} enabled — back in the prompt index next session.`
+      : `Skill ${pc.bold(name)} disabled — hidden from the prompt index (still readable via read_skill).`,
+  );
+  console.log();
+}
+
+function cmdRemove(name: string | undefined): void {
+  if (!name) {
+    fail(`Usage: ${pc.cyan("talon skill remove <name>")}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!deleteSkill(name)) {
+    fail(`No skill named "${name}" — see ${pc.cyan("talon skill list")}.`);
+    process.exitCode = 1;
+    return;
+  }
+  ok(`Removed skill ${pc.bold(name)} (folder deleted).`);
+  console.log();
+}
+
+// ── dispatch ────────────────────────────────────────────────────────────────
+
+export async function runSkillCommand(args: string[]): Promise<void> {
+  console.log();
+  const [subcommand, ...rest] = args;
+  switch (subcommand) {
+    case "list":
+    case undefined:
+      cmdList();
+      break;
+    case "install":
+      await cmdInstall(rest);
+      break;
+    case "enable":
+      cmdSetEnabled(rest[0], true);
+      break;
+    case "disable":
+      cmdSetEnabled(rest[0], false);
+      break;
+    case "remove":
+      cmdRemove(rest[0]);
+      break;
+    default:
+      console.log(USAGE);
+      process.exitCode = 1;
+  }
+}

--- a/src/cli/skill.ts
+++ b/src/cli/skill.ts
@@ -109,7 +109,9 @@ function installAll(dirs: string[], force: boolean): Skill[] {
     const outcome = installSkillFromDir(dir, { force });
     if (outcome.ok) {
       installed.push(outcome.skill);
-      ok(`Installed ${pc.bold(outcome.skill.name)} — ${outcome.skill.description}`);
+      ok(
+        `Installed ${pc.bold(outcome.skill.name)} — ${outcome.skill.description}`,
+      );
     } else {
       fail(outcome.error);
     }

--- a/src/core/engine/gateway-actions/plugins.ts
+++ b/src/core/engine/gateway-actions/plugins.ts
@@ -5,30 +5,47 @@
  */
 
 import { log, logWarn } from "../../../util/log.js";
+import type { Backend } from "../../agent-runtime/capabilities.js";
 import type { SharedActionHandlers } from "./types.js";
+
+/**
+ * The chat-independent half of a plugin reload: re-read config, reload
+ * plugins, rebuild the system prompt, and drop per-session prompt
+ * snapshots. Shared by the `reload_plugins` action (which additionally
+ * hot-swaps MCP servers on the caller's chat) and the gateway's
+ * `POST /plugins/reload` endpoint, which has no chat context. Throws on
+ * failure — each caller renders errors its own way.
+ */
+export async function performPluginReload(
+  backend?: Backend | null,
+): Promise<{ names: string[] }> {
+  const { reloadPlugins, getPluginPromptAdditions } =
+    await import("../../plugin/index.js");
+  const { rebuildSystemPrompt } = await import("../../../util/config.js");
+  const { clearSystemPromptSnapshots } =
+    await import("../../../backend/shared/system-prompt.js");
+
+  // reloadPlugins reads + validates config internally — no double read.
+  // Frontends are derived from config if not explicitly provided.
+  const { names, config: freshConfig } = await reloadPlugins();
+
+  // Rebuild system prompt on the freshConfig, then update the backend's
+  // live config reference so subsequent messages use the new prompt
+  rebuildSystemPrompt(freshConfig, getPluginPromptAdditions());
+  backend?.control?.updateSystemPrompt?.(freshConfig.systemPrompt);
+
+  // Plugin prompt additions changed — drop per-session prompt
+  // snapshots so every chat's next turn picks up the new prompt
+  // (deliberate one-time cache re-write per live session).
+  clearSystemPromptSnapshots();
+
+  return { names };
+}
 
 export const pluginHandlers: SharedActionHandlers = {
   reload_plugins: async (body, chatId, backend) => {
     try {
-      const { reloadPlugins, getPluginPromptAdditions } =
-        await import("../../plugin/index.js");
-      const { rebuildSystemPrompt } = await import("../../../util/config.js");
-      const { clearSystemPromptSnapshots } =
-        await import("../../../backend/shared/system-prompt.js");
-
-      // reloadPlugins reads + validates config internally — no double read.
-      // Frontends are derived from config if not explicitly provided.
-      const { names, config: freshConfig } = await reloadPlugins();
-
-      // Rebuild system prompt on the freshConfig, then update the backend's
-      // live config reference so subsequent messages use the new prompt
-      rebuildSystemPrompt(freshConfig, getPluginPromptAdditions());
-      backend?.control?.updateSystemPrompt?.(freshConfig.systemPrompt);
-
-      // Plugin prompt additions changed — drop per-session prompt
-      // snapshots so every chat's next turn picks up the new prompt
-      // (deliberate one-time cache re-write per live session).
-      clearSystemPromptSnapshots();
+      const { names } = await performPluginReload(backend);
 
       // Hot-swap MCP servers on the active query so new plugin tools
       // are available immediately (not just on the next message)

--- a/src/core/engine/gateway.ts
+++ b/src/core/engine/gateway.ts
@@ -475,6 +475,31 @@ export class Gateway {
           return;
         }
 
+        if (req.method === "POST" && req.url === "/plugins/reload") {
+          // Hot-reload plugins from config — the transport for
+          // `talon plugin install/enable/disable`, which has no chat
+          // context and so cannot use the reload_plugins action. Same
+          // 127.0.0.1 trust boundary as /action.
+          try {
+            const { performPluginReload } = await import(
+              "./gateway-actions/plugins.js"
+            );
+            const { names } = await performPluginReload(this.backend);
+            log("gateway", `/plugins/reload: ${names.length} plugins loaded`);
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: true, loaded: names }));
+          } catch (err) {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                ok: false,
+                error: `Plugin reload failed: ${err instanceof Error ? err.message : err}`,
+              }),
+            );
+          }
+          return;
+        }
+
         if (req.url?.startsWith(HUB_PATH_PREFIX)) {
           // MCP hub — daemon-hosted MCP-over-HTTP endpoints for every
           // backend (see core/mcp-hub). Same 127.0.0.1 trust boundary

--- a/src/core/engine/gateway.ts
+++ b/src/core/engine/gateway.ts
@@ -481,9 +481,8 @@ export class Gateway {
           // context and so cannot use the reload_plugins action. Same
           // 127.0.0.1 trust boundary as /action.
           try {
-            const { performPluginReload } = await import(
-              "./gateway-actions/plugins.js"
-            );
+            const { performPluginReload } =
+              await import("./gateway-actions/plugins.js");
             const { names } = await performPluginReload(this.backend);
             log("gateway", `/plugins/reload: ${names.length} plugins loaded`);
             res.writeHead(200, { "Content-Type": "application/json" });

--- a/src/core/plugin/loader.ts
+++ b/src/core/plugin/loader.ts
@@ -16,8 +16,11 @@ import type {
 import { isMcpPlugin } from "./types.js";
 import { registry, _deps } from "./registry.js";
 
-/** Candidate entry point paths, checked in order. */
-const ENTRY_CANDIDATES = [
+/**
+ * Candidate entry point paths, checked in order. Exported for
+ * `talon plugin install`, which verifies a module before adding it.
+ */
+export const ENTRY_CANDIDATES = [
   "src/index.ts",
   "dist/index.js",
   "index.ts",
@@ -35,6 +38,15 @@ export async function loadPlugins(
   activeFrontends?: string[],
 ): Promise<void> {
   for (const entry of pluginConfigs) {
+    // Disabled entries stay in config (so `talon plugin enable` can restore
+    // them) but are never loaded or registered.
+    if (entry.enabled === false) {
+      log(
+        "plugin",
+        `Skipped disabled plugin: ${isMcpPlugin(entry) ? entry.name : entry.path}`,
+      );
+      continue;
+    }
     // Standalone MCP servers are registered for getPluginMcpServers, not loaded as modules
     if (isMcpPlugin(entry)) {
       if (registry.registerMcpEntry(entry)) {

--- a/src/core/plugin/types.ts
+++ b/src/core/plugin/types.ts
@@ -8,6 +8,8 @@ import type { ActionResult } from "../types.js";
 export interface PluginPathEntry {
   path: string;
   config?: Record<string, unknown>;
+  /** `false` keeps the entry in config but skips loading it. Default true. */
+  enabled?: boolean;
 }
 
 /** Standalone MCP server entry (command + args, not a loadable module). */
@@ -16,6 +18,8 @@ export interface PluginMcpEntry {
   command: string;
   args?: string[];
   env?: Record<string, string>;
+  /** `false` keeps the entry in config but skips registering it. Default true. */
+  enabled?: boolean;
 }
 
 /** Configuration entry for a plugin in config.json. */

--- a/src/storage/skill-store.ts
+++ b/src/storage/skill-store.ts
@@ -327,8 +327,7 @@ export function setSkillEnabled(name: string, enabled: boolean): boolean {
 }
 
 export type SkillInstallResult =
-  | { ok: true; skill: Skill }
-  | { ok: false; error: string };
+  { ok: true; skill: Skill } | { ok: false; error: string };
 
 /**
  * Install a skill from a folder containing SKILL.md (plus any bundled
@@ -387,7 +386,10 @@ export function installSkillFromDir(
   cpSync(sourceDir, target, { recursive: true });
   const skill = readSkill(parsed.name);
   if (!skill) {
-    return { ok: false, error: `Install of "${parsed.name}" failed to read back` };
+    return {
+      ok: false,
+      error: `Install of "${parsed.name}" failed to read back`,
+    };
   }
   return { ok: true, skill };
 }

--- a/src/storage/skill-store.ts
+++ b/src/storage/skill-store.ts
@@ -15,12 +15,14 @@
  */
 
 import {
+  cpSync,
   existsSync,
   mkdirSync,
   readFileSync,
   readdirSync,
   rmSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { basename, resolve } from "node:path";
@@ -33,6 +35,12 @@ export type Skill = {
   body: string;
   path: string;
   updatedAt: number;
+  /**
+   * Disabled skills (a `.disabled` marker file in the folder) drop out of
+   * the prompt index and `find_skills`, but stay listable and readable —
+   * the toggle hides, it never restricts.
+   */
+  enabled: boolean;
   /** Relative filenames bundled in the skill folder (excludes SKILL.md). */
   resources: string[];
   /** Frontmatter keys beyond name/description, preserved on read. */
@@ -46,6 +54,12 @@ export type SkillSearchResult = {
 };
 
 const SKILL_FILE = "SKILL.md";
+/**
+ * Marker file for `talon skill disable`. Lives beside SKILL.md rather than
+ * in frontmatter because `save_skill` rewrites SKILL.md wholesale — a
+ * sibling file survives every update, and is visible in the filesystem.
+ */
+const DISABLED_FILE = ".disabled";
 const NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
 const DESCRIPTION_MAX_CHARS = 300;
 const BODY_MAX_BYTES = 128 * 1024;
@@ -109,7 +123,10 @@ function serializeSkill(input: {
   return ["---", yaml, "---", "", input.body.trimEnd(), ""].join("\n");
 }
 
-function parseSkill(path: string, raw: string): Omit<Skill, "resources"> {
+function parseSkill(
+  path: string,
+  raw: string,
+): Omit<Skill, "resources" | "enabled"> {
   const fallbackName = basename(resolve(path, ".."));
   if (!raw.startsWith("---\n")) {
     return {
@@ -174,7 +191,12 @@ function parseSkill(path: string, raw: string): Omit<Skill, "resources"> {
 function listResources(dir: string): string[] {
   try {
     return readdirSync(dir, { withFileTypes: true })
-      .filter((entry) => entry.isFile() && entry.name !== SKILL_FILE)
+      .filter(
+        (entry) =>
+          entry.isFile() &&
+          entry.name !== SKILL_FILE &&
+          entry.name !== DISABLED_FILE,
+      )
       .map((entry) => entry.name)
       .sort((a, b) => a.localeCompare(b));
   } catch {
@@ -207,7 +229,11 @@ export function readSkill(name: string): Skill | undefined {
   if (!existsSync(path)) return undefined;
   const raw = readFileSync(path, "utf-8");
   const parsed = parseSkill(path, raw);
-  const skill: Skill = { ...parsed, resources: listResources(dir) };
+  const skill: Skill = {
+    ...parsed,
+    enabled: !existsSync(resolve(dir, DISABLED_FILE)),
+    resources: listResources(dir),
+  };
   try {
     skill.updatedAt = Math.floor(statSync(path).mtimeMs);
   } catch {
@@ -271,6 +297,7 @@ export function searchSkills(
   const tokens = tokenizeQuery(query);
   if (tokens.length === 0) return [];
   return listSkills()
+    .filter((skill) => skill.enabled)
     .map((skill) => ({
       skill,
       score: scoreSkill(skill, tokens),
@@ -281,6 +308,88 @@ export function searchSkills(
       (a, b) => b.score - a.score || a.skill.name.localeCompare(b.skill.name),
     )
     .slice(0, Math.max(1, Math.min(50, limit)));
+}
+
+/**
+ * Toggle a skill's enabled state via the `.disabled` marker. Idempotent.
+ * Returns false when the skill doesn't exist (or the name is invalid).
+ */
+export function setSkillEnabled(name: string, enabled: boolean): boolean {
+  if (validateSkillName(name)) return false;
+  if (!existsSync(skillFilePath(name))) return false;
+  const marker = resolve(skillDir(name), DISABLED_FILE);
+  if (enabled) {
+    if (existsSync(marker)) unlinkSync(marker);
+  } else {
+    writeFileSync(marker, "", { encoding: "utf-8", mode: 0o600 });
+  }
+  return true;
+}
+
+export type SkillInstallResult =
+  | { ok: true; skill: Skill }
+  | { ok: false; error: string };
+
+/**
+ * Install a skill from a folder containing SKILL.md (plus any bundled
+ * resources) — the store half of `talon skill install`. The target folder
+ * name is the frontmatter `name`, so a checkout's directory name never
+ * leaks into the store. Refuses to overwrite an existing skill unless
+ * `force`, in which case the old folder (including its `.disabled` marker)
+ * is replaced wholesale.
+ */
+export function installSkillFromDir(
+  sourceDir: string,
+  options: { force?: boolean } = {},
+): SkillInstallResult {
+  const sourceFile = resolve(sourceDir, SKILL_FILE);
+  if (!existsSync(sourceFile)) {
+    return { ok: false, error: `No ${SKILL_FILE} in ${sourceDir}` };
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(sourceFile, "utf-8");
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Could not read ${sourceFile}: ${err instanceof Error ? err.message : err}`,
+    };
+  }
+
+  const parsed = parseSkill(sourceFile, raw);
+  const invalid =
+    validateSkillName(parsed.name) ??
+    validateSkillDescription(parsed.description) ??
+    validateSkillBody(parsed.body);
+  if (invalid) return { ok: false, error: `Invalid skill: ${invalid}` };
+
+  const target = skillDir(parsed.name);
+  // Installing the store's own folder onto itself would delete the source
+  // before the copy (rmSync + cpSync) — refuse rather than lose the skill.
+  if (resolve(sourceDir) === target) {
+    return {
+      ok: false,
+      error: `"${parsed.name}" is already the installed copy (${target})`,
+    };
+  }
+  if (existsSync(target)) {
+    if (!options.force) {
+      return {
+        ok: false,
+        error: `Skill "${parsed.name}" already exists (use --force to replace)`,
+      };
+    }
+    rmSync(target, { recursive: true, force: true });
+  }
+
+  mkdirSync(skillsDir(), { recursive: true });
+  cpSync(sourceDir, target, { recursive: true });
+  const skill = readSkill(parsed.name);
+  if (!skill) {
+    return { ok: false, error: `Install of "${parsed.name}" failed to read back` };
+  }
+  return { ok: true, skill };
 }
 
 export function deleteSkill(name: string): boolean {
@@ -297,7 +406,8 @@ export function formatSkill(skill: Skill): string {
   const updated = skill.updatedAt
     ? new Date(skill.updatedAt).toISOString().slice(0, 10)
     : "unknown";
-  return `- ${skill.name} (updated ${updated}) — ${skill.description}`;
+  const state = skill.enabled ? "" : " [disabled]";
+  return `- ${skill.name} (updated ${updated})${state} — ${skill.description}`;
 }
 
 export function formatSkillSearchResult(result: SkillSearchResult): string {
@@ -307,7 +417,8 @@ export function formatSkillSearchResult(result: SkillSearchResult): string {
 }
 
 export function renderSkillsPrompt(): string {
-  const skills = listSkills();
+  // Disabled skills stay out of the index; `list_skills` still shows them.
+  const skills = listSkills().filter((skill) => skill.enabled);
   if (skills.length === 0) return "";
   const visible = skills.slice(0, PROMPT_LIST_LIMIT);
   const hidden = skills.length - visible.length;

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -34,6 +34,7 @@ const pluginPathSchema = z
   .object({
     path: z.string(),
     config: z.record(z.string(), z.unknown()).optional(),
+    enabled: z.boolean().optional(),
   })
   .strict();
 
@@ -44,6 +45,7 @@ const pluginMcpSchema = z
     command: z.string(),
     args: z.array(z.string()).optional(),
     env: z.record(z.string(), z.string()).optional(),
+    enabled: z.boolean().optional(),
   })
   .strict();
 

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -55,6 +55,11 @@ const pluginEntrySchema = z
     command: z.string().optional(),
     args: z.array(z.string()).optional(),
     env: z.record(z.string(), z.string()).optional(),
+    /**
+     * `false` keeps the entry in config but skips loading it — the state
+     * behind `talon plugin enable/disable`. Valid on both entry formats.
+     */
+    enabled: z.boolean().optional(),
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -7,6 +7,7 @@
  * Layout:
  *   ~/.talon/
  *     config.json              Main configuration
+ *     plugins/                 CLI-installed plugins (npm prefix / git clones)
  *     data/                    Internal state
  *       talon.db               SQLite — all structured state (sessions,
  *                              history, settings, media, goals, scripts,
@@ -71,6 +72,8 @@ export const dirs = {
   skills: resolve(TALON_ROOT, "workspace", "skills"),
   /** Key material (bridge TLS identity, release keys): ~/.talon/keys/ */
   keys: resolve(TALON_ROOT, "keys"),
+  /** CLI-installed plugins (`talon plugin install`): ~/.talon/plugins/ */
+  plugins: resolve(TALON_ROOT, "plugins"),
 } as const;
 
 // ── Files ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

`talon plugin` and `talon skill` command groups — PR 1 of the plugin/skill management track (CLI + seams; bridge endpoints and Companion sub-menus follow).

```bash
talon plugin install @scope/my-talon-plugin    # npm → module under ~/.talon/plugins
talon plugin install some-mcp-server --mcp     # npm → standalone npx MCP entry
talon plugin install owner/repo                # git → module (staged + validated)
talon plugin list | enable <n> | disable <n> | remove <n>

talon skill install anthropics/skills/document-skills/pdf
talon skill list | enable <n> | disable <n> | remove <n>
```

## Seams

- **Plugin entries** get an optional `enabled` flag (zod schema + `PluginEntry` types); the loader skips disabled entries but keeps them in config. Built-ins (`github`, `mempalace`, `mem0`, `playwright`) toggle their existing `<section>.enabled` through the same verbs.
- **Skills** get a `.disabled` marker beside `SKILL.md` — survives `save_skill` updates (which rewrite only SKILL.md). Disabled skills leave the prompt index and `find_skills` but stay listable (`[disabled]`) and readable via `read_skill`: the toggle hides, it never restricts. `installSkillFromDir` validates frontmatter and installs a folder under its frontmatter name (self-install guard included so `--force` can't delete the store's own copy).
- **Gateway** gains `POST /plugins/reload` (chat-independent half of `reload_plugins`, extracted as `performPluginReload`) so CLI mutations hot-reload a running daemon; daemon down → change applies on next start.

## Cross-platform

All tools (`git`, `npm`) spawn via cross-spawn (Windows `.cmd`/`.exe` shims, no POSIX shell assumptions); path handling uses `node:path` throughout, including a cross-drive-safe managed-path check for `remove` cleanup.

## Testing

- New: `skill-lifecycle.test.ts` (marker/enable/install, 12 tests), `cli-plugin-entries.test.ts` (pure helpers + source grammar), disabled-entry cases in `plugin.test.ts`.
- Full suite: 3922 passed / 0 failed; tsc + oxlint clean.
- Smoke-tested both command groups end-to-end against a scratch `TALON_HOME` (install → disable → list → enable → remove, plus `--mcp` and built-in toggles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)