### PR TITLE
feat(core): VFS — unified talon:// namespace with /proc-style live mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Multi-platform agentic AI harness. Runs on **Telegram**, **Discord**, **Microsof
 | **Triggers**          | Self-authored watcher scripts (bash/python/node) that wake the bot when conditions are met                                                   |
 | **Task table**        | Every unit of agent work — chat turns, heartbeat, dream, isolated cron/trigger jobs — registered live; `talon ps` / `talon kill`             |
 | **Event bus**         | Typed internal pub-sub spine (task + turn lifecycle events); subsystems subscribe instead of importing each other; `talon events -f`         |
+| **VFS**               | Unified `talon://` namespace over workspace, skills, scripts, logs, plus /proc-style live views of the task table, event bus, and plugin registry; `talon ls` / `talon cat` |
 | **Per-chat settings** | Model, effort level, and pulse toggle per conversation via inline keyboard                                                                   |
 | **Model registry**    | Models discovered from the active backend at startup — new models appear in all pickers automatically                                        |
 

--- a/docs/vfs.md
+++ b/docs/vfs.md
@@ -40,6 +40,40 @@ filesystem with the tree mounted twice.
 (a registry view has nothing meaningful to write); nothing here restricts
 the agent, and nothing should be added that does.
 
+## The address grammar
+
+An address reaches the namespace in one of three spellings, resolved by
+one grammar (`Vfs.#parse`) — the grammar is total, so a spelling can never
+silently route to the wrong tree:
+
+| Spelling       | Example                       | Interpretation |
+| -------------- | ----------------------------- | -------------- |
+| scheme         | `talon://home/notes.md`       | always namespace |
+| mount-relative | `home/notes.md`               | namespace, routed by first segment |
+| OS-absolute    | `<workspace>/notes.md`        | routed through the mount table by containment (longest disk root wins), exactly like a kernel resolving through its mounts |
+
+File-backed mounts carry their disk root (`VfsMount.osRoot`) — the single
+fact that makes addresses bidirectional:
+
+- **OS → namespace**: an absolute path inside a mounted directory is the
+  same node as its `talon://` spelling and resolves to it. Outside every
+  mount, the resolver refuses (`not-found`) and names the mounted disk
+  roots — it never guesses.
+- **Namespace → OS**: `Vfs.locate(address)` answers where an address
+  lives on disk (`undefined` for synthetic nodes). The native
+  `read`/`write`/`edit`/`glob`/`search` tools use it, so they accept
+  `talon://` addresses: disk-backed nodes operate on the real file,
+  synthetic reads are served from the namespace, synthetic mutation
+  refuses honestly. Stats carry `osPath`, and the root listing shows each
+  mount's disk location.
+
+The one genuine boundary is the shell: `bash` hands paths to the OS, which
+has no `talon://`. The mapping is data, not tribal knowledge — the root
+listing (`talon ls`, `vfs_list ""`) prints `mount → disk root`, and a
+`too-large` read names the disk path to fall back to. Teleported chats
+refuse `talon://` addresses outright: the namespace names daemon state,
+and a teleported tool's paths belong to the device.
+
 ## Reads are bounded
 
 `read` serves UTF-8 text up to 256 KB and refuses binaries (null-byte

--- a/docs/vfs.md
+++ b/docs/vfs.md
@@ -1,0 +1,65 @@
+# VFS — the `talon://` namespace
+
+> Status: **implemented** (`src/core/vfs/`). One rooted, mountable
+> namespace over everything the daemon owns — real file stores and
+> synthetic views of live state answer the same four operations, in the
+> Plan 9 "everything is a file" tradition.
+
+## The model
+
+A **mount** is one store exposed under a single-segment name. The resolver
+owns the path discipline (scheme stripping, `/` separators on every
+platform, traversal rejection, routing by first segment); mounts only ever
+see clean mount-relative paths and answer `stat / list / read / write?`.
+Every operation returns a result with an errno-style code (`not-found`,
+`is-a-directory`, `not-writable`, `too-large`, `binary-file`, …) — no
+throws across the seam.
+
+| Mount      | Backing                                   | Writable |
+| ---------- | ----------------------------------------- | -------- |
+| `home/`    | the workspace (agent's home directory)    | yes      |
+| `skills/`  | SKILL.md bundles (`workspace/skills/`)    | yes      |
+| `scripts/` | agent script bodies                       | yes      |
+| `logs/`    | daily interaction logs                    | no — daemon-written |
+| `proc/`    | task table (`proc/tasks/<id>`) + event bus ring (`proc/events`) | no — synthetic |
+| `plugins/` | plugin registry view, one JSON file each  | no — synthetic |
+
+The synthetic mounts are the point: `proc/` is the only way to read live
+daemon state as plain files (`proc/tasks/17` is one task record as pretty
+JSON; `proc/events` is the bus ring as JSON Lines). Content-free by the
+same contract as the task table and bus — ids, kinds, labels, never
+message text.
+
+The namespace unifies access; it does not move data. Stores keep their
+formats and their richer dedicated tools (`save_skill` validates, the VFS
+write is raw). `home/` deliberately overlaps `skills/`/`scripts/`/`logs/`
+(they live inside the workspace) — same files, two names, as on any
+filesystem with the tree mounted twice.
+
+**Not a permission layer.** Mounts declare what is mechanically writable
+(a registry view has nothing meaningful to write); nothing here restricts
+the agent, and nothing should be added that does.
+
+## Reads are bounded
+
+`read` serves UTF-8 text up to 256 KB and refuses binaries (null-byte
+sniff) — a namespace read is a context payload, not a file transfer.
+Media stays with the media tools.
+
+## Surfaces
+
+- **Tools (gateway actions)** — `vfs_list`, `vfs_read`, `vfs_write`
+  (tag `vfs`), available to every backend through the shared action path.
+- **HTTP (gateway, 127.0.0.1)** — `GET /vfs/list?path=` and
+  `GET /vfs/read?path=`; same trust boundary as `/action`.
+- **CLI** — `talon ls [path]` and `talon cat <path>`. A running daemon
+  answers with live `proc/`/`plugins/` state; with the daemon down the CLI
+  serves the namespace in-process, so file mounts always work.
+
+## Growing the namespace
+
+A mount is ~50 lines against `VfsMount`; the resolver, tools, endpoints,
+and CLI come for free. Planned next: read-only sqlite views
+(`chats/<id>/history`, `media/`) and a `plugins/` upgrade to config-aware
+entries once the plugin manager lands. Synthetic mounts take injected
+providers (see `createProcMount`) so they stay testable with fixtures.

--- a/src/__tests__/native-vfs-address.test.ts
+++ b/src/__tests__/native-vfs-address.test.ts
@@ -119,10 +119,7 @@ describe("native tools on talon:// addresses", () => {
   });
 
   it("surfaces address errors from the resolver", async () => {
-    const res = await nativeHandlers.native_read(
-      { path: "talon://nope/x" },
-      1,
-    );
+    const res = await nativeHandlers.native_read({ path: "talon://nope/x" }, 1);
     expect(res.ok).toBe(false);
     expect(res.text).toContain("not-found");
   });

--- a/src/__tests__/native-vfs-address.test.ts
+++ b/src/__tests__/native-vfs-address.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Native fs tools × talon:// addresses — the OS side of the address
+ * grammar. read/write/edit/glob/search accept namespace addresses:
+ * disk-backed nodes translate to their real location, synthetic nodes are
+ * served (reads) or refused (mutation), and teleport refuses the
+ * combination outright rather than resolving against the wrong filesystem.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+let workspaceDir: string;
+vi.mock("../util/paths.js", async () => {
+  const real =
+    await vi.importActual<typeof import("../util/paths.js")>(
+      "../util/paths.js",
+    );
+  return {
+    ...real,
+    dirs: new Proxy(real.dirs, {
+      get(target, prop: string) {
+        if (prop === "workspace") return workspaceDir;
+        if (prop === "skills") return join(workspaceDir, "skills");
+        if (prop === "scripts") return join(workspaceDir, "scripts");
+        if (prop === "logs") return join(workspaceDir, "logs");
+        return target[prop as keyof typeof target];
+      },
+    }),
+  };
+});
+
+import { nativeHandlers } from "../core/engine/gateway-actions/native.js";
+import {
+  clearTeleport,
+  resetTeleportCache,
+  setTeleport,
+} from "../core/mesh/teleport.js";
+
+beforeAll(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "talon-native-vfs-"));
+  process.env.TALON_TELEPORT_STATE_FILE = join(workspaceDir, "teleport.json");
+});
+
+afterAll(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("native tools on talon:// addresses", () => {
+  it("reads a disk-backed address through its real location", async () => {
+    mkdirSync(join(workspaceDir, "notes"), { recursive: true });
+    writeFileSync(join(workspaceDir, "notes", "a.md"), "alpha\nbeta");
+    const res = await nativeHandlers.native_read(
+      { path: "talon://home/notes/a.md" },
+      1,
+    );
+    expect(res.ok).toBe(true);
+    expect(res.text).toContain(
+      `talon://home/notes/a.md → ${join(workspaceDir, "notes", "a.md")}`,
+    );
+    expect(res.text).toContain("alpha");
+  });
+
+  it("writes and edits through the namespace address", async () => {
+    const written = await nativeHandlers.native_write(
+      { path: "talon://home/deep/new.md", content: "v1" },
+      1,
+    );
+    expect(written.ok).toBe(true);
+    expect(readFileSync(join(workspaceDir, "deep", "new.md"), "utf8")).toBe(
+      "v1",
+    );
+
+    const edited = await nativeHandlers.native_edit(
+      { path: "talon://home/deep/new.md", old_string: "v1", new_string: "v2" },
+      1,
+    );
+    expect(edited.ok).toBe(true);
+    expect(readFileSync(join(workspaceDir, "deep", "new.md"), "utf8")).toBe(
+      "v2",
+    );
+  });
+
+  it("serves synthetic reads from the namespace and refuses mutation", async () => {
+    const read = await nativeHandlers.native_read(
+      { path: "talon://proc/events" },
+      1,
+    );
+    expect(read.ok).toBe(true);
+    expect(read.text).toContain("talon://proc/events [local]");
+
+    const write = await nativeHandlers.native_write(
+      { path: "talon://proc/events", content: "x" },
+      1,
+    );
+    expect(write.ok).toBe(false);
+    expect(write.text).toContain("synthetic");
+
+    const edit = await nativeHandlers.native_edit(
+      { path: "talon://plugins/x", old_string: "a", new_string: "b" },
+      1,
+    );
+    expect(edit.ok).toBe(false);
+    expect(edit.text).toContain("synthetic");
+  });
+
+  it("surfaces address errors from the resolver", async () => {
+    const res = await nativeHandlers.native_read(
+      { path: "talon://nope/x" },
+      1,
+    );
+    expect(res.ok).toBe(false);
+    expect(res.text).toContain("not-found");
+  });
+
+  it("globs and searches under a namespace root", async () => {
+    writeFileSync(join(workspaceDir, "findme.ts"), "const needle = 1;\n");
+    const globbed = await nativeHandlers.native_glob(
+      { pattern: "findme.ts", path: "talon://home" },
+      1,
+    );
+    expect(globbed.ok).toBe(true);
+    expect(globbed.text).toContain("findme.ts");
+
+    const searched = await nativeHandlers.native_search(
+      { pattern: "needle", path: "talon://home" },
+      1,
+    );
+    expect(searched.ok).toBe(true);
+    expect(searched.text).toContain("findme.ts");
+
+    const synthetic = await nativeHandlers.native_search(
+      { pattern: "x", path: "talon://proc" },
+      1,
+    );
+    expect(synthetic.ok).toBe(false);
+    expect(synthetic.text).toContain("vfs_list");
+  });
+
+  it("refuses namespace addresses while teleported", async () => {
+    await setTeleport(7, "device-1", "Pixel");
+    try {
+      const res = await nativeHandlers.native_read(
+        { path: "talon://home/x" },
+        7,
+      );
+      expect(res.ok).toBe(false);
+      expect(res.text).toContain("teleport_back");
+    } finally {
+      await clearTeleport(7);
+      resetTeleportCache();
+    }
+  });
+});

--- a/src/__tests__/vfs-actions.test.ts
+++ b/src/__tests__/vfs-actions.test.ts
@@ -1,0 +1,105 @@
+/**
+ * VFS gateway actions — what the model sees through vfs_list / vfs_read /
+ * vfs_write. Uses the real default namespace (built lazily on the first
+ * handler call, after beforeAll has pointed paths at a temp workspace).
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+let workspaceDir: string;
+vi.mock("../util/paths.js", async () => {
+  const real =
+    await vi.importActual<typeof import("../util/paths.js")>(
+      "../util/paths.js",
+    );
+  return {
+    ...real,
+    dirs: new Proxy(real.dirs, {
+      get(target, prop: string) {
+        if (prop === "workspace") return workspaceDir;
+        if (prop === "skills") return join(workspaceDir, "skills");
+        if (prop === "scripts") return join(workspaceDir, "scripts");
+        if (prop === "logs") return join(workspaceDir, "logs");
+        return target[prop as keyof typeof target];
+      },
+    }),
+  };
+});
+
+import { vfsHandlers } from "../core/engine/gateway-actions/vfs.js";
+
+beforeAll(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "talon-vfs-actions-"));
+});
+
+afterAll(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+async function call(
+  action: "vfs_list" | "vfs_read" | "vfs_write",
+  body: Record<string, unknown>,
+) {
+  return vfsHandlers[action]!(body, 0);
+}
+
+describe("vfs gateway actions", () => {
+  it("lists the namespace root with all default mounts", async () => {
+    const result = await call("vfs_list", { path: "" });
+    expect(result.ok).toBe(true);
+    expect(result.text).toContain("(6 entries)");
+    for (const mount of ["home/", "skills/", "proc/", "plugins/"]) {
+      expect(result.text).toContain(mount);
+    }
+  });
+
+  it("round-trips a write through the home mount", async () => {
+    const written = await call("vfs_write", {
+      path: "home/notes/idea.md",
+      content: "remember this",
+    });
+    expect(written.ok).toBe(true);
+    expect(written.text).toContain("talon://home/notes/idea.md");
+
+    const read = await call("vfs_read", { path: "home/notes/idea.md" });
+    expect(read).toMatchObject({ ok: true, text: "remember this" });
+
+    const listed = await call("vfs_list", { path: "home/notes" });
+    expect(listed.ok).toBe(true);
+    expect(listed.text).toContain("idea.md");
+  });
+
+  it("surfaces errno-style failures as tool errors", async () => {
+    const missing = await call("vfs_read", { path: "home/nope.md" });
+    expect(missing.ok).toBe(false);
+    expect(missing.error).toContain("not-found");
+
+    const readonly = await call("vfs_write", {
+      path: "proc/tasks/1",
+      content: "x",
+    });
+    expect(readonly.ok).toBe(false);
+    expect(readonly.error).toContain("not-writable");
+
+    const traversal = await call("vfs_list", { path: "home/../secrets" });
+    expect(traversal.ok).toBe(false);
+    expect(traversal.error).toContain("invalid-path");
+  });
+
+  it("exposes live proc structure through the same tools", async () => {
+    const listed = await call("vfs_list", { path: "proc" });
+    expect(listed.ok).toBe(true);
+    expect(listed.text).toContain("tasks/");
+    expect(listed.text).toContain("events");
+  });
+});

--- a/src/__tests__/vfs-actions.test.ts
+++ b/src/__tests__/vfs-actions.test.ts
@@ -96,6 +96,23 @@ describe("vfs gateway actions", () => {
     expect(traversal.error).toContain("invalid-path");
   });
 
+  it("accepts the OS spelling of a mounted path", async () => {
+    const written = await call("vfs_write", {
+      path: join(workspaceDir, "os-spelled.md"),
+      content: "hello",
+    });
+    expect(written.ok).toBe(true);
+
+    const read = await call("vfs_read", { path: "home/os-spelled.md" });
+    expect(read).toMatchObject({ ok: true, text: "hello" });
+  });
+
+  it("shows disk mappings for file mounts at the root", async () => {
+    const result = await call("vfs_list", { path: "" });
+    expect(result.ok).toBe(true);
+    expect(result.text).toContain(`home/  → ${workspaceDir}`);
+  });
+
   it("exposes live proc structure through the same tools", async () => {
     const listed = await call("vfs_list", { path: "proc" });
     expect(listed.ok).toBe(true);

--- a/src/__tests__/vfs.test.ts
+++ b/src/__tests__/vfs.test.ts
@@ -43,13 +43,18 @@ describe("resolver", () => {
     expect(listed.ok).toBe(true);
     if (!listed.ok) return;
     expect(listed.value.map((entry) => entry.name)).toEqual(["home"]);
-    expect(listed.value[0]).toMatchObject({ kind: "dir", writable: true });
+    expect(listed.value[0]).toMatchObject({
+      kind: "dir",
+      writable: true,
+      osPath: root,
+    });
   });
 
   it("strips the talon:// scheme and tolerates slash noise", () => {
     writeFileSync(join(root, "a.txt"), "hi");
     expect(vfs.read("talon://home/a.txt")).toEqual({ ok: true, value: "hi" });
-    expect(vfs.read("/home//a.txt/")).toEqual({ ok: true, value: "hi" });
+    expect(vfs.read("home//a.txt/")).toEqual({ ok: true, value: "hi" });
+    expect(vfs.read("talon://home//a.txt/")).toEqual({ ok: true, value: "hi" });
   });
 
   it("rejects traversal segments and backslashes", () => {
@@ -81,6 +86,13 @@ describe("resolver", () => {
     });
   });
 
+  it("addresses the namespace root as bare separators", () => {
+    const listed = vfs.list("/");
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(listed.value.map((entry) => entry.name)).toEqual(["home"]);
+  });
+
   it("rejects duplicate and invalid mount names", () => {
     expect(() =>
       vfs.mount(
@@ -94,6 +106,122 @@ describe("resolver", () => {
         createFileMount({ root, description: "bad", writable: false }),
       ),
     ).toThrow(/Invalid mount name/);
+  });
+});
+
+describe("address grammar — OS-absolute spellings", () => {
+  it("routes an OS path inside a mount root to the same node", () => {
+    writeFileSync(join(root, "a.txt"), "hi");
+    expect(vfs.read(join(root, "a.txt"))).toEqual({ ok: true, value: "hi" });
+
+    const stat = vfs.stat(join(root, "a.txt"));
+    expect(stat).toMatchObject({
+      ok: true,
+      value: { path: "home/a.txt", kind: "file" },
+    });
+
+    const written = vfs.write(join(root, "notes", "new.md"), "content");
+    expect(written).toMatchObject({
+      ok: true,
+      value: { path: "home/notes/new.md" },
+    });
+    expect(vfs.read("home/notes/new.md")).toEqual({
+      ok: true,
+      value: "content",
+    });
+  });
+
+  it("routes the mount root's own OS path to the mount", () => {
+    expect(vfs.stat(root)).toMatchObject({
+      ok: true,
+      value: { path: "home", kind: "dir" },
+    });
+  });
+
+  it("prefers the most specific mount for nested disk roots", () => {
+    mkdirSync(join(root, "notes"));
+    writeFileSync(join(root, "notes", "b.md"), "nested");
+    vfs.mount(
+      "sub",
+      createFileMount({
+        root: join(root, "notes"),
+        description: "nested",
+        writable: true,
+      }),
+    );
+    expect(vfs.stat(join(root, "notes", "b.md"))).toMatchObject({
+      ok: true,
+      value: { path: "sub/b.md" },
+    });
+    // Outside the nested root, the outer mount still claims the path.
+    writeFileSync(join(root, "top.txt"), "t");
+    expect(vfs.stat(join(root, "top.txt"))).toMatchObject({
+      ok: true,
+      value: { path: "home/top.txt" },
+    });
+  });
+
+  it("refuses OS paths outside every mount, naming the disk roots", () => {
+    const outside = vfs.read(`${root}-elsewhere${join("/", "x.txt")}`);
+    expect(outside.ok).toBe(false);
+    if (outside.ok) return;
+    expect(outside.error).toBe("not-found");
+    expect(outside.detail).toContain("Mounts on disk");
+    expect(outside.detail).toContain(root);
+  });
+
+  it("suggests the namespace respelling when the OS path shadows a mount", () => {
+    const result = vfs.read("/home/nope.txt");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("not-found");
+    expect(result.detail).toContain('did you mean "talon://home/nope.txt"');
+  });
+
+  it("refuses unexpanded tildes with guidance", () => {
+    expect(vfs.read("~/notes.md")).toMatchObject({
+      ok: false,
+      error: "invalid-path",
+      detail: expect.stringContaining("not expanded"),
+    });
+  });
+
+  it("never routes a foreign drive spelling against this host", () => {
+    const result = vfs.read("C:/definitely/not/mounted.txt");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("not-found");
+  });
+});
+
+describe("locate — namespace → disk", () => {
+  it("maps file-mount addresses to absolute paths, existing or not", () => {
+    expect(vfs.locate("home/a.txt")).toEqual({
+      ok: true,
+      value: join(root, "a.txt"),
+    });
+    expect(vfs.locate("talon://home/deep/unborn.md")).toEqual({
+      ok: true,
+      value: join(root, "deep", "unborn.md"),
+    });
+    expect(vfs.locate("home")).toEqual({ ok: true, value: root });
+  });
+
+  it("answers undefined for synthetic nodes and the root", () => {
+    vfs.mount("plugins", createPluginsMount(() => []));
+    expect(vfs.locate("plugins/x")).toEqual({ ok: true, value: undefined });
+    expect(vfs.locate("")).toEqual({ ok: true, value: undefined });
+  });
+
+  it("propagates address errors", () => {
+    expect(vfs.locate("home/../etc")).toMatchObject({
+      ok: false,
+      error: "invalid-path",
+    });
+    expect(vfs.locate("nope/x")).toMatchObject({
+      ok: false,
+      error: "not-found",
+    });
   });
 });
 
@@ -124,6 +252,7 @@ describe("file mount", () => {
       kind: "file",
       size: 5,
       writable: true,
+      osPath: join(root, "a.txt"),
     });
     expect(stat.value.modifiedAt).toBeGreaterThan(0);
   });
@@ -147,6 +276,9 @@ describe("file mount", () => {
     expect(vfs.read("home/big")).toMatchObject({
       ok: false,
       error: "too-large",
+      // The disk location is the escape hatch: OS tools can read what the
+      // namespace's context-sized cap refuses.
+      detail: expect.stringContaining(join(root, "big")),
     });
   });
 

--- a/src/__tests__/vfs.test.ts
+++ b/src/__tests__/vfs.test.ts
@@ -208,7 +208,10 @@ describe("locate — namespace → disk", () => {
   });
 
   it("answers undefined for synthetic nodes and the root", () => {
-    vfs.mount("plugins", createPluginsMount(() => []));
+    vfs.mount(
+      "plugins",
+      createPluginsMount(() => []),
+    );
     expect(vfs.locate("plugins/x")).toEqual({ ok: true, value: undefined });
     expect(vfs.locate("")).toEqual({ ok: true, value: undefined });
   });
@@ -423,7 +426,10 @@ describe("plugins mount", () => {
   ];
 
   beforeEach(() => {
-    vfs.mount("plugins", createPluginsMount(() => views));
+    vfs.mount(
+      "plugins",
+      createPluginsMount(() => views),
+    );
   });
 
   it("lists one file per registered plugin, sorted", () => {

--- a/src/__tests__/vfs.test.ts
+++ b/src/__tests__/vfs.test.ts
@@ -1,0 +1,325 @@
+/**
+ * VFS — resolver path discipline, file mounts, and the synthetic
+ * proc/plugins mounts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Vfs } from "../core/vfs/vfs.js";
+import { createFileMount } from "../core/vfs/mounts/files.js";
+import { createProcMount } from "../core/vfs/mounts/proc.js";
+import {
+  createPluginsMount,
+  type PluginView,
+} from "../core/vfs/mounts/plugins.js";
+import { VFS_MAX_READ_BYTES } from "../core/vfs/types.js";
+import type { TaskRecord } from "../core/tasks/index.js";
+import type { PublishedEvent } from "../core/bus/index.js";
+
+let root: string;
+let vfs: Vfs;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "talon-vfs-"));
+  vfs = new Vfs();
+  vfs.mount(
+    "home",
+    createFileMount({ root, description: "workspace", writable: true }),
+  );
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("resolver", () => {
+  it("lists mounts at the root and stats it as a directory", () => {
+    const stat = vfs.stat("");
+    expect(stat).toMatchObject({ ok: true, value: { kind: "dir" } });
+
+    const listed = vfs.list("");
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(listed.value.map((entry) => entry.name)).toEqual(["home"]);
+    expect(listed.value[0]).toMatchObject({ kind: "dir", writable: true });
+  });
+
+  it("strips the talon:// scheme and tolerates slash noise", () => {
+    writeFileSync(join(root, "a.txt"), "hi");
+    expect(vfs.read("talon://home/a.txt")).toEqual({ ok: true, value: "hi" });
+    expect(vfs.read("/home//a.txt/")).toEqual({ ok: true, value: "hi" });
+  });
+
+  it("rejects traversal segments and backslashes", () => {
+    expect(vfs.read("home/../etc/passwd")).toMatchObject({
+      ok: false,
+      error: "invalid-path",
+    });
+    expect(vfs.list("home\\x")).toMatchObject({
+      ok: false,
+      error: "invalid-path",
+    });
+  });
+
+  it("names the missing mount on unknown roots", () => {
+    expect(vfs.list("nope/x")).toMatchObject({
+      ok: false,
+      error: "not-found",
+    });
+  });
+
+  it("refuses writes to mounts without a write hook", () => {
+    vfs.mount(
+      "ro",
+      createFileMount({ root, description: "ro", writable: false }),
+    );
+    expect(vfs.write("ro/a.txt", "x")).toMatchObject({
+      ok: false,
+      error: "not-writable",
+    });
+  });
+
+  it("rejects duplicate and invalid mount names", () => {
+    expect(() =>
+      vfs.mount(
+        "home",
+        createFileMount({ root, description: "dup", writable: false }),
+      ),
+    ).toThrow(/already registered/);
+    expect(() =>
+      vfs.mount(
+        "Bad Name",
+        createFileMount({ root, description: "bad", writable: false }),
+      ),
+    ).toThrow(/Invalid mount name/);
+  });
+});
+
+describe("file mount", () => {
+  it("lists directories first with sizes and prefixed paths", () => {
+    mkdirSync(join(root, "notes"));
+    writeFileSync(join(root, "a.txt"), "12345");
+    writeFileSync(join(root, "notes", "b.md"), "x");
+
+    const listed = vfs.list("home");
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(listed.value.map((entry) => entry.path)).toEqual([
+      "home/notes",
+      "home/a.txt",
+    ]);
+    expect(listed.value[1]).toMatchObject({ kind: "file", size: 5 });
+  });
+
+  it("stats files with size and mtime", () => {
+    writeFileSync(join(root, "a.txt"), "12345");
+    const stat = vfs.stat("home/a.txt");
+    expect(stat.ok).toBe(true);
+    if (!stat.ok) return;
+    expect(stat.value).toMatchObject({
+      path: "home/a.txt",
+      name: "a.txt",
+      kind: "file",
+      size: 5,
+      writable: true,
+    });
+    expect(stat.value.modifiedAt).toBeGreaterThan(0);
+  });
+
+  it("reads UTF-8 text and refuses directories, binaries, oversize", () => {
+    writeFileSync(join(root, "ok.txt"), "héllo");
+    expect(vfs.read("home/ok.txt")).toEqual({ ok: true, value: "héllo" });
+
+    expect(vfs.read("home")).toMatchObject({
+      ok: false,
+      error: "is-a-directory",
+    });
+
+    writeFileSync(join(root, "bin"), Buffer.from([1, 0, 2]));
+    expect(vfs.read("home/bin")).toMatchObject({
+      ok: false,
+      error: "binary-file",
+    });
+
+    writeFileSync(join(root, "big"), "x".repeat(VFS_MAX_READ_BYTES + 1));
+    expect(vfs.read("home/big")).toMatchObject({
+      ok: false,
+      error: "too-large",
+    });
+  });
+
+  it("writes files, creating parents, and reports the new stat", () => {
+    const written = vfs.write("home/deep/nested/file.md", "content");
+    expect(written.ok).toBe(true);
+    if (!written.ok) return;
+    expect(written.value).toMatchObject({
+      path: "home/deep/nested/file.md",
+      kind: "file",
+      size: 7,
+    });
+    expect(vfs.read("home/deep/nested/file.md")).toEqual({
+      ok: true,
+      value: "content",
+    });
+  });
+
+  it("refuses to write over a directory", () => {
+    mkdirSync(join(root, "dir"));
+    expect(vfs.write("home/dir", "x")).toMatchObject({
+      ok: false,
+      error: "is-a-directory",
+    });
+  });
+
+  it("treats a missing mount root as an empty directory", () => {
+    vfs.mount(
+      "ghost",
+      createFileMount({
+        root: join(root, "does-not-exist"),
+        description: "lazy",
+        writable: true,
+      }),
+    );
+    expect(vfs.list("ghost")).toEqual({ ok: true, value: [] });
+    expect(vfs.stat("ghost")).toMatchObject({
+      ok: true,
+      value: { kind: "dir" },
+    });
+  });
+
+  it("rejects escapes even when handed a crafted relative path directly", () => {
+    const mount = createFileMount({
+      root,
+      description: "direct",
+      writable: true,
+    });
+    expect(mount.read("../outside")).toMatchObject({
+      ok: false,
+      error: "invalid-path",
+    });
+  });
+});
+
+describe("proc mount", () => {
+  const task: TaskRecord = {
+    id: 7,
+    kind: "turn",
+    label: "message",
+    chatId: "123",
+    state: "running",
+    killable: false,
+    queuedAt: 1000,
+    startedAt: 2000,
+  };
+  const event = {
+    type: "task.started",
+    task,
+    id: 1,
+    at: 3000,
+  } as PublishedEvent;
+
+  beforeEach(() => {
+    vfs.mount(
+      "proc",
+      createProcMount({ tasks: () => [task], events: () => [event] }),
+    );
+  });
+
+  it("exposes tasks/ and events at the mount root", () => {
+    const listed = vfs.list("proc");
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(listed.value.map((entry) => entry.path)).toEqual([
+      "proc/tasks",
+      "proc/events",
+    ]);
+  });
+
+  it("serves one JSON file per task", () => {
+    const listed = vfs.list("proc/tasks");
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(listed.value.map((entry) => entry.path)).toEqual(["proc/tasks/7"]);
+
+    const read = vfs.read("proc/tasks/7");
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(JSON.parse(read.value)).toMatchObject({ id: 7, kind: "turn" });
+  });
+
+  it("serves the event ring as JSON Lines with the last event's mtime", () => {
+    const read = vfs.read("proc/events");
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(JSON.parse(read.value.trim())).toMatchObject({
+      type: "task.started",
+      id: 1,
+    });
+
+    const stat = vfs.stat("proc/events");
+    expect(stat.ok).toBe(true);
+    if (!stat.ok) return;
+    expect(stat.value.modifiedAt).toBe(3000);
+  });
+
+  it("errors honestly on missing tasks, wrong node kinds, and writes", () => {
+    expect(vfs.read("proc/tasks/99")).toMatchObject({
+      ok: false,
+      error: "not-found",
+    });
+    expect(vfs.list("proc/events")).toMatchObject({
+      ok: false,
+      error: "not-a-directory",
+    });
+    expect(vfs.read("proc/tasks")).toMatchObject({
+      ok: false,
+      error: "is-a-directory",
+    });
+    expect(vfs.write("proc/tasks/7", "x")).toMatchObject({
+      ok: false,
+      error: "not-writable",
+    });
+  });
+});
+
+describe("plugins mount", () => {
+  const views: PluginView[] = [
+    { name: "github", kind: "module", version: "1.0.0", source: "(built-in)" },
+    { name: "fetch", kind: "mcp", source: "npx -y server-fetch" },
+  ];
+
+  beforeEach(() => {
+    vfs.mount("plugins", createPluginsMount(() => views));
+  });
+
+  it("lists one file per registered plugin, sorted", () => {
+    const listed = vfs.list("plugins");
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(listed.value.map((entry) => entry.name)).toEqual([
+      "fetch",
+      "github",
+    ]);
+  });
+
+  it("reads a plugin as its registry view in JSON", () => {
+    const read = vfs.read("plugins/github");
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(JSON.parse(read.value)).toEqual({
+      name: "github",
+      kind: "module",
+      version: "1.0.0",
+      source: "(built-in)",
+    });
+  });
+
+  it("reports unknown plugins as not-found", () => {
+    expect(vfs.read("plugins/nope")).toMatchObject({
+      ok: false,
+      error: "not-found",
+    });
+  });
+});

--- a/src/cli/fs.ts
+++ b/src/cli/fs.ts
@@ -1,0 +1,123 @@
+/**
+ * `talon ls` / `talon cat` — the talon:// namespace from the outside.
+ *
+ * A running daemon answers through the gateway (`GET /vfs/list|read`) so
+ * the synthetic mounts (proc, plugins) show live state. With no daemon,
+ * the same namespace is served in-process — file mounts work identically,
+ * the synthetic mounts are simply empty — so browsing the workspace never
+ * requires Talon to be up.
+ */
+
+import pc from "picocolors";
+import { findRunningInstance } from "../core/daemon/discovery.js";
+import type { VfsErrorCode, VfsResult, VfsStat } from "../core/vfs/index.js";
+import { fetchGateway } from "./daemon-api.js";
+
+/**
+ * Ask the daemon first (live proc/plugins state), fall back to serving the
+ * namespace in-process. `live` records which one answered.
+ */
+async function query(
+  op: "list" | "read",
+  path: string,
+): Promise<{ result: VfsResult<VfsStat[] | string>; live: boolean }> {
+  const instance = await findRunningInstance();
+  if (instance?.port) {
+    const body = (await fetchGateway(
+      instance.port,
+      `/vfs/${op}?path=${encodeURIComponent(path)}`,
+    )) as {
+      ok: boolean;
+      entries?: VfsStat[];
+      content?: string;
+      error?: string;
+      detail?: string;
+    };
+    const result: VfsResult<VfsStat[] | string> = body.ok
+      ? { ok: true, value: op === "list" ? body.entries! : body.content! }
+      : {
+          ok: false,
+          error: (body.error ?? "io-error") as VfsErrorCode,
+          ...(body.detail !== undefined ? { detail: body.detail } : {}),
+        };
+    return { result, live: true };
+  }
+
+  const { getVfs } = await import("../core/vfs/index.js");
+  const vfs = getVfs();
+  return {
+    result: op === "list" ? vfs.list(path) : vfs.read(path),
+    live: false,
+  };
+}
+
+function printError(path: string, result: { error: string; detail?: string }): void {
+  console.error(
+    `  ${pc.red("✖")} talon://${path}: ${result.error}${result.detail ? ` — ${result.detail}` : ""}`,
+  );
+  process.exitCode = 1;
+}
+
+function formatModified(entry: VfsStat): string {
+  if (entry.modifiedAt === undefined) return "-";
+  return new Date(entry.modifiedAt).toISOString().slice(0, 16).replace("T", " ");
+}
+
+export async function showLs(rawPath: string | undefined): Promise<void> {
+  const path = (rawPath ?? "").trim();
+  console.log();
+  const { result, live } = await query("list", path);
+  if (!result.ok) {
+    printError(path, result);
+    return;
+  }
+  const entries = result.value as VfsStat[];
+
+  if (!live) {
+    console.log(
+      `  ${pc.dim("Talon is not running — file mounts only; proc/ and plugins/ are empty.")}`,
+    );
+  }
+  if (entries.length === 0) {
+    console.log(`  ${pc.dim("(empty)")}\n`);
+    return;
+  }
+
+  const header = ["KIND", "SIZE", "MODIFIED", "NAME"];
+  const cells = entries.map((entry) => [
+    entry.kind === "dir" ? "dir" : "file",
+    entry.kind === "dir" ? "-" : String(entry.size ?? "?"),
+    formatModified(entry),
+    entry.kind === "dir" ? `${entry.name}/` : entry.name,
+  ]);
+  const widths = header.map((h, col) =>
+    Math.max(h.length, ...cells.map((row) => row[col]!.length)),
+  );
+  console.log(
+    `  ${pc.dim(header.map((h, col) => h.padEnd(widths[col]!)).join("  "))}`,
+  );
+  cells.forEach((row, i) => {
+    const padded = row.map((cell, col) => cell.padEnd(widths[col]!));
+    const name = entries[i]!.kind === "dir" ? pc.cyan(padded[3]!) : padded[3]!;
+    console.log(`  ${padded[0]}  ${padded[1]}  ${padded[2]}  ${name}`);
+  });
+  console.log();
+}
+
+export async function showCat(rawPath: string | undefined): Promise<void> {
+  if (!rawPath || !rawPath.trim()) {
+    console.error(
+      `  ${pc.red("✖")} Usage: ${pc.cyan("talon cat <path>")} — e.g. ${pc.cyan("talon cat proc/events")}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const path = rawPath.trim();
+  const { result } = await query("read", path);
+  if (!result.ok) {
+    printError(path, result);
+    return;
+  }
+  // Raw content, no decoration — `talon cat x | jq` must work.
+  process.stdout.write(result.value as string);
+}

--- a/src/cli/fs.ts
+++ b/src/cli/fs.ts
@@ -99,7 +99,14 @@ export async function showLs(rawPath: string | undefined): Promise<void> {
   cells.forEach((row, i) => {
     const padded = row.map((cell, col) => cell.padEnd(widths[col]!));
     const name = entries[i]!.kind === "dir" ? pc.cyan(padded[3]!) : padded[3]!;
-    console.log(`  ${padded[0]}  ${padded[1]}  ${padded[2]}  ${name}`);
+    // Root entries carry the mount's disk location — show the mapping, it's
+    // what shell commands (which can't read talon://) need.
+    const entry = entries[i]!;
+    const mapping =
+      entry.osPath !== undefined && !entry.path.includes("/")
+        ? pc.dim(`  → ${entry.osPath}`)
+        : "";
+    console.log(`  ${padded[0]}  ${padded[1]}  ${padded[2]}  ${name}${mapping}`);
   });
   console.log();
 }

--- a/src/cli/fs.ts
+++ b/src/cli/fs.ts
@@ -51,7 +51,10 @@ async function query(
   };
 }
 
-function printError(path: string, result: { error: string; detail?: string }): void {
+function printError(
+  path: string,
+  result: { error: string; detail?: string },
+): void {
   console.error(
     `  ${pc.red("✖")} talon://${path}: ${result.error}${result.detail ? ` — ${result.detail}` : ""}`,
   );
@@ -60,7 +63,10 @@ function printError(path: string, result: { error: string; detail?: string }): v
 
 function formatModified(entry: VfsStat): string {
   if (entry.modifiedAt === undefined) return "-";
-  return new Date(entry.modifiedAt).toISOString().slice(0, 16).replace("T", " ");
+  return new Date(entry.modifiedAt)
+    .toISOString()
+    .slice(0, 16)
+    .replace("T", " ");
 }
 
 export async function showLs(rawPath: string | undefined): Promise<void> {
@@ -106,7 +112,9 @@ export async function showLs(rawPath: string | undefined): Promise<void> {
       entry.osPath !== undefined && !entry.path.includes("/")
         ? pc.dim(`  → ${entry.osPath}`)
         : "";
-    console.log(`  ${padded[0]}  ${padded[1]}  ${padded[2]}  ${name}${mapping}`);
+    console.log(
+      `  ${padded[0]}  ${padded[1]}  ${padded[2]}  ${name}${mapping}`,
+    );
   });
   console.log();
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -32,6 +32,7 @@ import { startChat } from "./chat.js";
 import { daemonStart, daemonStop, daemonRestart } from "./daemon.js";
 import { showTasks, killTask } from "./tasks.js";
 import { showEvents } from "./events.js";
+import { showLs, showCat } from "./fs.js";
 import { mainMenu } from "./menu.js";
 
 export * from "./context.js";
@@ -60,6 +61,8 @@ const CLI_COMMANDS = [
   "ps",
   "kill",
   "events",
+  "ls",
+  "cat",
 ];
 
 /** Route a `talon <command>` invocation. Called by the entry point. */
@@ -112,6 +115,12 @@ export async function runCli(): Promise<void> {
         process.argv[3] === "-f" || process.argv[3] === "--follow",
       );
       break;
+    case "ls":
+      await showLs(process.argv[3]);
+      break;
+    case "cat":
+      await showCat(process.argv[3]);
+      break;
     case "--version":
     case "-v": {
       console.log(pkg.version);
@@ -133,6 +142,12 @@ export async function runCli(): Promise<void> {
       console.log(`    ${pc.cyan("kill")}       Abort a killable task by id`);
       console.log(
         `    ${pc.cyan("events")}     Tail the event bus (-f follows)`,
+      );
+      console.log(
+        `    ${pc.cyan("ls")}         List the talon:// namespace (ls proc/tasks)`,
+      );
+      console.log(
+        `    ${pc.cyan("cat")}        Read a talon:// file (cat proc/events)`,
       );
       console.log(`    ${pc.cyan("config")}     View/edit configuration`);
       console.log(`    ${pc.cyan("logs")}       Tail log file`);

--- a/src/core/engine/gateway-actions/index.ts
+++ b/src/core/engine/gateway-actions/index.ts
@@ -17,6 +17,7 @@
  *   - `plugins`   — plugin hot-reload
  *   - `models`    — model / backend discovery
  *   - `mesh`      — companion device mesh (presence + location)
+ *   - `vfs`       — the unified talon:// namespace (list/read/write)
  */
 
 import type { ActionResult } from "../../types.js";
@@ -33,6 +34,7 @@ import { pluginHandlers } from "./plugins.js";
 import { modelHandlers } from "./models.js";
 import { meshHandlers } from "./mesh.js";
 import { nativeHandlers } from "./native.js";
+import { vfsHandlers } from "./vfs.js";
 
 // Null-prototype so a request `action` of "toString" / "constructor" / etc.
 // can't resolve an inherited Object.prototype method — `handlers[action]` only
@@ -49,6 +51,7 @@ const handlers: SharedActionHandlers = Object.assign(Object.create(null), {
   ...modelHandlers,
   ...meshHandlers,
   ...nativeHandlers,
+  ...vfsHandlers,
 });
 
 export async function handleSharedAction(

--- a/src/core/engine/gateway-actions/native.ts
+++ b/src/core/engine/gateway-actions/native.ts
@@ -33,6 +33,7 @@ import {
   setTeleport,
   setTeleportCwd,
 } from "../../mesh/teleport.js";
+import { getVfs } from "../../vfs/index.js";
 import {
   clampExecOutput,
   createOutputCapture,
@@ -447,6 +448,65 @@ async function bashTeleported(
   };
 }
 
+// ── talon:// address resolution ─────────────────────────────────────────────
+
+const NAMESPACE_SCHEME = "talon://";
+
+type AddressResolution =
+  | { kind: "disk"; path: string }
+  | { kind: "virtual" }
+  | { kind: "error"; text: string };
+
+/**
+ * Native fs tools accept talon:// addresses: `Vfs.locate` maps them to the
+ * disk location the address names, and the tool then operates on the real
+ * file. Synthetic nodes (proc/, plugins/) have no disk location — reads are
+ * served straight from the namespace, mutation refuses honestly. Teleport
+ * can't cross address spaces: talon:// names daemon state, and a teleported
+ * chat's paths belong to the device, so the combination is refused rather
+ * than resolved against the wrong filesystem.
+ */
+function resolveNamespaceAddress(
+  address: string,
+  teleportedTo: string | undefined,
+): AddressResolution {
+  if (teleportedTo !== undefined) {
+    return {
+      kind: "error",
+      text:
+        `${address} names the daemon's namespace, but native tools are ` +
+        `teleported onto ${teleportedTo} — teleport_back first, or use a device path.`,
+    };
+  }
+  const located = getVfs().locate(address);
+  if (!located.ok) {
+    return {
+      kind: "error",
+      text: `Cannot resolve ${address}: ${located.error}${located.detail ? ` — ${located.detail}` : ""}`,
+    };
+  }
+  return located.value === undefined
+    ? { kind: "virtual" }
+    : { kind: "disk", path: located.value };
+}
+
+/** glob/search root: a talon:// address must name a disk-backed directory. */
+function resolveSearchRoot(
+  path: string | undefined,
+  teleportedTo: string | undefined,
+): { root: string } | { error: string } {
+  const root = path ?? ".";
+  if (!root.startsWith(NAMESPACE_SCHEME)) return { root };
+  const resolved = resolveNamespaceAddress(root, teleportedTo);
+  if (resolved.kind === "error") return { error: resolved.text };
+  if (resolved.kind === "virtual") {
+    return {
+      error: `${root} is a synthetic view with no files on disk — browse it with vfs_list instead.`,
+    };
+  }
+  return { root: resolved.path };
+}
+
 // ── read / write / edit ─────────────────────────────────────────────────────
 
 async function read(
@@ -455,15 +515,38 @@ async function read(
   offset: unknown,
   limit: unknown,
 ): Promise<Result> {
-  const p = str(path);
-  if (!p) return { ok: false, text: "A file path is required." };
+  const address = str(path);
+  if (!address) return { ok: false, text: "A file path is required." };
   const active = await getTeleport(chatId);
   const where = active ? active.deviceName : "local";
+
+  let p = address;
+  let virtualContent: string | undefined;
+  if (address.startsWith(NAMESPACE_SCHEME)) {
+    const resolved = resolveNamespaceAddress(address, active?.deviceName);
+    if (resolved.kind === "error") return { ok: false, text: resolved.text };
+    if (resolved.kind === "disk") {
+      p = resolved.path;
+    } else {
+      const served = getVfs().read(address);
+      if (!served.ok) {
+        return {
+          ok: false,
+          text: `Cannot read ${address}: ${served.error}${served.detail ? ` — ${served.detail}` : ""}`,
+        };
+      }
+      virtualContent = served.value;
+    }
+  }
+  const shown = p === address ? p : `${address} → ${p}`;
 
   // Image files: return a viewable image block, not the raw bytes decoded as
   // UTF-8. Without this, `read`ing a photo/screenshot/design hands the model
   // mojibake and it can't see the picture at all.
-  const mime = IMAGE_MIME[extname(p).toLowerCase()];
+  const mime =
+    virtualContent === undefined
+      ? IMAGE_MIME[extname(p).toLowerCase()]
+      : undefined;
   if (mime) {
     let bytes: Buffer;
     if (active) {
@@ -476,7 +559,7 @@ async function read(
       } catch (err) {
         return {
           ok: false,
-          text: `Cannot read ${p}: ${(err as Error).message}`,
+          text: `Cannot read ${shown}: ${(err as Error).message}`,
         };
       }
     }
@@ -484,14 +567,14 @@ async function read(
       return {
         ok: false,
         text:
-          `${p} [${where}] is ${(bytes.length / 1_048_576).toFixed(1)}MB — over the ` +
+          `${shown} [${where}] is ${(bytes.length / 1_048_576).toFixed(1)}MB — over the ` +
           `${MAX_IMAGE_BYTES / 1_048_576}MB image limit. Downscale it first ` +
           `(e.g. \`convert '${p}' -resize 1568x /tmp/small.jpg\`) and read that.`,
       };
     }
     return {
       ok: true,
-      text: `${p} [${where}] — image (${mime}, ${bytes.length} bytes)`,
+      text: `${shown} [${where}] — image (${mime}, ${bytes.length} bytes)`,
       image: { data: bytes.toString("base64"), mimeType: mime },
     };
   }
@@ -499,7 +582,9 @@ async function read(
   const start = num(offset) ?? 0;
   const max = Math.min(num(limit) ?? MAX_READ_LINES, MAX_READ_LINES);
   let content: string;
-  if (active) {
+  if (virtualContent !== undefined) {
+    content = virtualContent;
+  } else if (active) {
     const res = await getMeshService().readFileBytes(active.deviceId, p);
     if ("error" in res) return { ok: false, text: res.error };
     content = res.data.toString("utf8");
@@ -507,7 +592,10 @@ async function read(
     try {
       content = await readFile(p, "utf8");
     } catch (err) {
-      return { ok: false, text: `Cannot read ${p}: ${(err as Error).message}` };
+      return {
+        ok: false,
+        text: `Cannot read ${shown}: ${(err as Error).message}`,
+      };
     }
   }
   const lines = content.split("\n");
@@ -521,7 +609,7 @@ async function read(
       : "";
   return {
     ok: true,
-    text: `${p} [${where}] — ${lines.length} lines\n${numbered}${more}`,
+    text: `${shown} [${where}] — ${lines.length} lines\n${numbered}${more}`,
   };
 }
 
@@ -530,10 +618,23 @@ async function write(
   path: unknown,
   content: unknown,
 ): Promise<Result> {
-  const p = str(path);
-  if (!p) return { ok: false, text: "A file path is required." };
+  const address = str(path);
+  if (!address) return { ok: false, text: "A file path is required." };
   const body = typeof content === "string" ? content : "";
   const active = await getTeleport(chatId);
+  let p = address;
+  if (address.startsWith(NAMESPACE_SCHEME)) {
+    const resolved = resolveNamespaceAddress(address, active?.deviceName);
+    if (resolved.kind === "error") return { ok: false, text: resolved.text };
+    if (resolved.kind === "virtual") {
+      return {
+        ok: false,
+        text: `${address} is a synthetic view — there is no file on disk to write. Writable mounts: vfs_list "" shows where each lives.`,
+      };
+    }
+    p = resolved.path;
+  }
+  const shown = p === address ? p : `${address} → ${p}`;
   if (active) {
     return getMeshService().writeFileToDevice(active.deviceId, p, body);
   }
@@ -541,9 +642,12 @@ async function write(
     await mkdir(dirname(p), { recursive: true });
     await writeFile(p, body);
   } catch (err) {
-    return { ok: false, text: `Cannot write ${p}: ${(err as Error).message}` };
+    return {
+      ok: false,
+      text: `Cannot write ${shown}: ${(err as Error).message}`,
+    };
   }
-  return { ok: true, text: `Wrote ${body.length} bytes to ${p} [local].` };
+  return { ok: true, text: `Wrote ${body.length} bytes to ${shown} [local].` };
 }
 
 async function edit(
@@ -553,13 +657,26 @@ async function edit(
   newString: unknown,
   replaceAll: unknown,
 ): Promise<Result> {
-  const p = str(path);
-  if (!p) return { ok: false, text: "A file path is required." };
+  const address = str(path);
+  if (!address) return { ok: false, text: "A file path is required." };
   const from = typeof oldString === "string" ? oldString : "";
   const to = typeof newString === "string" ? newString : "";
   if (from === to)
     return { ok: false, text: "old_string and new_string are identical." };
   const active = await getTeleport(chatId);
+  let p = address;
+  if (address.startsWith(NAMESPACE_SCHEME)) {
+    const resolved = resolveNamespaceAddress(address, active?.deviceName);
+    if (resolved.kind === "error") return { ok: false, text: resolved.text };
+    if (resolved.kind === "virtual") {
+      return {
+        ok: false,
+        text: `${address} is a synthetic view — there is no file on disk to edit. Read it with vfs_read instead.`,
+      };
+    }
+    p = resolved.path;
+  }
+  const shown = p === address ? p : `${address} → ${p}`;
   const svc = getMeshService();
 
   let content: string;
@@ -571,7 +688,10 @@ async function edit(
     try {
       content = await readFile(p, "utf8");
     } catch (err) {
-      return { ok: false, text: `Cannot read ${p}: ${(err as Error).message}` };
+      return {
+        ok: false,
+        text: `Cannot read ${shown}: ${(err as Error).message}`,
+      };
     }
   }
 
@@ -579,13 +699,13 @@ async function edit(
   if (count === 0) {
     return {
       ok: false,
-      text: `old_string not found in ${p}.${nearMissHint(content, from)}`,
+      text: `old_string not found in ${shown}.${nearMissHint(content, from)}`,
     };
   }
   if (count > 1 && replaceAll !== true) {
     return {
       ok: false,
-      text: `old_string appears ${count}× in ${p}; pass replace_all or make it unique.`,
+      text: `old_string appears ${count}× in ${shown}; pass replace_all or make it unique.`,
     };
   }
   const updated =
@@ -598,18 +718,21 @@ async function edit(
     return res.ok
       ? {
           ok: true,
-          text: `Edited ${p} [${active.deviceName}] (${count} replacement${count === 1 ? "" : "s"}).`,
+          text: `Edited ${shown} [${active.deviceName}] (${count} replacement${count === 1 ? "" : "s"}).`,
         }
       : res;
   }
   try {
     await writeFile(p, updated);
   } catch (err) {
-    return { ok: false, text: `Cannot write ${p}: ${(err as Error).message}` };
+    return {
+      ok: false,
+      text: `Cannot write ${shown}: ${(err as Error).message}`,
+    };
   }
   return {
     ok: true,
-    text: `Edited ${p} [local] (${count} replacement${count === 1 ? "" : "s"}).`,
+    text: `Edited ${shown} [local] (${count} replacement${count === 1 ? "" : "s"}).`,
   };
 }
 
@@ -622,8 +745,10 @@ async function glob(
 ): Promise<Result> {
   const pat = str(pattern);
   if (!pat) return { ok: false, text: "A glob pattern is required." };
-  const root = str(path) ?? ".";
   const active = await getTeleport(chatId);
+  const rooted = resolveSearchRoot(str(path), active?.deviceName);
+  if ("error" in rooted) return { ok: false, text: rooted.error };
+  const root = rooted.root;
   if (active) {
     // Prefer rg on the device; fall back to find (basename patterns via
     // -name, path patterns via -path). `command -v` gates the choice so a
@@ -669,7 +794,10 @@ async function search(
 ): Promise<Result> {
   const pat = str(pattern);
   if (!pat) return { ok: false, text: "A search pattern is required." };
-  const root = str(path) ?? ".";
+  const active = await getTeleport(chatId);
+  const rooted = resolveSearchRoot(str(path), active?.deviceName);
+  if ("error" in rooted) return { ok: false, text: rooted.error };
+  const root = rooted.root;
   const g = str(globPat);
   const ci = caseInsensitive === true;
   // `-e` keeps a pattern that starts with "-" from being parsed as a flag
@@ -680,7 +808,6 @@ async function search(
     ...(ci ? ["-i"] : []),
     ...(g ? ["-g", g] : []),
   ];
-  const active = await getTeleport(chatId);
   if (active) {
     // Prefer rg on the device, fall back to grep (Android toybox has grep
     // but rarely rg). --include is grep's closest analogue of -g.

--- a/src/core/engine/gateway-actions/vfs.ts
+++ b/src/core/engine/gateway-actions/vfs.ts
@@ -7,7 +7,10 @@ import { getVfs, type VfsResult, type VfsStat } from "../../vfs/index.js";
 import { log } from "../../../util/log.js";
 import type { SharedActionHandlers } from "./types.js";
 
-function describeError(path: string, result: { error: string; detail?: string }): string {
+function describeError(
+  path: string,
+  result: { error: string; detail?: string },
+): string {
   return `talon://${path}: ${result.error}${result.detail ? ` — ${result.detail}` : ""}`;
 }
 

--- a/src/core/engine/gateway-actions/vfs.ts
+++ b/src/core/engine/gateway-actions/vfs.ts
@@ -19,7 +19,13 @@ function formatEntry(entry: VfsStat): string {
   const kind = entry.kind === "dir" ? "d" : "-";
   const write = entry.writable ? "w" : "-";
   const suffix = entry.kind === "dir" ? "/" : "";
-  return `${kind}${write} ${formatSize(entry).padStart(9)}  ${entry.name}${suffix}`;
+  // Root entries (single-segment paths) show where the mount lives on
+  // disk — the bridge for OS-level tools, which can't read talon://.
+  const mapping =
+    entry.osPath !== undefined && !entry.path.includes("/")
+      ? `  → ${entry.osPath}`
+      : "";
+  return `${kind}${write} ${formatSize(entry).padStart(9)}  ${entry.name}${suffix}${mapping}`;
 }
 
 function normalize(body: Record<string, unknown>): string {

--- a/src/core/engine/gateway-actions/vfs.ts
+++ b/src/core/engine/gateway-actions/vfs.ts
@@ -1,0 +1,60 @@
+/**
+ * VFS — the `talon://` namespace over the gateway: list / read / write.
+ * Formatting only; the namespace itself lives in core/vfs.
+ */
+
+import { getVfs, type VfsResult, type VfsStat } from "../../vfs/index.js";
+import { log } from "../../../util/log.js";
+import type { SharedActionHandlers } from "./types.js";
+
+function describeError(path: string, result: { error: string; detail?: string }): string {
+  return `talon://${path}: ${result.error}${result.detail ? ` — ${result.detail}` : ""}`;
+}
+
+function formatSize(entry: VfsStat): string {
+  return entry.kind === "dir" ? "-" : String(entry.size ?? "?");
+}
+
+function formatEntry(entry: VfsStat): string {
+  const kind = entry.kind === "dir" ? "d" : "-";
+  const write = entry.writable ? "w" : "-";
+  const suffix = entry.kind === "dir" ? "/" : "";
+  return `${kind}${write} ${formatSize(entry).padStart(9)}  ${entry.name}${suffix}`;
+}
+
+function normalize(body: Record<string, unknown>): string {
+  return String(body.path ?? "").trim();
+}
+
+export const vfsHandlers: SharedActionHandlers = {
+  vfs_list: (body) => {
+    const path = normalize(body);
+    const result = getVfs().list(path);
+    if (!result.ok) return { ok: false, error: describeError(path, result) };
+    const header = `talon://${path.replace(/\/+$/, "")}${path ? "/" : ""} (${result.value.length} entries)`;
+    const lines = result.value.map(formatEntry);
+    return {
+      ok: true,
+      text: [header, ...(lines.length > 0 ? lines : ["(empty)"])].join("\n"),
+    };
+  },
+
+  vfs_read: (body) => {
+    const path = normalize(body);
+    const result = getVfs().read(path);
+    if (!result.ok) return { ok: false, error: describeError(path, result) };
+    return { ok: true, text: result.value };
+  },
+
+  vfs_write: (body) => {
+    const path = normalize(body);
+    const content = String(body.content ?? "");
+    const result: VfsResult<VfsStat> = getVfs().write(path, content);
+    if (!result.ok) return { ok: false, error: describeError(path, result) };
+    log("gateway", `vfs_write: talon://${result.value.path}`);
+    return {
+      ok: true,
+      text: `Wrote ${result.value.size ?? content.length} bytes to talon://${result.value.path}`,
+    };
+  },
+};

--- a/src/core/engine/gateway.ts
+++ b/src/core/engine/gateway.ts
@@ -414,6 +414,34 @@ export class Gateway {
           return;
         }
 
+        if (
+          req.method === "GET" &&
+          (req.url?.startsWith("/vfs/list") || req.url?.startsWith("/vfs/read"))
+        ) {
+          // The talon:// namespace — the transport for `talon ls` /
+          // `talon cat`, which need the daemon's live synthetic mounts
+          // (proc, plugins). Same 127.0.0.1 trust boundary as /action.
+          const url = new URL(req.url, "http://gateway");
+          const path = url.searchParams.get("path") ?? "";
+          const { getVfs } = await import("../vfs/index.js");
+          const vfs = getVfs();
+          let result: Record<string, unknown>;
+          if (url.pathname === "/vfs/list") {
+            const listed = vfs.list(path);
+            result = listed.ok
+              ? { ok: true, entries: listed.value }
+              : { ok: false, error: listed.error, detail: listed.detail };
+          } else {
+            const content = vfs.read(path);
+            result = content.ok
+              ? { ok: true, content: content.value }
+              : { ok: false, error: content.error, detail: content.detail };
+          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(result));
+          return;
+        }
+
         if (req.method === "GET" && req.url === "/tasks") {
           // The task table — every live/recent unit of agent work. Read by
           // `talon ps`. Same 127.0.0.1 trust boundary as /action.

--- a/src/core/tools/index.ts
+++ b/src/core/tools/index.ts
@@ -23,6 +23,7 @@ import { adminTools } from "./admin.js";
 import { modelTools } from "./models.js";
 import { meshTools } from "./mesh.js";
 import { nativeTools } from "./native.js";
+import { vfsTools } from "./vfs.js";
 
 /** All built-in tool definitions. */
 export const ALL_TOOLS: readonly ToolDefinition[] = [
@@ -41,6 +42,7 @@ export const ALL_TOOLS: readonly ToolDefinition[] = [
   ...adminTools,
   ...modelTools,
   ...meshTools,
+  ...vfsTools,
 ];
 
 /**

--- a/src/core/tools/native.ts
+++ b/src/core/tools/native.ts
@@ -39,7 +39,8 @@ export const nativeTools: ToolDefinition[] = [
     name: "bash",
     description:
       "Run a shell command. Runs on the daemon host, or ON the active teleport device if one is engaged. On a teleported device, `cd` persists across calls (a real working-directory session). " +
-      "Foreground runs are killed at timeout_sec — for streaming/never-ending commands (adb logcat, tail -f, dev servers, watchers) set background:true instead: the command is launched detached in its own process group with stdout+stderr captured to a log file, and the tool returns immediately with the pid + log path so you can poll the log and kill it when done.",
+      "Foreground runs are killed at timeout_sec — for streaming/never-ending commands (adb logcat, tail -f, dev servers, watchers) set background:true instead: the command is launched detached in its own process group with stdout+stderr captured to a log file, and the tool returns immediately with the pid + log path so you can poll the log and kill it when done. " +
+      "talon:// addresses are not OS paths — the shell needs the disk locations the namespace root listing shows (vfs_list).",
     schema: {
       command: z.string().describe("The shell command to run."),
       cwd: z
@@ -69,7 +70,11 @@ export const nativeTools: ToolDefinition[] = [
     description:
       "Read a file (with line numbers). Runs on the daemon host or the active teleport device. Supports offset/limit for large files.",
     schema: {
-      path: z.string().describe("Absolute file path."),
+      path: z
+        .string()
+        .describe(
+          "Absolute file path, or a talon:// namespace address (resolved on the daemon host).",
+        ),
       offset: z.number().optional().describe("0-based line to start from."),
       limit: z
         .number()
@@ -84,7 +89,11 @@ export const nativeTools: ToolDefinition[] = [
     description:
       "Write (create/overwrite) a file with the given content. Runs on the daemon host or the active teleport device.",
     schema: {
-      path: z.string().describe("Absolute file path."),
+      path: z
+        .string()
+        .describe(
+          "Absolute file path, or a talon:// namespace address (resolved on the daemon host).",
+        ),
       content: z.string().describe("Full file content to write."),
     },
     execute: (params, bridge) => bridge("native_write", params),
@@ -95,7 +104,11 @@ export const nativeTools: ToolDefinition[] = [
     description:
       "Exact-string replacement in a file. old_string must be unique unless replace_all is set. Runs on the daemon host or the active teleport device.",
     schema: {
-      path: z.string().describe("Absolute file path."),
+      path: z
+        .string()
+        .describe(
+          "Absolute file path, or a talon:// namespace address (resolved on the daemon host).",
+        ),
       old_string: z.string().describe("Exact text to replace."),
       new_string: z.string().describe("Replacement text."),
       replace_all: z
@@ -115,7 +128,7 @@ export const nativeTools: ToolDefinition[] = [
       path: z
         .string()
         .optional()
-        .describe("Root directory to search (default cwd)."),
+        .describe("Root directory to search (default cwd; talon:// accepted)."),
     },
     execute: (params, bridge) => bridge("native_glob", params),
     tag: "native",
@@ -129,7 +142,7 @@ export const nativeTools: ToolDefinition[] = [
       path: z
         .string()
         .optional()
-        .describe("Root directory or file (default cwd)."),
+        .describe("Root directory or file (default cwd; talon:// accepted)."),
       glob: z
         .string()
         .optional()

--- a/src/core/tools/types.ts
+++ b/src/core/tools/types.ts
@@ -28,7 +28,8 @@ export type ToolTag =
   | "admin"
   | "models"
   | "mesh"
-  | "native";
+  | "native"
+  | "vfs";
 
 /** The bridge caller signature — injected into execute(). */
 export type BridgeFunction = (

--- a/src/core/tools/vfs.ts
+++ b/src/core/tools/vfs.ts
@@ -1,0 +1,55 @@
+/**
+ * VFS tools — the unified `talon://` namespace.
+ *
+ * One browsable tree over everything the daemon owns: real stores (the
+ * workspace, skills, scripts, logs) and live synthetic state (`proc/` for
+ * the task table and event bus, `plugins/` for the registry) answer the
+ * same three tools. The synthetic mounts are the point — this is the only
+ * way to read live daemon state as plain files.
+ */
+
+import { z } from "zod";
+import type { ToolDefinition } from "./types.js";
+
+const NAMESPACE = `Namespace roots: home/ (workspace), skills/, scripts/, logs/, proc/ (live task table under proc/tasks/<id> and the event ring at proc/events), plugins/ (registry view). List "" to see the root.`;
+
+export const vfsTools: ToolDefinition[] = [
+  {
+    name: "vfs_list",
+    description: `List a directory in the talon:// namespace — the unified view over Talon's own state. ${NAMESPACE} Entries show kind (d/-), writability, size, and name.`,
+    schema: {
+      path: z
+        .string()
+        .describe(
+          'Namespace path, e.g. "" (root), "proc/tasks", "skills/review-pr". Forward slashes on every platform; "talon://" prefix optional.',
+        ),
+    },
+    execute: (params, bridge) => bridge("vfs_list", params),
+    tag: "vfs",
+  },
+
+  {
+    name: "vfs_read",
+    description: `Read a file from the talon:// namespace (UTF-8 text, 256KB cap). ${NAMESPACE} Reading proc/tasks/<id> returns that task as JSON; proc/events returns the event ring as JSON Lines.`,
+    schema: {
+      path: z
+        .string()
+        .describe('Namespace file path, e.g. "proc/events" or "logs/2026-07-16.md"'),
+    },
+    execute: (params, bridge) => bridge("vfs_read", params),
+    tag: "vfs",
+  },
+
+  {
+    name: "vfs_write",
+    description: `Write a UTF-8 file into a writable part of the talon:// namespace (home/, skills/, scripts/). Parent directories are created; synthetic mounts (proc/, plugins/) and logs/ are read-only views.`,
+    schema: {
+      path: z
+        .string()
+        .describe('Namespace file path under a writable mount, e.g. "home/notes/ideas.md"'),
+      content: z.string().describe("Full file content (replaces any existing content)"),
+    },
+    execute: (params, bridge) => bridge("vfs_write", params),
+    tag: "vfs",
+  },
+];

--- a/src/core/tools/vfs.ts
+++ b/src/core/tools/vfs.ts
@@ -34,7 +34,9 @@ export const vfsTools: ToolDefinition[] = [
     schema: {
       path: z
         .string()
-        .describe('Namespace file path, e.g. "proc/events" or "logs/2026-07-16.md"'),
+        .describe(
+          'Namespace file path, e.g. "proc/events" or "logs/2026-07-16.md"',
+        ),
     },
     execute: (params, bridge) => bridge("vfs_read", params),
     tag: "vfs",
@@ -46,8 +48,12 @@ export const vfsTools: ToolDefinition[] = [
     schema: {
       path: z
         .string()
-        .describe('Namespace file path under a writable mount, e.g. "home/notes/ideas.md"'),
-      content: z.string().describe("Full file content (replaces any existing content)"),
+        .describe(
+          'Namespace file path under a writable mount, e.g. "home/notes/ideas.md"',
+        ),
+      content: z
+        .string()
+        .describe("Full file content (replaces any existing content)"),
     },
     execute: (params, bridge) => bridge("vfs_write", params),
     tag: "vfs",

--- a/src/core/tools/vfs.ts
+++ b/src/core/tools/vfs.ts
@@ -11,7 +11,7 @@
 import { z } from "zod";
 import type { ToolDefinition } from "./types.js";
 
-const NAMESPACE = `Namespace roots: home/ (workspace), skills/, scripts/, logs/, proc/ (live task table under proc/tasks/<id> and the event ring at proc/events), plugins/ (registry view). List "" to see the root.`;
+const NAMESPACE = `Namespace roots: home/ (workspace), skills/, scripts/, logs/, proc/ (live task table under proc/tasks/<id> and the event ring at proc/events), plugins/ (registry view). List "" to see the root and where each mount lives on disk. Absolute OS paths inside a mounted directory are accepted and translated.`;
 
 export const vfsTools: ToolDefinition[] = [
   {

--- a/src/core/vfs/index.ts
+++ b/src/core/vfs/index.ts
@@ -1,0 +1,113 @@
+/**
+ * VFS — public surface and default namespace.
+ *
+ * `getVfs()` serves the process-wide namespace, built on first use rather
+ * than at module load: the file mounts capture `dirs.*` when constructed,
+ * and eager construction would freeze those paths into whichever process
+ * (or test mock) happened to import this barrel first. Mounts project
+ * live singletons, so there is nothing to inject at bootstrap:
+ *
+ *   talon://
+ *     home/       workspace (writable)
+ *     skills/     SKILL.md bundles (writable)
+ *     scripts/    agent script bodies (writable)
+ *     logs/       daily logs (read-only — the daemon writes these)
+ *     proc/       task table + event bus ring (synthetic, read-only)
+ *     plugins/    plugin registry view (synthetic, read-only)
+ *
+ * Read surfaces: gateway `GET /vfs/list` / `GET /vfs/read` and the
+ * vfs_* MCP tools (via gateway actions); CLI `talon ls` / `talon cat`.
+ */
+
+import { dirs } from "../../util/paths.js";
+import { bus } from "../bus/index.js";
+import { registry } from "../plugin/registry.js";
+import { taskTable } from "../tasks/index.js";
+import { createFileMount } from "./mounts/files.js";
+import { createPluginsMount, type PluginView } from "./mounts/plugins.js";
+import { createProcMount } from "./mounts/proc.js";
+import { Vfs } from "./vfs.js";
+
+export { Vfs } from "./vfs.js";
+export { createFileMount } from "./mounts/files.js";
+export { createProcMount, type ProcMountDeps } from "./mounts/proc.js";
+export { createPluginsMount, type PluginView } from "./mounts/plugins.js";
+export type {
+  VfsErrorCode,
+  VfsMount,
+  VfsNodeKind,
+  VfsResult,
+  VfsStat,
+} from "./types.js";
+export { VFS_MAX_READ_BYTES, vfsError, vfsOk } from "./types.js";
+
+function pluginViews(): PluginView[] {
+  const modules: PluginView[] = registry.all.map(({ plugin, path }) => ({
+    name: plugin.name,
+    kind: "module",
+    ...(plugin.description !== undefined
+      ? { description: plugin.description }
+      : {}),
+    ...(plugin.version !== undefined ? { version: plugin.version } : {}),
+    source: path,
+  }));
+  const mcp: PluginView[] = registry.mcpEntries.map((entry) => ({
+    name: entry.name,
+    kind: "mcp",
+    source: `${entry.command}${entry.args ? ` ${entry.args.join(" ")}` : ""}`,
+  }));
+  return [...modules, ...mcp];
+}
+
+function buildDefaultNamespace(): Vfs {
+  const vfs = new Vfs();
+  vfs.mount(
+    "home",
+    createFileMount({
+      root: dirs.workspace,
+      description: "The workspace — the agent's home directory",
+      writable: true,
+    }),
+  );
+  vfs.mount(
+    "skills",
+    createFileMount({
+      root: dirs.skills,
+      description: "SKILL.md workflow bundles",
+      writable: true,
+    }),
+  );
+  vfs.mount(
+    "scripts",
+    createFileMount({
+      root: dirs.scripts,
+      description: "Agent-authored script bodies",
+      writable: true,
+    }),
+  );
+  vfs.mount(
+    "logs",
+    createFileMount({
+      root: dirs.logs,
+      description: "Daily interaction logs (daemon-written)",
+      writable: false,
+    }),
+  );
+  vfs.mount(
+    "proc",
+    createProcMount({
+      tasks: () => taskTable.list(),
+      events: () => bus.recent(0),
+    }),
+  );
+  vfs.mount("plugins", createPluginsMount(pluginViews));
+  return vfs;
+}
+
+let defaultVfs: Vfs | undefined;
+
+/** The process-wide namespace, built on first use. */
+export function getVfs(): Vfs {
+  defaultVfs ??= buildDefaultNamespace();
+  return defaultVfs;
+}

--- a/src/core/vfs/mounts/files.ts
+++ b/src/core/vfs/mounts/files.ts
@@ -1,0 +1,142 @@
+/**
+ * File mount — a real directory exposed into the namespace.
+ *
+ * Backs the workspace-shaped mounts (home, skills, scripts, logs). The
+ * resolver has already rejected traversal segments; the containment check
+ * here is belt-and-braces so no future caller can reach outside the root.
+ * A missing root reads as an empty directory — mounts exist from boot,
+ * the workspace dirs appear lazily.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import type { VfsMount, VfsResult, VfsStat } from "../types.js";
+import { VFS_MAX_READ_BYTES, vfsError, vfsOk } from "../types.js";
+
+export function createFileMount(options: {
+  root: string;
+  description: string;
+  writable: boolean;
+}): VfsMount {
+  const root = resolve(options.root);
+
+  /** Absolute path for `rel`, or undefined when it would escape the root. */
+  function realPath(rel: string): string | undefined {
+    const abs = resolve(root, ...rel.split("/"));
+    const offset = relative(root, abs);
+    if (offset.startsWith(`..${sep}`) || offset === ".." || isAbsolute(offset)) {
+      return undefined;
+    }
+    return abs;
+  }
+
+  function statAt(rel: string, abs: string): VfsResult<VfsStat> {
+    try {
+      const stats = statSync(abs);
+      const name = rel === "" ? "" : rel.split("/").at(-1)!;
+      return vfsOk({
+        path: rel,
+        name,
+        kind: stats.isDirectory() ? ("dir" as const) : ("file" as const),
+        ...(stats.isFile() ? { size: stats.size } : {}),
+        modifiedAt: Math.floor(stats.mtimeMs),
+        writable: options.writable,
+      });
+    } catch {
+      return vfsError("not-found");
+    }
+  }
+
+  return {
+    description: options.description,
+    writable: options.writable,
+
+    stat(rel) {
+      const abs = realPath(rel);
+      if (!abs) return vfsError("invalid-path");
+      if (rel === "" && !existsSync(abs)) {
+        return vfsOk({ path: "", name: "", kind: "dir", writable: options.writable });
+      }
+      return statAt(rel, abs);
+    },
+
+    list(rel) {
+      const abs = realPath(rel);
+      if (!abs) return vfsError("invalid-path");
+      if (rel === "" && !existsSync(abs)) return vfsOk([]);
+      let stats;
+      try {
+        stats = statSync(abs);
+      } catch {
+        return vfsError("not-found");
+      }
+      if (!stats.isDirectory()) return vfsError("not-a-directory");
+      const entries = readdirSync(abs, { withFileTypes: true })
+        .map((entry) => {
+          const childRel = rel === "" ? entry.name : `${rel}/${entry.name}`;
+          const child = statAt(childRel, resolve(abs, entry.name));
+          return child.ok ? child.value : undefined;
+        })
+        .filter((entry): entry is VfsStat => entry !== undefined)
+        .sort(
+          (a, b) =>
+            Number(a.kind === "file") - Number(b.kind === "file") ||
+            a.name.localeCompare(b.name),
+        );
+      return vfsOk(entries);
+    },
+
+    read(rel) {
+      const abs = realPath(rel);
+      if (!abs) return vfsError("invalid-path");
+      let stats;
+      try {
+        stats = statSync(abs);
+      } catch {
+        return vfsError("not-found");
+      }
+      if (stats.isDirectory()) return vfsError("is-a-directory");
+      if (stats.size > VFS_MAX_READ_BYTES) {
+        return vfsError(
+          "too-large",
+          `${stats.size} bytes (cap ${VFS_MAX_READ_BYTES})`,
+        );
+      }
+      const buffer = readFileSync(abs);
+      if (buffer.includes(0)) {
+        return vfsError("binary-file", "Content contains null bytes");
+      }
+      return vfsOk(buffer.toString("utf-8"));
+    },
+
+    ...(options.writable
+      ? {
+          write(rel: string, content: string): VfsResult<VfsStat> {
+            if (rel === "") return vfsError("is-a-directory");
+            const abs = realPath(rel);
+            if (!abs) return vfsError("invalid-path");
+            if (existsSync(abs) && statSync(abs).isDirectory()) {
+              return vfsError("is-a-directory");
+            }
+            try {
+              mkdirSync(dirname(abs), { recursive: true });
+              writeFileSync(abs, content, "utf-8");
+            } catch (err) {
+              return vfsError(
+                "io-error",
+                err instanceof Error ? err.message : String(err),
+              );
+            }
+            return statAt(rel, abs);
+          },
+        }
+      : {}),
+  };
+}

--- a/src/core/vfs/mounts/files.ts
+++ b/src/core/vfs/mounts/files.ts
@@ -31,7 +31,11 @@ export function createFileMount(options: {
   function realPath(rel: string): string | undefined {
     const abs = resolve(root, ...rel.split("/"));
     const offset = relative(root, abs);
-    if (offset.startsWith(`..${sep}`) || offset === ".." || isAbsolute(offset)) {
+    if (
+      offset.startsWith(`..${sep}`) ||
+      offset === ".." ||
+      isAbsolute(offset)
+    ) {
       return undefined;
     }
     return abs;

--- a/src/core/vfs/mounts/files.ts
+++ b/src/core/vfs/mounts/files.ts
@@ -48,6 +48,7 @@ export function createFileMount(options: {
         ...(stats.isFile() ? { size: stats.size } : {}),
         modifiedAt: Math.floor(stats.mtimeMs),
         writable: options.writable,
+        osPath: abs,
       });
     } catch {
       return vfsError("not-found");
@@ -57,12 +58,19 @@ export function createFileMount(options: {
   return {
     description: options.description,
     writable: options.writable,
+    osRoot: root,
 
     stat(rel) {
       const abs = realPath(rel);
       if (!abs) return vfsError("invalid-path");
       if (rel === "" && !existsSync(abs)) {
-        return vfsOk({ path: "", name: "", kind: "dir", writable: options.writable });
+        return vfsOk({
+          path: "",
+          name: "",
+          kind: "dir",
+          writable: options.writable,
+          osPath: abs,
+        });
       }
       return statAt(rel, abs);
     },
@@ -106,7 +114,7 @@ export function createFileMount(options: {
       if (stats.size > VFS_MAX_READ_BYTES) {
         return vfsError(
           "too-large",
-          `${stats.size} bytes (cap ${VFS_MAX_READ_BYTES})`,
+          `${stats.size} bytes (cap ${VFS_MAX_READ_BYTES}) — on disk at ${abs}`,
         );
       }
       const buffer = readFileSync(abs);

--- a/src/core/vfs/mounts/plugins.ts
+++ b/src/core/vfs/mounts/plugins.ts
@@ -1,0 +1,71 @@
+/**
+ * Plugins mount — the plugin registry as a synthetic read-only directory:
+ * one file per loaded plugin (or registered standalone MCP entry), whose
+ * content is the registry's view of it as pretty JSON. Provider-injected
+ * like proc — the index wires the live registry, tests wire fixtures.
+ */
+
+import type { VfsMount, VfsResult, VfsStat } from "../types.js";
+import { vfsError, vfsOk } from "../types.js";
+
+/** The registry facts one plugin file exposes. */
+export interface PluginView {
+  readonly name: string;
+  readonly kind: "module" | "mcp";
+  readonly description?: string;
+  readonly version?: string;
+  /** Module path, or the MCP entry's command line. */
+  readonly source: string;
+}
+
+function render(view: PluginView): string {
+  return `${JSON.stringify(view, null, 2)}\n`;
+}
+
+function fileStat(view: PluginView): VfsStat {
+  return {
+    path: view.name,
+    name: view.name,
+    kind: "file",
+    size: Buffer.byteLength(render(view), "utf-8"),
+    writable: false,
+  };
+}
+
+export function createPluginsMount(
+  plugins: () => readonly PluginView[],
+): VfsMount {
+  function byName(rel: string): PluginView | undefined {
+    return plugins().find((view) => view.name === rel);
+  }
+
+  return {
+    description: "Loaded plugins and registered MCP servers (registry view)",
+    writable: false,
+
+    stat(rel): VfsResult<VfsStat> {
+      if (rel === "") return vfsOk({ path: "", name: "", kind: "dir", writable: false });
+      const view = byName(rel);
+      return view ? vfsOk(fileStat(view)) : vfsError("not-found");
+    },
+
+    list(rel) {
+      if (rel !== "") {
+        return byName(rel)
+          ? vfsError("not-a-directory")
+          : vfsError("not-found");
+      }
+      return vfsOk(
+        plugins()
+          .map(fileStat)
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      );
+    },
+
+    read(rel) {
+      if (rel === "") return vfsError("is-a-directory");
+      const view = byName(rel);
+      return view ? vfsOk(render(view)) : vfsError("not-found");
+    },
+  };
+}

--- a/src/core/vfs/mounts/plugins.ts
+++ b/src/core/vfs/mounts/plugins.ts
@@ -44,7 +44,8 @@ export function createPluginsMount(
     writable: false,
 
     stat(rel): VfsResult<VfsStat> {
-      if (rel === "") return vfsOk({ path: "", name: "", kind: "dir", writable: false });
+      if (rel === "")
+        return vfsOk({ path: "", name: "", kind: "dir", writable: false });
       const view = byName(rel);
       return view ? vfsOk(fileStat(view)) : vfsError("not-found");
     },

--- a/src/core/vfs/mounts/proc.ts
+++ b/src/core/vfs/mounts/proc.ts
@@ -64,9 +64,7 @@ export function createProcMount(deps: ProcMountDeps): VfsMount {
     if (rel === "tasks") return vfsOk(DIR("tasks", "tasks"));
     if (rel === "events") {
       const events = deps.events();
-      return vfsOk(
-        fileStat("events", renderEvents(events), events.at(-1)?.at),
-      );
+      return vfsOk(fileStat("events", renderEvents(events), events.at(-1)?.at));
     }
     const taskId = rel.startsWith("tasks/") ? rel.slice("tasks/".length) : null;
     if (taskId !== null && !taskId.includes("/")) {

--- a/src/core/vfs/mounts/proc.ts
+++ b/src/core/vfs/mounts/proc.ts
@@ -1,0 +1,127 @@
+/**
+ * Proc mount — live daemon state as a synthetic read-only tree, in the
+ * /proc tradition:
+ *
+ *   proc/
+ *     tasks/<id>   one task table record, pretty JSON
+ *     events       the event bus ring, JSON Lines (newest last)
+ *
+ * Providers are injected so the mount is a pure projection — the index
+ * wires the real task table and bus, tests wire fixtures. Sizes and
+ * timestamps are computed from the rendered content on demand; this is a
+ * view of live state, nothing is cached.
+ */
+
+import type { PublishedEvent } from "../../bus/index.js";
+import type { TaskRecord } from "../../tasks/index.js";
+import type { VfsMount, VfsResult, VfsStat } from "../types.js";
+import { vfsError, vfsOk } from "../types.js";
+
+export interface ProcMountDeps {
+  tasks: () => readonly TaskRecord[];
+  events: () => readonly PublishedEvent[];
+}
+
+const DIR = (path: string, name: string): VfsStat => ({
+  path,
+  name,
+  kind: "dir",
+  writable: false,
+});
+
+function fileStat(path: string, content: string, modifiedAt?: number): VfsStat {
+  return {
+    path,
+    name: path.split("/").at(-1)!,
+    kind: "file",
+    size: Buffer.byteLength(content, "utf-8"),
+    ...(modifiedAt !== undefined ? { modifiedAt } : {}),
+    writable: false,
+  };
+}
+
+function renderTask(task: TaskRecord): string {
+  return `${JSON.stringify(task, null, 2)}\n`;
+}
+
+function taskModifiedAt(task: TaskRecord): number {
+  return task.endedAt ?? task.startedAt ?? task.queuedAt;
+}
+
+function renderEvents(events: readonly PublishedEvent[]): string {
+  if (events.length === 0) return "";
+  return events.map((event) => JSON.stringify(event)).join("\n") + "\n";
+}
+
+export function createProcMount(deps: ProcMountDeps): VfsMount {
+  function taskById(id: string): TaskRecord | undefined {
+    if (!/^\d+$/.test(id)) return undefined;
+    return deps.tasks().find((task) => task.id === Number(id));
+  }
+
+  function resolveNode(rel: string): VfsResult<VfsStat> {
+    if (rel === "") return vfsOk(DIR("", ""));
+    if (rel === "tasks") return vfsOk(DIR("tasks", "tasks"));
+    if (rel === "events") {
+      const events = deps.events();
+      return vfsOk(
+        fileStat("events", renderEvents(events), events.at(-1)?.at),
+      );
+    }
+    const taskId = rel.startsWith("tasks/") ? rel.slice("tasks/".length) : null;
+    if (taskId !== null && !taskId.includes("/")) {
+      const task = taskById(taskId);
+      if (!task) return vfsError("not-found");
+      return vfsOk(
+        fileStat(`tasks/${task.id}`, renderTask(task), taskModifiedAt(task)),
+      );
+    }
+    return vfsError("not-found");
+  }
+
+  return {
+    description: "Live daemon state: task table and event bus ring",
+    writable: false,
+
+    stat: resolveNode,
+
+    list(rel) {
+      if (rel === "") {
+        const events = deps.events();
+        return vfsOk([
+          DIR("tasks", "tasks"),
+          fileStat("events", renderEvents(events), events.at(-1)?.at),
+        ]);
+      }
+      if (rel === "tasks") {
+        return vfsOk(
+          deps
+            .tasks()
+            .map((task) =>
+              fileStat(
+                `tasks/${task.id}`,
+                renderTask(task),
+                taskModifiedAt(task),
+              ),
+            )
+            .sort((a, b) => Number(a.name) - Number(b.name)),
+        );
+      }
+      const node = resolveNode(rel);
+      if (!node.ok) return node;
+      return vfsError("not-a-directory");
+    },
+
+    read(rel) {
+      if (rel === "events") return vfsOk(renderEvents(deps.events()));
+      if (rel.startsWith("tasks/")) {
+        const task = taskById(rel.slice("tasks/".length));
+        if (!task) return vfsError("not-found");
+        return vfsOk(renderTask(task));
+      }
+      const node = resolveNode(rel);
+      if (!node.ok) return node;
+      return vfsError("is-a-directory");
+    },
+  };
+}

--- a/src/core/vfs/types.ts
+++ b/src/core/vfs/types.ts
@@ -37,7 +37,11 @@ export type VfsErrorCode =
 
 export type VfsResult<T> =
   | { readonly ok: true; readonly value: T }
-  | { readonly ok: false; readonly error: VfsErrorCode; readonly detail?: string };
+  | {
+      readonly ok: false;
+      readonly error: VfsErrorCode;
+      readonly detail?: string;
+    };
 
 export function vfsOk<T>(value: T): VfsResult<T> {
   return { ok: true, value };

--- a/src/core/vfs/types.ts
+++ b/src/core/vfs/types.ts
@@ -1,0 +1,80 @@
+/**
+ * VFS vocabulary — the unified `talon://` namespace.
+ *
+ * One rooted, mountable namespace over everything the daemon owns, in the
+ * Plan 9 tradition: real-file stores (workspace, skills, scripts, logs)
+ * and synthetic /proc-style views of live state (task table, event bus,
+ * plugin registry) answer the same four operations. The namespace is for
+ * unification and introspection — mounts decide what they can do (a
+ * synthetic view has nothing meaningful to write), but the VFS is never a
+ * permission layer.
+ *
+ * Paths are `/`-separated on every platform (`skills/review-pr/SKILL.md`),
+ * relative to the root; the `talon://` scheme prefix is accepted and
+ * stripped. Mounts receive mount-relative paths ("" = the mount root) and
+ * report entry paths mount-relative too — the resolver owns prefixing.
+ */
+
+/** What a path points at. */
+export type VfsNodeKind = "dir" | "file";
+
+/** Errno-style failure vocabulary — every operation fails with one of these. */
+export type VfsErrorCode =
+  | "not-found"
+  | "invalid-path"
+  | "is-a-directory"
+  | "not-a-directory"
+  | "not-writable"
+  | "too-large"
+  | "binary-file"
+  | "io-error";
+
+export type VfsResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: VfsErrorCode; readonly detail?: string };
+
+export function vfsOk<T>(value: T): VfsResult<T> {
+  return { ok: true, value };
+}
+
+export function vfsError<T>(
+  error: VfsErrorCode,
+  detail?: string,
+): VfsResult<T> {
+  return { ok: false, error, ...(detail !== undefined ? { detail } : {}) };
+}
+
+/** One node's metadata — also the shape of directory listing entries. */
+export interface VfsStat {
+  /** Root-relative path (`skills/review-pr/SKILL.md`); "" is the root. */
+  readonly path: string;
+  /** Last path segment; the mount name for a mount root. */
+  readonly name: string;
+  readonly kind: VfsNodeKind;
+  /** Content size in bytes, when the mount can know it cheaply. */
+  readonly size?: number;
+  /** Last modification, epoch ms, when known. */
+  readonly modifiedAt?: number;
+  /** Whether write() can target this node (or nodes under this dir). */
+  readonly writable: boolean;
+}
+
+/**
+ * One mounted store. Implementations receive mount-relative paths that the
+ * resolver has already normalized (no "..", no backslashes, no empty
+ * segments) and return stats with mount-relative `path`s.
+ */
+export interface VfsMount {
+  /** One line shown when listing the namespace root. */
+  readonly description: string;
+  /** Can write() ever succeed here? Synthetic views say false. */
+  readonly writable: boolean;
+  stat(rel: string): VfsResult<VfsStat>;
+  list(rel: string): VfsResult<VfsStat[]>;
+  read(rel: string): VfsResult<string>;
+  /** Optional — absent means the whole mount is read-only. */
+  write?(rel: string, content: string): VfsResult<VfsStat>;
+}
+
+/** Read cap — a namespace read is a context payload, not a file transfer. */
+export const VFS_MAX_READ_BYTES = 256 * 1024;

--- a/src/core/vfs/types.ts
+++ b/src/core/vfs/types.ts
@@ -9,10 +9,16 @@
  * synthetic view has nothing meaningful to write), but the VFS is never a
  * permission layer.
  *
- * Paths are `/`-separated on every platform (`skills/review-pr/SKILL.md`),
- * relative to the root; the `talon://` scheme prefix is accepted and
- * stripped. Mounts receive mount-relative paths ("" = the mount root) and
- * report entry paths mount-relative too — the resolver owns prefixing.
+ * An address reaches the namespace in one of three spellings, all resolved
+ * by the same grammar (see `Vfs.#parse`):
+ *
+ *   - scheme:         `talon://skills/review-pr/SKILL.md`
+ *   - mount-relative: `skills/review-pr/SKILL.md` (`/`-separated everywhere)
+ *   - OS-absolute:    the disk spelling of a node inside a file-backed
+ *                     mount's root — the same node, other coordinate system
+ *
+ * Mounts receive mount-relative paths ("" = the mount root) and report
+ * entry paths mount-relative too — the resolver owns prefixing.
  */
 
 /** What a path points at. */
@@ -57,6 +63,12 @@ export interface VfsStat {
   readonly modifiedAt?: number;
   /** Whether write() can target this node (or nodes under this dir). */
   readonly writable: boolean;
+  /**
+   * Where this node lives on disk, for file-backed mounts. Absent on
+   * synthetic nodes — they have no disk representation. This is what lets
+   * OS-level tools (shell, editors) reach a node the namespace named.
+   */
+  readonly osPath?: string;
 }
 
 /**
@@ -69,6 +81,13 @@ export interface VfsMount {
   readonly description: string;
   /** Can write() ever succeed here? Synthetic views say false. */
   readonly writable: boolean;
+  /**
+   * Absolute disk root, for file-backed mounts. The single fact that makes
+   * addresses bidirectional: the resolver routes OS-absolute addresses into
+   * the mount by containment, and `Vfs.locate` maps namespace addresses
+   * back to disk. Synthetic mounts omit it.
+   */
+  readonly osRoot?: string;
   stat(rel: string): VfsResult<VfsStat>;
   list(rel: string): VfsResult<VfsStat[]>;
   read(rel: string): VfsResult<string>;

--- a/src/core/vfs/vfs.ts
+++ b/src/core/vfs/vfs.ts
@@ -199,7 +199,10 @@ export class Vfs {
         best = {
           mount,
           prefix: name,
-          rel: offset.split(sep).filter((s) => s.length > 0).join("/"),
+          rel: offset
+            .split(sep)
+            .filter((s) => s.length > 0)
+            .join("/"),
           rootLength: mount.osRoot.length,
         };
       }

--- a/src/core/vfs/vfs.ts
+++ b/src/core/vfs/vfs.ts
@@ -1,16 +1,33 @@
 /**
- * VFS resolver — the mount table and the path discipline.
+ * VFS resolver — the mount table and the address grammar.
  *
- * The resolver owns everything mounts shouldn't have to repeat: scheme
- * stripping, normalization, traversal rejection, routing to the mount by
- * first segment, and re-prefixing the mount-relative stats that come back.
- * Mounts therefore only ever see clean relative paths.
+ * The resolver owns everything mounts shouldn't have to repeat: address
+ * parsing, normalization, traversal rejection, routing to the mount, and
+ * re-prefixing the mount-relative stats that come back. Mounts therefore
+ * only ever see clean relative paths.
+ *
+ * An address is one of three spellings of the same node:
+ *
+ *   talon://home/notes.md   scheme form — always namespace-interpreted
+ *   home/notes.md           mount-relative form
+ *   <workspace>/notes.md    OS-absolute form — routed through the mount
+ *                           table by containment, exactly like a kernel
+ *                           resolving a path through its mounts
+ *
+ * The grammar is total: an unschemed address starting with a separator or
+ * drive prefix is always an OS path, never mount-relative — so an OS path
+ * can't silently misroute into a like-named mount, and a namespace path
+ * can't be mistaken for disk.
  */
 
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import type { VfsMount, VfsResult, VfsStat } from "./types.js";
 import { vfsError, vfsOk } from "./types.js";
 
 const SCHEME = "talon://";
+
+/** OS-absolute spellings: `/x`, `\\server\x`, `C:\x`, `C:/x`. */
+const OS_ABSOLUTE = /^(?:[\\/]|[A-Za-z]:[\\/])/;
 
 /** A parsed path: which mount, and the path inside it. */
 type Resolved = { mount: VfsMount; prefix: string; rel: string };
@@ -55,6 +72,7 @@ export class Vfs {
           name,
           kind: "dir" as const,
           writable: mount.writable,
+          ...(mount.osRoot !== undefined ? { osPath: mount.osRoot } : {}),
         })),
       );
     }
@@ -84,6 +102,25 @@ export class Vfs {
     return result.ok ? vfsOk(withPrefix(result.value, prefix)) : result;
   }
 
+  /**
+   * Where an address lives on disk: the absolute path for nodes of
+   * file-backed mounts (whether or not the node exists yet), `undefined`
+   * for addresses with no disk representation (the root, synthetic
+   * mounts). This is the namespace→OS direction of the address grammar —
+   * OS-level tools call it to run real file operations on a talon://
+   * address.
+   */
+  locate(path: string): VfsResult<string | undefined> {
+    const parsed = this.#parse(path);
+    if (!parsed.ok) return parsed;
+    if (parsed.value === null) return vfsOk(undefined);
+    const { mount, rel } = parsed.value;
+    if (mount.osRoot === undefined) return vfsOk(undefined);
+    return vfsOk(
+      rel === "" ? mount.osRoot : resolve(mount.osRoot, ...rel.split("/")),
+    );
+  }
+
   /** Mount names + descriptions, for docs/tool output. */
   describeMounts(): { name: string; description: string; writable: boolean }[] {
     return [...this.#mounts.entries()].map(([name, mount]) => ({
@@ -96,7 +133,20 @@ export class Vfs {
   /** null = the namespace root. */
   #parse(raw: string): VfsResult<Resolved | null> {
     let path = raw.trim();
-    if (path.startsWith(SCHEME)) path = path.slice(SCHEME.length);
+    const schemed = path.startsWith(SCHEME);
+    if (schemed) {
+      path = path.slice(SCHEME.length);
+    } else {
+      // Bare separators address the namespace root ("talon ls /").
+      if (/^[\\/]+$/.test(path)) return vfsOk(null);
+      if (OS_ABSOLUTE.test(path)) return this.#parseOsPath(path);
+      if (path.startsWith("~")) {
+        return vfsError(
+          "invalid-path",
+          '"~" is not expanded — use an absolute path or a talon:// address',
+        );
+      }
+    }
     if (path.includes("\\")) {
       return vfsError(
         "invalid-path",
@@ -118,6 +168,63 @@ export class Vfs {
       );
     }
     return vfsOk({ mount, prefix: head!, rel: rest.join("/") });
+  }
+
+  /**
+   * Route an OS-absolute address through the mount table by containment —
+   * the most specific (longest) disk root wins, so a mount nested inside
+   * another's root (skills/ inside the workspace) claims its own subtree.
+   * Outside every mount there is nothing to address: refuse with the mount
+   * table rather than guess.
+   */
+  #parseOsPath(osPath: string): VfsResult<Resolved> {
+    // isAbsolute guards the host boundary: a foreign spelling (a drive path
+    // on POSIX) can't be resolved against this host's roots.
+    if (isAbsolute(osPath)) {
+      const abs = resolve(osPath);
+      let best: (Resolved & { rootLength: number }) | undefined;
+      for (const [name, mount] of this.#mounts) {
+        if (mount.osRoot === undefined) continue;
+        const offset = relative(mount.osRoot, abs);
+        if (
+          offset === ".." ||
+          offset.startsWith(`..${sep}`) ||
+          isAbsolute(offset)
+        ) {
+          continue;
+        }
+        if (best !== undefined && mount.osRoot.length <= best.rootLength) {
+          continue;
+        }
+        best = {
+          mount,
+          prefix: name,
+          rel: offset.split(sep).filter((s) => s.length > 0).join("/"),
+          rootLength: mount.osRoot.length,
+        };
+      }
+      if (best !== undefined) {
+        return vfsOk({ mount: best.mount, prefix: best.prefix, rel: best.rel });
+      }
+    }
+    const respelled = osPath
+      .split(/[\\/]+/)
+      .filter((s) => s.length > 0 && !/^[A-Za-z]:$/.test(s));
+    if (respelled[0] !== undefined && this.#mounts.has(respelled[0])) {
+      return vfsError(
+        "not-found",
+        `OS paths resolve only inside a mounted directory — did you mean "talon://${respelled.join("/")}"?`,
+      );
+    }
+    const roots = [...this.#mounts.entries()]
+      .filter(([, mount]) => mount.osRoot !== undefined)
+      .map(([name, mount]) => `${name} → ${mount.osRoot}`);
+    return vfsError(
+      "not-found",
+      roots.length > 0
+        ? `Not inside any mounted directory. Mounts on disk: ${roots.join(", ")}`
+        : "Not inside any mounted directory",
+    );
   }
 }
 

--- a/src/core/vfs/vfs.ts
+++ b/src/core/vfs/vfs.ts
@@ -1,0 +1,127 @@
+/**
+ * VFS resolver — the mount table and the path discipline.
+ *
+ * The resolver owns everything mounts shouldn't have to repeat: scheme
+ * stripping, normalization, traversal rejection, routing to the mount by
+ * first segment, and re-prefixing the mount-relative stats that come back.
+ * Mounts therefore only ever see clean relative paths.
+ */
+
+import type { VfsMount, VfsResult, VfsStat } from "./types.js";
+import { vfsError, vfsOk } from "./types.js";
+
+const SCHEME = "talon://";
+
+/** A parsed path: which mount, and the path inside it. */
+type Resolved = { mount: VfsMount; prefix: string; rel: string };
+
+export class Vfs {
+  readonly #mounts = new Map<string, VfsMount>();
+
+  /** Register a mount under a single-segment name ("skills", "proc"). */
+  mount(name: string, mount: VfsMount): void {
+    if (!/^[a-z0-9-]+$/.test(name)) {
+      throw new Error(`Invalid mount name: "${name}"`);
+    }
+    if (this.#mounts.has(name)) {
+      throw new Error(`Mount "${name}" already registered`);
+    }
+    this.#mounts.set(name, mount);
+  }
+
+  stat(path: string): VfsResult<VfsStat> {
+    const parsed = this.#parse(path);
+    if (!parsed.ok) return parsed;
+    if (parsed.value === null) {
+      return vfsOk({
+        path: "",
+        name: SCHEME,
+        kind: "dir" as const,
+        writable: false,
+      });
+    }
+    const { mount, prefix, rel } = parsed.value;
+    const result = mount.stat(rel);
+    return result.ok ? vfsOk(withPrefix(result.value, prefix)) : result;
+  }
+
+  list(path: string): VfsResult<VfsStat[]> {
+    const parsed = this.#parse(path);
+    if (!parsed.ok) return parsed;
+    if (parsed.value === null) {
+      return vfsOk(
+        [...this.#mounts.entries()].map(([name, mount]) => ({
+          path: name,
+          name,
+          kind: "dir" as const,
+          writable: mount.writable,
+        })),
+      );
+    }
+    const { mount, prefix, rel } = parsed.value;
+    const result = mount.list(rel);
+    return result.ok
+      ? vfsOk(result.value.map((entry) => withPrefix(entry, prefix)))
+      : result;
+  }
+
+  read(path: string): VfsResult<string> {
+    const parsed = this.#parse(path);
+    if (!parsed.ok) return parsed;
+    if (parsed.value === null) return vfsError("is-a-directory");
+    return parsed.value.mount.read(parsed.value.rel);
+  }
+
+  write(path: string, content: string): VfsResult<VfsStat> {
+    const parsed = this.#parse(path);
+    if (!parsed.ok) return parsed;
+    if (parsed.value === null) return vfsError("is-a-directory");
+    const { mount, prefix, rel } = parsed.value;
+    if (!mount.write) {
+      return vfsError("not-writable", `talon://${prefix} is read-only`);
+    }
+    const result = mount.write(rel, content);
+    return result.ok ? vfsOk(withPrefix(result.value, prefix)) : result;
+  }
+
+  /** Mount names + descriptions, for docs/tool output. */
+  describeMounts(): { name: string; description: string; writable: boolean }[] {
+    return [...this.#mounts.entries()].map(([name, mount]) => ({
+      name,
+      description: mount.description,
+      writable: mount.writable,
+    }));
+  }
+
+  /** null = the namespace root. */
+  #parse(raw: string): VfsResult<Resolved | null> {
+    let path = raw.trim();
+    if (path.startsWith(SCHEME)) path = path.slice(SCHEME.length);
+    if (path.includes("\\")) {
+      return vfsError(
+        "invalid-path",
+        "Namespace paths use / on every platform",
+      );
+    }
+    const segments = path.split("/").filter((s) => s.length > 0);
+    if (segments.some((s) => s === "." || s === "..")) {
+      return vfsError("invalid-path", "Relative segments are not allowed");
+    }
+    if (segments.length === 0) return vfsOk(null);
+
+    const [head, ...rest] = segments;
+    const mount = this.#mounts.get(head!);
+    if (!mount) {
+      return vfsError(
+        "not-found",
+        `No mount "${head}" — the root lists what exists`,
+      );
+    }
+    return vfsOk({ mount, prefix: head!, rel: rest.join("/") });
+  }
+}
+
+function withPrefix(stat: VfsStat, prefix: string): VfsStat {
+  const path = stat.path === "" ? prefix : `${prefix}/${stat.path}`;
+  return { ...stat, path, name: stat.path === "" ? prefix : stat.name };
+}


### PR DESCRIPTION
## What

The filesystem step of the OS track: one rooted, mountable **`talon://` namespace** over everything the daemon owns — real file stores and synthetic views of live state answer the same four operations (`stat / list / read / write`), Plan 9 style.

```
talon://
  home/       workspace (writable)
  skills/     SKILL.md bundles (writable)
  scripts/    agent script bodies (writable)
  logs/       daily logs (read-only — daemon-written)
  proc/       task table (proc/tasks/<id>) + event ring (proc/events) — synthetic
  plugins/    plugin registry view, one JSON file each — synthetic
```

The synthetic mounts are the point: `proc/` is the only way to read live daemon state as plain files. Content-free by the same contract as the task table and bus.

## Design

- **Resolver owns the path discipline** (`core/vfs/vfs.ts`): scheme stripping, `/` separators on every platform, traversal rejection, routing by first segment, prefixing. Mounts only ever see clean relative paths.
- **Errno-style results** — every operation returns `{ok} | {ok:false, error: "not-found" | "is-a-directory" | "too-large" | …}`; no throws across the seam.
- **File mounts**: belt-and-braces containment check, UTF-8 reads capped at 256KB with binary sniffing, writes create parents, missing roots read as empty dirs.
- **Synthetic mounts take injected providers** (`createProcMount({tasks, events})`) — the index wires the live singletons, tests wire fixtures.
- **Lazy default namespace** (`getVfs()`): nothing captures `dirs.*` at import time — eager construction broke test-mocked paths, and the full suite caught it.
- **Not a permission layer** — mounts declare what is mechanically writable; nothing restricts the agent.

## Surfaces (all thin over the same core)

- `vfs_list` / `vfs_read` / `vfs_write` MCP tools (new `vfs` tag) via gateway actions
- `GET /vfs/list?path=` / `GET /vfs/read?path=` on the 127.0.0.1 gateway
- `talon ls [path]` / `talon cat <path>` — daemon-first for live `proc/`/`plugins/`; served in-process when the daemon is down, so file mounts always work

## Testing

- `vfs.test.ts` (20 tests): resolver discipline, file mount incl. containment/binary/oversize, proc + plugins mounts via fixtures.
- `vfs-actions.test.ts`: the model-facing tool formatting end-to-end against the real default namespace on a temp workspace.
- **Live verification**: booted a scratch daemon (`desktop` frontend) and confirmed `talon ls proc` / `cat proc/events` served by the gateway; daemon-down fallback verified separately.
- Full suite 3916 passed / 0 failed; tsc + oxlint clean.

Follow-ups noted in `docs/vfs.md`: read-only sqlite mounts (`chats/<id>/history`, `media/`), richer `plugins/` once the plugin manager (#559) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)