### PR TITLE
feat(core): killable turns — talon kill interrupts a running chat turn on every backend

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -9,12 +9,12 @@
 A **task** is one bounded run of agent work. Four kinds exist today, one per
 place the runtime actually starts an agent:
 
-| Kind        | Registered by                        | Killable | Usage captured |
-| ----------- | ------------------------------------ | -------- | -------------- |
-| `turn`      | `core/weaver` (every chat turn)      | no       | yes            |
-| `heartbeat` | `core/background/heartbeat/agent.ts` | yes      | no             |
-| `dream`     | `core/background/dream.ts`           | yes      | no             |
-| `cron` / `trigger` | `core/background/job-oneshot.ts` (isolated query jobs) | yes | no |
+| Kind               | Registered by                                          | Killable | Usage captured |
+| ------------------ | ------------------------------------------------------ | -------- | -------------- |
+| `turn`             | `core/weaver` (every chat turn)                        | yes      | yes            |
+| `heartbeat`        | `core/background/heartbeat/agent.ts`                   | yes      | no             |
+| `dream`            | `core/background/dream.ts`                             | yes      | no             |
+| `cron` / `trigger` | `core/background/job-oneshot.ts` (isolated query jobs) | yes      | no             |
 
 Deliberately **not** tasks: trigger watcher scripts (long-lived OS processes
 the trigger store already tracks, pid and all), cron `message` jobs (a single
@@ -26,12 +26,21 @@ Settlement is idempotent — the first terminal state wins.
 
 ## Kill semantics
 
-A task is killable when its owner registered an abort hook (in practice: the
-run is driven by an `AbortController`). `kill` delivers the abort and returns
-immediately; the task settles as `killed` when the owner's failure path lands.
-A run that completes despite the abort settles as `done` — a kill only
-"takes" when the run actually dies. Chat turns have no abort path today, so
-they are honestly reported as not killable rather than pretending.
+A task is killable when its owner registered an abort hook. `kill` delivers
+the abort and returns immediately; the task settles as `killed` when the
+owner's failure path lands. A background run that completes despite the
+abort settles as `done` — a kill only "takes" when the run actually dies.
+
+Chat turns kill through `ChatBackend.interruptChatTurn` — the same
+capability behind the frontend stop affordance, implemented by every
+backend (the Claude SDK's native `Query.interrupt()`; the callback
+backends via the shared `backend/shared/turn-interrupt.ts` registry, where
+a user interrupt is a synthetic turn terminator: the stream closes as a
+normal completion carrying the partial text and real usage, never as an
+error or a retry). The weaver settles the killed turn's task as `killed`
+with that usage while the partial result flows back to the caller. A turn
+killed while still queued in its chat's FIFO never reaches the backend —
+and never interrupts the same chat's currently running turn.
 
 The table is observational: it never schedules, retries, or times out a run.
 Those disciplines stay with the owning module (weaver, heartbeat scheduler,

--- a/src/__tests__/task-table.test.ts
+++ b/src/__tests__/task-table.test.ts
@@ -101,6 +101,24 @@ describe("task table", () => {
     });
   });
 
+  it("fail records usage when the owner reports what the run burned", () => {
+    const table = new TaskTable();
+    const task = table.begin({ kind: "turn", label: "message" });
+
+    task.fail(new Error("interrupted by kill"), {
+      inputTokens: 9,
+      outputTokens: 4,
+      cacheRead: 2,
+      cacheWrite: 1,
+    });
+
+    expect(table.list()[0]).toMatchObject({
+      state: "failed",
+      error: "interrupted by kill",
+      usage: { inputTokens: 9, outputTokens: 4, cacheRead: 2, cacheWrite: 1 },
+    });
+  });
+
   it("settlement is idempotent — the first terminal state wins", () => {
     const table = new TaskTable();
     const task = table.begin({ kind: "turn", label: "message" });

--- a/src/__tests__/turn-interrupt.test.ts
+++ b/src/__tests__/turn-interrupt.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Turn-interrupt registry — the shared `ChatBackend.interruptChatTurn`
+ * for the callback backends. Registration lifecycle, identity-guarded
+ * unregistration (retry recursion safety), and the best-effort result
+ * contract.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+import {
+  interruptChatTurn,
+  registerTurnInterrupt,
+} from "../backend/shared/turn-interrupt.js";
+
+describe("turn-interrupt registry", () => {
+  it("reports false when no turn is in flight", async () => {
+    expect(await interruptChatTurn("nobody")).toBe(false);
+  });
+
+  it("invokes the registered interrupt and reports true", async () => {
+    const interrupt = vi.fn(async () => {});
+    const unregister = registerTurnInterrupt("chat-a", interrupt);
+
+    expect(await interruptChatTurn("chat-a")).toBe(true);
+    expect(interrupt).toHaveBeenCalledTimes(1);
+
+    unregister();
+    expect(await interruptChatTurn("chat-a")).toBe(false);
+  });
+
+  it("reports false when the interrupt itself fails", async () => {
+    const unregister = registerTurnInterrupt("chat-b", () => {
+      throw new Error("session gone");
+    });
+    expect(await interruptChatTurn("chat-b")).toBe(false);
+    unregister();
+  });
+
+  it("never lets a stale unregister tear down a retry's registration", async () => {
+    // A retry re-enters the handler and re-registers for the same chat;
+    // the first attempt's finally must not remove the retry's entry.
+    const first = vi.fn();
+    const second = vi.fn();
+    const unregisterFirst = registerTurnInterrupt("chat-c", first);
+    const unregisterSecond = registerTurnInterrupt("chat-c", second);
+
+    unregisterFirst(); // stale — identity mismatch, must be a no-op
+    expect(await interruptChatTurn("chat-c")).toBe(true);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+
+    unregisterSecond();
+    expect(await interruptChatTurn("chat-c")).toBe(false);
+  });
+});

--- a/src/__tests__/weaver.test.ts
+++ b/src/__tests__/weaver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { RetrievedMemory } from "../core/agent-runtime/capabilities.js";
 import type { MemoryRetriever } from "../core/memory/retrieval.js";
 import type { QueryParams } from "../backend/shared/handler-types.js";
+import { handlerToEvents } from "../backend/shared/handler-to-events.js";
 import { Loom, Thread, Weaver } from "../core/weaver/index.js";
 import { bus } from "../core/bus/index.js";
 import { taskTable, type TaskRecord } from "../core/tasks/index.js";
@@ -272,6 +273,110 @@ describe("weaver task registration", () => {
       .filter((t) => t.chatId === "task-fifo")
       .map((t) => t.state);
     expect(states).toEqual(["done", "done"]);
+  });
+
+  it("kills a running turn through the backend interrupt, settling killed with usage", async () => {
+    const gate = deferred();
+    const query = vi.fn(async () => {
+      // The turn hangs until the interrupt fires, then closes cleanly
+      // with the partial result — the interruptChatTurn contract.
+      await gate.promise;
+      return {
+        text: "partial",
+        durationMs: 1,
+        inputTokens: 5,
+        outputTokens: 2,
+        cacheRead: 1,
+        cacheWrite: 0,
+      };
+    });
+    const interruptChatTurn = vi.fn(async () => {
+      gate.resolve();
+      return true;
+    });
+    const backend = stubBackend({
+      chat: {
+        runChatTurn: (p) => handlerToEvents(query, p),
+        interruptChatTurn,
+      },
+    });
+    const weaver = makeWeaver(backend);
+
+    const turn = weaver.runTurn(params({ chatId: "task-kill" }));
+    await vi.waitFor(() => {
+      expect(turnTask("task-kill")).toMatchObject({
+        state: "running",
+        killable: true,
+      });
+    });
+
+    expect(taskTable.kill(turnTask("task-kill")!.id)).toEqual({ ok: true });
+
+    const result = await turn;
+    expect(result.text).toBe("partial");
+    expect(interruptChatTurn).toHaveBeenCalledWith("task-kill");
+    expect(turnTask("task-kill")).toMatchObject({
+      state: "killed",
+      error: expect.stringContaining("interrupted"),
+      usage: { inputTokens: 5, outputTokens: 2, cacheRead: 1, cacheWrite: 0 },
+    });
+  });
+
+  it("kills a queued turn without starting it or interrupting the running one", async () => {
+    const gate = deferred();
+    const query = vi.fn(async (queryParams: QueryParams) => {
+      if (queryParams.text === "first") await gate.promise;
+      return {
+        text: queryParams.text,
+        durationMs: 1,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      };
+    });
+    const interruptChatTurn = vi.fn(async () => true);
+    const backend = stubBackend({
+      chat: {
+        runChatTurn: (p) => handlerToEvents(query, p),
+        interruptChatTurn,
+      },
+    });
+    const weaver = makeWeaver(backend);
+
+    const p1 = weaver.runTurn(
+      params({ chatId: "task-qkill", prompt: "first" }),
+    );
+    const p2 = weaver.runTurn(
+      params({ chatId: "task-qkill", prompt: "second" }),
+    );
+    await vi.waitFor(() => {
+      const states = taskTable
+        .list()
+        .filter((t) => t.chatId === "task-qkill")
+        .map((t) => t.state);
+      expect(states).toEqual(["running", "queued"]);
+    });
+
+    const queued = taskTable
+      .list()
+      .find((t) => t.chatId === "task-qkill" && t.state === "queued")!;
+    expect(taskTable.kill(queued.id)).toEqual({ ok: true });
+    // The started guard: a queued turn's kill must never signal the
+    // backend — that would interrupt the chat's currently running turn.
+    expect(interruptChatTurn).not.toHaveBeenCalled();
+
+    gate.resolve();
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.text).toBe("first");
+    expect(r2.text).toContain("killed before it started");
+    // The killed turn never reached the backend.
+    expect(query).toHaveBeenCalledTimes(1);
+    const states = taskTable
+      .list()
+      .filter((t) => t.chatId === "task-qkill")
+      .map((t) => t.state);
+    expect(states).toEqual(["done", "killed"]);
   });
 });
 

--- a/src/backend/codex/factory.ts
+++ b/src/backend/codex/factory.ts
@@ -10,6 +10,7 @@ import { registerBackend } from "../../core/agent-runtime/backend-registry.js";
 import type { BackendFactory } from "../../core/agent-runtime/backend-registry.js";
 import { log } from "../../util/log.js";
 import { handlerToEvents } from "../shared/handler-to-events.js";
+import { interruptChatTurn } from "../shared/turn-interrupt.js";
 import {
   composeBackend,
   type ChatBackend,
@@ -46,6 +47,7 @@ const codexFactory: BackendFactory = {
     const chat: ChatBackend = {
       runChatTurn: (params) =>
         handlerToEvents((p) => codexHandleMessage(p), params),
+      interruptChatTurn: (chatId) => interruptChatTurn(chatId),
     };
 
     const background: BackgroundRunner = {

--- a/src/backend/codex/handler/message.ts
+++ b/src/backend/codex/handler/message.ts
@@ -40,6 +40,7 @@ import {
   recordTurnMetrics,
   recordFailedTurnAccounting,
   pushLiveUsage,
+  registerTurnInterrupt,
 } from "../../shared/index.js";
 
 import {
@@ -322,6 +323,14 @@ export async function handleMessage(
   const codexToolMetrics = { count: 0 };
   const abortController = new AbortController();
   activeAborts.set(chatId, abortController);
+  // A user interrupt is a synthetic turn terminator: marking the flag
+  // before aborting routes the close through the same clean path a
+  // model-fired end_turn takes (abort swallowed, no retry, no flow
+  // violation), settling with the partial text and real usage.
+  const unregisterInterrupt = registerTurnInterrupt(chatId, () => {
+    streamState.turnTerminated = true;
+    abortController.abort();
+  });
 
   let usage: Usage | null = null;
   let turnFailedError: string | undefined;
@@ -539,6 +548,7 @@ export async function handleMessage(
       throw outcome.classified;
     }
   } finally {
+    unregisterInterrupt();
     if (activeAborts.get(chatId) === abortController) {
       activeAborts.delete(chatId);
     }

--- a/src/backend/kilo/factory.ts
+++ b/src/backend/kilo/factory.ts
@@ -13,6 +13,7 @@ import { registerBackend } from "../../core/agent-runtime/backend-registry.js";
 import type { BackendFactory } from "../../core/agent-runtime/backend-registry.js";
 import { log } from "../../util/log.js";
 import { handlerToEvents } from "../shared/handler-to-events.js";
+import { interruptChatTurn } from "../shared/turn-interrupt.js";
 import {
   composeBackend,
   type ChatBackend,
@@ -47,6 +48,7 @@ const kiloFactory: BackendFactory = {
     const chat: ChatBackend = {
       runChatTurn: (params) =>
         handlerToEvents((p) => kiloHandleMessage(p), params),
+      interruptChatTurn: (chatId) => interruptChatTurn(chatId),
     };
 
     const background: BackgroundRunner = {

--- a/src/backend/kilo/handler/message.ts
+++ b/src/backend/kilo/handler/message.ts
@@ -45,6 +45,7 @@ import {
   applyRetryDecision,
   recordTurnMetrics,
   recordFailedTurnAccounting,
+  registerTurnInterrupt,
 } from "../../shared/index.js";
 import { activeSessions } from "./state.js";
 import { runKiloTurn } from "./turn.js";
@@ -119,6 +120,14 @@ export async function handleMessage(
   // into the live-turn overlay — /status updates while the turn runs.
   const state = createStreamState(chatId);
   state.newSessionId = sessionId;
+  // A user interrupt is a synthetic turn terminator: marking the flag
+  // before aborting the session routes the close through the same clean
+  // path a model-fired end_turn takes (MessageAborted swallowed as the
+  // expected close, no retry), settling with whatever the turn produced.
+  const unregisterInterrupt = registerTurnInterrupt(chatId, async () => {
+    state.turnTerminated = true;
+    await oc.session.abort({ sessionID: sessionId });
+  });
   const promptStartedAt = Date.now();
   const seenQuestionIds = new Set<string>();
   const seenToolCallIds = new Set<string>();
@@ -185,6 +194,7 @@ export async function handleMessage(
     logError("agent", `[${chatId}] Kilo error: ${outcome.classified.message}`);
     throw outcome.classified;
   } finally {
+    unregisterInterrupt();
     if (activeSessions.get(chatId) === sessionId) {
       activeSessions.delete(chatId);
     }

--- a/src/backend/openai-agents/factory.ts
+++ b/src/backend/openai-agents/factory.ts
@@ -13,6 +13,7 @@ import { registerBackend } from "../../core/agent-runtime/backend-registry.js";
 import type { BackendFactory } from "../../core/agent-runtime/backend-registry.js";
 import { log } from "../../util/log.js";
 import { handlerToEvents } from "../shared/handler-to-events.js";
+import { interruptChatTurn } from "../shared/turn-interrupt.js";
 import {
   composeBackend,
   type ChatBackend,
@@ -46,6 +47,7 @@ const openAIAgentsFactory: BackendFactory = {
     const chat: ChatBackend = {
       runChatTurn: (params) =>
         handlerToEvents((p) => openAIAgentsHandleMessage(p), params),
+      interruptChatTurn: (chatId) => interruptChatTurn(chatId),
     };
 
     const defaultIdSync = (): string | null => {

--- a/src/backend/openai-agents/handler/message.ts
+++ b/src/backend/openai-agents/handler/message.ts
@@ -38,6 +38,7 @@ import {
   recordTurnMetrics,
   recordFailedTurnAccounting,
   recordFlowViolation,
+  registerTurnInterrupt,
 } from "../../shared/index.js";
 import {
   detectFlowViolation,
@@ -182,6 +183,14 @@ export async function handleMessage(
   const seenToolCallIds = new Set<string>();
   const abortController = new AbortController();
   activeAborts.set(chatId, abortController);
+  // A user interrupt is a synthetic turn terminator: marking the flag
+  // before aborting routes the close through the same clean path a
+  // model-fired end_turn takes (abort swallowed, no retry, no flow
+  // violation), settling with the partial text and real usage.
+  const unregisterInterrupt = registerTurnInterrupt(chatId, () => {
+    streamState.turnTerminated = true;
+    abortController.abort();
+  });
 
   const setupMs = Date.now() - t0;
   let turnMs = 0;
@@ -385,6 +394,7 @@ export async function handleMessage(
       throw classified;
     }
   } finally {
+    unregisterInterrupt();
     if (activeAborts.get(chatId) === abortController) {
       activeAborts.delete(chatId);
     }

--- a/src/backend/opencode/factory.ts
+++ b/src/backend/opencode/factory.ts
@@ -13,6 +13,7 @@ import { registerBackend } from "../../core/agent-runtime/backend-registry.js";
 import type { BackendFactory } from "../../core/agent-runtime/backend-registry.js";
 import { log } from "../../util/log.js";
 import { handlerToEvents } from "../shared/handler-to-events.js";
+import { interruptChatTurn } from "../shared/turn-interrupt.js";
 import {
   composeBackend,
   type ChatBackend,
@@ -47,6 +48,7 @@ const opencodeFactory: BackendFactory = {
     const chat: ChatBackend = {
       runChatTurn: (params) =>
         handlerToEvents((p) => ocHandleMessage(p), params),
+      interruptChatTurn: (chatId) => interruptChatTurn(chatId),
     };
 
     const background: BackgroundRunner = {

--- a/src/backend/opencode/handler/message.ts
+++ b/src/backend/opencode/handler/message.ts
@@ -47,6 +47,7 @@ import {
   applyRetryDecision,
   recordTurnMetrics,
   recordFailedTurnAccounting,
+  registerTurnInterrupt,
 } from "../../shared/index.js";
 import { activeSessions } from "./state.js";
 import { runOpenCodeTurn } from "./turn.js";
@@ -122,6 +123,14 @@ export async function handleMessage(
   // into the live-turn overlay — /status updates while the turn runs.
   const state = createStreamState(chatId);
   state.newSessionId = sessionId;
+  // A user interrupt is a synthetic turn terminator: marking the flag
+  // before aborting the session routes the close through the same clean
+  // path a model-fired end_turn takes (MessageAborted swallowed as the
+  // expected close, no retry), settling with whatever the turn produced.
+  const unregisterInterrupt = registerTurnInterrupt(chatId, async () => {
+    state.turnTerminated = true;
+    await oc.session.abort({ sessionID: sessionId });
+  });
   const promptStartedAt = Date.now();
   const seenQuestionIds = new Set<string>();
   const seenToolCallIds = new Set<string>();
@@ -191,6 +200,7 @@ export async function handleMessage(
     );
     throw outcome.classified;
   } finally {
+    unregisterInterrupt();
     if (activeSessions.get(chatId) === sessionId) {
       activeSessions.delete(chatId);
     }

--- a/src/backend/shared/index.ts
+++ b/src/backend/shared/index.ts
@@ -21,6 +21,8 @@
  *     (assembly itself lives in `core/prompt/`).
  *   - `model-retry` — session-expiry / context-overflow / fallback decisions.
  *   - `stream-state` — backend-agnostic accumulator for stream loops.
+ *   - `turn-interrupt` — user-driven mid-turn interrupt registry (the
+ *     shared `ChatBackend.interruptChatTurn` for callback backends).
  *
  * What's NOT here (intentionally):
  *   - SDK-specific event types — those live in each backend.
@@ -42,6 +44,8 @@ export {
   type FlowViolationInputs,
   type FlowViolationResult,
 } from "./flow-violation.js";
+
+export { registerTurnInterrupt, interruptChatTurn } from "./turn-interrupt.js";
 
 export {
   formatUserPrompt,

--- a/src/backend/shared/turn-interrupt.ts
+++ b/src/backend/shared/turn-interrupt.ts
@@ -1,0 +1,61 @@
+/**
+ * User-driven mid-turn interrupts, shared by the callback backends
+ * (Codex, OpenAI Agents, Kilo, OpenCode). The Claude SDK backend has a
+ * native `Query.interrupt()` and doesn't come through here.
+ *
+ * A handler registers how to stop its in-flight turn when the turn
+ * starts and unregisters when it settles; `interruptChatTurn` — the
+ * shared implementation of `ChatBackend.interruptChatTurn` — invokes it.
+ *
+ * The registered closure must make the turn end the way a model-fired
+ * terminator does: mark `state.turnTerminated` FIRST, then fire the
+ * native abort. Every backend's close-out logic already keys off that
+ * flag — abort errors are swallowed as the expected close, wrap-up
+ * round-trips are skipped, and the flow-violation retry (which would
+ * otherwise resurrect a killed turn as a "missed delivery") stands
+ * down. The stream then settles as a normal completion carrying the
+ * partial text and real usage — never as an error, never as a retry.
+ */
+
+import { log, logWarn } from "../../util/log.js";
+import { incrementCounter } from "../../util/metrics.js";
+
+const interrupts = new Map<string, () => void | Promise<void>>();
+
+/**
+ * Register the abort path for a chat's in-flight turn. Returns the
+ * unregister function; it only removes its own registration, so a retry
+ * that re-registered for the same chat is never torn down by the
+ * attempt that spawned it.
+ */
+export function registerTurnInterrupt(
+  chatId: string,
+  interrupt: () => void | Promise<void>,
+): () => void {
+  interrupts.set(chatId, interrupt);
+  return () => {
+    if (interrupts.get(chatId) === interrupt) interrupts.delete(chatId);
+  };
+}
+
+/**
+ * Best-effort interrupt of the chat's in-flight turn. Resolves `true`
+ * when a running turn was found and signalled, `false` otherwise —
+ * the `ChatBackend.interruptChatTurn` contract.
+ */
+export async function interruptChatTurn(chatId: string): Promise<boolean> {
+  const interrupt = interrupts.get(chatId);
+  if (!interrupt) return false;
+  try {
+    await interrupt();
+    log("agent", `[${chatId}] turn interrupted by user`);
+    incrementCounter("turn_interrupted");
+    return true;
+  } catch (err) {
+    logWarn(
+      "agent",
+      `[${chatId}] interrupt failed: ${err instanceof Error ? err.message : err}`,
+    );
+    return false;
+  }
+}

--- a/src/cli/tasks.ts
+++ b/src/cli/tasks.ts
@@ -174,7 +174,7 @@ export async function killTask(rawId: string | undefined): Promise<void> {
       return;
     case "not-killable":
       console.log(
-        `  ${pc.yellow("!")} Task ${id} has no abort hook (chat turns run to completion) — it cannot be killed.\n`,
+        `  ${pc.yellow("!")} Task ${id} has no abort hook — its backend can't interrupt a running turn.\n`,
       );
       return;
   }

--- a/src/core/tasks/table.ts
+++ b/src/core/tasks/table.ts
@@ -92,7 +92,7 @@ export class TaskTable {
       start: () => this.start(id),
       bind: (binding) => this.bind(id, binding),
       succeed: (usage) => this.settle(id, "done", undefined, usage),
-      fail: (error) => this.settle(id, "failed", error),
+      fail: (error, usage) => this.settle(id, "failed", error, usage),
     };
   }
 

--- a/src/core/tasks/types.ts
+++ b/src/core/tasks/types.ts
@@ -87,8 +87,12 @@ export interface TaskHandle {
   bind(binding: TaskBinding): void;
   /** Settle as `done`, optionally recording token usage. */
   succeed(usage?: TaskUsage): void;
-  /** Settle as `failed` — or `killed` when a kill was requested first. */
-  fail(error: unknown): void;
+  /**
+   * Settle as `failed` — or `killed` when a kill was requested first.
+   * Usage is recorded when the owner knows what the run burned before it
+   * died (an interrupted turn still spent real tokens).
+   */
+  fail(error: unknown, usage?: TaskUsage): void;
 }
 
 /** Result of `TaskTable.kill`. */

--- a/src/core/weaver/weaver.ts
+++ b/src/core/weaver/weaver.ts
@@ -73,14 +73,32 @@ export class Weaver {
 
   runTurn(params: ExecuteParams): Promise<ExecuteResult> {
     const thread = this.loom.thread(params.chatId);
+    // A turn is killable when its backend can interrupt an in-flight
+    // chat turn. The abort hook tracks lifecycle through this closure:
+    // before the turn starts, a kill just marks it (run() then refuses to
+    // start); once running, the kill signals the backend — which stops
+    // the turn cleanly per the interruptChatTurn contract. The started
+    // guard matters in a queue: killing a queued turn must never
+    // interrupt the same chat's currently running one.
+    const chat = this.deps.getBackend(params.chatId).chat;
+    const interrupt = chat?.interruptChatTurn?.bind(chat);
+    const lifecycle = { started: false, killed: false };
     // Registered before enqueueing so a turn waiting in its chat's FIFO is
     // visible as `queued` in the task table, not invisible until it runs.
     const task = taskTable.enqueue({
       kind: "turn",
       label: params.source,
       chatId: params.chatId,
+      ...(interrupt
+        ? {
+            abort: () => {
+              lifecycle.killed = true;
+              if (lifecycle.started) void interrupt(params.chatId);
+            },
+          }
+        : {}),
     });
-    return thread.enqueue(() => this.run(thread, params, task));
+    return thread.enqueue(() => this.run(thread, params, task, lifecycle));
   }
 
   /** Number of turns currently running (not queued) across all chats. */
@@ -101,17 +119,36 @@ export class Weaver {
     thread: Thread,
     params: ExecuteParams,
     task: TaskHandle,
+    lifecycle: { started: boolean; killed: boolean },
   ): Promise<ExecuteResult> {
+    if (lifecycle.killed) {
+      // Killed while queued — the turn never reaches the backend. The
+      // caller still gets a resolved (empty) result; nothing is delivered
+      // to the chat, which is the point of the kill.
+      task.fail(new Error("killed while queued"));
+      return this.emptyResult("Turn killed before it started.", params);
+    }
+    lifecycle.started = true;
     this.activeCount++;
     task.start();
     try {
       const result = await this.executeInner(thread, params, task);
-      task.succeed({
+      const usage = {
         inputTokens: result.inputTokens,
         outputTokens: result.outputTokens,
         cacheRead: result.cacheRead,
         cacheWrite: result.cacheWrite,
-      });
+      };
+      if (lifecycle.killed) {
+        // The interrupt landed and the backend closed the turn early but
+        // cleanly — that IS the interrupt contract, so the stream ends as
+        // a completion, not an error. The task still settles as killed
+        // (the truthful outcome of `talon kill`), usage included; the
+        // partial result flows back to the caller for normal handling.
+        task.fail(new Error("interrupted by kill"), usage);
+      } else {
+        task.succeed(usage);
+      }
       return result;
     } catch (err) {
       task.fail(err);


### PR DESCRIPTION
## What

`talon ps` has always listed chat turns; `talon kill` could not touch them — turns were honestly reported as `killable: no`. This PR makes every chat turn killable, mid-flight, on all five backends.

## How

**One contract, two implementations:**
- **Claude SDK** — already had `interruptChatTurn` via the SDK's native `Query.interrupt()`. Unchanged.
- **Codex, OpenAI Agents, Kilo, OpenCode** — a new shared registry (`backend/shared/turn-interrupt.ts`). Each handler registers its abort path when the turn starts (identity-guarded unregister, so retry recursion can't tear down the wrong entry), and the shared `interruptChatTurn` fires it.

**A user interrupt is a synthetic turn terminator.** The registered closure marks `state.turnTerminated` before firing the native abort (`AbortController.abort()` for Codex/OpenAI Agents, `session.abort` for Kilo/OpenCode). Every backend's close-out logic already keys off that flag, so the interrupted stream ends exactly like a model-fired `end_turn`: abort errors swallowed as the expected close, wrap-up round-trips skipped, **no model-fallback retry**, and — critically — the flow-violation retry (which would otherwise re-prompt and resurrect the killed turn as a "missed delivery") stands down. The turn settles as a normal completion carrying partial text and real usage.

**Weaver wiring.** `runTurn` registers the task-table abort hook whenever the backend exposes `interruptChatTurn` (presence-based killability — a backend without it stays `killable: no`, no pretending):
- kill a **running** turn → backend interrupt → clean close → task settles **`killed`** with the usage it burned (`TaskHandle.fail` gains an optional usage arg); the partial result still flows back to the caller for normal handling.
- kill a **queued** turn → it never reaches the backend, settles `killed` — and the started-guard ensures it never interrupts the same chat's currently *running* turn.

This is also the same capability behind the frontend stop affordance, which now lights up on every backend, not just Claude.

## Tests

- `turn-interrupt.test.ts` — registry lifecycle, identity-guarded unregister, best-effort result contract.
- `weaver.test.ts` — kill-running (settles killed + usage, partial result returned, interrupt called), kill-queued (never starts, never signals the running turn, backend query called exactly once).
- `task-table.test.ts` — fail-with-usage settlement.
- Backend Live CI matrix exercises all five backends on ubuntu/macos/windows.

## Docs

`docs/tasks.md` — turn row flips to killable, kill-semantics section describes the interrupt path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)