### PR TITLE
feat(core): event journal — durable bus tail in talon.db

### DIFF
--- a/docs/bus.md
+++ b/docs/bus.md
@@ -37,9 +37,9 @@ feeds, mesh presence transitions.
 
 ## Tail
 
-The bus keeps a bounded ring (200) of recent events with monotonic ids.
-In-memory only — events describe moments in a live process, so nothing is
-persisted.
+The bus keeps a bounded ring (200) of recent events with monotonic ids —
+the live-tail surface. Live state stays in-memory; history is the
+journal's job (below).
 
 - **HTTP (gateway, 127.0.0.1)** — `GET /events/recent?since=<id>` returns
   `{ ok, events }`, id-ascending; `since` is the follow cursor.
@@ -47,3 +47,28 @@ persisted.
 
 Event payloads are content-free (ids, kinds, labels, counts — never message
 text), same contract as the task table.
+
+## Journal — the durable tail
+
+> Status: **implemented** (`src/storage/journal.ts`). The bus's syslog.
+
+A bootstrap subscriber (`bus.subscribeAll`) appends every published event
+to the `journal` table in talon.db — one JSON document per row, type and
+timestamp lifted into columns, `seq` as the durable cursor (per-process
+bus ids restart with the daemon). Retention is bounded (20k rows, pruned
+opportunistically); appends never throw — a full disk must not break the
+bus or the publisher behind it.
+
+This is what makes history answerable across restarts, with or without a
+daemon:
+
+- `talon events --history [N]` — the last N journal entries, read
+  straight from talon.db.
+- `talon ps --all` — the live task table plus settled runs reconstructed
+  from `task.settled` events (deduped by `(id, queuedAt)`, since
+  per-process task ids repeat between daemon runs).
+
+The division of truth is deliberate: the task table and ring describe a
+live process and stay in-memory; the journal records what *happened* —
+and everything that happens already crosses the bus as a typed,
+content-free event, so one subscriber journals the entire runtime.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -44,9 +44,11 @@ and never interrupts the same chat's currently running turn.
 
 The table is observational: it never schedules, retries, or times out a run.
 Those disciplines stay with the owning module (weaver, heartbeat scheduler,
-dream, job-oneshot). It is also in-memory only — a task is a live run, and a
-daemon restart ends every run, so there is nothing truthful to persist. The
-settled history is a bounded ring (50 entries).
+dream, job-oneshot). The live table is in-memory — a task is a live run, and
+a daemon restart ends every run — with a bounded settled ring (50 entries)
+for the recent past. Durable history lives in the event journal: every
+`task.settled` event is appended to talon.db (see `docs/bus.md`), so
+`talon ps --all` answers across restarts.
 
 ## Token accounting
 

--- a/src/__tests__/journal.test.ts
+++ b/src/__tests__/journal.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Event journal — the bus's durable tail in talon.db.
+ *
+ * Uses a per-test TALON_DB_PATH temp database (same pattern as the
+ * other SQLite store tests) with module reset, so the lazily-opened
+ * db handle and the store's prune counter start fresh every time.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PublishedEvent } from "../core/bus/index.js";
+
+const dbEnvBackup = process.env.TALON_DB_PATH;
+let tempDir: string;
+let closeDb: (() => void) | null = null;
+
+async function freshJournal() {
+  vi.resetModules();
+  const db = await import("../storage/db.js");
+  closeDb = db.closeDatabase;
+  return await import("../storage/journal.js");
+}
+
+function turnCompleted(chatId: string, id: number, at: number): PublishedEvent {
+  return {
+    type: "turn.completed",
+    chatId,
+    source: "message",
+    durationMs: 5,
+    inputTokens: 10,
+    outputTokens: 3,
+    id,
+    at,
+  };
+}
+
+function taskSettled(taskId: number, id: number, at: number): PublishedEvent {
+  return {
+    type: "task.settled",
+    task: {
+      id: taskId,
+      kind: "turn",
+      label: "message",
+      state: "done",
+      killable: true,
+      queuedAt: at - 10,
+      startedAt: at - 9,
+      endedAt: at,
+    },
+    id,
+    at,
+  };
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "talon-journal-"));
+  process.env.TALON_DB_PATH = join(tempDir, "talon.db");
+});
+
+afterEach(() => {
+  closeDb?.();
+  closeDb = null;
+  if (dbEnvBackup === undefined) delete process.env.TALON_DB_PATH;
+  else process.env.TALON_DB_PATH = dbEnvBackup;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("event journal", () => {
+  it("round-trips events with durable, monotonic cursors", async () => {
+    const journal = await freshJournal();
+
+    journal.appendToJournal(turnCompleted("a", 1, 1_000));
+    journal.appendToJournal(taskSettled(7, 2, 2_000));
+
+    const entries = journal.readJournal();
+    expect(entries).toHaveLength(2);
+    // Newest first.
+    expect(entries[0]).toMatchObject({
+      at: 2_000,
+      event: { type: "task.settled", task: { id: 7, state: "done" } },
+    });
+    expect(entries[1]).toMatchObject({
+      at: 1_000,
+      event: { type: "turn.completed", chatId: "a" },
+    });
+    expect(entries[0]!.seq).toBeGreaterThan(entries[1]!.seq);
+    expect(journal.journalSize()).toBe(2);
+  });
+
+  it("filters by type and honours the limit", async () => {
+    const journal = await freshJournal();
+    for (let i = 1; i <= 5; i++) {
+      journal.appendToJournal(turnCompleted(`chat-${i}`, i, i * 100));
+      journal.appendToJournal(taskSettled(i, i + 10, i * 100 + 1));
+    }
+
+    const settled = journal.readJournal({ type: "task.settled", limit: 3 });
+    expect(settled).toHaveLength(3);
+    expect(settled.every((e) => e.event.type === "task.settled")).toBe(true);
+    // Newest three of the five.
+    expect(
+      settled.map((e) =>
+        e.event.type === "task.settled" ? e.event.task.id : -1,
+      ),
+    ).toEqual([5, 4, 3]);
+  });
+
+  it("survives a daemon restart — same db, fresh process state", async () => {
+    let journal = await freshJournal();
+    journal.appendToJournal(turnCompleted("persist", 1, 1_234));
+    closeDb?.();
+
+    journal = await freshJournal();
+    const entries = journal.readJournal();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.event).toMatchObject({
+      type: "turn.completed",
+      chatId: "persist",
+    });
+  });
+
+  it("skips corrupt payload rows instead of failing the read", async () => {
+    const journal = await freshJournal();
+    journal.appendToJournal(turnCompleted("good", 1, 1_000));
+    const repo = await import("../storage/repositories/journal-repo.js");
+    repo.append(2_000, "task.settled", "{not json");
+
+    const entries = journal.readJournal();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.event).toMatchObject({ chatId: "good" });
+  });
+
+  it("prunes to the retention bound, keeping the newest rows", async () => {
+    await freshJournal();
+    const repo = await import("../storage/repositories/journal-repo.js");
+    for (let i = 1; i <= 10; i++) {
+      repo.append(
+        i,
+        "turn.completed",
+        JSON.stringify({ type: "turn.completed", n: i }),
+      );
+    }
+
+    repo.prune(4);
+
+    const rows = repo.recent(100);
+    expect(rows).toHaveLength(4);
+    expect(rows.map((r) => r.at)).toEqual([10, 9, 8, 7]);
+  });
+});

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -23,6 +23,7 @@ import {
   execute as dispatcherExecute,
 } from "./core/engine/dispatcher.js";
 import { bus } from "./core/bus/index.js";
+import { appendToJournal } from "./storage/journal.js";
 import { initPulse, resetPulseTimer } from "./core/background/pulse.js";
 import { initCron } from "./core/background/cron.js";
 import {
@@ -418,6 +419,10 @@ export async function initBackendAndDispatcher(
   // completed turn resets the pulse idle timer.
   bus.subscribe("turn.started", () => maybeStartDream());
   bus.subscribe("turn.completed", () => resetPulseTimer());
+  // The journal is the bus's durable tail: every published event lands in
+  // talon.db so history survives restarts (`talon events --history`,
+  // `talon ps --all`). Append failures are logged and swallowed inside.
+  bus.subscribeAll((event) => appendToJournal(event));
 
   initPulse();
   initCron({

--- a/src/cli/events.ts
+++ b/src/cli/events.ts
@@ -2,13 +2,15 @@
  * `talon events` — tail the daemon's event bus.
  *
  * Renders the gateway's `/events/recent` ring; `--follow` (`-f`) keeps
- * polling with a since-cursor for a live tail. Rendering only — the bus
- * itself lives in core/bus/.
+ * polling with a since-cursor for a live tail; `--history [N]` reads the
+ * durable journal in talon.db instead (works across restarts, daemon up
+ * or down). Rendering only — the bus lives in core/bus/, the journal in
+ * storage/journal.ts.
  */
 
 import pc from "picocolors";
 import { fetchGateway, requireGatewayPort } from "./daemon-api.js";
-import type { PublishedEvent } from "../core/bus/index.js";
+import type { PublishedEvent, TalonEvent } from "../core/bus/index.js";
 
 const FOLLOW_POLL_MS = 1_000;
 
@@ -17,7 +19,7 @@ function timestamp(at: number): string {
 }
 
 /** One tail line of type-specific detail, content-free like the events. */
-function describe(event: PublishedEvent): string {
+function describe(event: TalonEvent): string {
   switch (event.type) {
     case "task.started":
       return (
@@ -36,10 +38,35 @@ function describe(event: PublishedEvent): string {
   }
 }
 
-function render(event: PublishedEvent): void {
+function render(event: TalonEvent, at: number): void {
   console.log(
-    `  ${pc.dim(timestamp(event.at))}  ${pc.cyan(event.type.padEnd(14))}  ${describe(event)}`,
+    `  ${pc.dim(timestamp(at))}  ${pc.cyan(event.type.padEnd(14))}  ${describe(event)}`,
   );
+}
+
+/**
+ * The journal path: read the durable tail from talon.db directly — no
+ * daemon required, and it answers across restarts (unlike the ring).
+ */
+async function showHistory(limit: number): Promise<void> {
+  const { readJournal } = await import("../storage/journal.js");
+  let entries;
+  try {
+    entries = readJournal({ limit });
+  } catch (err) {
+    console.log(
+      `  ${pc.red("✖")} Could not read the journal: ${err instanceof Error ? err.message : err}\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (entries.length === 0) {
+    console.log(`  ${pc.dim("Journal is empty — no events recorded yet.")}\n`);
+    return;
+  }
+  // readJournal returns newest-first; a tail reads oldest-to-newest.
+  for (const entry of entries.reverse()) render(entry.event, entry.at);
+  console.log();
 }
 
 async function fetchEvents(
@@ -57,21 +84,29 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export async function showEvents(follow: boolean): Promise<void> {
+export async function showEvents(options: {
+  follow: boolean;
+  history?: number;
+}): Promise<void> {
   console.log();
+  if (options.history !== undefined) {
+    await showHistory(options.history);
+    return;
+  }
+
   const port = await requireGatewayPort();
   if (port === null) return;
 
   let cursor = 0;
   try {
     const events = await fetchEvents(port, cursor);
-    if (events.length === 0 && !follow) {
+    if (events.length === 0 && !options.follow) {
       console.log(
-        `  ${pc.dim("No events yet — the bus ring starts empty on each daemon start.")}\n`,
+        `  ${pc.dim("No events yet — the ring starts empty on each daemon start. Older events: talon events --history")}\n`,
       );
       return;
     }
-    for (const event of events) render(event);
+    for (const event of events) render(event, event.at);
     cursor = events.at(-1)?.id ?? 0;
   } catch (err) {
     console.log(
@@ -80,7 +115,7 @@ export async function showEvents(follow: boolean): Promise<void> {
     return;
   }
 
-  if (!follow) {
+  if (!options.follow) {
     console.log();
     return;
   }
@@ -89,7 +124,7 @@ export async function showEvents(follow: boolean): Promise<void> {
     await sleep(FOLLOW_POLL_MS);
     try {
       const events = await fetchEvents(port, cursor);
-      for (const event of events) render(event);
+      for (const event of events) render(event, event.at);
       if (events.length > 0) cursor = events.at(-1)!.id;
     } catch {
       // Transient gateway hiccup (restart mid-follow) — keep polling.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -105,16 +105,23 @@ export async function runCli(): Promise<void> {
       runDoctor();
       break;
     case "ps":
-      await showTasks();
+      await showTasks(process.argv[3] === "--all" || process.argv[3] === "-a");
       break;
     case "kill":
       await killTask(process.argv[3]);
       break;
-    case "events":
-      await showEvents(
-        process.argv[3] === "-f" || process.argv[3] === "--follow",
-      );
+    case "events": {
+      const args = process.argv.slice(3);
+      const historyAt = args.findIndex((a) => a === "--history");
+      const next = historyAt >= 0 ? Number(args[historyAt + 1]) : NaN;
+      await showEvents({
+        follow: args.includes("-f") || args.includes("--follow"),
+        ...(historyAt >= 0
+          ? { history: Number.isInteger(next) && next > 0 ? next : 100 }
+          : {}),
+      });
       break;
+    }
     case "ls":
       await showLs(process.argv[3]);
       break;
@@ -138,10 +145,12 @@ export async function runCli(): Promise<void> {
       console.log(`    ${pc.cyan("run")}        Run in foreground (attached)`);
       console.log(`    ${pc.cyan("chat")}       Terminal chat mode`);
       console.log(`    ${pc.cyan("status")}     Show bot health`);
-      console.log(`    ${pc.cyan("ps")}         List agent tasks (task table)`);
+      console.log(
+        `    ${pc.cyan("ps")}         List agent tasks (--all includes journal history)`,
+      );
       console.log(`    ${pc.cyan("kill")}       Abort a killable task by id`);
       console.log(
-        `    ${pc.cyan("events")}     Tail the event bus (-f follows)`,
+        `    ${pc.cyan("events")}     Tail the event bus (-f follows, --history [N] reads the journal)`,
       );
       console.log(
         `    ${pc.cyan("ls")}         List the talon:// namespace (ls proc/tasks)`,

--- a/src/cli/tasks.ts
+++ b/src/cli/tasks.ts
@@ -2,12 +2,14 @@
  * `talon ps` / `talon kill` — the task table from the outside.
  *
  * Data comes from the running daemon's gateway (`GET /tasks`,
- * `POST /tasks/kill`); discovery finds the instance the same way
- * `talon status` does. This module only renders — the table itself
- * lives in core/tasks/.
+ * `POST /tasks/kill`); `--all` also folds in settled runs from the
+ * durable journal in talon.db, which answers across restarts — with or
+ * without a daemon. This module only renders — the table lives in
+ * core/tasks/, the journal in storage/journal.ts.
  */
 
 import pc from "picocolors";
+import { findRunningInstance } from "../core/daemon/discovery.js";
 import { fetchGateway, requireGatewayPort } from "./daemon-api.js";
 import type {
   KillOutcome,
@@ -64,7 +66,12 @@ function displayOrder(tasks: TaskRecord[]): TaskRecord[] {
     (t) => t.state !== "running" && t.state !== "queued",
   );
   live.sort((a, b) => a.id - b.id);
-  settled.sort((a, b) => b.id - a.id);
+  // By time, not id: journal history spans daemon restarts, and per-process
+  // ids restart with the daemon.
+  settled.sort(
+    (a, b) =>
+      (b.endedAt ?? b.queuedAt) - (a.endedAt ?? a.queuedAt) || b.id - a.id,
+  );
   return [...live, ...settled];
 }
 
@@ -105,27 +112,85 @@ function renderTable(tasks: TaskRecord[], now: number): void {
   console.log();
 }
 
-export async function showTasks(): Promise<void> {
-  console.log();
-  const port = await requireGatewayPort();
-  if (port === null) return;
+/** Settled runs from the journal, minus any already in the live table. */
+async function journalTasks(
+  liveTasks: readonly TaskRecord[],
+  limit: number,
+): Promise<TaskRecord[]> {
+  const { readJournal } = await import("../storage/journal.js");
+  const seen = new Set(liveTasks.map((t) => `${t.id}:${t.queuedAt}`));
+  const historical: TaskRecord[] = [];
+  for (const entry of readJournal({ type: "task.settled", limit })) {
+    if (entry.event.type !== "task.settled") continue;
+    const task = entry.event.task;
+    // (id, queuedAt) identifies a run across surfaces — per-process ids
+    // repeat between daemon runs, enqueue times don't.
+    if (seen.has(`${task.id}:${task.queuedAt}`)) continue;
+    seen.add(`${task.id}:${task.queuedAt}`);
+    historical.push(task);
+  }
+  return historical;
+}
 
-  let tasks: TaskRecord[];
-  try {
-    const body = (await fetchGateway(port, "/tasks")) as {
-      tasks?: TaskRecord[];
-    };
-    tasks = body.tasks ?? [];
-  } catch (err) {
-    console.log(
-      `  ${pc.red("✖")} Could not read the task table: ${err instanceof Error ? err.message : err}\n`,
-    );
-    return;
+export async function showTasks(all = false): Promise<void> {
+  console.log();
+
+  let tasks: TaskRecord[] = [];
+  let daemonUp = true;
+  if (all) {
+    // History works without a daemon — fold in the live table only when
+    // one is actually running.
+    const instance = await findRunningInstance();
+    if (instance?.port) {
+      try {
+        const body = (await fetchGateway(instance.port, "/tasks")) as {
+          tasks?: TaskRecord[];
+        };
+        tasks = body.tasks ?? [];
+      } catch {
+        daemonUp = false;
+      }
+    } else {
+      daemonUp = false;
+    }
+  } else {
+    const port = await requireGatewayPort();
+    if (port === null) return;
+    try {
+      const body = (await fetchGateway(port, "/tasks")) as {
+        tasks?: TaskRecord[];
+      };
+      tasks = body.tasks ?? [];
+    } catch (err) {
+      console.log(
+        `  ${pc.red("✖")} Could not read the task table: ${err instanceof Error ? err.message : err}\n`,
+      );
+      return;
+    }
+  }
+
+  if (all) {
+    if (!daemonUp) {
+      console.log(
+        `  ${pc.dim("Talon is not running — journal history only.")}`,
+      );
+    }
+    try {
+      tasks = [...tasks, ...(await journalTasks(tasks, 200))];
+    } catch (err) {
+      console.log(
+        `  ${pc.red("✖")} Could not read the journal: ${err instanceof Error ? err.message : err}\n`,
+      );
+      process.exitCode = 1;
+      return;
+    }
   }
 
   if (tasks.length === 0) {
     console.log(
-      `  ${pc.dim("No tasks — the table starts empty on each daemon start.")}\n`,
+      all
+        ? `  ${pc.dim("No tasks — nothing live and the journal is empty.")}\n`
+        : `  ${pc.dim("No tasks — the table starts empty on each daemon start. Older runs: talon ps --all")}\n`,
     );
     return;
   }

--- a/src/storage/journal.ts
+++ b/src/storage/journal.ts
@@ -1,0 +1,91 @@
+/**
+ * Event journal — the bus's durable tail in talon.db.
+ *
+ * The task table and the bus ring are deliberately in-memory: they
+ * describe a live process. What IS truthful to persist is history —
+ * "what happened" — and every task settlement, turn completion, and
+ * future event family already flows through the bus as a typed,
+ * content-free record. So the journal is one subscriber (wired at the
+ * composition root) appending every published event, and history
+ * surfaces (`talon events --history`, `talon ps --all`) read it back —
+ * across daemon restarts, with or without a daemon running.
+ *
+ * Appending must never hurt the daemon: failures are logged once and
+ * swallowed, and retention is pruned opportunistically (every
+ * PRUNE_EVERY appends) rather than on a timer.
+ */
+
+import type { PublishedEvent, TalonEvent } from "../core/bus/index.js";
+import { logError } from "../util/log.js";
+import * as repo from "./repositories/journal-repo.js";
+
+/** Rows kept after a prune — bounded, but generous for a busy daemon. */
+export const JOURNAL_RETENTION = 20_000;
+
+/** Appends between opportunistic prunes. */
+const PRUNE_EVERY = 500;
+
+/** One journal record: the event plus its durable cursor and time. */
+export interface JournalEntry {
+  /** Durable, monotonic cursor — survives restarts (unlike bus ids). */
+  readonly seq: number;
+  /** Publish time, epoch ms. */
+  readonly at: number;
+  readonly event: TalonEvent;
+}
+
+let appendsSincePrune = 0;
+let appendFailureLogged = false;
+
+/**
+ * Append one published event. Never throws — the journal is an
+ * observer, and a full disk or locked database must not break the bus
+ * or the publisher behind it.
+ */
+export function appendToJournal(event: PublishedEvent): void {
+  try {
+    repo.append(event.at, event.type, JSON.stringify(event));
+    if (++appendsSincePrune >= PRUNE_EVERY) {
+      appendsSincePrune = 0;
+      repo.prune(JOURNAL_RETENTION);
+    }
+    appendFailureLogged = false;
+  } catch (err) {
+    if (!appendFailureLogged) {
+      appendFailureLogged = true;
+      logError("journal", "Failed to append event to the journal", err);
+    }
+  }
+}
+
+/**
+ * Read the journal, newest first. `type` narrows to one event type
+ * (indexed). Rows whose payload no longer parses are skipped — a
+ * corrupt row must not take down the readable ones around it.
+ */
+export function readJournal(
+  options: { limit?: number; type?: TalonEvent["type"] } = {},
+): JournalEntry[] {
+  const limit = options.limit ?? 100;
+  const rows = options.type
+    ? repo.recentByType(options.type, limit)
+    : repo.recent(limit);
+  const entries: JournalEntry[] = [];
+  for (const row of rows) {
+    try {
+      entries.push({
+        seq: row.seq,
+        at: row.at,
+        event: JSON.parse(row.payload) as TalonEvent,
+      });
+    } catch {
+      // skip the corrupt row
+    }
+  }
+  return entries;
+}
+
+/** Total journal rows — surfaced by status/debug tooling. */
+export function journalSize(): number {
+  return repo.count();
+}

--- a/src/storage/repositories/journal-repo.ts
+++ b/src/storage/repositories/journal-repo.ts
@@ -1,0 +1,38 @@
+/**
+ * Journal repository — executes the statements in sql/journal.sql
+ * against the `journal` table; no SQL text lives here. The public store
+ * (storage/journal.ts) owns (de)serialisation and error handling.
+ */
+
+import { getDatabase } from "../db.js";
+import { journalSql } from "../sql/statements.generated.js";
+
+export interface JournalRow {
+  seq: number;
+  at: number;
+  type: string;
+  payload: string;
+}
+
+export function append(at: number, type: string, payload: string): void {
+  getDatabase().prepare(journalSql.append).run(at, type, payload);
+}
+
+export function recent(limit: number): JournalRow[] {
+  return getDatabase().prepare(journalSql.recent).all(limit) as JournalRow[];
+}
+
+export function recentByType(type: string, limit: number): JournalRow[] {
+  return getDatabase()
+    .prepare(journalSql.recentByType)
+    .all(type, limit) as JournalRow[];
+}
+
+export function prune(keep: number): void {
+  getDatabase().prepare(journalSql.prune).run(keep);
+}
+
+export function count(): number {
+  const row = getDatabase().prepare(journalSql.count).get() as { n: number };
+  return row.n;
+}

--- a/src/storage/sql/journal.sql
+++ b/src/storage/sql/journal.sql
@@ -1,0 +1,16 @@
+-- Statements for the event journal (see storage/journal.ts).
+
+-- name: append
+INSERT INTO journal (at, type, payload) VALUES (?, ?, ?)
+
+-- name: recent
+SELECT seq, at, type, payload FROM journal ORDER BY seq DESC LIMIT ?
+
+-- name: recentByType
+SELECT seq, at, type, payload FROM journal WHERE type = ? ORDER BY seq DESC LIMIT ?
+
+-- name: prune
+DELETE FROM journal WHERE seq NOT IN (SELECT seq FROM journal ORDER BY seq DESC LIMIT ?)
+
+-- name: count
+SELECT COUNT(*) AS n FROM journal

--- a/src/storage/sql/schema.sql
+++ b/src/storage/sql/schema.sql
@@ -232,3 +232,18 @@ CREATE TABLE IF NOT EXISTS turn_meta (
   meta    TEXT NOT NULL,
   PRIMARY KEY (chat_id, msg_id)
 );
+
+-- The event journal: the bus's durable tail. A bootstrap subscriber
+-- appends every published event (one JSON document per row, with the
+-- type and timestamp lifted into columns for filtering) and prunes to a
+-- bounded retention — so `talon events --history` and `talon ps --all`
+-- can answer across daemon restarts. The in-memory ring in core/bus
+-- stays the live-tail surface; this is the daemon's syslog. `seq` is
+-- the durable cursor (per-process bus ids restart with the daemon).
+CREATE TABLE IF NOT EXISTS journal (
+  seq     INTEGER PRIMARY KEY AUTOINCREMENT,
+  at      INTEGER NOT NULL,
+  type    TEXT    NOT NULL,
+  payload TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_journal_type ON journal(type, seq);

--- a/src/storage/sql/statements.generated.ts
+++ b/src/storage/sql/statements.generated.ts
@@ -236,7 +236,22 @@ CREATE TABLE IF NOT EXISTS turn_meta (
   msg_id  TEXT NOT NULL,
   meta    TEXT NOT NULL,
   PRIMARY KEY (chat_id, msg_id)
-);`;
+);
+
+-- The event journal: the bus's durable tail. A bootstrap subscriber
+-- appends every published event (one JSON document per row, with the
+-- type and timestamp lifted into columns for filtering) and prunes to a
+-- bounded retention — so \`talon events --history\` and \`talon ps --all\`
+-- can answer across daemon restarts. The in-memory ring in core/bus
+-- stays the live-tail surface; this is the daemon's syslog. \`seq\` is
+-- the durable cursor (per-process bus ids restart with the daemon).
+CREATE TABLE IF NOT EXISTS journal (
+  seq     INTEGER PRIMARY KEY AUTOINCREMENT,
+  at      INTEGER NOT NULL,
+  type    TEXT    NOT NULL,
+  payload TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_journal_type ON journal(type, seq);`;
 
 export const chatSettingsSql = {
   upsert: `INSERT OR REPLACE INTO chat_settings (chat_id, settings) VALUES (?, ?)`,
@@ -365,6 +380,14 @@ ORDER BY last_seen DESC`,
        COALESCE(MAX(timestamp), 0) AS newest
 FROM history_messages WHERE chat_id = ?`,
   distinctChatCount: `SELECT COUNT(DISTINCT chat_id) AS chats FROM history_messages`,
+} as const;
+
+export const journalSql = {
+  append: `INSERT INTO journal (at, type, payload) VALUES (?, ?, ?)`,
+  recent: `SELECT seq, at, type, payload FROM journal ORDER BY seq DESC LIMIT ?`,
+  recentByType: `SELECT seq, at, type, payload FROM journal WHERE type = ? ORDER BY seq DESC LIMIT ?`,
+  prune: `DELETE FROM journal WHERE seq NOT IN (SELECT seq FROM journal ORDER BY seq DESC LIMIT ?)`,
+  count: `SELECT COUNT(*) AS n FROM journal`,
 } as const;
 
 export const kvSql = {

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -25,6 +25,7 @@ export type LogComponent =
   | "bridge"
   | "bus"
   | "db"
+  | "journal"
   | "kv"
   | "media"
   | "agent"


### PR DESCRIPTION
## What

The daemon now has a syslog. The task table and event ring are deliberately in-memory — they describe a live process — but *history* is truthful to persist, and everything that happens already crosses the bus as a typed, content-free event. So the journal is one `bus.subscribeAll` subscriber at the composition root, appending every published event to a `journal` table in talon.db.

## Design

- **One table, one writer.** `seq` (autoincrement) is the durable cursor — per-process bus ids restart with the daemon, journal seqs don't. Type and timestamp are lifted into indexed columns; the event itself is one JSON document per row.
- **Never hurts the daemon.** Appends catch and swallow (logged once, not per-event); retention is bounded (20k rows) and pruned opportunistically every 500 appends. A corrupt row is skipped on read, never fails the rows around it.
- **Storage layering** follows the house recipe: `sql/journal.sql` → `repositories/journal-repo.ts` → `storage/journal.ts`, schema in `schema.sql`, statements embedded via `npm run build:sql`.

## Surfaces

- `talon events --history [N]` — last N journal entries rendered by the same formatter as the live tail, read straight from talon.db: works with the daemon down, and across restarts.
- `talon ps --all` — live task table plus settled runs reconstructed from `task.settled` events, deduped by `(id, queuedAt)` (task ids repeat between daemon runs; enqueue times don't). Settled rows now order by end time rather than id for the same reason. Daemon down → journal history only, with a note.

## Docs & tests

- `docs/bus.md` gains a "Journal — the durable tail" section; `docs/tasks.md`'s in-memory paragraph now points at it.
- `journal.test.ts`: round-trip with durable cursors, type filter + limit, restart survival (same db, fresh process), corrupt-row skip, retention prune.

Follow-up (later PR): a `proc/journal` view once the VFS (#560) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)