### PR TITLE
feat(companion): Plugins & Skills settings sub-menus

### DIFF
--- a/apps/companion/lib/src/models/bridge_models.dart
+++ b/apps/companion/lib/src/models/bridge_models.dart
@@ -334,10 +334,12 @@ class ClientChat {
         effort: j['effort'] is String ? j['effort'] as String : null,
         pulse: j['pulse'] is bool ? j['pulse'] as bool : null,
         context: j['context'] is Map
-            ? ContextInfo.fromJson((j['context'] as Map).cast<String, dynamic>())
+            ? ContextInfo.fromJson(
+                (j['context'] as Map).cast<String, dynamic>())
             : null,
         queued: j['queued'] is Map
-            ? QueuedMessage.fromJson((j['queued'] as Map).cast<String, dynamic>())
+            ? QueuedMessage.fromJson(
+                (j['queued'] as Map).cast<String, dynamic>())
             : null,
       );
 
@@ -431,6 +433,10 @@ class BridgeStatus {
   final int activeChats;
   final String startedAt;
 
+  /// Additive bridge features this daemon supports (e.g. "plugins-skills").
+  /// The app gates optional surfaces on these instead of protocol bumps.
+  final List<String> capabilities;
+
   const BridgeStatus({
     required this.protocol,
     required this.botName,
@@ -438,7 +444,10 @@ class BridgeStatus {
     required this.model,
     required this.activeChats,
     required this.startedAt,
+    this.capabilities = const [],
   });
+
+  bool hasCapability(String name) => capabilities.contains(name);
 
   factory BridgeStatus.fromJson(Map<String, dynamic> j) => BridgeStatus(
         protocol: _int(j['protocol'], 1),
@@ -447,6 +456,11 @@ class BridgeStatus {
         model: _string(j['model']),
         activeChats: _int(j['activeChats']),
         startedAt: _string(j['startedAt']),
+        capabilities: j['capabilities'] is List
+            ? (j['capabilities'] as List)
+                .whereType<String>()
+                .toList(growable: false)
+            : const [],
       );
 
   static const empty = BridgeStatus(
@@ -501,6 +515,7 @@ class ToolActivity {
   bool done;
   String? error;
   Map<String, dynamic> input;
+
   /// Truncated string form of the tool's result, shown in the expanded view.
   /// Arrives on the `result` phase (or re-hydrated from history).
   String? output;
@@ -594,5 +609,52 @@ class SearchHit {
         chatId: _string(j['chatId']),
         chatTitle: _string(j['chatTitle']),
         message: ClientMessage.fromJson(_map(j['message'])),
+      );
+}
+
+/// One installed plugin, as `GET /plugins` lists it (behind the
+/// `plugins-skills` bridge capability).
+class PluginInfo {
+  final String name;
+
+  /// "builtin" (config-section plugin), "module", or "mcp".
+  final String kind;
+  final bool enabled;
+
+  /// Where it comes from: a config section, module path, or MCP command.
+  final String source;
+
+  const PluginInfo({
+    required this.name,
+    required this.kind,
+    required this.enabled,
+    required this.source,
+  });
+
+  factory PluginInfo.fromJson(Map<String, dynamic> j) => PluginInfo(
+        name: _string(j['name']),
+        kind: _string(j['kind']),
+        enabled: _bool(j['enabled']),
+        source: _string(j['source']),
+      );
+}
+
+/// One installed skill, as `GET /skills` lists it. A disabled skill drops
+/// out of the model's prompt index but stays installed.
+class SkillInfo {
+  final String name;
+  final String description;
+  final bool enabled;
+
+  const SkillInfo({
+    required this.name,
+    required this.description,
+    required this.enabled,
+  });
+
+  factory SkillInfo.fromJson(Map<String, dynamic> j) => SkillInfo(
+        name: _string(j['name']),
+        description: _string(j['description']),
+        enabled: _bool(j['enabled']),
       );
 }

--- a/apps/companion/lib/src/services/bridge_client.dart
+++ b/apps/companion/lib/src/services/bridge_client.dart
@@ -346,6 +346,51 @@ class BridgeClient {
     );
   }
 
+  /// Installed plugins with their enabled state (`plugins-skills` capability).
+  Future<List<PluginInfo>> listPlugins() async {
+    final j = await _getJson('/plugins');
+    return _list(j['plugins'])
+        .map((p) => PluginInfo.fromJson(_map(p)))
+        .toList();
+  }
+
+  /// Enable/disable a plugin. The daemon persists and hot-reloads; `ok`
+  /// is the application outcome (always HTTP 200, mirroring `/backend`).
+  Future<({bool ok, String? error})> togglePlugin(
+    String name,
+    bool enabled,
+  ) async {
+    final j = await _postJson('/plugins/toggle', {
+      'name': name,
+      'enabled': enabled,
+    });
+    return (
+      ok: j['ok'] == true,
+      error: j['error'] is String ? j['error'] as String : null,
+    );
+  }
+
+  /// Installed skills with their enabled state (`plugins-skills` capability).
+  Future<List<SkillInfo>> listSkills() async {
+    final j = await _getJson('/skills');
+    return _list(j['skills']).map((s) => SkillInfo.fromJson(_map(s))).toList();
+  }
+
+  /// Enable/disable a skill (drops it from / restores it to the prompt index).
+  Future<({bool ok, String? error})> toggleSkill(
+    String name,
+    bool enabled,
+  ) async {
+    final j = await _postJson('/skills/toggle', {
+      'name': name,
+      'enabled': enabled,
+    });
+    return (
+      ok: j['ok'] == true,
+      error: j['error'] is String ? j['error'] as String : null,
+    );
+  }
+
   /// A page of history: the newest window by default, or — when [before] is
   /// given — the window of messages strictly older than that message id.
   Future<List<ClientMessage>> history(

--- a/apps/companion/lib/src/state/app_state.dart
+++ b/apps/companion/lib/src/state/app_state.dart
@@ -162,8 +162,7 @@ class AppState extends ChangeNotifier {
   List<DeviceInfo> meshDevices = [];
   List<DeviceLocation> meshLocations = [];
   MeshForegroundHealth meshBackgroundHealth = evaluateMeshForegroundHealth(
-    supported:
-        MeshForegroundController.isSupported ||
+    supported: MeshForegroundController.isSupported ||
         MeshForegroundController.isResidentDesktop,
     sharingEnabled: false,
     serviceRunning: false,
@@ -819,6 +818,59 @@ class AppState extends ChangeNotifier {
     return result;
   }
 
+  /// Seeded extension lists for widget tests / the screenshot gallery —
+  /// [listPlugins]/[listSkills] serve these instead of hitting the bridge.
+  List<PluginInfo>? _debugPlugins;
+  List<SkillInfo>? _debugSkills;
+
+  /// Installed plugins for the settings sub-menu. Throws on transport
+  /// failure — the screen owns the error presentation.
+  Future<List<PluginInfo>> listPlugins() async {
+    final seeded = _debugPlugins;
+    if (seeded != null) return seeded;
+    final client = _client;
+    if (client == null) throw BridgeException('Not connected');
+    return client.listPlugins();
+  }
+
+  Future<({bool ok, String? error})> togglePlugin(
+    String name,
+    bool enabled,
+  ) async {
+    final client = _client;
+    if (client == null) return (ok: false, error: 'Not connected');
+    try {
+      return await client.togglePlugin(name, enabled);
+    } catch (e) {
+      AppLog.warn('app_state', 'plugin toggle failed', e);
+      return (ok: false, error: e.toString());
+    }
+  }
+
+  /// Installed skills for the settings sub-menu. Throws on transport
+  /// failure — the screen owns the error presentation.
+  Future<List<SkillInfo>> listSkills() async {
+    final seeded = _debugSkills;
+    if (seeded != null) return seeded;
+    final client = _client;
+    if (client == null) throw BridgeException('Not connected');
+    return client.listSkills();
+  }
+
+  Future<({bool ok, String? error})> toggleSkill(
+    String name,
+    bool enabled,
+  ) async {
+    final client = _client;
+    if (client == null) return (ok: false, error: 'Not connected');
+    try {
+      return await client.toggleSkill(name, enabled);
+    } catch (e) {
+      AppLog.warn('app_state', 'skill toggle failed', e);
+      return (ok: false, error: e.toString());
+    }
+  }
+
   /// Newest daemon log entries for the log viewer. Throws on transport
   /// failure — the screen owns the error presentation.
   Future<List<DaemonLogEntry>> daemonLogs({
@@ -1174,6 +1226,8 @@ class AppState extends ChangeNotifier {
     String? select,
     ConnState? connState,
     BridgeStatus? bridgeStatus,
+    List<PluginInfo>? plugins,
+    List<SkillInfo>? skills,
   }) {
     if (chats != null) {
       this.chats
@@ -1191,6 +1245,8 @@ class AppState extends ChangeNotifier {
     if (select != null) selectedChatId = select;
     if (connState != null) conn = connState;
     if (bridgeStatus != null) status = bridgeStatus;
+    if (plugins != null) _debugPlugins = plugins;
+    if (skills != null) _debugSkills = skills;
     notifyListeners();
   }
 

--- a/apps/companion/lib/src/ui/extensions_screen.dart
+++ b/apps/companion/lib/src/ui/extensions_screen.dart
@@ -1,0 +1,343 @@
+import 'package:flutter/material.dart';
+
+import '../models/bridge_models.dart';
+import '../services/haptics.dart';
+import '../services/log.dart';
+import '../state/app_state.dart';
+import '../theme.dart';
+import 'glass.dart';
+
+/// Plugins sub-menu: every installed plugin (built-ins, module plugins,
+/// MCP servers) with a live enable/disable switch. Toggles persist to the
+/// daemon's config and hot-reload, so a change is real on the next turn.
+class PluginsScreen extends StatelessWidget {
+  final AppState state;
+  const PluginsScreen({super.key, required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    return _ExtensionListScreen<PluginInfo>(
+      title: 'Plugins',
+      emptyText: 'No plugins installed — add one with `talon plugin install`.',
+      load: state.listPlugins,
+      toggle: state.togglePlugin,
+      nameOf: (p) => p.name,
+      enabledOf: (p) => p.enabled,
+      iconOf: (p) => switch (p.kind) {
+        'builtin' => Icons.inventory_2_outlined,
+        'mcp' => Icons.cable_outlined,
+        _ => Icons.extension_outlined,
+      },
+      subtitleOf: (p) => p.kind == 'builtin' ? 'built-in' : p.source,
+    );
+  }
+}
+
+/// Skills sub-menu: every installed SKILL.md bundle with a live switch. A
+/// disabled skill drops out of the model's prompt index but stays
+/// installed, so re-enabling is instant.
+class SkillsScreen extends StatelessWidget {
+  final AppState state;
+  const SkillsScreen({super.key, required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    return _ExtensionListScreen<SkillInfo>(
+      title: 'Skills',
+      emptyText:
+          'No skills installed — add one with `talon skill install`, or ask '
+          'Talon to save one.',
+      load: state.listSkills,
+      toggle: state.toggleSkill,
+      nameOf: (s) => s.name,
+      enabledOf: (s) => s.enabled,
+      iconOf: (_) => Icons.menu_book_outlined,
+      subtitleOf: (s) => s.description,
+    );
+  }
+}
+
+/// The shared list-and-toggle screen behind both sub-menus: load → glass
+/// list with switches, optimistic toggling with revert + toast on failure,
+/// pull-to-refresh, and the standard skeleton/error states.
+class _ExtensionListScreen<T> extends StatefulWidget {
+  final String title;
+  final String emptyText;
+  final Future<List<T>> Function() load;
+  final Future<({bool ok, String? error})> Function(String name, bool enabled)
+      toggle;
+  final String Function(T) nameOf;
+  final bool Function(T) enabledOf;
+  final IconData Function(T) iconOf;
+  final String Function(T) subtitleOf;
+
+  const _ExtensionListScreen({
+    super.key,
+    required this.title,
+    required this.emptyText,
+    required this.load,
+    required this.toggle,
+    required this.nameOf,
+    required this.enabledOf,
+    required this.iconOf,
+    required this.subtitleOf,
+  });
+
+  @override
+  State<_ExtensionListScreen<T>> createState() =>
+      _ExtensionListScreenState<T>();
+}
+
+class _ExtensionListScreenState<T> extends State<_ExtensionListScreen<T>> {
+  List<T> _items = const [];
+  bool _loading = true;
+  String? _error;
+
+  /// Optimistic overrides for in-flight toggles, keyed by item name. The
+  /// switch flips the moment it's tapped; the entry is dropped when the
+  /// daemon confirms (reload replaces it) or reverted with a toast when
+  /// the round-trip fails.
+  final Map<String, bool> _pending = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final items = await widget.load();
+      if (!mounted) return;
+      setState(() {
+        _items = items;
+        _loading = false;
+      });
+    } catch (e) {
+      AppLog.warn('extensions', '${widget.title} fetch failed', e);
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = e.toString();
+      });
+    }
+  }
+
+  Future<void> _toggle(T item, bool enabled) async {
+    final name = widget.nameOf(item);
+    Haptics.selection();
+    setState(() => _pending[name] = enabled);
+    final result = await widget.toggle(name, enabled);
+    if (!mounted) return;
+    if (result.ok) {
+      await _load();
+      if (!mounted) return;
+      setState(() => _pending.remove(name));
+      return;
+    }
+    setState(() => _pending.remove(name));
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          result.error ?? 'Could not ${enabled ? 'enable' : 'disable'} $name',
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<int>(
+      valueListenable: TalonTheme.revision,
+      builder: (context, _, __) => TalonBackdrop(
+        child: Scaffold(
+          backgroundColor: Colors.transparent,
+          appBar: AppBar(
+            backgroundColor: Colors.transparent,
+            title: Text(widget.title),
+            actions: [
+              IconButton(
+                onPressed: _load,
+                icon: const Icon(Icons.refresh),
+                tooltip: 'Refresh',
+              ),
+            ],
+          ),
+          body: RefreshIndicator(
+            onRefresh: _load,
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.all(20),
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 560),
+                  child: _body(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _body() {
+    if (_loading) return const _ListSkeleton();
+    if (_error != null) {
+      return Glass(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Could not load ${widget.title.toLowerCase()}',
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              _error!,
+              style: TextStyle(fontSize: 12.5, color: TalonColors.textFaint),
+            ),
+            const SizedBox(height: 10),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed: _load,
+                icon: const Icon(Icons.refresh, size: 16),
+                label: const Text('Retry'),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+    if (_items.isEmpty) {
+      return Glass(
+        padding: const EdgeInsets.all(20),
+        child: Text(
+          widget.emptyText,
+          style: TextStyle(color: TalonColors.textFaint),
+        ),
+      );
+    }
+    return Glass(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Column(
+        children: [
+          for (var i = 0; i < _items.length; i++) ...[
+            if (i > 0)
+              Divider(
+                height: 1,
+                indent: 52,
+                color: TalonColors.glassStroke,
+              ),
+            _row(_items[i]),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _row(T item) {
+    final name = widget.nameOf(item);
+    final enabled = _pending[name] ?? widget.enabledOf(item);
+    final subtitle = widget.subtitleOf(item);
+    final busy = _pending.containsKey(name);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      child: Row(
+        children: [
+          Icon(
+            widget.iconOf(item),
+            size: 20,
+            color: enabled ? TalonColors.accent : TalonColors.textFaint,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  name,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    fontSize: 14,
+                    color: enabled ? null : TalonColors.textDim,
+                  ),
+                ),
+                if (subtitle.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: TalonColors.textFaint,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Switch(
+            value: enabled,
+            onChanged: busy ? null : (v) => _toggle(item, v),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Placeholder rows while the first fetch is in flight.
+class _ListSkeleton extends StatelessWidget {
+  const _ListSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Glass(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Column(
+        children: [
+          for (var i = 0; i < 4; i++)
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 14,
+                vertical: 14,
+              ),
+              child: Row(
+                children: [
+                  Container(
+                    width: 20,
+                    height: 20,
+                    decoration: BoxDecoration(
+                      color: TalonColors.glassStroke,
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Container(
+                      height: 12,
+                      decoration: BoxDecoration(
+                        color: TalonColors.glassStroke,
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 48),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/companion/lib/src/ui/settings_screen.dart
+++ b/apps/companion/lib/src/ui/settings_screen.dart
@@ -13,6 +13,7 @@ import '../services/mesh_background.dart';
 import '../state/app_state.dart';
 import '../theme.dart';
 import 'connect_screen.dart';
+import 'extensions_screen.dart';
 import 'glass.dart';
 import 'logs_screen.dart';
 
@@ -209,6 +210,43 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() => _dreaming = true);
     await _runControl('dream');
     if (mounted) setState(() => _dreaming = false);
+  }
+
+  /// Plugins + Skills sub-menus. Gated on the daemon's `plugins-skills`
+  /// bridge capability — an older daemon simply doesn't show the card.
+  Widget _extensionsCard() {
+    return _Section(
+      title: 'Extensions',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _ControlButton(
+            icon: Icons.extension_outlined,
+            label: 'Plugins',
+            subtitle:
+                'Built-ins, module plugins, and MCP servers — view & toggle',
+            pending: false,
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => PluginsScreen(state: widget.state),
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          _ControlButton(
+            icon: Icons.menu_book_outlined,
+            label: 'Skills',
+            subtitle: 'SKILL.md workflow bundles — view & toggle',
+            pending: false,
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => SkillsScreen(state: widget.state),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   Widget _controlsCard() {
@@ -430,6 +468,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
           ),
           const SizedBox(height: 16),
+          if (widget.state.status.hasCapability('plugins-skills')) ...[
+            _extensionsCard(),
+            const SizedBox(height: 16),
+          ],
           _meshCard(),
           const SizedBox(height: 16),
           _controlsCard(),
@@ -613,8 +655,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     ];
     final seed = TalonTheme.accentSeed.value;
     final isPreset = seed != null &&
-        TalonAccents.presets
-            .any((p) => p.$2.toARGB32() == seed.toARGB32());
+        TalonAccents.presets.any((p) => p.$2.toARGB32() == seed.toARGB32());
     final isCustom = seed != null && !isPreset;
     final scale = TalonTheme.textScale.value;
     final mobile = defaultTargetPlatform == TargetPlatform.android ||
@@ -685,8 +726,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 _AccentSwatch(
                   tooltip: label,
                   color: color,
-                  selected:
-                      seed != null && seed.toARGB32() == color.toARGB32(),
+                  selected: seed != null && seed.toARGB32() == color.toARGB32(),
                   onTap: () => _setAccent(color),
                 ),
               _AccentSwatch(
@@ -1490,8 +1530,7 @@ class _AccentSwatch extends StatelessWidget {
   Widget build(BuildContext context) {
     // Pick a glyph color that survives both light swatches (amber) and dark.
     final base = color ?? const Color(0xFF7C8CFF);
-    final glyph =
-        base.computeLuminance() > 0.6 ? Colors.black87 : Colors.white;
+    final glyph = base.computeLuminance() > 0.6 ? Colors.black87 : Colors.white;
     return Tooltip(
       message: tooltip,
       waitDuration: const Duration(milliseconds: 400),

--- a/apps/companion/test/screenshots/gallery_test.dart
+++ b/apps/companion/test/screenshots/gallery_test.dart
@@ -20,6 +20,7 @@ import 'package:talon_companion/src/services/prefs.dart';
 import 'package:talon_companion/src/state/app_state.dart';
 import 'package:talon_companion/src/theme.dart';
 import 'package:talon_companion/src/ui/connect_screen.dart';
+import 'package:talon_companion/src/ui/extensions_screen.dart';
 import 'package:talon_companion/src/ui/glass.dart';
 import 'package:talon_companion/src/ui/root_view.dart';
 import 'package:talon_companion/src/ui/settings_screen.dart';
@@ -184,6 +185,50 @@ Map<String, List<ClientMessage>> _demoMessages() => {
       ],
     };
 
+List<PluginInfo> _demoPlugins() => const [
+      PluginInfo(
+          name: 'github',
+          kind: 'builtin',
+          enabled: true,
+          source: 'config.github'),
+      PluginInfo(
+          name: 'mempalace',
+          kind: 'builtin',
+          enabled: true,
+          source: 'config.mempalace'),
+      PluginInfo(
+          name: 'playwright',
+          kind: 'builtin',
+          enabled: false,
+          source: 'config.playwright'),
+      PluginInfo(
+          name: 'weather-tools',
+          kind: 'module',
+          enabled: true,
+          source: '~/.talon/plugins/node_modules/weather-tools'),
+      PluginInfo(
+          name: 'fetch',
+          kind: 'mcp',
+          enabled: false,
+          source: 'npx -y @modelcontextprotocol/server-fetch'),
+    ];
+
+List<SkillInfo> _demoSkills() => const [
+      SkillInfo(
+          name: 'review-pr',
+          description: 'Checklist-driven pull request review with repo context',
+          enabled: true),
+      SkillInfo(
+          name: 'trip-planner',
+          description:
+              'Plan multi-day trips: routes, bookings, weather windows',
+          enabled: true),
+      SkillInfo(
+          name: 'meeting-notes',
+          description: 'Summarise a transcript into decisions and actions',
+          enabled: false),
+    ];
+
 AppState _demoState({required bool narrow, String? select}) {
   final prefs = Prefs(_FakePrefsBacking.instance);
   final state = AppState(prefs, narrowLayout: narrow);
@@ -199,7 +244,10 @@ AppState _demoState({required bool narrow, String? select}) {
       'model': 'opus',
       'activeChats': 6,
       'startedAt': '',
+      'capabilities': ['mesh', 'mesh-commands', 'plugins-skills'],
     }),
+    plugins: _demoPlugins(),
+    skills: _demoSkills(),
   );
   return state;
 }
@@ -302,6 +350,22 @@ void main() {
     addTearDown(state.dispose);
     await tester.pumpWidget(_app(SettingsScreen(state: state)));
     await _shoot(tester, 'phone_settings');
+  });
+
+  testWidgets('phone · plugins', (tester) async {
+    _phone(tester);
+    final state = _demoState(narrow: true);
+    addTearDown(state.dispose);
+    await tester.pumpWidget(_app(PluginsScreen(state: state)));
+    await _shoot(tester, 'phone_plugins');
+  });
+
+  testWidgets('phone · skills', (tester) async {
+    _phone(tester);
+    final state = _demoState(narrow: true);
+    addTearDown(state.dispose);
+    await tester.pumpWidget(_app(SkillsScreen(state: state)));
+    await _shoot(tester, 'phone_skills');
   });
 
   testWidgets('phone · conversation (emerald accent)', (tester) async {


### PR DESCRIPTION
## What

The Companion app's half of the plugin/skill manager track: an **Extensions** card in Talon settings with two sub-menus, **Plugins** and **Skills** — every installed plugin (built-ins, module plugins, MCP servers) and skill listed with a live enable/disable switch.

- Optimistic toggles: the switch flips on tap, reverts with a toast if the daemon round-trip fails (the daemon's application-level error is shown verbatim).
- Pull-to-refresh + refresh action, skeleton first-load, error card with retry.
- Gated on the `plugins-skills` bridge capability (now parsed on `BridgeStatus`) — connected to an older daemon, the card simply doesn't appear.
- `BridgeClient` + `AppState` grow the four calls (`GET /plugins`, `POST /plugins/toggle`, `GET /skills`, `POST /skills/toggle`), seedable through `debugSeed` for widget tests and the gallery.

Depends at **runtime** on the bridge endpoints from #563 (stacked on #559) — no compile-time coupling, so this is based on main.

## Screenshots

Generated via the screenshot gallery (`TALON_SCREENSHOTS=1 flutter test --update-goldens test/screenshots`): `phone_plugins.png`, `phone_skills.png` — glass list cards matching the app's design language, kind icons (built-in / module / MCP), disabled rows dimmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)