### PR TITLE
feat(core): one-shot runs report token usage — talon ps accounts heartbeat/dream/cron burn

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -51,9 +51,13 @@ settled history is a bounded ring (50 entries).
 ## Token accounting
 
 `turn` tasks record `usage` (input/output/cache tokens) from the turn result.
-Isolated one-shots run through `runOneShotAgent`, which reports no usage, so
-their tasks settle without it. When the background capability grows usage
-reporting, the wiring point is already there (`TaskHandle.succeed(usage)`).
+One-shots report usage too: `runOneShotAgent` resolves with the run's token
+usage when the backend's SDK surfaces it (Claude's final result message,
+Codex's cumulative `turn.completed`, the remote-server family's prompt
+response), and heartbeat / dream / job-oneshot hand it to
+`TaskHandle.succeed(usage)` — so background runs show real spend in
+`talon ps` instead of a dash. A backend that can't report simply settles
+without usage.
 
 ## Surfaces
 

--- a/src/__tests__/job-oneshot.test.ts
+++ b/src/__tests__/job-oneshot.test.ts
@@ -133,6 +133,21 @@ describe("runIsolatedAgent", () => {
     expect(run).toHaveBeenCalledOnce();
   });
 
+  it("resolves with the usage the backend reports", async () => {
+    const usage = {
+      inputTokens: 120,
+      outputTokens: 45,
+      cacheRead: 30,
+      cacheWrite: 5,
+    };
+    const result = await runIsolatedAgent({
+      background: fakeBackground(async () => usage),
+      params: params(),
+      timeoutMs: 1000,
+    });
+    expect(result).toEqual(usage);
+  });
+
   it("propagates an agent error without aborting", async () => {
     const p = params();
     const abortSpy = vi.spyOn(p.abortController, "abort");

--- a/src/__tests__/job-oneshot.test.ts
+++ b/src/__tests__/job-oneshot.test.ts
@@ -84,7 +84,7 @@ function params(): OneShotAgentParams {
 }
 
 function fakeBackground(
-  run: (p: OneShotAgentParams) => Promise<void>,
+  run: BackgroundRunner["runOneShotAgent"],
   evict?: BackgroundRunner["evictOrphanSubprocesses"],
 ): BackgroundRunner {
   return { runOneShotAgent: run, evictOrphanSubprocesses: evict };

--- a/src/backend/claude-sdk/one-shot.ts
+++ b/src/backend/claude-sdk/one-shot.ts
@@ -14,7 +14,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
-import type { OneShotAgentParams } from "../../core/types.js";
+import type { OneShotAgentParams, OneShotUsage } from "../../core/types.js";
 import { log } from "../../util/log.js";
 import { ALLOWED_TOOLS_BACKGROUND } from "../../core/constants.js";
 import { buildMcpServers, buildPluginMcpServers } from "./options.js";
@@ -53,7 +53,7 @@ export function initClaudeOneShot(cfg: OneShotConfig): void {
 
 export async function runOneShotAgent(
   params: OneShotAgentParams,
-): Promise<void> {
+): Promise<OneShotUsage | void> {
   const {
     prompt,
     systemPrompt,
@@ -86,9 +86,22 @@ export async function runOneShotAgent(
     options: options as Parameters<typeof query>[0]["options"],
   });
 
+  // The final `result` message carries the run's total token usage — the
+  // settlement figure the task table records.
+  let usage: OneShotUsage | undefined;
   for await (const msg of qi) {
     await formatAndAppendMessage(appendLog, msg);
+    if (msg.type === "result") {
+      const u = msg.usage;
+      usage = {
+        inputTokens: u.input_tokens ?? 0,
+        outputTokens: u.output_tokens ?? 0,
+        cacheRead: u.cache_read_input_tokens ?? 0,
+        cacheWrite: u.cache_creation_input_tokens ?? 0,
+      };
+    }
   }
+  return usage;
 }
 
 /**

--- a/src/backend/codex/one-shot.ts
+++ b/src/backend/codex/one-shot.ts
@@ -17,7 +17,7 @@
  * fires — no orphan process handling needed.
  */
 
-import type { OneShotAgentParams } from "../../core/types.js";
+import type { OneShotAgentParams, OneShotUsage } from "../../core/types.js";
 import { log, logWarn } from "../../util/log.js";
 import { appendBackendSuffix } from "../shared/index.js";
 import { ensureCodex, getCodexAuthInfo } from "./init.js";
@@ -69,7 +69,7 @@ function resolveOneShotModel(requested: string): {
 
 export async function runOneShotAgent(
   params: OneShotAgentParams,
-): Promise<void> {
+): Promise<OneShotUsage | void> {
   const {
     prompt,
     systemPrompt,
@@ -118,10 +118,25 @@ export async function runOneShotAgent(
       signal: abortController.signal,
     });
 
+    // `turn.completed.usage` is cumulative across the run — the last one
+    // seen is the settlement figure the task table records.
+    let usage: OneShotUsage | undefined;
     for await (const event of events) {
       if (abortController.signal.aborted) break;
       await appendCodexEvent(appendLog, event);
+      if (event.type === "turn.completed") {
+        const u = (event as { usage?: Record<string, number> }).usage;
+        if (u) {
+          usage = {
+            inputTokens: u.input_tokens ?? 0,
+            outputTokens: u.output_tokens ?? 0,
+            cacheRead: u.cached_input_tokens ?? 0,
+            cacheWrite: 0, // Codex doesn't report cache writes
+          };
+        }
+      }
     }
+    return usage;
   } catch (err) {
     if (
       abortController.signal.aborted ||

--- a/src/backend/kilo/one-shot.ts
+++ b/src/backend/kilo/one-shot.ts
@@ -7,7 +7,7 @@
  * suffix; everything else is the shared lifecycle.
  */
 
-import type { OneShotAgentParams } from "../../core/types.js";
+import type { OneShotAgentParams, OneShotUsage } from "../../core/types.js";
 import { runRemoteOneShotAgent } from "../remote-server/one-shot.js";
 import {
   ensureServer,
@@ -21,7 +21,9 @@ import {
   errMsg,
 } from "./server.js";
 
-export function runOneShotAgent(params: OneShotAgentParams): Promise<void> {
+export function runOneShotAgent(
+  params: OneShotAgentParams,
+): Promise<OneShotUsage | void> {
   return runRemoteOneShotAgent(
     {
       label: "Kilo",

--- a/src/backend/opencode/one-shot.ts
+++ b/src/backend/opencode/one-shot.ts
@@ -7,7 +7,7 @@
  * suffix; everything else is the shared lifecycle.
  */
 
-import type { OneShotAgentParams } from "../../core/types.js";
+import type { OneShotAgentParams, OneShotUsage } from "../../core/types.js";
 import { runRemoteOneShotAgent } from "../remote-server/one-shot.js";
 import {
   ensureServer,
@@ -21,7 +21,9 @@ import {
   errMsg,
 } from "./server.js";
 
-export function runOneShotAgent(params: OneShotAgentParams): Promise<void> {
+export function runOneShotAgent(
+  params: OneShotAgentParams,
+): Promise<OneShotUsage | void> {
   return runRemoteOneShotAgent(
     {
       label: "OpenCode",

--- a/src/backend/remote-server/one-shot.ts
+++ b/src/backend/remote-server/one-shot.ts
@@ -26,8 +26,12 @@
  * model stops spending tokens once the timeout fires.
  */
 
-import type { OneShotAgentParams } from "../../core/types.js";
+import type { OneShotAgentParams, OneShotUsage } from "../../core/types.js";
 import { logWarn } from "../../util/log.js";
+import {
+  extractAssistantUsage,
+  type RemoteAssistantInfo,
+} from "./session-helpers.js";
 import { appendBackendSuffix } from "../shared/index.js";
 
 // ── Client surface ──────────────────────────────────────────────────────────
@@ -86,7 +90,7 @@ export async function runRemoteOneShotAgent<
 >(
   bindings: RemoteOneShotBindings<TClient>,
   params: OneShotAgentParams,
-): Promise<void> {
+): Promise<OneShotUsage | void> {
   const {
     prompt,
     systemPrompt,
@@ -161,6 +165,21 @@ export async function runRemoteOneShotAgent<
 
     for (const part of parts) {
       await appendResponsePart(appendLog, part);
+    }
+
+    // The prompt response's assistant info carries the run's token usage —
+    // the settlement figure the task table records.
+    const info = data?.info as RemoteAssistantInfo | undefined;
+    if (info) {
+      const u = extractAssistantUsage(info);
+      if (u.inputTokens > 0 || u.outputTokens > 0) {
+        return {
+          inputTokens: u.inputTokens,
+          outputTokens: u.outputTokens,
+          cacheRead: u.cacheRead,
+          cacheWrite: u.cacheWrite,
+        };
+      }
     }
   } finally {
     abortController.signal.removeEventListener("abort", onAbort);

--- a/src/core/agent-runtime/capabilities.ts
+++ b/src/core/agent-runtime/capabilities.ts
@@ -27,6 +27,7 @@ import type {
   ModelPickerOptions,
   ModelPickerResult,
   OneShotAgentParams,
+  OneShotUsage,
   UnifiedModelInfo,
   UnifiedModelResolution,
   UnifiedProviderInfo,
@@ -131,12 +132,14 @@ export interface ChatBackend {
  *   - `runOneShotAgent(params)` — accepts `OneShotAgentParams`
  *     (with its `appendLog` callback) so the heartbeat / dream /
  *     trigger log-file producers keep their direct write path.
+ *     Resolves with the run's token usage when the SDK reports it
+ *     (the task table records it at settlement); void otherwise.
  *   - `evictOrphanSubprocesses(label)` — backends that spawn
  *     per-run subprocesses (Claude SDK) implement this so a hung
  *     run can be force-cleaned after the abort grace window.
  */
 export interface BackgroundRunner {
-  runOneShotAgent(params: OneShotAgentParams): Promise<void>;
+  runOneShotAgent(params: OneShotAgentParams): Promise<OneShotUsage | void>;
   evictOrphanSubprocesses?(contextLabel: string): Promise<{
     found: number;
     termed: number;

--- a/src/core/background/dream.ts
+++ b/src/core/background/dream.ts
@@ -296,15 +296,17 @@ If commands fail, log the error and continue — this stage is optional.`
   });
 
   const agentPromise = (async () => {
-    await background.runOneShotAgent(oneShotParams);
+    const usage = await background.runOneShotAgent(oneShotParams);
     appendDreamLog(
       dreamLogFile,
       `\n---\n**Dream completed at ${new Date().toISOString()}**\n`,
     );
+    return usage;
   })();
 
+  let usage: Awaited<typeof agentPromise>;
   try {
-    await Promise.race([agentPromise, timeoutPromise]);
+    usage = await Promise.race([agentPromise, timeoutPromise]);
   } catch (err) {
     task.fail(err);
     appendDreamLog(
@@ -332,7 +334,7 @@ If commands fail, log the error and continue — this stage is optional.`
     if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
-  task.succeed();
+  task.succeed(usage ?? undefined);
   return dreamLogFile;
 }
 

--- a/src/core/background/heartbeat/agent.ts
+++ b/src/core/background/heartbeat/agent.ts
@@ -220,15 +220,17 @@ export async function runHeartbeatAgent(
   });
 
   const agentPromise = (async () => {
-    await background.runOneShotAgent(oneShotParams);
+    const usage = await background.runOneShotAgent(oneShotParams);
     await appendHeartbeatLog(
       heartbeatLogFile,
       `\n---\n**Heartbeat #${runCount} completed at ${new Date().toISOString()}**\n`,
     );
+    return usage;
   })();
 
+  let usage: Awaited<typeof agentPromise>;
   try {
-    await Promise.race([agentPromise, timeoutPromise]);
+    usage = await Promise.race([agentPromise, timeoutPromise]);
   } catch (err) {
     // Snapshot timeout state and clear the timer immediately, BEFORE any awaits
     // in the error-handling path. Otherwise the timer can fire during the async
@@ -278,7 +280,7 @@ export async function runHeartbeatAgent(
     if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
-  task.succeed();
+  task.succeed(usage ?? undefined);
   return heartbeatLogFile;
 }
 

--- a/src/core/background/isolated-agent.ts
+++ b/src/core/background/isolated-agent.ts
@@ -15,7 +15,7 @@
  */
 
 import type { BackgroundRunner } from "../agent-runtime/capabilities.js";
-import type { OneShotAgentParams } from "../types.js";
+import type { OneShotAgentParams, OneShotUsage } from "../types.js";
 import { logWarn, logError } from "../../util/log.js";
 
 /** Default bounded grace after an abort before giving up on the backend. */
@@ -55,11 +55,12 @@ async function raceWithTimeout<T>(
 
 /**
  * Run the one-shot under a hard timeout. Throws on timeout (after the grace
- * window) and re-throws any agent error.
+ * window) and re-throws any agent error. Resolves with the run's token
+ * usage when the backend reports it.
  */
 export async function runIsolatedAgent(
   opts: IsolatedRunOptions,
-): Promise<void> {
+): Promise<OneShotUsage | void> {
   const { background, params, timeoutMs } = opts;
   const graceMs = opts.abortGraceMs ?? DEFAULT_ABORT_GRACE_MS;
 
@@ -81,7 +82,7 @@ export async function runIsolatedAgent(
   });
 
   try {
-    await Promise.race([agentPromise, timeoutPromise]);
+    return await Promise.race([agentPromise, timeoutPromise]);
   } catch (err) {
     // Snapshot + clear before any await so a late timer can't reclassify a
     // non-timeout failure as a timeout (heartbeat learned this the hard way).

--- a/src/core/background/job-oneshot.ts
+++ b/src/core/background/job-oneshot.ts
@@ -157,7 +157,7 @@ export async function runJobOneShot(
     };
 
     try {
-      await runIsolatedAgent({
+      const usage = await runIsolatedAgent({
         background,
         params: oneShot,
         timeoutMs: params.timeoutMs ?? DEFAULT_JOB_TIMEOUT_MS,
@@ -165,7 +165,7 @@ export async function runJobOneShot(
         // sweep here could kill a concurrent heartbeat's subprocess. Bounded
         // abort-grace is enough.
       });
-      task.succeed();
+      task.succeed(usage ?? undefined);
     } catch (err) {
       task.fail(err);
       throw err;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -120,6 +120,18 @@ export interface ModelPickerResult {
  * fire-and-forget agent invocation: spawn an agent with a prompt, let it run
  * tools, log everything to a file, return when it finishes (or when aborted).
  */
+/**
+ * Token usage a one-shot run reports at settlement, when the backend's SDK
+ * surfaces it. Shape-compatible with the task table's `TaskUsage`, so the
+ * background callers can hand it straight to `TaskHandle.succeed`.
+ */
+export type OneShotUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheRead: number;
+  cacheWrite: number;
+};
+
 export type OneShotAgentParams = {
   /** The user prompt the agent should execute. */
   prompt: string;


### PR DESCRIPTION
## What

The last unaccounted resource in the task table: isolated one-shot runs (heartbeat, dream, cron/trigger jobs) settled without usage, showing a dash in `talon ps` while burning real tokens. `BackgroundRunner.runOneShotAgent` now resolves with the run's token usage when the backend's SDK reports it, and every caller threads it into `TaskHandle.succeed(usage)` — the wiring point docs/tasks.md always said was waiting.

## Per backend

- **Claude SDK** — the final `result` message's usage (input/output/cache read/cache write).
- **Codex** — `turn.completed.usage` (cumulative; last event wins), cache writes not reported.
- **Kilo / OpenCode** — the shared remote-server runner reads the prompt response's assistant info through the existing `extractAssistantUsage` helper.
- A backend that can't report simply resolves void; the task settles without usage, as before.

## Callers

`runIsolatedAgent` (cron/trigger jobs) passes the race result through; heartbeat and dream capture the agent promise's value on their existing success paths. No timing/locking semantics changed — the abort/grace/eviction discipline is untouched.

## Tests & docs

- `job-oneshot.test.ts`: the isolated runner resolves with the backend's reported usage.
- `docs/tasks.md`: kind table flips the one-shot rows to usage-captured, token accounting section rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)