### PR TITLE
fix(codex): per-turn token accounting — rollout delta over cumulative SDK usage

### DIFF
--- a/src/__tests__/codex-handler.test.ts
+++ b/src/__tests__/codex-handler.test.ts
@@ -703,6 +703,51 @@ describe("codex / handleMessage — context tokens wiring", () => {
     expect(result.outputTokens).toBe(0);
     expect(result.cacheRead).toBe(0);
   });
+
+  it("prefers the rollout delta over turn.completed's CUMULATIVE usage", async () => {
+    // Codex's SDK Usage on turn.completed sums input across every API
+    // call in the turn — a ~20-call turn reports ~20× the real context
+    // fill. The regression: that figure was recorded as the turn's
+    // input whenever turn.completed fired, so the companion UI showed
+    // 812k-token "small conversations". The rollout delta is the only
+    // per-turn source of truth; the SDK figure is unreliable.
+    setupHandler();
+    writeRolloutWithTotals("thr_cumulative", {
+      input: 40_000,
+      cached: 30_000,
+      output: 900,
+    });
+    MOCK_EVENTS = [
+      { type: "thread.started", thread_id: "thr_cumulative" },
+      { type: "turn.started" },
+      {
+        type: "item.completed",
+        item: { id: "i1", type: "agent_message", text: "done" },
+      },
+      {
+        type: "turn.completed",
+        usage: {
+          input_tokens: 812_000, // cumulative across ~20 calls — wrong units
+          output_tokens: 4_000,
+          cached_input_tokens: 700_000,
+          reasoning_output_tokens: 0,
+        },
+      },
+    ] as never;
+
+    const result = await handleMessage({
+      chatId: "test-chat",
+      text: "hi",
+      senderName: "Dylan",
+      isGroup: false,
+    });
+
+    // Fresh thread → zero baseline → this turn's usage IS the rollout
+    // totals, never the SDK's cumulative figure.
+    expect(result.inputTokens).toBe(40_000);
+    expect(result.cacheRead).toBe(30_000);
+    expect(result.outputTokens).toBe(900);
+  });
 });
 
 describe("codex / handleMessage — error paths", () => {

--- a/src/backend/codex/handler/message.ts
+++ b/src/backend/codex/handler/message.ts
@@ -388,42 +388,39 @@ export async function handleMessage(
 
   // Final authoritative usage settlement — shared by the success post-loop
   // and the terminal-failure path so failed turns account for the tokens
-  // they burned too. Codex's `turn.completed.usage` is CUMULATIVE, so we
-  // read the per-call `token_count` event from the rollout JSONL for an
-  // accurate /status display, falling back silently when unavailable.
+  // they burned too. Codex's `turn.completed.usage` is CUMULATIVE across
+  // every API call in the turn — never in the per-turn units the shared
+  // stream state (and everything downstream: /status, the companion's
+  // per-message counts) speaks. The rollout JSONL's totals diffed against
+  // the pre-turn baseline are this turn's real usage; that is the ONLY
+  // authoritative source. The SDK figure is a last-resort fallback when
+  // the rollout can't be read, and it overstates multi-call turns.
   const settleUsageAccounting = async (): Promise<void> => {
-    if (usage) {
-      recordTokens(streamState, {
-        inputTokens: usage.input_tokens,
-        outputTokens: usage.output_tokens,
-        cacheRead: usage.cached_input_tokens,
-        cacheWrite: 0, // Codex doesn't report cache writes
-      });
-    }
-    if (!resolvedThreadId) return;
-    const last = await readLastRolloutSnapshot(resolvedThreadId).catch(
-      () => null,
-    );
-    if (!last) return;
-    if (last.usage) {
+    const last = resolvedThreadId
+      ? await readLastRolloutSnapshot(resolvedThreadId).catch(() => null)
+      : null;
+    if (last?.usage) {
       streamState.contextTokens = last.usage.contextTokens;
       if (last.usage.contextWindow) {
         streamState.contextWindow = last.usage.contextWindow;
       }
     }
-    if (typeof last.numApiCalls === "number") {
+    if (typeof last?.numApiCalls === "number") {
       streamState.numApiCalls = last.numApiCalls;
     }
-    // Terminator-driven turns abort the stream before `turn.completed`
-    // fires, so the SDK-side `usage` capture above is null on almost
-    // every Talon turn. Recover this turn's real usage by diffing the
-    // rollout's cumulative totals against the pre-turn baseline.
-    if (!usage && last.totals && baselineTotals) {
+    if (last?.totals && baselineTotals) {
       recordTokens(streamState, {
         inputTokens: last.totals.inputTokens - baselineTotals.inputTokens,
         outputTokens: last.totals.outputTokens - baselineTotals.outputTokens,
         cacheRead:
           last.totals.cachedInputTokens - baselineTotals.cachedInputTokens,
+        cacheWrite: 0, // Codex doesn't report cache writes
+      });
+    } else if (usage) {
+      recordTokens(streamState, {
+        inputTokens: usage.input_tokens,
+        outputTokens: usage.output_tokens,
+        cacheRead: usage.cached_input_tokens,
         cacheWrite: 0, // Codex doesn't report cache writes
       });
     }


### PR DESCRIPTION
Codex's `turn.completed.usage` is cumulative across every API call in the turn — never per-turn units. The settlement path recorded it into the shared stream state whenever `turn.completed` fired, so the companion UI showed ~20x input counts (812k for a small conversation). Now the rollout-totals-minus-baseline delta (already used for terminator-aborted turns) is always preferred; the SDK figure is strictly a last-resort fallback when the rollout is unreadable.

Regression test: a turn with a readable rollout and a cumulative `turn.completed` usage must record the delta (40k), never the SDK figure (812k). All 96 codex tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)