### PR TITLE
chore(quality): machine-checked architecture boundaries + stricter gates

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,0 +1,192 @@
+/**
+ * Architecture boundaries, machine-checked.
+ *
+ * The layer diagram these rules encode (see also src/core/types.ts):
+ *
+ *   util, native            — leaves; import nothing above themselves
+ *   storage                 — persistence; no core/backend/frontend imports
+ *   core                    — the engine; no frontend/backend imports (types.ts:5)
+ *   backend                 — agent-runtime adapters; no frontend imports
+ *   frontend                — platform drivers; no direct backend imports
+ *   cli, app, bootstrap     — composition roots; may import anything
+ *
+ * Severity discipline:
+ *   error — the rule holds today; a violation is a regression and fails CI.
+ *   warn  — the rule is the target state of an in-flight migration; each
+ *           carries the migration that ratchets it to error. Never add new
+ *           violations to a warn rule.
+ */
+module.exports = {
+  forbidden: [
+    // ── Ratified boundaries (error = CI gate) ────────────────────────────
+    {
+      name: "core-not-to-frontend",
+      comment:
+        "core/ imports nothing from frontend/ (src/core/types.ts:5). " +
+        "Frontends register handlers with the engine at startup; the engine " +
+        "never reaches into a platform.",
+      severity: "error",
+      from: { path: "^src/core/" },
+      to: { path: "^src/frontend/" },
+    },
+    {
+      name: "core-not-to-backend",
+      comment:
+        "core/ imports nothing from backend/ (src/core/types.ts:5). " +
+        "Backends are bound through the agent-runtime seam, not imported. " +
+        "doctor.ts is carved out below with its own migration rule.",
+      severity: "error",
+      from: { path: "^src/core/", pathNot: "^src/core/doctor\\.ts$" },
+      to: { path: "^src/backend/" },
+    },
+    {
+      name: "backend-not-to-frontend",
+      comment:
+        "Backends speak to frontends only through the gateway action " +
+        "protocol — never by import.",
+      severity: "error",
+      from: { path: "^src/backend/" },
+      to: { path: "^src/frontend/" },
+    },
+    {
+      name: "util-is-a-leaf",
+      comment:
+        "util/ is the bottom of the stack — anything it imported from the " +
+        "layers above would be a cycle waiting to happen. The #prompt-assets " +
+        "subpath import is exempt: it is the build-time asset seam " +
+        "(package.json `imports` switches disk/embedded prompts per runtime), " +
+        "not a layering edge. config.ts and metrics.ts are carved out below " +
+        "with their own migration rules.",
+      severity: "error",
+      from: {
+        path: "^src/util/",
+        pathNot: "^src/util/(config|metrics)\\.ts$",
+      },
+      to: {
+        path: "^src/(core|backend|frontend|storage|cli|plugins)/",
+        dependencyTypesNot: ["aliased-subpath-import"],
+      },
+    },
+    {
+      name: "native-is-a-leaf",
+      comment: "native/ bricks are self-contained; same rule as util/.",
+      severity: "error",
+      from: { path: "^src/native/" },
+      to: { path: "^src/(core|backend|frontend|storage|cli|plugins)/" },
+    },
+    {
+      name: "storage-below-the-engine",
+      comment:
+        "storage/ persists; it never calls up into the engine or the " +
+        "platform layers.",
+      severity: "error",
+      from: { path: "^src/storage/" },
+      to: { path: "^src/(core|backend|frontend|cli)/" },
+    },
+    {
+      name: "db-handle-stays-in-storage",
+      comment:
+        "Only stores open the SQLite handle — everything else goes through " +
+        "a store's API. Composition roots (app, cli, bootstrap, index) are " +
+        "exempt: they own process lifecycle, which includes the final " +
+        "flushDatabase.",
+      severity: "error",
+      from: {
+        pathNot: "^src/(storage/|cli/|app\\.ts$|bootstrap\\.ts$|index\\.ts$)",
+      },
+      to: { path: "^src/storage/db\\.ts$" },
+    },
+    {
+      name: "no-circular",
+      severity: "error",
+      comment:
+        "Import cycles make ownership ambiguous and break incremental " +
+        "reasoning. Cycles closed only through a dynamic import() are " +
+        "allowed: the lazy edge is the deliberate cycle-break (module " +
+        "load order stays acyclic).",
+      from: {},
+      to: {
+        circular: true,
+        viaOnly: { dependencyTypesNot: ["dynamic-import"] },
+      },
+    },
+
+    // ── Migration targets (warn = visible, ratchets to error) ────────────
+    {
+      name: "sessions-owned-by-weaver",
+      comment:
+        "TARGET (Weaver step 5): only the Weaver owns session state; " +
+        "backends receive a session handle from the Thread's warp instead " +
+        "of importing the store. Ratchets to error when " +
+        "engine/backend-controller/legacy.ts is deleted. Do not add new " +
+        "importers.",
+      severity: "warn",
+      from: {
+        path: "^src/(backend|core/engine)/",
+        pathNot: "^src/core/engine/backend-controller/",
+      },
+      to: { path: "^src/storage/sessions\\.ts$" },
+    },
+    {
+      name: "doctor-probes-move-behind-registry",
+      comment:
+        "TARGET: doctor.ts checks backend health by importing backend " +
+        "modules directly. Ratchets to error when backends export " +
+        "DoctorCheck providers and the composition root wires them in. " +
+        "Do not add new backend imports here.",
+      severity: "warn",
+      from: { path: "^src/core/doctor\\.ts$" },
+      to: { path: "^src/backend/" },
+    },
+    {
+      name: "config-belongs-in-core",
+      comment:
+        "TARGET: util/config.ts imports core/prompt and core/agent-runtime " +
+        "— it is engine configuration, not a leaf utility, and should move " +
+        "to core/config/. Ratchets to error when the move lands. Do not " +
+        "add new upward imports.",
+      severity: "warn",
+      from: { path: "^src/util/config\\.ts$" },
+      to: { path: "^src/(core|backend|frontend|storage|cli|plugins)/" },
+    },
+    {
+      name: "metrics-read-shape-moves-down",
+      comment:
+        "TARGET: util/metrics.ts re-exposes session read shapes from " +
+        "storage/. Either the read shape moves into storage/ proper or " +
+        "this module moves up beside its data. Ratchets to error with " +
+        "that move. Do not add new upward imports.",
+      severity: "warn",
+      from: { path: "^src/util/metrics\\.ts$" },
+      to: { path: "^src/(core|backend|frontend|storage|cli|plugins)/" },
+    },
+    {
+      name: "frontend-not-to-backend",
+      comment:
+        "TARGET: frontends consume turn results through the engine, not by " +
+        "importing backend/shared helpers. Ratchets to error when the " +
+        "Shuttle owns turn choreography and backend/shared shrinks to the " +
+        "adapter contract. Do not add new importers.",
+      severity: "warn",
+      from: { path: "^src/frontend/" },
+      to: { path: "^src/backend/" },
+    },
+  ],
+  options: {
+    doNotFollow: { path: "node_modules" },
+    exclude: { path: "(^|/)__tests__/|\\.test\\.ts$|\\.d\\.m?ts$" },
+    // The repo compiles with typescript@7 (tsgo), whose API dependency-cruiser
+    // cannot drive yet — swc is the parser here, used for import extraction only.
+    parser: "swc",
+    tsConfig: { fileName: "tsconfig.json" },
+    tsPreCompilationDeps: true,
+    enhancedResolveOptions: {
+      exportsFields: ["exports"],
+      conditionNames: ["import", "require", "node", "default", "types"],
+      extensions: [".ts", ".mts", ".js", ".mjs"],
+    },
+    reporterOptions: {
+      text: { highlightFocused: true },
+    },
+  },
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Architecture boundaries (dependency-cruiser)
+        run: npm run depcruise
+
+      - name: Ratchet gates
+        run: npm run ratchets
+
       - name: Check for .only/.skip in tests
         run: |
           if grep -rn '\.only\s*(' --include='*.test.ts' src/__tests__/ || \

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,11 @@
         "talon": "bin/talon.js"
       },
       "devDependencies": {
+        "@swc/core": "^1.15.46",
         "@types/node": "^26.0.0",
         "@types/write-file-atomic": "^4.0.3",
         "@vitest/coverage-v8": "^4.1.3",
+        "dependency-cruiser": "^18.1.0",
         "fast-check": "^4.6.0",
         "knip": "^6.3.1",
         "oxlint": "^1.59.0",
@@ -3292,6 +3294,286 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/@swc/core": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.46.tgz",
+      "integrity": "sha512-Ri3em2mBpq3h2zSPliCYl63otDGqek8PPEfv2nWgRQEbZ/VBCNyypVTVQ6cEbTCXBhy+WE2T3fQb08moIyuYaw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.27"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.46",
+        "@swc/core-darwin-x64": "1.15.46",
+        "@swc/core-linux-arm-gnueabihf": "1.15.46",
+        "@swc/core-linux-arm64-gnu": "1.15.46",
+        "@swc/core-linux-arm64-musl": "1.15.46",
+        "@swc/core-linux-ppc64-gnu": "1.15.46",
+        "@swc/core-linux-s390x-gnu": "1.15.46",
+        "@swc/core-linux-x64-gnu": "1.15.46",
+        "@swc/core-linux-x64-musl": "1.15.46",
+        "@swc/core-win32-arm64-msvc": "1.15.46",
+        "@swc/core-win32-ia32-msvc": "1.15.46",
+        "@swc/core-win32-x64-msvc": "1.15.46"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.46.tgz",
+      "integrity": "sha512-IsISIT22EfktVJrlvIpnAxG2u/A9aob9l99HMlx80x72WlFmFPk1V3UhkEzx86eJP8hw049KTFv/RISho2cq2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.46.tgz",
+      "integrity": "sha512-4Tj4ppVIPCmUMpmGFiGtyEriwLyJ+yi/US4WfBrP/ok8COGddDZXLEzQETnKyK46mjvr1v0jevrS23zjoff7vA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.46.tgz",
+      "integrity": "sha512-i8tUGnNjyOgMmfmgFSg4aeJLQoFyfpIHK5FjpQAwpRyQIqEUB2w1e8zIDQzY1WhOxx8NoS1S5iUL813Un4Sf5A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.46.tgz",
+      "integrity": "sha512-c0OnhqzdhfOvv6qhNCcByepB+sNYOGZyhtr2Qa6ZCHvAWTYhSRw4j/u92Stue9PbZ/6q74b9nHzi76+kVzqQHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.46.tgz",
+      "integrity": "sha512-imyRpNEcUzFQFV2LE4jL68ErvmKEuZCbvZru77iQREunJ+bR4i658cupTgtG1mLYM3F1Tzy3Sb9xYb02KghWTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.46.tgz",
+      "integrity": "sha512-ctEfcl/HcUeomK33cbySiHZm98GEDIxTm1EkpBsYCiHxElYBzvTXVeuQT2YwbUXn9XCrjiw4ipyUNk33k26qRg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.46.tgz",
+      "integrity": "sha512-DxlMdnt84TtRVTv7WL/thWyz9+QU8QZNNoAP9rrk0P68LziuhfePp8MjQ44zIprpTHTsEwyziIuGUUN5iSC1bQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.46.tgz",
+      "integrity": "sha512-SKxI7J6t90XPl8hRUqtJi9NfGdunN/E/vZMc7Bc0figeRdOPDBT+Tm8g7cx9xM0T0mewh2l+8dewa3Am27/P+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.46.tgz",
+      "integrity": "sha512-qj9T6B7bosI0VEsrWOVXZN1OXxS8Tp63ywyrLxNdOycnUtLdkgYcoBsN5y8ImnDDsnwrEWZOy1e+J4xSe7mA3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.46.tgz",
+      "integrity": "sha512-8p7l4c3LU+eA5g9Et1JPhNeMC1oQwXTGU+uah8DPIBX7YXzqswvaBtyKVmXefVGi/DJU1x3YJsc3mbAp9aWzSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.46.tgz",
+      "integrity": "sha512-tUEnfr3Bn9u6FOjUb3PN9p+09qZC2j+wNDLKHzXXZn22rqGcUqR/ohCRSS+nG9B9+X+U+3FewNEHJkTmdIvMjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.46.tgz",
+      "integrity": "sha512-Vux7UDzBJYQggSuPfcl2w9iu+IJpgpRCxHzgCaVkELnAXAE4XZMOTX9HNcaNiwfeIDqdu2rkr69RuDm6wY8neA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -4016,6 +4298,62 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn-loose": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/afinn-165": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-2.0.2.tgz",
@@ -4098,7 +4436,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4523,7 +4860,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4667,7 +5003,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4679,8 +5014,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -4995,6 +5329,54 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dependency-cruiser": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-18.1.0.tgz",
+      "integrity": "sha512-pbsH0gQ15BxXi97SCuMeVgsh8VzYpziGIVaMdnALbVu+TYjSZrW9/nOvsPU+NjHLmJSF9R1UijjoACq6Ne/ybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "8.17.0",
+        "acorn-jsx": "5.3.2",
+        "acorn-jsx-walk": "2.0.0",
+        "acorn-loose": "8.5.2",
+        "acorn-walk": "8.3.5",
+        "commander": "15.0.0",
+        "enhanced-resolve": "5.24.2",
+        "ignore": "7.0.6",
+        "interpret": "3.1.1",
+        "is-installed-globally": "1.0.0",
+        "json5": "2.2.3",
+        "picomatch": "4.0.5",
+        "prompts": "2.4.2",
+        "rechoir": "0.8.0",
+        "safe-regex": "2.1.1",
+        "semver": "7.8.5",
+        "tsconfig-paths-webpack-plugin": "4.2.0",
+        "watskeburt": "6.0.0"
+      },
+      "bin": {
+        "depcruise": "bin/dependency-cruise.mjs",
+        "depcruise-baseline": "bin/depcruise-baseline.mjs",
+        "depcruise-fmt": "bin/depcruise-fmt.mjs",
+        "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
+        "dependency-cruise": "bin/dependency-cruise.mjs",
+        "dependency-cruiser": "bin/dependency-cruise.mjs"
+      },
+      "engines": {
+        "node": "^22||^24||>=26"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5206,6 +5588,20 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -6051,6 +6447,32 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "10.9.0",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
@@ -6367,6 +6789,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -6388,6 +6820,16 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/interpret": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -6413,6 +6855,22 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -6449,6 +6907,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-network-error": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
@@ -6469,6 +6944,19 @@
       "peer": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-promise": {
@@ -6718,6 +7206,19 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
@@ -6772,6 +7273,16 @@
       "peer": true,
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/knip": {
@@ -8534,6 +9045,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -8726,9 +9244,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9005,6 +9523,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -9217,6 +9749,19 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
     "node_modules/redis": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
@@ -9235,6 +9780,16 @@
         "@redis/time-series": "1.1.0"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -9242,6 +9797,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -9357,6 +9934,16 @@
       ],
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -9790,6 +10377,16 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
@@ -9837,6 +10434,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/sylvester": {
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz",
@@ -9844,6 +10454,20 @@
       "peer": true,
       "engines": {
         "node": ">=0.2.6"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar-fs": {
@@ -10101,6 +10725,37 @@
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
       "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
       "license": "MIT"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -10531,6 +11186,19 @@
       },
       "bin": {
         "wasmoon": "bin/wasmoon"
+      }
+    },
+    "node_modules/watskeburt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-6.0.0.tgz",
+      "integrity": "sha512-jfiuDABaxSkC71T6oZ3vCS99roYkSHm/+As+G0Dz8taAHQb+SJBvLEm5RlsgG71XdfAj3rv7eudUBTgwcQUPlQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "watskeburt": "dist/run-cli.js"
+      },
+      "engines": {
+        "node": "^22.13||^24||>=26"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "src/native/",
     "src/plugins/",
     "src/storage/",
+    "src/types/",
     "src/util/",
     "src/app.ts",
     "src/bootstrap.ts",
@@ -77,6 +78,8 @@
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint src/",
+    "depcruise": "depcruise src",
+    "ratchets": "node scripts/check-ratchets.mjs",
     "knip": "knip",
     "format": "prettier --write src/ prompts/",
     "format:check": "prettier --check src/ prompts/",
@@ -130,9 +133,11 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@swc/core": "^1.15.46",
     "@types/node": "^26.0.0",
     "@types/write-file-atomic": "^4.0.3",
     "@vitest/coverage-v8": "^4.1.3",
+    "dependency-cruiser": "^18.1.0",
     "fast-check": "^4.6.0",
     "knip": "^6.3.1",
     "oxlint": "^1.59.0",

--- a/scripts/check-ratchets.mjs
+++ b/scripts/check-ratchets.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Ratchet gates — metrics that may only improve.
+ *
+ * Each ratchet counts something we want less of and fails CI when the
+ * count RISES above the committed baseline. When a change lowers a
+ * count, the script says so and the baseline here should be lowered in
+ * the same PR — that's the ratchet clicking one tooth tighter. Deleting
+ * a ratchet requires reaching zero first (then promote the invariant to
+ * a real lint/type rule if one exists).
+ *
+ * Deliberately dependency-free and dumb: plain recursive grep, exact
+ * string match, no AST. A false positive in a comment is acceptable
+ * noise for a gate this cheap.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** @type {{name: string, dir: string, needle: string, baseline: number, why: string}[]} */
+const RATCHETS = [
+  {
+    name: "naked-throw-in-core",
+    dir: "src/core",
+    needle: "throw new Error(",
+    baseline: 38,
+    why:
+      "core/ should throw classified errors (core/errors.ts) so retry and " +
+      "interrupt behaviour stays well-defined at the engine boundary. " +
+      "Guard-style programmer-error throws are tolerated at the current " +
+      "baseline; new engine code classifies.",
+  },
+];
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+      yield* walk(path);
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      yield path;
+    }
+  }
+}
+
+let failed = false;
+for (const ratchet of RATCHETS) {
+  let count = 0;
+  const hits = [];
+  for (const file of walk(ratchet.dir)) {
+    const lines = readFileSync(file, "utf8").split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].includes(ratchet.needle)) {
+        count++;
+        hits.push(`${file}:${i + 1}`);
+      }
+    }
+  }
+  if (count > ratchet.baseline) {
+    failed = true;
+    console.error(
+      `✖ ratchet "${ratchet.name}": ${count} > baseline ${ratchet.baseline}`,
+    );
+    console.error(`  ${ratchet.why}`);
+    for (const hit of hits) console.error(`  ${hit}`);
+  } else if (count < ratchet.baseline) {
+    console.log(
+      `→ ratchet "${ratchet.name}": ${count} < baseline ${ratchet.baseline} — lower the baseline in scripts/check-ratchets.mjs to lock it in`,
+    );
+  } else {
+    console.log(`✔ ratchet "${ratchet.name}": ${count} (at baseline)`);
+  }
+}
+
+process.exit(failed ? 1 : 0);

--- a/src/__tests__/chat-settings.test.ts
+++ b/src/__tests__/chat-settings.test.ts
@@ -37,9 +37,10 @@ const {
   setChatPulseInterval,
   getRegisteredPulseChats,
   loadChatSettings,
-  resolveModelName,
   EFFORT_LEVELS,
 } = await import("../storage/chat-settings.js");
+const { resolveModelId: resolveModelName } =
+  await import("../core/models/catalog.js");
 
 // Register Claude models (static — no SDK subprocess in tests)
 const { registerClaudeModelsStatic, CLAUDE_MODELS_STATIC } =

--- a/src/__tests__/fuzz.test.ts
+++ b/src/__tests__/fuzz.test.ts
@@ -49,7 +49,8 @@ const { classify, TalonError } = await import("../core/errors.js");
 await import("../storage/cron-store.js");
 const { handleSharedAction } =
   await import("../core/engine/gateway-actions/index.js");
-const { resolveModelName } = await import("../storage/chat-settings.js");
+const { resolveModelId: resolveModelName } =
+  await import("../core/models/catalog.js");
 const { registerClaudeModelsStatic, CLAUDE_MODELS_STATIC } =
   await import("../backend/claude-sdk/models/index.js");
 registerClaudeModelsStatic(CLAUDE_MODELS_STATIC);

--- a/src/__tests__/integration/kilo-live-discovery.test.ts
+++ b/src/__tests__/integration/kilo-live-discovery.test.ts
@@ -96,6 +96,7 @@ vi.mock("../../backend/kilo/server.js", () => {
       }
       return testClient;
     }),
+    onServerStop: vi.fn(),
   };
 });
 

--- a/src/__tests__/integration/opencode-live-discovery.test.ts
+++ b/src/__tests__/integration/opencode-live-discovery.test.ts
@@ -52,6 +52,7 @@ vi.mock("../../backend/opencode/server.js", () => {
       }
       return testClient;
     }),
+    onServerStop: vi.fn(),
   };
 });
 

--- a/src/__tests__/journal.test.ts
+++ b/src/__tests__/journal.test.ts
@@ -96,7 +96,10 @@ describe("event journal", () => {
       journal.appendToJournal(taskSettled(i, i + 10, i * 100 + 1));
     }
 
-    const settled = journal.readJournal({ type: "task.settled", limit: 3 });
+    const settled = journal.readJournal<PublishedEvent>({
+      type: "task.settled",
+      limit: 3,
+    });
     expect(settled).toHaveLength(3);
     expect(settled.every((e) => e.event.type === "task.settled")).toBe(true);
     // Newest three of the five.

--- a/src/__tests__/kilo-model-provider.test.ts
+++ b/src/__tests__/kilo-model-provider.test.ts
@@ -19,6 +19,7 @@ vi.mock("../util/log.js", () => ({
 }));
 
 vi.mock("../backend/kilo/server.js", () => ({
+  onServerStop: vi.fn(),
   ensureServer: vi.fn(async () => {
     throw new Error(
       "ensureServer should not be called from kilo-model-provider tests",

--- a/src/__tests__/kilo-models.test.ts
+++ b/src/__tests__/kilo-models.test.ts
@@ -12,6 +12,7 @@ vi.mock("../util/log.js", () => ({
 // kilo server module still gets imported for type resolution. Stub it so the
 // import doesn't try to spin up a real Kilo process.
 vi.mock("../backend/kilo/server.js", () => ({
+  onServerStop: vi.fn(),
   ensureServer: vi.fn(async () => {
     throw new Error("ensureServer should not be called from kilo-models tests");
   }),

--- a/src/__tests__/kilo-quickpicks.test.ts
+++ b/src/__tests__/kilo-quickpicks.test.ts
@@ -34,6 +34,7 @@ vi.mock("../util/log.js", () => ({
 }));
 
 vi.mock("../backend/kilo/server.js", () => ({
+  onServerStop: vi.fn(),
   ensureServer: vi.fn(async () => {
     throw new Error(
       "ensureServer should not be called from kilo-quickpicks tests",

--- a/src/__tests__/kilo-summary.test.ts
+++ b/src/__tests__/kilo-summary.test.ts
@@ -7,6 +7,7 @@ vi.mock("../util/log.js", () => ({
 }));
 
 vi.mock("../backend/kilo/server.js", () => ({
+  onServerStop: vi.fn(),
   ensureServer: vi.fn(async () => {
     throw new Error(
       "ensureServer should not be called from kilo-summary tests",

--- a/src/__tests__/kilo-ui.test.ts
+++ b/src/__tests__/kilo-ui.test.ts
@@ -7,6 +7,7 @@ vi.mock("../util/log.js", () => ({
 }));
 
 vi.mock("../backend/kilo/server.js", () => ({
+  onServerStop: vi.fn(),
   ensureServer: vi.fn(async () => {
     throw new Error("ensureServer should not be called from kilo-ui tests");
   }),

--- a/src/__tests__/terminal-commands.test.ts
+++ b/src/__tests__/terminal-commands.test.ts
@@ -34,7 +34,10 @@ vi.mock("../storage/chat-settings.js", () => ({
     mockSetChatModel(chatId, model),
   setChatEffort: (chatId: string, effort: string | undefined) =>
     mockSetChatEffort(chatId, effort),
-  resolveModelName: (s: string) => mockResolveModelName(s),
+}));
+vi.mock("../core/models/catalog.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../core/models/catalog.js")>()),
+  resolveModelId: (s: string) => mockResolveModelName(s),
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/backend/kilo/models/index.ts
+++ b/src/backend/kilo/models/index.ts
@@ -13,7 +13,7 @@
  * Kilo ids routinely contain "/" and ":" (e.g. "inclusionai/ling-2.6-1t:free").
  */
 
-import { ensureServer } from "../server.js";
+import { ensureServer, onServerStop } from "../server.js";
 import { createRemoteModelCatalogModule } from "../../remote-server/model-catalog/index.js";
 
 export type {
@@ -40,6 +40,9 @@ const kiloModels = createRemoteModelCatalogModule({
   allowCallbackSeparators: true,
   quickPickLimit: 24,
 });
+
+// A stopped server invalidates the catalog it served.
+onServerStop(kiloModels.clearCache);
 
 export const getOpenCodeModelCatalog = kiloModels.getCatalog;
 export const clearModelCatalogCache = kiloModels.clearCache;

--- a/src/backend/kilo/server.ts
+++ b/src/backend/kilo/server.ts
@@ -25,13 +25,12 @@ import type { TalonConfig } from "../../util/config.js";
 import type { FrontendName } from "../../core/agent-runtime/backend-registry.js";
 import { logWarn } from "../../util/log.js";
 import { buildDeliveryContract } from "../shared/delivery-contract.js";
-import { clearModelCatalogCache } from "./models/index.js";
 import {
   guessProviderID,
   getBucketPriority,
   normalizeModelLookup,
-  parseOpenCodeModelQuery,
-} from "./models/index.js";
+  parseRemoteModelQuery as parseOpenCodeModelQuery,
+} from "../remote-server/model-catalog/index.js";
 import {
   createRemoteServerState,
   ensureRemoteServer as ensureRemoteServerShared,
@@ -154,13 +153,27 @@ async function prewarmPluginMcpServers(): Promise<void> {
 }
 
 /**
+ * Callbacks run when the server stops — cache invalidation lives with the
+ * caches. The models module registers its clear here at load time, so the
+ * server never has to import it (which would be a cycle).
+ */
+const stopHooks = new Set<() => void>();
+
+/** Register a callback to run whenever the Kilo server is stopped. */
+export function onServerStop(hook: () => void): void {
+  stopHooks.add(hook);
+}
+
+/**
  * Stop the local Kilo server (if we own it) and clear caches.
  *
  * Idempotent: safe to call multiple times. If we reused a pre-existing
  * server, this leaves it running — we don't own it.
  */
 export function stopKiloServer(): void {
-  stopRemoteServer(state, clearModelCatalogCache);
+  stopRemoteServer(state, () => {
+    for (const hook of stopHooks) hook();
+  });
 }
 
 // ── Server lifecycle ────────────────────────────────────────────────────────

--- a/src/backend/openai-agents/session.ts
+++ b/src/backend/openai-agents/session.ts
@@ -251,7 +251,7 @@ export class TalonSession extends MemorySession {
     return current;
   }
 
-  async addItems(items: AgentInputItem[]): Promise<void> {
+  override async addItems(items: AgentInputItem[]): Promise<void> {
     await super.addItems(items);
     await this.enforceCap();
   }

--- a/src/backend/opencode/models/index.ts
+++ b/src/backend/opencode/models/index.ts
@@ -12,7 +12,7 @@
  * stay at 4 and only short separator-free ids are embedded raw.
  */
 
-import { ensureServer } from "../server.js";
+import { ensureServer, onServerStop } from "../server.js";
 import { createRemoteModelCatalogModule } from "../../remote-server/model-catalog/index.js";
 
 export type {
@@ -39,6 +39,9 @@ const opencodeModels = createRemoteModelCatalogModule({
   allowCallbackSeparators: false,
   quickPickLimit: 4,
 });
+
+// A stopped server invalidates the catalog it served.
+onServerStop(opencodeModels.clearCache);
 
 export const getOpenCodeModelCatalog = opencodeModels.getCatalog;
 export const clearModelCatalogCache = opencodeModels.clearCache;

--- a/src/backend/opencode/server.ts
+++ b/src/backend/opencode/server.ts
@@ -25,13 +25,12 @@ import type { TalonConfig } from "../../util/config.js";
 import type { FrontendName } from "../../core/agent-runtime/backend-registry.js";
 import { logWarn } from "../../util/log.js";
 import { buildDeliveryContract } from "../shared/delivery-contract.js";
-import { clearModelCatalogCache } from "./models/index.js";
 import {
   guessProviderID,
   getBucketPriority,
   normalizeModelLookup,
-  parseOpenCodeModelQuery,
-} from "./models/index.js";
+  parseRemoteModelQuery as parseOpenCodeModelQuery,
+} from "../remote-server/model-catalog/index.js";
 import {
   createRemoteServerState,
   ensureRemoteServer as ensureRemoteServerShared,
@@ -108,8 +107,22 @@ async function prewarmPluginMcpServers(): Promise<void> {
   await ensurePluginMcpServers(client, "prewarm");
 }
 
+/**
+ * Callbacks run when the server stops — cache invalidation lives with the
+ * caches. The models module registers its clear here at load time, so the
+ * server never has to import it (which would be a cycle).
+ */
+const stopHooks = new Set<() => void>();
+
+/** Register a callback to run whenever the OpenCode server is stopped. */
+export function onServerStop(hook: () => void): void {
+  stopHooks.add(hook);
+}
+
 export function stopOpenCodeServer(): void {
-  stopRemoteServer(state, clearModelCatalogCache);
+  stopRemoteServer(state, () => {
+    for (const hook of stopHooks) hook();
+  });
 }
 
 // ── Server lifecycle ────────────────────────────────────────────────────────

--- a/src/backend/shared/system-prompt.ts
+++ b/src/backend/shared/system-prompt.ts
@@ -41,6 +41,7 @@ import {
   type TalonConfig,
 } from "../../util/config.js";
 import { getPluginPromptAdditions } from "../../core/plugin/index.js";
+import { onPromptInputsChanged } from "../../core/prompt/invalidation.js";
 import { frontendForChatId, nonTerminalFrontends } from "./frontends.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -111,6 +112,10 @@ const MAX_SNAPSHOTS = 256;
 export function clearSystemPromptSnapshots(): void {
   snapshots.clear();
 }
+
+// Core and frontends invalidate through the core-side seam — they never
+// import this module (layer rule: nothing above backend/ reaches into it).
+onPromptInputsChanged(clearSystemPromptSnapshots);
 
 // ── Public API ──────────────────────────────────────────────────────────────
 

--- a/src/cli/events.ts
+++ b/src/cli/events.ts
@@ -52,7 +52,7 @@ async function showHistory(limit: number): Promise<void> {
   const { readJournal } = await import("../storage/journal.js");
   let entries;
   try {
-    entries = readJournal({ limit });
+    entries = readJournal<TalonEvent & { at: number }>({ limit });
   } catch (err) {
     console.log(
       `  ${pc.red("✖")} Could not read the journal: ${err instanceof Error ? err.message : err}\n`,

--- a/src/cli/tasks.ts
+++ b/src/cli/tasks.ts
@@ -16,6 +16,7 @@ import type {
   TaskRecord,
   TaskState,
 } from "../core/tasks/index.js";
+import type { PublishedEvent } from "../core/bus/index.js";
 
 function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000);
@@ -120,7 +121,10 @@ async function journalTasks(
   const { readJournal } = await import("../storage/journal.js");
   const seen = new Set(liveTasks.map((t) => `${t.id}:${t.queuedAt}`));
   const historical: TaskRecord[] = [];
-  for (const entry of readJournal({ type: "task.settled", limit })) {
+  for (const entry of readJournal<PublishedEvent>({
+    type: "task.settled",
+    limit,
+  })) {
     if (entry.event.type !== "task.settled") continue;
     const task = entry.event.task;
     // (id, queuedAt) identifies a run across surfaces — per-process ids

--- a/src/core/background/triggers/pid.ts
+++ b/src/core/background/triggers/pid.ts
@@ -1,0 +1,28 @@
+/**
+ * PID-starttime probe — the /proc read shared by spawn (capture at fork)
+ * and resume (compare after restart). Lives alone so neither module has
+ * to import the other for it.
+ */
+
+import { readFileSync } from "node:fs";
+
+/**
+ * Read field 22 (start time in jiffies since boot) from /proc/<pid>/stat.
+ * Returns undefined if /proc isn't available (non-Linux) or the read fails.
+ *
+ * Parsing note: the `comm` field (2nd) is wrapped in parens and may itself
+ * contain ')' — the safe parse finds the LAST ')' and splits the rest on
+ * space. After that split, index 19 corresponds to field 22.
+ */
+export function readPidStarttimeSync(pid: number): number | undefined {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+    const lastParen = stat.lastIndexOf(")");
+    if (lastParen < 0) return undefined;
+    const tail = stat.slice(lastParen + 2).split(" ");
+    const starttime = Number(tail[19]);
+    return Number.isFinite(starttime) ? starttime : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/core/background/triggers/resume.ts
+++ b/src/core/background/triggers/resume.ts
@@ -1,10 +1,10 @@
 /**
  * Post-restart resume — respawn persistent triggers, fire late wakes for
- * recently-terminated ones, plus the /proc-based PID-starttime probe and the
- * orphan-kill used to avoid duplicate spawns after an unclean crash.
+ * recently-terminated ones, plus the orphan-kill used to avoid duplicate
+ * spawns after an unclean crash. The /proc PID-starttime probe both this
+ * and spawn use lives in ./pid.ts.
  */
 
-import { readFileSync } from "node:fs";
 import {
   getAllTriggers,
   updateTrigger,
@@ -15,6 +15,7 @@ import { log, logError } from "../../../util/log.js";
 import { depsHolder } from "./state.js";
 import { fireWake } from "./output.js";
 import { spawnTrigger } from "./spawn.js";
+import { readPidStarttimeSync } from "./pid.js";
 
 /**
  * After the dispatcher is wired, walk the store and clean up leftover state
@@ -65,27 +66,6 @@ export async function resumeAfterRestart(): Promise<void> {
     ) {
       await fireWake(t.id, "terminated", t.lastError, /* terminal */ true);
     }
-  }
-}
-
-/**
- * Read field 22 (start time in jiffies since boot) from /proc/<pid>/stat.
- * Returns undefined if /proc isn't available (non-Linux) or the read fails.
- *
- * Parsing note: the `comm` field (2nd) is wrapped in parens and may itself
- * contain ')' — the safe parse finds the LAST ')' and splits the rest on
- * space. After that split, index 19 corresponds to field 22.
- */
-export function readPidStarttimeSync(pid: number): number | undefined {
-  try {
-    const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
-    const lastParen = stat.lastIndexOf(")");
-    if (lastParen < 0) return undefined;
-    const tail = stat.slice(lastParen + 2).split(" ");
-    const starttime = Number(tail[19]);
-    return Number.isFinite(starttime) ? starttime : undefined;
-  } catch {
-    return undefined;
   }
 }
 

--- a/src/core/background/triggers/spawn.ts
+++ b/src/core/background/triggers/spawn.ts
@@ -25,7 +25,7 @@ import {
 import { commandForLanguage } from "./command.js";
 import { handleStdoutLine, handleStderrLine } from "./output.js";
 import { handleTimeout, finalizeExit, failTrigger } from "./exit.js";
-import { readPidStarttimeSync } from "./resume.js";
+import { readPidStarttimeSync } from "./pid.js";
 
 /**
  * Spawn a trigger's script as a supervised child process.

--- a/src/core/engine/gateway-actions/plugins.ts
+++ b/src/core/engine/gateway-actions/plugins.ts
@@ -22,8 +22,8 @@ export async function performPluginReload(
   const { reloadPlugins, getPluginPromptAdditions } =
     await import("../../plugin/index.js");
   const { rebuildSystemPrompt } = await import("../../../util/config.js");
-  const { clearSystemPromptSnapshots } =
-    await import("../../../backend/shared/system-prompt.js");
+  const { notifyPromptInputsChanged } =
+    await import("../../prompt/invalidation.js");
 
   // reloadPlugins reads + validates config internally — no double read.
   // Frontends are derived from config if not explicitly provided.
@@ -37,7 +37,7 @@ export async function performPluginReload(
   // Plugin prompt additions changed — drop per-session prompt
   // snapshots so every chat's next turn picks up the new prompt
   // (deliberate one-time cache re-write per live session).
-  clearSystemPromptSnapshots();
+  notifyPromptInputsChanged();
 
   return { names };
 }

--- a/src/core/prompt/invalidation.ts
+++ b/src/core/prompt/invalidation.ts
@@ -1,0 +1,23 @@
+/**
+ * Prompt-input invalidation — the core-side seam callers use when prompt
+ * inputs change out from under live sessions on purpose (plugin reload,
+ * skill toggle).
+ *
+ * Whoever caches assembled prompts registers a hook here (today: the
+ * per-session snapshot store in backend/shared/system-prompt.ts, at its
+ * module load). Core and frontends call `notifyPromptInputsChanged()`
+ * and never import the cache — the dependency points backend → core,
+ * as the layer rule requires.
+ */
+
+const hooks = new Set<() => void>();
+
+/** Register a callback run whenever prompt inputs are invalidated. */
+export function onPromptInputsChanged(hook: () => void): void {
+  hooks.add(hook);
+}
+
+/** Invalidate: every registered prompt cache drops its state. */
+export function notifyPromptInputsChanged(): void {
+  for (const hook of hooks) hook();
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -29,8 +29,8 @@ export type UnifiedModelInfo = {
   unavailableReason?: string;
 };
 
-export type ReasoningEffortLevel =
-  "off" | "minimal" | "low" | "medium" | "high" | "max" | "xhigh";
+export type { ReasoningEffortLevel } from "../types/effort.js";
+import type { ReasoningEffortLevel } from "../types/effort.js";
 
 /** Result of resolving a user's model query. */
 export type UnifiedModelResolution =

--- a/src/frontend/discord/callbacks/components.ts
+++ b/src/frontend/discord/callbacks/components.ts
@@ -34,9 +34,9 @@ import {
   setChatModelForBackend,
   setChatBackend,
   setChatEffort,
-  resolveModelName,
   type EffortLevel,
 } from "../../../storage/chat-settings.js";
+import { resolveModelId as resolveModelName } from "../../../core/models/catalog.js";
 import {
   registerChat,
   disablePulse,

--- a/src/frontend/discord/commands/settings.ts
+++ b/src/frontend/discord/commands/settings.ts
@@ -18,9 +18,9 @@ import {
   setChatBackend,
   setChatEffort,
   setChatPulseInterval,
-  resolveModelName,
   type EffortLevel,
 } from "../../../storage/chat-settings.js";
+import { resolveModelId as resolveModelName } from "../../../core/models/catalog.js";
 import {
   registerChat,
   disablePulse,

--- a/src/frontend/native/extensions.ts
+++ b/src/frontend/native/extensions.ts
@@ -21,7 +21,7 @@ import type { Backend } from "../../core/agent-runtime/capabilities.js";
 import { performPluginReload } from "../../core/engine/gateway-actions/plugins.js";
 import { getPluginPromptAdditions } from "../../core/plugin/index.js";
 import { listPluginItems, setPluginEnabled } from "../../core/plugin/manage.js";
-import { clearSystemPromptSnapshots } from "../../backend/shared/system-prompt.js";
+import { notifyPromptInputsChanged } from "../../core/prompt/invalidation.js";
 import { listSkills, setSkillEnabled } from "../../storage/skill-store.js";
 import { rebuildSystemPrompt, type TalonConfig } from "../../util/config.js";
 import { log } from "../../util/log.js";
@@ -88,6 +88,6 @@ export function toggleSkill(
   log("native", `Skill ${name} ${enabled ? "enabled" : "disabled"} via bridge`);
   rebuildSystemPrompt(config, getPluginPromptAdditions());
   backend?.control?.updateSystemPrompt?.(config.systemPrompt);
-  clearSystemPromptSnapshots();
+  notifyPromptInputsChanged();
   return { ok: true };
 }

--- a/src/frontend/telegram/callbacks/model.ts
+++ b/src/frontend/telegram/callbacks/model.ts
@@ -11,8 +11,8 @@ import type { Context } from "grammy";
 import {
   setChatModelForBackend,
   setChatBackend,
-  resolveModelName,
 } from "../../../storage/chat-settings.js";
+import { resolveModelId as resolveModelName } from "../../../core/models/catalog.js";
 import { resetSession } from "../../../storage/sessions.js";
 import { clearHistory } from "../../../storage/history.js";
 import {

--- a/src/frontend/telegram/commands/settings.ts
+++ b/src/frontend/telegram/commands/settings.ts
@@ -9,9 +9,9 @@ import {
   setChatBackend,
   setChatEffort,
   setChatPulseInterval,
-  resolveModelName,
   type EffortLevel,
 } from "../../../storage/chat-settings.js";
+import { resolveModelId as resolveModelName } from "../../../core/models/catalog.js";
 import {
   registerChat,
   disablePulse,

--- a/src/frontend/terminal/commands.ts
+++ b/src/frontend/terminal/commands.ts
@@ -20,8 +20,8 @@ import {
   getChatSettings,
   setChatModel,
   setChatEffort,
-  resolveModelName,
 } from "../../storage/chat-settings.js";
+import { resolveModelId as resolveModelName } from "../../core/models/catalog.js";
 import {
   getAllSessions,
   getSession,

--- a/src/plugins/github/index.ts
+++ b/src/plugins/github/index.ts
@@ -12,7 +12,7 @@
  */
 
 import { execFileSync } from "node:child_process";
-import type { TalonPlugin } from "../../core/plugin/index.js";
+import type { TalonPlugin } from "../../core/plugin/types.js";
 import { log, logWarn } from "../../util/log.js";
 
 /**

--- a/src/plugins/mem0/index.ts
+++ b/src/plugins/mem0/index.ts
@@ -21,7 +21,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { TalonPlugin } from "../../core/plugin/index.js";
+import type { TalonPlugin } from "../../core/plugin/types.js";
 import { log, logWarn } from "../../util/log.js";
 import { dirs } from "../../util/paths.js";
 

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -18,7 +18,7 @@ import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { execFile as execFileCb, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
-import type { TalonPlugin } from "../../core/plugin/index.js";
+import type { TalonPlugin } from "../../core/plugin/types.js";
 import { log, logWarn } from "../../util/log.js";
 import { dirs } from "../../util/paths.js";
 

--- a/src/plugins/playwright/index.ts
+++ b/src/plugins/playwright/index.ts
@@ -21,7 +21,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import type { TalonPlugin } from "../../core/plugin/index.js";
+import type { TalonPlugin } from "../../core/plugin/types.js";
 import { log } from "../../util/log.js";
 
 export function createPlaywrightPlugin(config: {

--- a/src/storage/chat-settings.ts
+++ b/src/storage/chat-settings.ts
@@ -22,63 +22,12 @@ import { recordError } from "../util/watchdog.js";
 import { files } from "../util/paths.js";
 import { importLegacyJson } from "./legacy-import.js";
 import * as repo from "./repositories/chat-settings-repo.js";
-import type { ReasoningEffortLevel } from "../core/types.js";
+import type { ReasoningEffortLevel } from "../types/effort.js";
 
 export type EffortLevel = ReasoningEffortLevel;
 
-export type ChatSettings = {
-  /**
-   * Per-backend model overrides for this chat. Keyed by backend id
-   * (`"claude"`, `"codex"`, `"openai-agents"`, etc). Each entry is the
-   * model id the user picked on that backend.
-   *
-   * Switching backends preserves each side's last pick — your Codex
-   * chat remembers `gpt-5.5`, your OpenRouter chat remembers
-   * `meta-llama/...`. Replaces the single legacy `model` field which
-   * couldn't differentiate per-backend choices and produced the
-   * orphan-bug class (model from backend X persisting when switching
-   * to backend Y).
-   *
-   * Resolution order (see `core/models/active-model.ts`):
-   *   1. `modelByBackend[activeBackend]` if it validates on the catalog
-   *   2. `backend.getDefaultModel()` (canonical for backends that have one)
-   *   3. `config.backendDefaults[activeBackend]` (operator override)
-   *   4. `config.model` (only when activeBackend === config.backend)
-   *   5. null → "No model selected" UI + send guard refuses.
-   */
-  modelByBackend?: Record<string, string>;
-  /**
-   * @deprecated Single-slot model field. Retained for back-compat with
-   * old stores; migrated into `modelByBackend` on load. New writes go
-   * through `setChatModelForBackend` instead.
-   */
-  model?: string;
-  /**
-   * Backend override for this chat. When set, queries from this chat
-   * route to the override backend instead of the global `config.backend`.
-   * The backend controller refcounts pool instances, so two chats on
-   * two different backends keep both alive concurrently.
-   *
-   * Stored as the registry id (e.g. `"claude"`, `"openai-agents"`).
-   * Cleared via `setChatBackend(cid, undefined)` — chat reverts to
-   * the global default.
-   */
-  backend?: string;
-  /** Effort level override (maps to SDK thinking + effort options). */
-  effort?: EffortLevel;
-  /** Whether pulse is enabled for this chat. */
-  pulse?: boolean;
-  /** Per-chat pulse check interval in milliseconds. */
-  pulseIntervalMs?: number;
-  /** Last message ID checked by pulse (persisted to avoid reprocessing on restart). */
-  pulseLastCheckMsgId?: number;
-  /**
-   * When true, the model picker filters to free-tier models by default.
-   * Only meaningful for backends that report free-tier metadata (currently
-   * `openai-agents` against OpenRouter); other backends ignore the flag.
-   */
-  freeOnly?: boolean;
-};
+export type { ChatSettings } from "./repositories/chat-settings-repo.js";
+import type { ChatSettings } from "./repositories/chat-settings-repo.js";
 
 // In-memory cache over the chat_settings table. Reads serve live
 // references from here; writes go through persist() so each mutation
@@ -488,9 +437,3 @@ export const EFFORT_LEVELS: EffortLevel[] = [
   "max",
   "xhigh",
 ];
-
-/**
- * Resolve a user-provided model name (alias or full ID) to the canonical model ID.
- * Delegates to the model registry; falls through unknown names unchanged.
- */
-export { resolveModelId as resolveModelName } from "../core/models/catalog.js";

--- a/src/storage/cron-store.ts
+++ b/src/storage/cron-store.ts
@@ -20,87 +20,13 @@ import { inTransaction } from "./db.js";
 import * as repo from "./repositories/cron-repo.js";
 import { nextDueMs, type CatchupPolicy } from "../native/scheduler-core.js";
 
-export type CronJobType = "message" | "query";
+export type {
+  CronJob,
+  CronJobType,
+  CronRunStatus,
+} from "./repositories/cron-repo.js";
 export type { CatchupPolicy };
-
-/** Outcome of the most recent execution — surfaced in list_cron_jobs. */
-export type CronRunStatus = "ok" | "error";
-
-export type CronJob = {
-  id: string;
-  chatId: string;
-  /**
-   * Cron expression (5-field: minute hour day month weekday). Optional — a job
-   * carries EITHER `schedule` (cron mode) OR `everyMs` (interval mode), never
-   * both. The store validator (`isCronJob`) enforces exactly one.
-   */
-  schedule?: string;
-  /**
-   * Fixed interval in milliseconds (interval mode). Mutually exclusive with
-   * `schedule`. The job fires roughly every `everyMs` after its anchor
-   * (`lastRunAt`, else `startAt`, else `createdAt`). Wires the native
-   * scheduler-core interval math (next-due + missed-run catch-up) directly.
-   */
-  everyMs?: number;
-  /** "message" sends content as text; "query" runs content as a Claude prompt with tools */
-  type: CronJobType;
-  /** The message text or query prompt */
-  content: string;
-  /** Human-readable name for the job */
-  name: string;
-  enabled: boolean;
-  createdAt: number;
-  lastRunAt?: number;
-  runCount: number;
-  /** IANA timezone (e.g. "America/New_York"). Defaults to system timezone. */
-  timezone?: string;
-  /**
-   * Optional model override for `query` jobs. Unset = the chat's model. `query`
-   * cron jobs run as an isolated one-shot (no chat session), so unlike triggers
-   * the model may be on a different provider — see `provider`.
-   */
-  model?: string;
-  /**
-   * Optional provider/backend id for the override (e.g. a cheaper provider than
-   * the chat). Requires `model`. Unset = the chat's backend. Since cron runs
-   * isolated, a different provider is fine here.
-   */
-  provider?: string;
-  /**
-   * Optional short brief that becomes the isolated agent's system prompt — what
-   * the job is and how to do it. Useful to orient a cheaper override model.
-   */
-  instructions?: string;
-  /**
-   * Don't fire before this epoch-ms instant (a delayed start / "not before").
-   * Unset = eligible immediately.
-   */
-  startAt?: number;
-  /**
-   * Don't fire after this epoch-ms instant; the job auto-disables once now
-   * passes it (a natural expiry / "until"). Unset = no end.
-   */
-  endAt?: number;
-  /**
-   * Auto-disable after this many total runs (`runCount >= maxRuns`). A value of
-   * 1 makes the job one-shot. Unset = unbounded.
-   */
-  maxRuns?: number;
-  /**
-   * Missed-run policy for runs that were due while Talon was down:
-   *   "skip" (default) — drop them, resume on the next due tick
-   *   "once"           — collapse any number of missed runs into a single catch-up
-   *   "all"            — replay every missed run, capped by CATCHUP_MAX
-   * Decided by the native scheduler-core `catchupRunCount`.
-   */
-  catchup?: CatchupPolicy;
-  /** Status of the most recent execution. */
-  lastStatus?: CronRunStatus;
-  /** Error message from the most recent failed execution (cleared on success). */
-  lastError?: string;
-  /** Wall-clock duration of the most recent execution, in ms. */
-  lastDurationMs?: number;
-};
+import type { CronJob, CronRunStatus } from "./repositories/cron-repo.js";
 
 /** Telemetry recorded after each execution attempt. */
 export type CronRunOutcome = {

--- a/src/storage/goal-store.ts
+++ b/src/storage/goal-store.ts
@@ -17,25 +17,16 @@
 import { randomUUID } from "node:crypto";
 import * as repo from "./repositories/goals-repo.js";
 
-export type GoalStatus = "active" | "paused" | "completed" | "abandoned";
-export type GoalPriority = "low" | "normal" | "high";
-
-export type Goal = {
-  id: string;
-  /** Chat the goal belongs to — progress reports route back here. */
-  chatId: string;
-  title: string;
-  description?: string;
-  status: GoalStatus;
-  priority: GoalPriority;
-  createdAt: number;
-  updatedAt: number;
-  /** Optional soft deadline (unix ms). */
-  dueAt?: number;
-  /** Rolling note from the last progress update. */
-  lastProgressNote?: string;
-  lastProgressAt?: number;
-};
+export type {
+  Goal,
+  GoalPriority,
+  GoalStatus,
+} from "./repositories/goals-repo.js";
+import type {
+  Goal,
+  GoalPriority,
+  GoalStatus,
+} from "./repositories/goals-repo.js";
 
 export const GOAL_STATUSES: readonly GoalStatus[] = [
   "active",

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -26,19 +26,8 @@ import { formatSmartTimestamp, formatRelativeAge } from "../util/time.js";
 import { importLegacyJson } from "./legacy-import.js";
 import * as repo from "./repositories/history-repo.js";
 
-export type HistoryMessage = {
-  msgId: number;
-  senderId: number;
-  senderName: string;
-  text: string;
-  replyToMsgId?: number;
-  timestamp: number;
-  mediaType?:
-    "photo" | "document" | "voice" | "sticker" | "video" | "animation";
-  stickerFileId?: string;
-  /** Saved file path for downloaded media. */
-  filePath?: string;
-};
+export type { HistoryMessage } from "./repositories/history-repo.js";
+import type { HistoryMessage } from "./repositories/history-repo.js";
 
 // ── Persistence lifecycle ───────────────────────────────────────────────────
 

--- a/src/storage/journal.ts
+++ b/src/storage/journal.ts
@@ -15,9 +15,20 @@
  * PRUNE_EVERY appends) rather than on a timer.
  */
 
-import type { PublishedEvent, TalonEvent } from "../core/bus/index.js";
 import { logError } from "../util/log.js";
 import * as repo from "./repositories/journal-repo.js";
+
+/**
+ * The shape the journal needs from a record: a type column to index on
+ * and a publish time. The bus's `PublishedEvent` satisfies it; the
+ * journal itself stays ignorant of the event vocabulary (storage never
+ * imports upward from core) — readers narrow with the type parameter
+ * on `readJournal`.
+ */
+export interface JournalRecord {
+  readonly type: string;
+  readonly at: number;
+}
 
 /** Rows kept after a prune — bounded, but generous for a busy daemon. */
 export const JOURNAL_RETENTION = 20_000;
@@ -26,12 +37,12 @@ export const JOURNAL_RETENTION = 20_000;
 const PRUNE_EVERY = 500;
 
 /** One journal record: the event plus its durable cursor and time. */
-export interface JournalEntry {
+export interface JournalEntry<E extends JournalRecord = JournalRecord> {
   /** Durable, monotonic cursor — survives restarts (unlike bus ids). */
   readonly seq: number;
   /** Publish time, epoch ms. */
   readonly at: number;
-  readonly event: TalonEvent;
+  readonly event: E;
 }
 
 let appendsSincePrune = 0;
@@ -42,7 +53,7 @@ let appendFailureLogged = false;
  * observer, and a full disk or locked database must not break the bus
  * or the publisher behind it.
  */
-export function appendToJournal(event: PublishedEvent): void {
+export function appendToJournal(event: JournalRecord): void {
   try {
     repo.append(event.at, event.type, JSON.stringify(event));
     if (++appendsSincePrune >= PRUNE_EVERY) {
@@ -63,20 +74,20 @@ export function appendToJournal(event: PublishedEvent): void {
  * (indexed). Rows whose payload no longer parses are skipped — a
  * corrupt row must not take down the readable ones around it.
  */
-export function readJournal(
-  options: { limit?: number; type?: TalonEvent["type"] } = {},
-): JournalEntry[] {
+export function readJournal<E extends JournalRecord = JournalRecord>(
+  options: { limit?: number; type?: E["type"] } = {},
+): JournalEntry<E>[] {
   const limit = options.limit ?? 100;
   const rows = options.type
     ? repo.recentByType(options.type, limit)
     : repo.recent(limit);
-  const entries: JournalEntry[] = [];
+  const entries: JournalEntry<E>[] = [];
   for (const row of rows) {
     try {
       entries.push({
         seq: row.seq,
         at: row.at,
-        event: JSON.parse(row.payload) as TalonEvent,
+        event: JSON.parse(row.payload) as E,
       });
     } catch {
       // skip the corrupt row

--- a/src/storage/media-index.ts
+++ b/src/storage/media-index.ts
@@ -24,28 +24,8 @@ import { importLegacyJson } from "./legacy-import.js";
 import { setMessageFilePath } from "./history.js";
 import * as repo from "./repositories/media-index-repo.js";
 
-export type MediaEntry = {
-  id: string; // unique key: chatId:msgId
-  chatId: string;
-  msgId: number;
-  senderName: string;
-  type:
-    | "photo"
-    | "document"
-    | "voice"
-    | "video"
-    | "animation"
-    | "audio"
-    | "sticker";
-  filePath: string;
-  caption?: string;
-  timestamp: number;
-  /**
-   * BLAKE3 hex digest of the file contents (native/blake3-wasm).
-   * Filled in asynchronously after addMedia; undefined until hashed.
-   */
-  contentHash?: string;
-};
+export type { MediaEntry } from "./repositories/media-index-repo.js";
+import type { MediaEntry } from "./repositories/media-index-repo.js";
 
 const RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 

--- a/src/storage/repositories/chat-settings-repo.ts
+++ b/src/storage/repositories/chat-settings-repo.ts
@@ -13,7 +13,61 @@
 
 import { getDatabase, inTransaction } from "../db.js";
 import { chatSettingsSql } from "../sql/statements.generated.js";
-import type { ChatSettings } from "../chat-settings.js";
+import type { ReasoningEffortLevel } from "../../types/effort.js";
+
+export type ChatSettings = {
+  /**
+   * Per-backend model overrides for this chat. Keyed by backend id
+   * (`"claude"`, `"codex"`, `"openai-agents"`, etc). Each entry is the
+   * model id the user picked on that backend.
+   *
+   * Switching backends preserves each side's last pick — your Codex
+   * chat remembers `gpt-5.5`, your OpenRouter chat remembers
+   * `meta-llama/...`. Replaces the single legacy `model` field which
+   * couldn't differentiate per-backend choices and produced the
+   * orphan-bug class (model from backend X persisting when switching
+   * to backend Y).
+   *
+   * Resolution order (see `core/models/active-model.ts`):
+   *   1. `modelByBackend[activeBackend]` if it validates on the catalog
+   *   2. `backend.getDefaultModel()` (canonical for backends that have one)
+   *   3. `config.backendDefaults[activeBackend]` (operator override)
+   *   4. `config.model` (only when activeBackend === config.backend)
+   *   5. null → "No model selected" UI + send guard refuses.
+   */
+  modelByBackend?: Record<string, string>;
+  /**
+   * @deprecated Single-slot model field. Retained for back-compat with
+   * old stores; migrated into `modelByBackend` on load. New writes go
+   * through `setChatModelForBackend` instead.
+   */
+  model?: string;
+  /**
+   * Backend override for this chat. When set, queries from this chat
+   * route to the override backend instead of the global `config.backend`.
+   * The backend controller refcounts pool instances, so two chats on
+   * two different backends keep both alive concurrently.
+   *
+   * Stored as the registry id (e.g. `"claude"`, `"openai-agents"`).
+   * Cleared via `setChatBackend(cid, undefined)` — chat reverts to
+   * the global default.
+   */
+  backend?: string;
+  /** Effort level override (maps to SDK thinking + effort options). */
+  effort?: ReasoningEffortLevel;
+  /** Whether pulse is enabled for this chat. */
+  pulse?: boolean;
+  /** Per-chat pulse check interval in milliseconds. */
+  pulseIntervalMs?: number;
+  /** Last message ID checked by pulse (persisted to avoid reprocessing on restart). */
+  pulseLastCheckMsgId?: number;
+  /**
+   * When true, the model picker filters to free-tier models by default.
+   * Only meaningful for backends that report free-tier metadata (currently
+   * `openai-agents` against OpenRouter); other backends ignore the flag.
+   */
+  freeOnly?: boolean;
+};
 
 export function upsert(chatId: string, settings: ChatSettings): void {
   getDatabase()

--- a/src/storage/repositories/cron-repo.ts
+++ b/src/storage/repositories/cron-repo.ts
@@ -7,12 +7,88 @@
 
 import { getDatabase } from "../db.js";
 import { cronSql } from "../sql/statements.generated.js";
-import type {
-  CatchupPolicy,
-  CronJob,
-  CronJobType,
-  CronRunStatus,
-} from "../cron-store.js";
+import type { CatchupPolicy } from "../../native/scheduler-core.js";
+
+export type CronJobType = "message" | "query";
+
+/** Outcome of the most recent execution — surfaced in list_cron_jobs. */
+export type CronRunStatus = "ok" | "error";
+
+export type CronJob = {
+  id: string;
+  chatId: string;
+  /**
+   * Cron expression (5-field: minute hour day month weekday). Optional — a job
+   * carries EITHER `schedule` (cron mode) OR `everyMs` (interval mode), never
+   * both. The store validator (`isCronJob`) enforces exactly one.
+   */
+  schedule?: string;
+  /**
+   * Fixed interval in milliseconds (interval mode). Mutually exclusive with
+   * `schedule`. The job fires roughly every `everyMs` after its anchor
+   * (`lastRunAt`, else `startAt`, else `createdAt`). Wires the native
+   * scheduler-core interval math (next-due + missed-run catch-up) directly.
+   */
+  everyMs?: number;
+  /** "message" sends content as text; "query" runs content as a Claude prompt with tools */
+  type: CronJobType;
+  /** The message text or query prompt */
+  content: string;
+  /** Human-readable name for the job */
+  name: string;
+  enabled: boolean;
+  createdAt: number;
+  lastRunAt?: number;
+  runCount: number;
+  /** IANA timezone (e.g. "America/New_York"). Defaults to system timezone. */
+  timezone?: string;
+  /**
+   * Optional model override for `query` jobs. Unset = the chat's model. `query`
+   * cron jobs run as an isolated one-shot (no chat session), so unlike triggers
+   * the model may be on a different provider — see `provider`.
+   */
+  model?: string;
+  /**
+   * Optional provider/backend id for the override (e.g. a cheaper provider than
+   * the chat). Requires `model`. Unset = the chat's backend. Since cron runs
+   * isolated, a different provider is fine here.
+   */
+  provider?: string;
+  /**
+   * Optional short brief that becomes the isolated agent's system prompt — what
+   * the job is and how to do it. Useful to orient a cheaper override model.
+   */
+  instructions?: string;
+  /**
+   * Don't fire before this epoch-ms instant (a delayed start / "not before").
+   * Unset = eligible immediately.
+   */
+  startAt?: number;
+  /**
+   * Don't fire after this epoch-ms instant; the job auto-disables once now
+   * passes it (a natural expiry / "until"). Unset = no end.
+   */
+  endAt?: number;
+  /**
+   * Auto-disable after this many total runs (`runCount >= maxRuns`). A value of
+   * 1 makes the job one-shot. Unset = unbounded.
+   */
+  maxRuns?: number;
+  /**
+   * Missed-run policy for runs that were due while Talon was down:
+   *   "skip" (default) — drop them, resume on the next due tick
+   *   "once"           — collapse any number of missed runs into a single catch-up
+   *   "all"            — replay every missed run, capped by CATCHUP_MAX
+   * Decided by the native scheduler-core `catchupRunCount`.
+   */
+  catchup?: CatchupPolicy;
+  /** Status of the most recent execution. */
+  lastStatus?: CronRunStatus;
+  /** Error message from the most recent failed execution (cleared on success). */
+  lastError?: string;
+  /** Wall-clock duration of the most recent execution, in ms. */
+  lastDurationMs?: number;
+};
 
 type Row = {
   id: string;

--- a/src/storage/repositories/goals-repo.ts
+++ b/src/storage/repositories/goals-repo.ts
@@ -7,7 +7,26 @@
 
 import { getDatabase } from "../db.js";
 import { goalsSql } from "../sql/statements.generated.js";
-import type { Goal, GoalPriority, GoalStatus } from "../goal-store.js";
+export type GoalStatus = "active" | "paused" | "completed" | "abandoned";
+export type GoalPriority = "low" | "normal" | "high";
+
+/** One persistent goal as the domain sees it. */
+export type Goal = {
+  id: string;
+  /** Chat the goal belongs to — progress reports route back here. */
+  chatId: string;
+  title: string;
+  description?: string;
+  status: GoalStatus;
+  priority: GoalPriority;
+  createdAt: number;
+  updatedAt: number;
+  /** Optional soft deadline (unix ms). */
+  dueAt?: number;
+  /** Rolling note from the last progress update. */
+  lastProgressNote?: string;
+  lastProgressAt?: number;
+};
 
 type Row = {
   id: string;

--- a/src/storage/repositories/history-repo.ts
+++ b/src/storage/repositories/history-repo.ts
@@ -8,7 +8,20 @@
 import { escapeLike } from "../../native/sqlguard.js";
 import { getDatabase, inTransaction } from "../db.js";
 import { historySql } from "../sql/statements.generated.js";
-import type { HistoryMessage } from "../history.js";
+/** One chat message as the domain sees it — the shape the rows map to. */
+export type HistoryMessage = {
+  msgId: number;
+  senderId: number;
+  senderName: string;
+  text: string;
+  replyToMsgId?: number;
+  timestamp: number;
+  mediaType?:
+    "photo" | "document" | "voice" | "sticker" | "video" | "animation";
+  stickerFileId?: string;
+  /** Saved file path for downloaded media. */
+  filePath?: string;
+};
 
 type Row = {
   msg_id: number;

--- a/src/storage/repositories/media-index-repo.ts
+++ b/src/storage/repositories/media-index-repo.ts
@@ -14,7 +14,29 @@
 
 import { getDatabase, inTransaction } from "../db.js";
 import { mediaIndexSql } from "../sql/statements.generated.js";
-import type { MediaEntry } from "../media-index.js";
+/** One indexed media file as the domain sees it. */
+export type MediaEntry = {
+  id: string; // unique key: chatId:msgId
+  chatId: string;
+  msgId: number;
+  senderName: string;
+  type:
+    | "photo"
+    | "document"
+    | "voice"
+    | "video"
+    | "animation"
+    | "audio"
+    | "sticker";
+  filePath: string;
+  caption?: string;
+  timestamp: number;
+  /**
+   * BLAKE3 hex digest of the file contents (native/blake3-wasm).
+   * Filled in asynchronously after addMedia; undefined until hashed.
+   */
+  contentHash?: string;
+};
 
 type Row = {
   chat_id: string;

--- a/src/storage/repositories/scripts-repo.ts
+++ b/src/storage/repositories/scripts-repo.ts
@@ -8,7 +8,22 @@
 
 import { getDatabase } from "../db.js";
 import { scriptsSql } from "../sql/statements.generated.js";
-import type { Script, ScriptLanguage } from "../script-store.js";
+export type ScriptLanguage = "bash" | "python" | "node";
+
+/** One saved script as the domain sees it. */
+export type Script = {
+  id: string;
+  /** Unique lookup key — also the script's filename stem. */
+  name: string;
+  /** One-liner shown in listings; tells the agent when to reach for it. */
+  description: string;
+  language: ScriptLanguage;
+  scriptPath: string;
+  createdAt: number;
+  updatedAt: number;
+  useCount: number;
+  lastUsedAt?: number;
+};
 
 type Row = {
   id: string;

--- a/src/storage/repositories/sessions-repo.ts
+++ b/src/storage/repositories/sessions-repo.ts
@@ -19,7 +19,7 @@ import {
   normaliseMetrics,
   type SessionMetrics,
   type SessionState,
-} from "../sessions.js";
+} from "../session-record.js";
 
 type Row = {
   chat_id: string;

--- a/src/storage/repositories/triggers-repo.ts
+++ b/src/storage/repositories/triggers-repo.ts
@@ -8,11 +8,66 @@
 
 import { getDatabase } from "../db.js";
 import { triggersSql } from "../sql/statements.generated.js";
-import type {
-  Trigger,
-  TriggerLanguage,
-  TriggerStatus,
-} from "../trigger-store.js";
+export type TriggerLanguage = "bash" | "python" | "node" | "lua";
+
+export type TriggerStatus =
+  | "pending" // created, not yet spawned (transient)
+  | "running" // child process alive
+  | "fired" // exited 0 — fired final wake message
+  | "errored" // exited non-zero — fired error wake message
+  | "cancelled" // killed by user (trigger_cancel)
+  | "timed_out" // killed by hard timeout
+  | "terminated"; // killed by Talon shutdown / restart
+
+export type Trigger = {
+  id: string;
+  chatId: string;
+  numericChatId: number;
+  name: string;
+  language: TriggerLanguage;
+  /** Absolute path to the script body on disk. */
+  scriptPath: string;
+  /** Absolute path to the run log (interleaved stdout+stderr). */
+  logPath: string;
+  description?: string;
+  status: TriggerStatus;
+  createdAt: number;
+  startedAt?: number;
+  endedAt?: number;
+  /** PID of the child process while running (cleared on exit). */
+  pid?: number;
+  /** Linux /proc/<pid>/stat field 22 (start time in jiffies) captured at
+   *  spawn. Used by killOrphan to defend against PID reuse — start time is
+   *  monotonic per boot and unchanged by exec(), so a match guarantees the
+   *  current owner of the PID is the same process we spawned. Undefined on
+   *  non-Linux platforms. */
+  pidStarttime?: number;
+  /** Hard timeout in seconds. Default 24h, max 7d. */
+  timeoutSeconds: number;
+  /** Exit code on terminal status. */
+  exitCode?: number;
+  /** Total wake-ups fired for this trigger — sum of mid-run TALON_FIRE: lines
+   *  plus the terminal exit fire. Incremented every time fireWake() runs. */
+  fireCount: number;
+  lastFireAt?: number;
+  /** Truncated tail of the most recent fire payload (for diagnostics). */
+  lastFirePayload?: string;
+  lastError?: string;
+  /** If true, the trigger is respawned on Talon startup if it was still
+   *  active when Talon went down. Triggers in any terminal state
+   *  (fired/errored/cancelled) are NOT respawned — only ones interrupted
+   *  by Talon shutdown or crash. (Persistent triggers have no hard timeout,
+   *  so timed_out is unreachable for them — see spawnTrigger.) */
+  persistent?: boolean;
+  /**
+   * Optional model override for the wake-up turn — a model id valid on the
+   * chat's own backend. Unset = inherit the chat's model (preferred). When set,
+   * the fired wake-up runs on this (typically cheaper) model instead, while
+   * still resuming the chat session (restricted to the same backend so
+   * continuity is preserved).
+   */
+  model?: string;
+};
 
 type Row = {
   id: string;

--- a/src/storage/script-store.ts
+++ b/src/storage/script-store.ts
@@ -22,21 +22,8 @@ import { dirname, resolve } from "node:path";
 import { dirs } from "../util/paths.js";
 import * as repo from "./repositories/scripts-repo.js";
 
-export type ScriptLanguage = "bash" | "python" | "node";
-
-export type Script = {
-  id: string;
-  /** Unique lookup key — also the script's filename stem. */
-  name: string;
-  /** One-liner shown in listings; tells the agent when to reach for it. */
-  description: string;
-  language: ScriptLanguage;
-  scriptPath: string;
-  createdAt: number;
-  updatedAt: number;
-  useCount: number;
-  lastUsedAt?: number;
-};
+export type { Script, ScriptLanguage } from "./repositories/scripts-repo.js";
+import type { Script, ScriptLanguage } from "./repositories/scripts-repo.js";
 
 export const SCRIPT_LANGUAGES: readonly ScriptLanguage[] = [
   "bash",

--- a/src/storage/session-record.ts
+++ b/src/storage/session-record.ts
@@ -1,0 +1,220 @@
+/**
+ * Session record shapes + their constructors and normalisers — the
+ * vocabulary both the public store (storage/sessions.ts) and the
+ * repository (repositories/sessions-repo.ts) speak, extracted so the
+ * repo never has to import the store (which imports the repo).
+ *
+ * Mutation logic (fold/add/bucket) stays in the store; this module owns
+ * only "what a well-formed record looks like" and "how a raw JSON blob
+ * becomes one".
+ */
+
+export type SessionUsage = {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheRead: number;
+  totalCacheWrite: number;
+  /** Last turn's total prompt tokens (cumulative across all API calls in the turn, including tool-use loops). */
+  lastPromptTokens: number;
+  /** Actual context window fill from the last API call (last iteration's prompt tokens). */
+  contextTokens: number;
+  /** Model's context window size in tokens (from SDK modelUsage). */
+  contextWindow: number;
+  /** Number of API round-trips in the last turn (tool-use steps). */
+  numApiCalls: number;
+  /** Estimated cost in USD. */
+  estimatedCostUsd: number;
+  /** Total response time in ms (for averaging). */
+  totalResponseMs: number;
+  /** Last response time in ms. */
+  lastResponseMs: number;
+  /** Fastest response time in ms. */
+  fastestResponseMs: number;
+};
+
+export type MetricsCounterSet = {
+  queries: number;
+  toolCalls: number;
+  turnsWithTools: number;
+  apiCalls: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  failedTurns: number;
+  flowViolationRetries: number;
+  flowViolationCapExhausted: number;
+  trailingTextDropped: number;
+};
+
+export type MetricsLatencyAgg = {
+  count: number;
+  sumMs: number;
+  minMs: number;
+  maxMs: number;
+};
+
+export type MetricsGrain = {
+  counters: MetricsCounterSet;
+  latency: MetricsLatencyAgg;
+  toolCallsByName: Record<string, number>;
+  backend: Record<string, MetricsCounterSet & { latency: MetricsLatencyAgg }>;
+  cacheHitPercent: MetricsLatencyAgg;
+  toolCallsPerTurn: MetricsLatencyAgg;
+  apiCallsPerTurn: MetricsLatencyAgg;
+};
+
+export type SessionMetrics = {
+  lifetime: MetricsGrain;
+  buckets: Record<string, MetricsGrain>;
+};
+
+export type SessionState = {
+  /** Backend server-side session ID. */
+  sessionId: string | undefined;
+  /** Turn count. */
+  turns: number;
+  /** Last activity timestamp. */
+  lastActive: number;
+  /** Created timestamp. */
+  createdAt: number;
+  /** Cumulative usage stats. */
+  usage: SessionUsage;
+  /** Persistent per-session metrics, bucketed by UTC day. */
+  metrics: SessionMetrics;
+  /** ID of the last message sent by the bot in this chat. */
+  lastBotMessageId?: number;
+  /** Descriptive session name derived from first message. */
+  sessionName?: string;
+  /** Model used for this session's cost tracking. */
+  lastModel?: string;
+};
+
+export const emptyUsage = (): SessionUsage => ({
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  totalCacheRead: 0,
+  totalCacheWrite: 0,
+  lastPromptTokens: 0,
+  contextTokens: 0,
+  contextWindow: 0,
+  numApiCalls: 0,
+  estimatedCostUsd: 0,
+  totalResponseMs: 0,
+  lastResponseMs: 0,
+  fastestResponseMs: Infinity,
+});
+
+export const emptyCounters = (): MetricsCounterSet => ({
+  queries: 0,
+  toolCalls: 0,
+  turnsWithTools: 0,
+  apiCalls: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  failedTurns: 0,
+  flowViolationRetries: 0,
+  flowViolationCapExhausted: 0,
+  trailingTextDropped: 0,
+});
+
+export const emptyLatency = (): MetricsLatencyAgg => ({
+  count: 0,
+  sumMs: 0,
+  minMs: Infinity,
+  maxMs: 0,
+});
+
+export const emptyGrain = (): MetricsGrain => ({
+  counters: emptyCounters(),
+  latency: emptyLatency(),
+  toolCallsByName: {},
+  backend: {},
+  cacheHitPercent: emptyLatency(),
+  toolCallsPerTurn: emptyLatency(),
+  apiCallsPerTurn: emptyLatency(),
+});
+
+export const emptyMetrics = (): SessionMetrics => ({
+  lifetime: emptyGrain(),
+  buckets: {},
+});
+
+function normaliseLatency(raw: unknown): MetricsLatencyAgg {
+  const r = raw as Partial<MetricsLatencyAgg> | undefined;
+  const count =
+    typeof r?.count === "number" && Number.isFinite(r.count) ? r.count : 0;
+  return {
+    count,
+    sumMs:
+      typeof r?.sumMs === "number" && Number.isFinite(r.sumMs) ? r.sumMs : 0,
+    minMs:
+      typeof r?.minMs === "number" && Number.isFinite(r.minMs)
+        ? r.minMs
+        : count > 0
+          ? 0
+          : Infinity,
+    maxMs:
+      typeof r?.maxMs === "number" && Number.isFinite(r.maxMs) ? r.maxMs : 0,
+  };
+}
+
+function normaliseCounters(raw: unknown): MetricsCounterSet {
+  const base = emptyCounters();
+  const r = raw as Partial<MetricsCounterSet> | undefined;
+  for (const key of Object.keys(base) as Array<keyof MetricsCounterSet>) {
+    const value = r?.[key];
+    if (typeof value === "number" && Number.isFinite(value)) base[key] = value;
+  }
+  return base;
+}
+
+function normaliseGrain(raw: unknown): MetricsGrain {
+  const r = raw as Partial<MetricsGrain> | undefined;
+  const grain = emptyGrain();
+  grain.counters = normaliseCounters(r?.counters);
+  grain.latency = normaliseLatency(r?.latency);
+  grain.cacheHitPercent = normaliseLatency(r?.cacheHitPercent);
+  grain.toolCallsPerTurn = normaliseLatency(r?.toolCallsPerTurn);
+  grain.apiCallsPerTurn = normaliseLatency(r?.apiCallsPerTurn);
+  if (r?.toolCallsByName && typeof r.toolCallsByName === "object") {
+    for (const [key, value] of Object.entries(r.toolCallsByName)) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        grain.toolCallsByName[key] = value;
+      }
+    }
+  }
+  if (r?.backend && typeof r.backend === "object") {
+    for (const [key, value] of Object.entries(r.backend)) {
+      grain.backend[key] = {
+        ...normaliseCounters(value),
+        latency: normaliseLatency((value as { latency?: unknown }).latency),
+      };
+    }
+  }
+  return grain;
+}
+
+/**
+ * Coerce an untrusted/persisted metrics blob into a well-formed
+ * SessionMetrics: missing fields backfilled, non-finite numbers dropped,
+ * JSON's `minMs: null` (Infinity doesn't survive JSON.stringify) restored
+ * to the domain sentinel. Runs once at the load boundary (sessions-repo);
+ * in-memory metrics stay well-formed by construction after that.
+ */
+export function normaliseMetrics(metrics: unknown): SessionMetrics {
+  const raw = metrics as Partial<SessionMetrics> | undefined;
+  const result: SessionMetrics = {
+    lifetime: normaliseGrain(raw?.lifetime),
+    buckets: {},
+  };
+  if (raw?.buckets && typeof raw.buckets === "object") {
+    for (const [day, grain] of Object.entries(raw.buckets)) {
+      if (/^\d{4}-\d{2}-\d{2}$/.test(day))
+        result.buckets[day] = normaliseGrain(grain);
+    }
+  }
+  return result;
+}

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -24,87 +24,28 @@ import { files } from "../util/paths.js";
 import { importLegacyJson } from "./legacy-import.js";
 import * as repo from "./repositories/sessions-repo.js";
 
-export type SessionUsage = {
-  totalInputTokens: number;
-  totalOutputTokens: number;
-  totalCacheRead: number;
-  totalCacheWrite: number;
-  /** Last turn's total prompt tokens (cumulative across all API calls in the turn, including tool-use loops). */
-  lastPromptTokens: number;
-  /** Actual context window fill from the last API call (last iteration's prompt tokens). */
-  contextTokens: number;
-  /** Model's context window size in tokens (from SDK modelUsage). */
-  contextWindow: number;
-  /** Number of API round-trips in the last turn (tool-use steps). */
-  numApiCalls: number;
-  /** Estimated cost in USD. */
-  estimatedCostUsd: number;
-  /** Total response time in ms (for averaging). */
-  totalResponseMs: number;
-  /** Last response time in ms. */
-  lastResponseMs: number;
-  /** Fastest response time in ms. */
-  fastestResponseMs: number;
-};
-
-export type MetricsCounterSet = {
-  queries: number;
-  toolCalls: number;
-  turnsWithTools: number;
-  apiCalls: number;
-  inputTokens: number;
-  outputTokens: number;
-  cacheReadTokens: number;
-  cacheWriteTokens: number;
-  failedTurns: number;
-  flowViolationRetries: number;
-  flowViolationCapExhausted: number;
-  trailingTextDropped: number;
-};
-
-export type MetricsLatencyAgg = {
-  count: number;
-  sumMs: number;
-  minMs: number;
-  maxMs: number;
-};
-
-export type MetricsGrain = {
-  counters: MetricsCounterSet;
-  latency: MetricsLatencyAgg;
-  toolCallsByName: Record<string, number>;
-  backend: Record<string, MetricsCounterSet & { latency: MetricsLatencyAgg }>;
-  cacheHitPercent: MetricsLatencyAgg;
-  toolCallsPerTurn: MetricsLatencyAgg;
-  apiCallsPerTurn: MetricsLatencyAgg;
-};
-
-export type SessionMetrics = {
-  lifetime: MetricsGrain;
-  buckets: Record<string, MetricsGrain>;
-};
-
-export type SessionState = {
-  /** Backend server-side session ID. */
-  sessionId: string | undefined;
-  /** Turn count. */
-  turns: number;
-  /** Last activity timestamp. */
-  lastActive: number;
-  /** Created timestamp. */
-  createdAt: number;
-  /** Cumulative usage stats. */
-  usage: SessionUsage;
-  /** Persistent per-session metrics, bucketed by UTC day. */
-  metrics: SessionMetrics;
-  /** ID of the last message sent by the bot in this chat. */
-  lastBotMessageId?: number;
-  /** Descriptive session name derived from first message. */
-  sessionName?: string;
-  /** Model used for this session's cost tracking. */
-  lastModel?: string;
-};
-
+export type {
+  MetricsCounterSet,
+  MetricsGrain,
+  MetricsLatencyAgg,
+  SessionMetrics,
+  SessionState,
+  SessionUsage,
+} from "./session-record.js";
+export { emptyMetrics, normaliseMetrics } from "./session-record.js";
+import {
+  emptyCounters,
+  emptyGrain,
+  emptyLatency,
+  emptyMetrics,
+  emptyUsage,
+  type MetricsCounterSet,
+  type MetricsGrain,
+  type MetricsLatencyAgg,
+  type SessionMetrics,
+  type SessionState,
+  type SessionUsage,
+} from "./session-record.js";
 // In-memory cache over the sessions table. Reads serve live references
 // from here; writes go through persist() so each mutation commits.
 const cache = new Map<string, SessionState>();
@@ -272,135 +213,6 @@ function persist(chatId: string, session: SessionState): void {
 }
 
 // ── Core operations ─────────────────────────────────────────────────────────
-
-const emptyUsage = (): SessionUsage => ({
-  totalInputTokens: 0,
-  totalOutputTokens: 0,
-  totalCacheRead: 0,
-  totalCacheWrite: 0,
-  lastPromptTokens: 0,
-  contextTokens: 0,
-  contextWindow: 0,
-  numApiCalls: 0,
-  estimatedCostUsd: 0,
-  totalResponseMs: 0,
-  lastResponseMs: 0,
-  fastestResponseMs: Infinity,
-});
-
-const emptyCounters = (): MetricsCounterSet => ({
-  queries: 0,
-  toolCalls: 0,
-  turnsWithTools: 0,
-  apiCalls: 0,
-  inputTokens: 0,
-  outputTokens: 0,
-  cacheReadTokens: 0,
-  cacheWriteTokens: 0,
-  failedTurns: 0,
-  flowViolationRetries: 0,
-  flowViolationCapExhausted: 0,
-  trailingTextDropped: 0,
-});
-
-const emptyLatency = (): MetricsLatencyAgg => ({
-  count: 0,
-  sumMs: 0,
-  minMs: Infinity,
-  maxMs: 0,
-});
-
-const emptyGrain = (): MetricsGrain => ({
-  counters: emptyCounters(),
-  latency: emptyLatency(),
-  toolCallsByName: {},
-  backend: {},
-  cacheHitPercent: emptyLatency(),
-  toolCallsPerTurn: emptyLatency(),
-  apiCallsPerTurn: emptyLatency(),
-});
-
-export const emptyMetrics = (): SessionMetrics => ({
-  lifetime: emptyGrain(),
-  buckets: {},
-});
-
-function normaliseLatency(raw: unknown): MetricsLatencyAgg {
-  const r = raw as Partial<MetricsLatencyAgg> | undefined;
-  const count =
-    typeof r?.count === "number" && Number.isFinite(r.count) ? r.count : 0;
-  return {
-    count,
-    sumMs:
-      typeof r?.sumMs === "number" && Number.isFinite(r.sumMs) ? r.sumMs : 0,
-    minMs:
-      typeof r?.minMs === "number" && Number.isFinite(r.minMs)
-        ? r.minMs
-        : count > 0
-          ? 0
-          : Infinity,
-    maxMs:
-      typeof r?.maxMs === "number" && Number.isFinite(r.maxMs) ? r.maxMs : 0,
-  };
-}
-
-function normaliseCounters(raw: unknown): MetricsCounterSet {
-  const base = emptyCounters();
-  const r = raw as Partial<MetricsCounterSet> | undefined;
-  for (const key of Object.keys(base) as Array<keyof MetricsCounterSet>) {
-    const value = r?.[key];
-    if (typeof value === "number" && Number.isFinite(value)) base[key] = value;
-  }
-  return base;
-}
-
-function normaliseGrain(raw: unknown): MetricsGrain {
-  const r = raw as Partial<MetricsGrain> | undefined;
-  const grain = emptyGrain();
-  grain.counters = normaliseCounters(r?.counters);
-  grain.latency = normaliseLatency(r?.latency);
-  grain.cacheHitPercent = normaliseLatency(r?.cacheHitPercent);
-  grain.toolCallsPerTurn = normaliseLatency(r?.toolCallsPerTurn);
-  grain.apiCallsPerTurn = normaliseLatency(r?.apiCallsPerTurn);
-  if (r?.toolCallsByName && typeof r.toolCallsByName === "object") {
-    for (const [key, value] of Object.entries(r.toolCallsByName)) {
-      if (typeof value === "number" && Number.isFinite(value)) {
-        grain.toolCallsByName[key] = value;
-      }
-    }
-  }
-  if (r?.backend && typeof r.backend === "object") {
-    for (const [key, value] of Object.entries(r.backend)) {
-      grain.backend[key] = {
-        ...normaliseCounters(value),
-        latency: normaliseLatency((value as { latency?: unknown }).latency),
-      };
-    }
-  }
-  return grain;
-}
-
-/**
- * Coerce an untrusted/persisted metrics blob into a well-formed
- * SessionMetrics: missing fields backfilled, non-finite numbers dropped,
- * JSON's `minMs: null` (Infinity doesn't survive JSON.stringify) restored
- * to the domain sentinel. Runs once at the load boundary (sessions-repo);
- * in-memory metrics stay well-formed by construction after that.
- */
-export function normaliseMetrics(metrics: unknown): SessionMetrics {
-  const raw = metrics as Partial<SessionMetrics> | undefined;
-  const result: SessionMetrics = {
-    lifetime: normaliseGrain(raw?.lifetime),
-    buckets: {},
-  };
-  if (raw?.buckets && typeof raw.buckets === "object") {
-    for (const [day, grain] of Object.entries(raw.buckets)) {
-      if (/^\d{4}-\d{2}-\d{2}$/.test(day))
-        result.buckets[day] = normaliseGrain(grain);
-    }
-  }
-  return result;
-}
 
 function addLatency(agg: MetricsLatencyAgg, value: number): void {
   if (!Number.isFinite(value)) return;

--- a/src/storage/trigger-store.ts
+++ b/src/storage/trigger-store.ts
@@ -27,66 +27,12 @@ import * as repo from "./repositories/triggers-repo.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-export type TriggerLanguage = "bash" | "python" | "node" | "lua";
-
-export type TriggerStatus =
-  | "pending" // created, not yet spawned (transient)
-  | "running" // child process alive
-  | "fired" // exited 0 — fired final wake message
-  | "errored" // exited non-zero — fired error wake message
-  | "cancelled" // killed by user (trigger_cancel)
-  | "timed_out" // killed by hard timeout
-  | "terminated"; // killed by Talon shutdown / restart
-
-export type Trigger = {
-  id: string;
-  chatId: string;
-  numericChatId: number;
-  name: string;
-  language: TriggerLanguage;
-  /** Absolute path to the script body on disk. */
-  scriptPath: string;
-  /** Absolute path to the run log (interleaved stdout+stderr). */
-  logPath: string;
-  description?: string;
-  status: TriggerStatus;
-  createdAt: number;
-  startedAt?: number;
-  endedAt?: number;
-  /** PID of the child process while running (cleared on exit). */
-  pid?: number;
-  /** Linux /proc/<pid>/stat field 22 (start time in jiffies) captured at
-   *  spawn. Used by killOrphan to defend against PID reuse — start time is
-   *  monotonic per boot and unchanged by exec(), so a match guarantees the
-   *  current owner of the PID is the same process we spawned. Undefined on
-   *  non-Linux platforms. */
-  pidStarttime?: number;
-  /** Hard timeout in seconds. Default 24h, max 7d. */
-  timeoutSeconds: number;
-  /** Exit code on terminal status. */
-  exitCode?: number;
-  /** Total wake-ups fired for this trigger — sum of mid-run TALON_FIRE: lines
-   *  plus the terminal exit fire. Incremented every time fireWake() runs. */
-  fireCount: number;
-  lastFireAt?: number;
-  /** Truncated tail of the most recent fire payload (for diagnostics). */
-  lastFirePayload?: string;
-  lastError?: string;
-  /** If true, the trigger is respawned on Talon startup if it was still
-   *  active when Talon went down. Triggers in any terminal state
-   *  (fired/errored/cancelled) are NOT respawned — only ones interrupted
-   *  by Talon shutdown or crash. (Persistent triggers have no hard timeout,
-   *  so timed_out is unreachable for them — see spawnTrigger.) */
-  persistent?: boolean;
-  /**
-   * Optional model override for the wake-up turn — a model id valid on the
-   * chat's own backend. Unset = inherit the chat's model (preferred). When set,
-   * the fired wake-up runs on this (typically cheaper) model instead, while
-   * still resuming the chat session (restricted to the same backend so
-   * continuity is preserved).
-   */
-  model?: string;
-};
+export type {
+  Trigger,
+  TriggerLanguage,
+  TriggerStatus,
+} from "./repositories/triggers-repo.js";
+import type { Trigger, TriggerLanguage } from "./repositories/triggers-repo.js";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 

--- a/src/types/effort.ts
+++ b/src/types/effort.ts
@@ -1,0 +1,12 @@
+/**
+ * Reasoning-effort vocabulary — a dependency-free primitive shared by
+ * every layer (storage persists it, core resolves it, backends map it
+ * to provider knobs, frontends render pickers over it).
+ *
+ * Lives in src/types/ (a leaf: imports nothing from src/) so the layers
+ * below core/ can name the type without importing upward. core/types.ts
+ * re-exports it for the engine-side importers.
+ */
+
+export type ReasoningEffortLevel =
+  "off" | "minimal" | "low" | "medium" | "high" | "max" | "xhigh";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,12 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "strict": true,
+    // Beyond-strict gates. Two more are measured but not yet on — the fix
+    // waves are their own PRs: noUncheckedIndexedAccess (666 errors),
+    // exactOptionalPropertyTypes (303 errors).
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "verbatimModuleSyntax": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",


### PR DESCRIPTION
## What

Step 1 of the SOLID/quality program: the enforcement scaffolding, plus every boundary violation that could be fixed properly rather than exempted.

### New gates (CI: quality job)

- **dependency-cruiser** — `.dependency-cruiser.cjs` encodes the layer diagram as rules. `error` severity = holds today, a violation fails CI. `warn` severity = target state of an in-flight migration (Weaver session ownership, doctor probes behind a registry, `util/config` → core), each with its promotion criterion documented inline. Current state: **0 errors, 20 warnings** (all on documented ratchet rules).
- **tsconfig** — `noImplicitOverride`, `noFallthroughCasesInSwitch`, `verbatimModuleSyntax` now on. `noUncheckedIndexedAccess` (666 errors) and `exactOptionalPropertyTypes` (303 errors) were measured and documented as their own follow-up fix waves.
- **Ratchet gates** — `scripts/check-ratchets.mjs`: counts that may only fall. First ratchet: naked `throw new Error(` in `src/core` (baseline 38; engine code should throw classified errors from `core/errors.ts`).
- Backend conformance already exists (`core/agent-runtime/contract-tests.ts` runs every `BackendId` through the composed contract) — verified, not duplicated.

### Violations fixed (not exempted)

- **16 import cycles broken**
  - 8× store↔repo: domain record types moved into the repo that owns the row↔domain mapping; stores re-export them, so every external import path is unchanged. Sessions grew `storage/session-record.ts` (types + empty/normalise constructors) since its cycle was already runtime, not type-only.
  - kilo/opencode `server↔models`: servers expose `onServerStop(hook)`; the models module registers its catalog-cache clear at load. Servers import the catalog helpers from `remote-server/model-catalog` (their real source) instead of the models re-export.
  - triggers `spawn↔resume`: shared `/proc` PID-starttime probe extracted to `triggers/pid.ts`.
  - plugins import `TalonPlugin` from `core/plugin/types.js` directly.
- **core → backend runtime import removed**: prompt-snapshot invalidation now goes through `core/prompt/invalidation.ts` (`notifyPromptInputsChanged`); the snapshot store in `backend/shared/system-prompt.ts` registers its clear hook at module load. `frontend/native/extensions.ts` switched to the same seam (one fewer frontend→backend edge too).
- **storage → core imports removed**: the journal is structurally typed (`JournalRecord` + generic `readJournal<E>`); `ReasoningEffortLevel` moved to `src/types/effort.ts` (a dependency-free leaf, `core/types.ts` re-exports); the `resolveModelName` re-export was dropped from `chat-settings` — frontends import `resolveModelId` from the model catalog directly.
- `src/types/` added to `files[]` so the npm tarball ships the new leaf (tarball check passes).

### Notes

- dependency-cruiser can't drive typescript@7's API yet, so it parses via `@swc/core` (devDep, parse-only). swc doesn't classify `import type`, which is why the type cycles were *fixed* rather than exempted — the honest outcome anyway, since one of them had already degraded into a runtime cycle.
- Behavior-preserving throughout: no public import path changed except `resolveModelName` (5 frontend call sites updated in-PR).

### Verification

- `tsc --noEmit` clean with the new flags
- `depcruise src`: 0 errors
- full vitest suite: 4033 passed, 0 failed
- functional tier: 70 passed
- lint: no new warnings; prettier clean; tarball check passes

Next steps in the program (separate PRs, each promoting a warn rule to error): Weaver completes session ownership → Shuttle owns turn choreography → gateway split + frontend registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)