### PR TITLE
fix(security): closed-by-default bridge auth + owner-only at-rest permissions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,12 @@ Instead, use [GitHub's private vulnerability reporting](https://github.com/dylan
 - **Bridge auth**: bearer-token auth with constant-time comparison. A
   non-loopback bind with no configured token auto-mints a persistent one
   (`~/.talon/keys/bridge-token`) — the bridge is never open on the network.
+- **Brute-force lockout**: an address presenting repeated wrong tokens is
+  refused (HTTP 429) for a cooldown window, and the lockout is logged for
+  fail2ban-style tooling. Tokenless probes don't count — only wrong secrets.
+- **Minimal pre-auth surface**: unauthenticated `/health` serves only what
+  pairing needs (identity, protocol version, certificate fingerprint);
+  operational details require the token.
 - **At rest**: `~/.talon/`, `data/`, and `keys/` are clamped to owner-only
   (0700) on every boot; `config.json`, `talon.log`, `talon.db`, and the
   Telegram session file are clamped to 0600.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,18 @@ Instead, use [GitHub's private vulnerability reporting](https://github.com/dylan
 - Status update within 7 days
 - Fix or mitigation for confirmed vulnerabilities as soon as practical
 
+## Security measures
+
+- **Bridge transport**: the companion bridge serves TLS by default whenever it
+  binds a non-loopback host, using a persistent locally-minted certificate
+  (ECDSA P-256) whose SHA-256 fingerprint clients pin on first connect.
+- **Bridge auth**: bearer-token auth with constant-time comparison. A
+  non-loopback bind with no configured token auto-mints a persistent one
+  (`~/.talon/keys/bridge-token`) — the bridge is never open on the network.
+- **At rest**: `~/.talon/`, `data/`, and `keys/` are clamped to owner-only
+  (0700) on every boot; `config.json`, `talon.log`, `talon.db`, and the
+  Telegram session file are clamped to 0600.
+
 ## Scope
 
 Talon is an AI agent with tool access (file system, web, messaging). Security issues of particular interest include:

--- a/src/__tests__/harden.test.ts
+++ b/src/__tests__/harden.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { chmod, mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const POSIX = process.platform !== "win32";
+const ORIGINAL_TALON_HOME = process.env.TALON_HOME;
+
+// paths.ts resolves TALON_HOME at import time, so each test points the env
+// at a fresh tree and re-imports the module graph.
+async function importHardenFor(root: string) {
+  process.env.TALON_HOME = root;
+  vi.resetModules();
+  return import("../util/harden.js");
+}
+
+afterEach(() => {
+  if (ORIGINAL_TALON_HOME === undefined) delete process.env.TALON_HOME;
+  else process.env.TALON_HOME = ORIGINAL_TALON_HOME;
+  vi.resetModules();
+});
+
+describe("hardenTalonPermissions", () => {
+  it.skipIf(!POSIX)(
+    "clamps sensitive dirs to 0700 and files to 0600",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "talon-harden-"));
+      await chmod(root, 0o755);
+      await mkdir(join(root, "data"), { mode: 0o755 });
+      await mkdir(join(root, "keys"), { mode: 0o755 });
+      await writeFile(join(root, "config.json"), "{}\n", { mode: 0o644 });
+      await writeFile(join(root, "talon.log"), "", { mode: 0o644 });
+      await writeFile(join(root, ".user-session"), "session", {
+        mode: 0o644,
+      });
+      await writeFile(join(root, "data", "talon.db"), "", { mode: 0o644 });
+
+      const { hardenTalonPermissions } = await importHardenFor(root);
+      hardenTalonPermissions();
+
+      const mode = async (...parts: string[]) =>
+        (await stat(join(root, ...parts))).mode & 0o777;
+      expect(await mode()).toBe(0o700);
+      expect(await mode("data")).toBe(0o700);
+      expect(await mode("keys")).toBe(0o700);
+      expect(await mode("config.json")).toBe(0o600);
+      expect(await mode("talon.log")).toBe(0o600);
+      expect(await mode(".user-session")).toBe(0o600);
+      expect(await mode("data", "talon.db")).toBe(0o600);
+    },
+  );
+
+  it("is a silent no-op when nothing exists yet", async () => {
+    const root = join(await mkdtemp(join(tmpdir(), "talon-harden-")), "ghost");
+    const { hardenTalonPermissions } = await importHardenFor(root);
+    expect(() => hardenTalonPermissions()).not.toThrow();
+  });
+});

--- a/src/__tests__/native-auth.test.ts
+++ b/src/__tests__/native-auth.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+import {
+  bridgeTokenPath,
+  loadOrCreateBridgeToken,
+} from "../frontend/native/auth.js";
+
+const POSIX = process.platform !== "win32";
+
+describe("bridge auth token", () => {
+  async function freshDir(): Promise<string> {
+    return mkdtemp(join(tmpdir(), "talon-auth-"));
+  }
+
+  it("mints a url-safe high-entropy token and keeps it stable", async () => {
+    const dir = await freshDir();
+    const first = loadOrCreateBridgeToken(dir);
+    expect(first).toMatch(/^[A-Za-z0-9_-]{43}$/); // 32 bytes, base64url
+    expect(loadOrCreateBridgeToken(dir)).toBe(first); // persisted, not re-rolled
+    const onDisk = await readFile(bridgeTokenPath(dir), "utf-8");
+    expect(onDisk.trim()).toBe(first);
+  });
+
+  it("mints distinct tokens per identity dir", async () => {
+    const [a, b] = [await freshDir(), await freshDir()];
+    expect(loadOrCreateBridgeToken(a)).not.toBe(loadOrCreateBridgeToken(b));
+  });
+
+  it.skipIf(!POSIX)("persists owner-only", async () => {
+    const dir = await freshDir();
+    loadOrCreateBridgeToken(dir);
+    expect((await stat(bridgeTokenPath(dir))).mode & 0o777).toBe(0o600);
+  });
+
+  it("honours an operator-seeded token file", async () => {
+    const dir = await freshDir();
+    await writeFile(bridgeTokenPath(dir), "operator-chosen-secret\n");
+    expect(loadOrCreateBridgeToken(dir)).toBe("operator-chosen-secret");
+  });
+
+  it("re-mints over an empty token file", async () => {
+    const dir = await freshDir();
+    await writeFile(bridgeTokenPath(dir), "\n");
+    expect(loadOrCreateBridgeToken(dir)).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+});

--- a/src/__tests__/native-frontend.test.ts
+++ b/src/__tests__/native-frontend.test.ts
@@ -463,7 +463,14 @@ describe("native mesh bridge routes", () => {
   it("advertises mesh in health and auth-protects mesh routes", async () => {
     const { server, port } = await startMeshServer();
     try {
-      const health = await fetch(`http://127.0.0.1:${port}/health`);
+      // Capability advertisement is for paired clients — the pre-auth
+      // /health body stays down to pairing essentials.
+      const probe = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(await probe.json()).not.toHaveProperty("capabilities");
+
+      const health = await fetch(`http://127.0.0.1:${port}/health`, {
+        headers: { Authorization: "Bearer secret" },
+      });
       expect(await health.json()).toMatchObject({
         capabilities: ["mesh", "mesh-commands", "mesh-file-stream"],
       });

--- a/src/__tests__/native-server-security.test.ts
+++ b/src/__tests__/native-server-security.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+import {
+  BridgeServer,
+  type BridgeServerHandlers,
+} from "../frontend/native/server.js";
+
+const handlers: BridgeServerHandlers = {
+  status: () => ({
+    app: "talon-bridge",
+    protocol: 1,
+    botName: "Talon",
+    backend: "test",
+    model: "m1",
+    activeChats: 2,
+    startedAt: "now",
+  }),
+  listChats: () => [],
+  createChat: () => {
+    throw new Error("unused");
+  },
+  renameChat: () => null,
+  deleteChat: () => false,
+  history: () => [],
+  search: () => [],
+  send: () => {},
+  upload: async () => ({ imagePath: "", path: "" }),
+  listModels: () => ({ active: "", models: [] }),
+  setModel: () => {},
+  listBackends: () => ({ active: "", backends: [] }),
+  setBackend: async () => ({ ok: true }),
+  setEffort: () => {},
+  effortLevels: async () => ({ active: "", levels: [] }),
+  listPlugins: () => [],
+  setPluginEnabled: async () => ({ ok: true }),
+  listSkills: () => [],
+  setSkillEnabled: () => ({ ok: true }),
+  resetChat: () => false,
+  interruptTurn: async () => false,
+  setPulse: () => {},
+  queueMessage: () => {},
+  getConfig: () => ({}) as never,
+  setConfig: () => ({}) as never,
+  control: async () => ({ ok: true, message: "" }),
+  logs: () => [],
+  liveTurnEvents: () => [],
+  mediaPath: () => null,
+  registerDevice: async () => ({}) as never,
+  storeLocation: async () => ({}) as never,
+  listDevices: () => ({ devices: [], locations: [] }),
+  completeCommand: () => false,
+  acceptFileUpload: async () => ({ ok: false, error: "unused" }),
+  openFileDownload: async () => null,
+};
+
+describe("bridge server security posture", () => {
+  let server: BridgeServer | null = null;
+
+  afterEach(async () => {
+    await server?.stop();
+    server = null;
+  });
+
+  async function startServer(token?: string): Promise<number> {
+    server = new BridgeServer(
+      { host: "127.0.0.1", port: 0, token, startedAt: "boot" },
+      handlers,
+    );
+    return server.start();
+  }
+
+  const get = (port: number, path: string, token?: string) =>
+    fetch(`http://127.0.0.1:${port}${path}`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+
+  it("serves only pairing data on unauthenticated /health", async () => {
+    const port = await startServer("secret");
+    const res = await get(port, "/health");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.app).toBe("talon-bridge");
+    expect(body.authRequired).toBe(true);
+    expect(typeof body.protocol).toBe("number");
+    for (const leaked of [
+      "botName",
+      "backend",
+      "model",
+      "activeChats",
+      "startedAt",
+      "host",
+      "capabilities",
+    ]) {
+      expect(body).not.toHaveProperty(leaked);
+    }
+  });
+
+  it("serves the full /health to an authenticated client", async () => {
+    const port = await startServer("secret");
+    const body = (await (await get(port, "/health", "secret")).json()) as Record<
+      string,
+      unknown
+    >;
+    expect(body.botName).toBe("Talon");
+    expect(body.backend).toBe("test");
+    expect(body.activeChats).toBe(2);
+    expect(body.startedAt).toBe("boot");
+  });
+
+  it("keeps the full /health when no token is configured (local use)", async () => {
+    const port = await startServer();
+    const body = (await (await get(port, "/health")).json()) as Record<
+      string,
+      unknown
+    >;
+    expect(body.botName).toBe("Talon");
+    expect(body.authRequired).toBe(false);
+  });
+
+  it("locks out an address after repeated wrong tokens", async () => {
+    const port = await startServer("secret");
+    for (let i = 0; i < 20; i++) {
+      expect((await get(port, "/chats", "wrong")).status).toBe(401);
+    }
+    // Locked out now — even the correct token is refused for the window.
+    const locked = await get(port, "/chats", "secret");
+    expect(locked.status).toBe(429);
+    expect(locked.headers.get("retry-after")).toBeTruthy();
+  });
+
+  it("does not count tokenless probes toward the lockout", async () => {
+    const port = await startServer("secret");
+    for (let i = 0; i < 25; i++) {
+      expect((await get(port, "/chats")).status).toBe(401);
+    }
+    expect((await get(port, "/chats", "secret")).status).toBe(200);
+  });
+
+  it("resets the failure count on a successful auth", async () => {
+    const port = await startServer("secret");
+    for (let i = 0; i < 19; i++) await get(port, "/chats", "wrong");
+    expect((await get(port, "/chats", "secret")).status).toBe(200);
+    // Counter cleared — 19 more misses still don't trip the lockout.
+    for (let i = 0; i < 19; i++) await get(port, "/chats", "wrong");
+    expect((await get(port, "/chats", "secret")).status).toBe(200);
+  });
+
+  it("marks every response nosniff", async () => {
+    const port = await startServer("secret");
+    for (const res of [
+      await get(port, "/health"),
+      await get(port, "/chats", "secret"),
+      await get(port, "/chats", "wrong"),
+    ]) {
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    }
+  });
+});

--- a/src/__tests__/native-server-security.test.ts
+++ b/src/__tests__/native-server-security.test.ts
@@ -104,10 +104,9 @@ describe("bridge server security posture", () => {
 
   it("serves the full /health to an authenticated client", async () => {
     const port = await startServer("secret");
-    const body = (await (await get(port, "/health", "secret")).json()) as Record<
-      string,
-      unknown
-    >;
+    const body = (await (
+      await get(port, "/health", "secret")
+    ).json()) as Record<string, unknown>;
     expect(body.botName).toBe("Talon");
     expect(body.backend).toBe("test");
     expect(body.activeChats).toBe(2);

--- a/src/frontend/native/auth.ts
+++ b/src/frontend/native/auth.ts
@@ -1,0 +1,52 @@
+/**
+ * Bridge auth token — the shared secret behind every non-/health route.
+ *
+ * The operator can set one explicitly (`native.token`); this module covers
+ * the case where they didn't but the bridge is about to bind a non-loopback
+ * host. Serving the full agent API unauthenticated to the LAN is never an
+ * acceptable default, so a token is minted once and persisted under
+ * ~/.talon/keys/ — stable across restarts so paired clients keep working.
+ *
+ * The token value itself never goes to the log (SECURITY.md treats
+ * credentials in logs as a vulnerability); same-machine clients pick it up
+ * from the 0600 discovery file, remote clients read it from the key file.
+ */
+
+import { randomBytes } from "node:crypto";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { dirs } from "../../util/paths.js";
+import { log } from "../../util/log.js";
+
+const TOKEN_FILE = "bridge-token";
+/** 32 random bytes → 43 base64url chars; comfortably beyond brute force. */
+const TOKEN_BYTES = 32;
+
+/** Path of the persisted token, for operator-facing messages. */
+export function bridgeTokenPath(dir: string = dirs.keys): string {
+  return resolve(dir, TOKEN_FILE);
+}
+
+/**
+ * Load the persisted auto-generated bridge token, minting it on first use.
+ * Lives under ~/.talon/keys/ with owner-only permissions, like the TLS
+ * identity next to it.
+ */
+export function loadOrCreateBridgeToken(dir: string = dirs.keys): string {
+  const path = bridgeTokenPath(dir);
+  try {
+    const existing = readFileSync(path, "utf-8").trim();
+    if (existing) return existing;
+  } catch {
+    // first boot — nothing persisted yet
+  }
+  const token = randomBytes(TOKEN_BYTES).toString("base64url");
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeFileSync(path, `${token}\n`, { mode: 0o600 });
+  chmodSync(path, 0o600); // mode above is ignored when the file exists
+  log(
+    "native",
+    `Minted bridge auth token (non-loopback bind with no native.token) — pair remote clients with the value in ${path}`,
+  );
+  return token;
+}

--- a/src/frontend/native/index.ts
+++ b/src/frontend/native/index.ts
@@ -75,6 +75,7 @@ import { createNativeActionHandler } from "./actions.js";
 import { getMeshService } from "../../core/mesh/index.js";
 import { removeBridgeDiscovery, writeBridgeDiscovery } from "./discovery.js";
 import { isLoopbackHost, loadOrCreateBridgeTlsIdentity } from "./tls.js";
+import { loadOrCreateBridgeToken } from "./auth.js";
 import { readLogEntries } from "./logs.js";
 import {
   BRIDGE_PROTOCOL_VERSION,
@@ -1200,11 +1201,16 @@ export function createNativeFrontend(
   // Encrypted by default the moment the bridge leaves the machine; loopback
   // stays plain HTTP unless explicitly opted in (`native.tls`).
   const bridgeTls = nativeCfg.tls ?? !isLoopbackHost(bridgeHost);
+  // Never serve the agent API to the network unauthenticated: a non-loopback
+  // bind with no configured token gets a persistent auto-minted one instead.
+  const bridgeToken =
+    nativeCfg.token ??
+    (isLoopbackHost(bridgeHost) ? undefined : loadOrCreateBridgeToken());
   const server = new BridgeServer(
     {
       host: bridgeHost,
       port: nativeCfg.port ?? 19880,
-      token: nativeCfg.token,
+      token: bridgeToken,
       startedAt,
       ...(bridgeTls ? { tls: () => loadOrCreateBridgeTlsIdentity() } : {}),
     },
@@ -1274,7 +1280,7 @@ export function createNativeFrontend(
       const fingerprint = server.getFingerprint();
       await writeBridgeDiscovery({
         port: server.getPort(),
-        token: nativeCfg.token,
+        token: bridgeToken,
         scheme: server.getScheme(),
         ...(fingerprint ? { fingerprint } : {}),
         startedAt: Date.parse(startedAt),

--- a/src/frontend/native/server.ts
+++ b/src/frontend/native/server.ts
@@ -25,7 +25,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
 import { extname } from "node:path";
-import { log, logError, logDebug } from "../../util/log.js";
+import { log, logError, logDebug, logWarn } from "../../util/log.js";
 import { formatFingerprint, type BridgeTlsIdentity } from "./tls.js";
 import {
   BRIDGE_PROTOCOL_VERSION,
@@ -149,12 +149,32 @@ const MAX_BODY_BYTES = 256 * 1024;
 const MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
 const PORT_FALLBACKS = 5;
 
+// Failed-auth lockout: after this many wrong tokens from one address inside
+// the window, that address gets 429s until the window lapses. The token's
+// 256 bits make brute force hopeless anyway — this is about not letting an
+// internet-facing bridge be hammered for free (and giving fail2ban-style
+// tooling a clean signal in the log). Only *presented-and-wrong* secrets
+// count: tokenless probes are just scanners finding a locked door.
+const AUTH_LOCKOUT_MAX_FAILURES = 20;
+const AUTH_LOCKOUT_WINDOW_MS = 15 * 60 * 1000;
+/** Hard cap on tracked addresses so the map can't become a memory lever. */
+const AUTH_LOCKOUT_MAX_TRACKED = 10_000;
+
+/**
+ * ok: request carries the right token (or none is required).
+ * anonymous: no credential presented — a pre-pairing probe, not an attack.
+ * bad: a credential was presented and it is wrong.
+ */
+type AuthState = "ok" | "anonymous" | "bad";
+
 export class BridgeServer {
   private server: Server | null = null;
   private clients = new Set<ServerResponse>();
   private pingTimer: ReturnType<typeof setInterval> | undefined;
   private port = 0;
   private tlsIdentity: BridgeTlsIdentity | null = null;
+  /** Wrong-token counts per remote address (behind a proxy: per proxy). */
+  private authFailures = new Map<string, { count: number; resetAt: number }>();
 
   constructor(
     private readonly opts: {
@@ -311,21 +331,43 @@ export class BridgeServer {
       return;
     }
 
+    const remote = req.socket.remoteAddress ?? "unknown";
+    if (this.authLockedOut(remote)) {
+      res.writeHead(429, {
+        ...this.jsonHeaders(),
+        "Retry-After": String(Math.ceil(AUTH_LOCKOUT_WINDOW_MS / 1000)),
+      });
+      res.end(
+        JSON.stringify({ ok: false, error: "Too many failed auth attempts" }),
+      );
+      return;
+    }
+
+    const auth = this.authState(req, url);
+    if (auth === "bad") this.recordAuthFailure(remote);
+    else if (auth === "ok") this.authFailures.delete(remote);
+
     // /health is unauthenticated so clients can discover/ping the bridge
-    // before they hold a token. It exposes no chat content.
+    // before they hold a token. Pre-auth it serves only what pairing needs
+    // (identity, protocol, fingerprint) — operational details like bot name,
+    // backend, and chat count are not for internet scanners to enumerate.
     if (method === "GET" && path === "/health") {
-      const s = this.handlers.status();
-      return this.json(res, 200, {
+      const base = {
         app: "talon-bridge",
         ok: true,
         protocol: BRIDGE_PROTOCOL_VERSION,
-        host: this.opts.host,
         port: this.port,
         scheme: this.getScheme(),
         // The certificate's own hash — public by definition (any TLS client
         // sees the certificate), surfaced so pairing UIs can display it.
         fingerprint: this.getFingerprint(),
         authRequired: Boolean(this.opts.token),
+      };
+      if (auth !== "ok") return this.json(res, 200, base);
+      const s = this.handlers.status();
+      return this.json(res, 200, {
+        ...base,
+        host: this.opts.host,
         startedAt: this.opts.startedAt,
         botName: s.botName,
         backend: s.backend,
@@ -335,7 +377,7 @@ export class BridgeServer {
       });
     }
 
-    if (!this.authOk(req, url)) {
+    if (auth !== "ok") {
       return this.json(res, 401, { ok: false, error: "Unauthorized" });
     }
 
@@ -677,17 +719,54 @@ export class BridgeServer {
 
   // ── Helpers ──────────────────────────────────────────────────────────────
 
-  private authOk(req: IncomingMessage, url: URL): boolean {
-    if (!this.opts.token) return true;
+  private authState(req: IncomingMessage, url: URL): AuthState {
+    if (!this.opts.token) return "ok";
     const header = req.headers["authorization"];
-    if (
-      typeof header === "string" &&
-      header.startsWith("Bearer ") &&
-      this.tokenMatches(header.slice("Bearer ".length))
-    )
-      return true;
+    const fromHeader =
+      typeof header === "string" && header.startsWith("Bearer ")
+        ? header.slice("Bearer ".length)
+        : null;
     // EventSource can't set headers, so SSE clients pass ?token=… instead.
-    return this.tokenMatches(url.searchParams.get("token"));
+    const candidate = fromHeader ?? url.searchParams.get("token");
+    if (candidate === null) return "anonymous";
+    return this.tokenMatches(candidate) ? "ok" : "bad";
+  }
+
+  private authLockedOut(remote: string): boolean {
+    const entry = this.authFailures.get(remote);
+    if (!entry) return false;
+    if (Date.now() >= entry.resetAt) {
+      this.authFailures.delete(remote);
+      return false;
+    }
+    return entry.count >= AUTH_LOCKOUT_MAX_FAILURES;
+  }
+
+  private recordAuthFailure(remote: string): void {
+    const now = Date.now();
+    const entry = this.authFailures.get(remote);
+    if (!entry || now >= entry.resetAt) {
+      if (this.authFailures.size >= AUTH_LOCKOUT_MAX_TRACKED) {
+        for (const [ip, e] of this.authFailures) {
+          if (now >= e.resetAt) this.authFailures.delete(ip);
+        }
+        // Still saturated after pruning live entries — under that much churn
+        // dropping the newest attacker beats unbounded growth.
+        if (this.authFailures.size >= AUTH_LOCKOUT_MAX_TRACKED) return;
+      }
+      this.authFailures.set(remote, {
+        count: 1,
+        resetAt: now + AUTH_LOCKOUT_WINDOW_MS,
+      });
+      return;
+    }
+    entry.count++;
+    if (entry.count === AUTH_LOCKOUT_MAX_FAILURES) {
+      logWarn(
+        "native",
+        `Bridge auth lockout for ${remote} (${AUTH_LOCKOUT_MAX_FAILURES} wrong tokens in ${AUTH_LOCKOUT_WINDOW_MS / 60_000}m)`,
+      );
+    }
   }
 
   /**
@@ -708,6 +787,8 @@ export class BridgeServer {
       "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
       "Access-Control-Allow-Headers": "Authorization, Content-Type",
       "Access-Control-Max-Age": "86400",
+      // Every response states its type; never let a browser guess one.
+      "X-Content-Type-Options": "nosniff",
     };
   }
 

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, mkdirSync } from "node:fs";
 import writeFileAtomic from "write-file-atomic";
 import { z } from "zod";
 import { dirs, files as pathFiles } from "./paths.js";
+import { hardenTalonPermissions } from "./harden.js";
 import { setTimezone } from "./time.js";
 import { BACKEND_IDS } from "../core/agent-runtime/model-ref.js";
 import {
@@ -137,6 +138,8 @@ const frontendEnum = z.enum([
  * Defaults are loopback-only and unauthenticated (single-machine use). To
  * reach Talon remotely, set `host: "0.0.0.0"` and a `token` — the bridge
  * then requires `Authorization: Bearer <token>` (or `?token=` for SSE).
+ * A non-loopback bind with no token auto-mints a persistent one
+ * (~/.talon/keys/bridge-token) rather than serving the LAN open.
  */
 const nativeConfigSchema = z
   .object({
@@ -150,8 +153,9 @@ const nativeConfigSchema = z
     host: z.string().default("127.0.0.1"),
     /**
      * Optional shared secret. When set, every request must present it as a
-     * bearer token (header) or `?token=` query param (SSE). Required in
-     * practice whenever `host` is not loopback.
+     * bearer token (header) or `?token=` query param (SSE). When unset on a
+     * non-loopback `host`, the bridge mints and persists one automatically
+     * (~/.talon/keys/bridge-token) — the network never gets an open bridge.
      */
     token: z.string().optional(),
     /**
@@ -596,9 +600,11 @@ function ensureConfigFile(): boolean {
   if (!existsSync(dirs.root)) mkdirSync(dirs.root, { recursive: true });
   if (!existsSync(dirs.data)) mkdirSync(dirs.data, { recursive: true });
   if (!existsSync(CONFIG_FILE)) {
+    // Owner-only from birth: the config accumulates bot tokens and API keys.
     writeFileAtomic.sync(
       CONFIG_FILE,
       JSON.stringify(DEFAULT_CONFIG, null, 2) + "\n",
+      { mode: 0o600 },
     );
     return true;
   }
@@ -613,6 +619,7 @@ function ensureConfigFile(): boolean {
 
 export function loadConfig(): TalonConfig {
   ensureConfigFile();
+  hardenTalonPermissions();
   const fileConfig = normalizeDeprecatedFrontendConfig(loadConfigFile());
 
   // Runtime frontend override (TALON_FRONTEND_OVERRIDE). Lets the native

--- a/src/util/harden.ts
+++ b/src/util/harden.ts
@@ -1,0 +1,50 @@
+/**
+ * At-rest permission hardening for ~/.talon/.
+ *
+ * The tree holds credentials (config.json carries bot tokens, API keys and
+ * the bridge token; .user-session is a full Telegram login) plus chat
+ * history and logs. Node creates most of it with umask defaults, so on a
+ * multi-user machine everything is group/world readable. This pass clamps
+ * the sensitive surface to owner-only on every boot — idempotent, cheap,
+ * and it repairs installs created before the tightened modes existed.
+ *
+ * Best-effort by design: a missing path just hasn't been created yet, and
+ * a chmod failure (read-only mount, foreign owner) must never block boot.
+ * Windows has no POSIX modes worth mapping, so the pass is a no-op there.
+ */
+
+import { chmodSync } from "node:fs";
+import { dirs, files } from "./paths.js";
+
+const OWNER_DIR = 0o700;
+const OWNER_FILE = 0o600;
+
+/** Owner-only directories: everything under them inherits the protection. */
+const HARDENED_DIRS: readonly string[] = [dirs.root, dirs.data, dirs.keys];
+
+/** Belt-and-braces owner-only files, should they ever move out of the tree. */
+const HARDENED_FILES: readonly string[] = [
+  files.config,
+  files.log,
+  files.database,
+  files.userSession,
+];
+
+/** Clamp permissions on the sensitive parts of ~/.talon/. */
+export function hardenTalonPermissions(): void {
+  if (process.platform === "win32") return;
+  for (const dir of HARDENED_DIRS) {
+    try {
+      chmodSync(dir, OWNER_DIR);
+    } catch {
+      // absent or not ours — nothing to protect yet
+    }
+  }
+  for (const file of HARDENED_FILES) {
+    try {
+      chmodSync(file, OWNER_FILE);
+    } catch {
+      // absent or not ours — nothing to protect yet
+    }
+  }
+}

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -137,7 +137,8 @@ if (!quiet) {
 if (!IS_VITEST) {
   streams.push({
     level: "trace",
-    stream: createWriteStream(LOG_FILE, { flags: "a" }),
+    // 0600: turns and tool output land here — same sensitivity as history.
+    stream: createWriteStream(LOG_FILE, { flags: "a", mode: 0o600 }),
   });
 }
 


### PR DESCRIPTION
## What

Security review of the encryption/transport story. The pinned-TLS bridge transport itself is solid (persistent locally-minted P-256 cert, fingerprint pinning, constant-time token compare); this PR closes the gaps around it. The bridge is exposed off-machine, so the bar is "safe on the open internet without sacrificing zero-config local use".

### 1. Closed-by-default bridge auth
`authOk()` passed every request when no `native.token` was configured — a non-loopback bind without a token served the **full agent API unauthenticated** to the network. The bridge now auto-mints a persistent token when it binds off-loopback with no token configured:

- stored at `~/.talon/keys/bridge-token` (0600, dir 0700), stable across restarts so paired clients keep working
- fed to both the `BridgeServer` and the discovery file, so same-machine companion clients pair automatically
- the token value never goes to the log (per SECURITY.md, credentials-in-logs is itself a vuln); the log line points at the file
- an explicit `native.token` still wins; loopback binds are unchanged

### 2. Owner-only at-rest permissions
`~/.talon/` was created with umask defaults: `config.json` (bot tokens, API keys, GitHub PAT) at 0644, plus `talon.log`, `talon.db`, and the Telegram `.user-session` all group/world readable — and the 0700 intent for `keys/` in tls.ts never applied to pre-existing dirs. Now `hardenTalonPermissions()` runs on every boot (from `loadConfig()`): clamps `~/.talon`, `data/`, `keys/` to 0700 and the secret-bearing files to 0600 — idempotent, best-effort, Windows no-op, repairs existing installs. `config.json` and the pino log stream are created 0600 from birth.

### 3. Internet-exposure layers (second commit)
- **Per-address auth lockout**: 20 presented-and-wrong tokens within 15 minutes → 429 + `Retry-After` for that address, logged once for fail2ban-style tooling. Tokenless probes don't count (scanners can't lock out a legit client); successful auth clears the counter; the tracking map is size-capped.
- **Minimal pre-auth `/health`**: unauthenticated probes get pairing essentials only (app id, protocol, scheme, fingerprint, `authRequired`). Bot name, backend, model, active-chat count, capabilities, uptime now require the token. The companion only checks `app == 'talon-bridge'` pre-auth and reads status from the authed SSE `hello`, so nothing user-visible changes.
- **`X-Content-Type-Options: nosniff`** on every response.

SECURITY.md documents the resulting posture.

## Testing

- `native-auth.test.ts` — token minting: format/entropy, persistence, per-dir uniqueness, 0600 perms, operator-seeded file honoured, empty file re-mints
- `harden.test.ts` — perms clamped on a populated tree; silent no-op on a missing one
- `native-server-security.test.ts` — pre-auth /health trimmed, authed /health full, no-token /health unchanged, lockout trips at threshold, tokenless 401s don't count, success resets the counter, nosniff everywhere
- Full suite: 4047 passed / 42 skipped; typecheck, oxlint, depcruise (no new violations vs main), ratchets clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)