### PR TITLE
fix(companion): restore two-pane layout on re-expand + flat attach icon

### DIFF
--- a/apps/companion/lib/src/ui/app_shell.dart
+++ b/apps/companion/lib/src/ui/app_shell.dart
@@ -24,7 +24,7 @@ class AppShell extends StatefulWidget {
   State<AppShell> createState() => _AppShellState();
 }
 
-class _AppShellState extends State<AppShell> {
+class _AppShellState extends State<AppShell> with WidgetsBindingObserver {
   /// Last layout mode reported by the LayoutBuilder.
   bool _narrow = false;
 
@@ -37,13 +37,34 @@ class _AppShellState extends State<AppShell> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     widget.state.addListener(_scheduleSync);
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     widget.state.removeListener(_scheduleSync);
     super.dispose();
+  }
+
+  /// While a conversation route covers this shell (narrow layout), the
+  /// two-pane LayoutBuilder below is offstage and never sees a resize — so
+  /// growing the window back past the breakpoint would strand the user on
+  /// the pushed route with no sidebar. Watch the window metrics directly:
+  /// crossing the breakpoint re-runs the route sync, which pops the
+  /// conversation and lands on the two-pane layout with the chat still
+  /// selected. The LayoutBuilder keeps owning the onstage transitions.
+  @override
+  void didChangeMetrics() {
+    if (!mounted) return;
+    final view = View.of(context);
+    final wide = view.physicalSize.width / view.devicePixelRatio >=
+        AppShell._wideBreakpoint;
+    if (_narrow == !wide) return;
+    widget.state.setNarrowLayout(!wide);
+    _narrow = !wide;
+    _scheduleSync();
   }
 
   /// Selection/layout changes can arrive mid-build — reconcile the navigator

--- a/apps/companion/lib/src/ui/composer.dart
+++ b/apps/companion/lib/src/ui/composer.dart
@@ -337,10 +337,6 @@ class _AttachButton extends StatelessWidget {
       onPressed: enabled ? onTap : null,
       icon: const Icon(Icons.add_photo_alternate_outlined, size: 20),
       color: TalonColors.textDim,
-      style: IconButton.styleFrom(
-        backgroundColor: TalonColors.surfaceHi.withValues(alpha: 0.72),
-        disabledBackgroundColor: TalonColors.surfaceHi.withValues(alpha: 0.34),
-      ),
       tooltip: 'Attach image',
     );
   }

--- a/apps/companion/test/app_shell_test.dart
+++ b/apps/companion/test/app_shell_test.dart
@@ -6,6 +6,7 @@ import 'package:talon_companion/src/services/prefs.dart';
 import 'package:talon_companion/src/state/app_state.dart';
 import 'package:talon_companion/src/theme.dart';
 import 'package:talon_companion/src/ui/app_shell.dart';
+import 'package:talon_companion/src/ui/sidebar.dart';
 
 /// The Android back contract: from an open conversation, the system back
 /// button/gesture returns to the chat list; from the list it pops for real
@@ -81,6 +82,44 @@ void main() {
     // From the list, back is NOT consumed — the app may background/exit.
     final poppedAgain = await tester.binding.handlePopRoute();
     expect(poppedAgain, isFalse);
+
+    // Flush AppState's debounced snapshot timer before teardown.
+    await tester.pump(const Duration(seconds: 3));
+  });
+
+  testWidgets('re-expanding past the breakpoint restores the two panes',
+      (tester) async {
+    // Drive size through the view (not setSurfaceSize) so the resize fires
+    // didChangeMetrics — the shell can't rely on its LayoutBuilder here,
+    // which is exactly the regression: while the conversation route covers
+    // it, the two-pane layout is offstage and never relays out.
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final state = await seededState();
+    addTearDown(state.dispose);
+    await tester.pumpWidget(host(state));
+    await tester.pumpAndSettle();
+
+    // Wide start: sidebar + conversation, most recent chat adopted.
+    expect(state.selectedChatId, 'c1');
+    expect(find.byType(Sidebar), findsOneWidget);
+
+    // Shrink with the chat open: the conversation becomes a pushed route
+    // covering the list — no sidebar on screen.
+    tester.view.physicalSize = const Size(400, 800);
+    await tester.pumpAndSettle();
+    expect(find.text('hello there'), findsOneWidget);
+    expect(find.byType(Sidebar), findsNothing);
+
+    // Re-expand: the route pops, the two panes return, and the chat is
+    // still selected — no stranded full-screen conversation.
+    tester.view.physicalSize = const Size(1200, 800);
+    await tester.pumpAndSettle();
+    expect(find.byType(Sidebar), findsOneWidget);
+    expect(find.text('hello there'), findsOneWidget);
+    expect(state.selectedChatId, 'c1');
 
     // Flush AppState's debounced snapshot timer before teardown.
     await tester.pump(const Duration(seconds: 3));


### PR DESCRIPTION
## What

Two companion fixes:

**1. Sidebar lost after shrink → re-expand.** On the narrow layout the conversation is a real pushed route (that's what makes predictive back work), but the route covers the shell — so the shell's `LayoutBuilder` is offstage and never sees the window grow back past the breakpoint. `_narrow` never flipped, the route never popped, and the user was stranded full-screen with a back button and no sidebar. The shell now also implements `WidgetsBindingObserver.didChangeMetrics`: crossing the breakpoint re-runs the existing `_syncConversationRoute`, which pops the conversation and lands on the two-pane layout **with the chat still selected** (the pop guard only clears selection when still narrow). Auto-hide on shrink is untouched — that's the desired behavior and it stays.

**2. Composer attach icon** loses its filled circular background — bare icon, per feedback that the circle read as slop.

## Testing

- New regression test drives the resize through `tester.view.physicalSize` (which fires `didChangeMetrics`, exactly the path the fix uses): wide → shrink (sidebar gone, conversation route up) → re-expand (sidebar back, chat still selected). Verified it **fails without the fix** and passes with it.
- Full companion suite: 124/124 pass; `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)