### PR TITLE
feat(terminal): add prompt history and richer status

### DIFF
--- a/src/__tests__/terminal-commands.test.ts
+++ b/src/__tests__/terminal-commands.test.ts
@@ -462,6 +462,8 @@ describe("/status command", () => {
         totalCacheRead: 200,
         totalCacheWrite: 0,
         lastPromptTokens: 100,
+        contextTokens: 100,
+        contextWindow: 200_000,
         estimatedCostUsd: 0.01,
         totalResponseMs: 5000,
         lastResponseMs: 1000,
@@ -470,8 +472,41 @@ describe("/status command", () => {
     });
     const ctx = makeMockContext();
     await tryRunCommand("/status", ctx);
-    expect(ctx.renderer.writeln).toHaveBeenCalled();
+    const output = (ctx.renderer.writeln as ReturnType<typeof vi.fn>).mock.calls
+      .flat()
+      .join(" ");
+    expect(output).toContain("Context");
+    expect(output).toContain("0%");
+    expect(output).toContain("$0.0100");
+    expect(output).toContain("response last 1s");
     expect(ctx.reprompt).toHaveBeenCalled();
+  });
+
+  it("warns when the current context is at least 80% full", async () => {
+    mockGetSessionInfo.mockReturnValueOnce({
+      turns: 2,
+      usage: {
+        totalInputTokens: 10_000,
+        totalOutputTokens: 500,
+        totalCacheRead: 0,
+        totalCacheWrite: 0,
+        lastPromptTokens: 160_000,
+        contextTokens: 160_000,
+        contextWindow: 200_000,
+        estimatedCostUsd: 0,
+        totalResponseMs: 2000,
+        lastResponseMs: 1000,
+        fastestResponseMs: 1000,
+      },
+    });
+
+    const ctx = makeMockContext();
+    await tryRunCommand("/status", ctx);
+    const output = (ctx.renderer.writeln as ReturnType<typeof vi.fn>).mock.calls
+      .flat()
+      .join(" ");
+    expect(output).toContain("80%");
+    expect(output).toContain("nearing limit");
   });
 
   it("displays session name when set", async () => {
@@ -594,7 +629,7 @@ describe("/status command", () => {
       .join(" ");
     expect(output).toContain("1,389,045");
     expect(output).toContain("3,675");
-    expect(output).toContain("204,800");
+    expect(output).toContain("204.8k");
   });
 });
 

--- a/src/__tests__/terminal-input-history.test.ts
+++ b/src/__tests__/terminal-input-history.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { PromptHistory, type InputPart } from "../frontend/terminal/input.js";
+
+const text = (content: string): InputPart[] => [{ type: "text", content }];
+
+describe("PromptHistory", () => {
+  it("walks backward and forward, then restores the unfinished draft", () => {
+    const history = new PromptHistory();
+    history.add(text("first"));
+    history.add(text("second"));
+
+    expect(history.move("previous", text("draft"))).toEqual(text("second"));
+    expect(history.move("previous", text("second"))).toEqual(text("first"));
+    expect(history.move("next", text("first"))).toEqual(text("second"));
+    expect(history.move("next", text("second"))).toEqual(text("draft"));
+  });
+
+  it("keeps collapsed paste content intact and returns defensive copies", () => {
+    const history = new PromptHistory();
+    const prompt: InputPart[] = [
+      { type: "text", content: "Review" },
+      { type: "paste", content: "line one\nline two\nline three" },
+    ];
+    history.add(prompt);
+
+    const recalled = history.move("previous", text(""))!;
+    expect(recalled).toEqual(prompt);
+    recalled[1]!.content = "changed";
+
+    expect(history.move("previous", recalled)).toEqual(prompt);
+  });
+
+  it("deduplicates adjacent entries and enforces its size limit", () => {
+    const history = new PromptHistory(2);
+    history.add(text("one"));
+    history.add(text("one"));
+    history.add(text("two"));
+    history.add(text("three"));
+
+    expect(history.move("previous", text(""))).toEqual(text("three"));
+    expect(history.move("previous", text("three"))).toEqual(text("two"));
+    expect(history.move("previous", text("two"))).toEqual(text("two"));
+  });
+
+  it("preserves edits to a recalled prompt as the draft", () => {
+    const history = new PromptHistory();
+    history.add(text("saved"));
+
+    const edited = text("saved with edit");
+    history.move("previous", text("original draft"));
+    history.detach(edited);
+
+    expect(history.move("previous", edited)).toEqual(text("saved"));
+    expect(history.move("next", text("saved"))).toEqual(edited);
+  });
+});

--- a/src/__tests__/terminal-renderer.test.ts
+++ b/src/__tests__/terminal-renderer.test.ts
@@ -329,6 +329,19 @@ describe("createRenderer", () => {
     expect(text).not.toContain("cache");
   });
 
+  it("renderStatusLine shows a non-zero estimated cost", () => {
+    const r = createRenderer(80);
+    output = [];
+    r.renderStatusLine(1500, 0, {
+      model: "Sonnet 4.6",
+      turns: 2,
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.01234,
+    });
+    expect(output.join("")).toContain("$0.0123");
+  });
+
   it("renderStatusLine pluralizes tool count correctly", () => {
     const r = createRenderer(80);
 

--- a/src/frontend/shared/format.ts
+++ b/src/frontend/shared/format.ts
@@ -38,6 +38,12 @@ export function formatTokenCount(n: number): string {
   return String(n);
 }
 
+/** Keep small model costs legible without making larger totals noisy. */
+export function formatUsd(cost: number): string {
+  const safeCost = Number.isFinite(cost) && cost > 0 ? cost : 0;
+  return `$${safeCost > 0.5 ? safeCost.toFixed(2) : safeCost.toFixed(4)}`;
+}
+
 export function formatBytes(bytes: number): string {
   if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
   if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;

--- a/src/frontend/terminal/commands.ts
+++ b/src/frontend/terminal/commands.ts
@@ -15,7 +15,15 @@ import {
   resolveModel as coreResolveModel,
   getModels,
 } from "../../core/models/catalog.js";
-import { buildCacheDisplay } from "../shared/status-context.js";
+import {
+  buildCacheDisplay,
+  buildContextDisplay,
+} from "../shared/status-context.js";
+import {
+  formatDuration,
+  formatTokenCount,
+  formatUsd,
+} from "../shared/format.js";
 import {
   getChatSettings,
   setChatModel,
@@ -282,7 +290,7 @@ export function registerBuiltinCommands(): void {
       let displayCacheRead = u.totalCacheRead;
       let displayCacheWrite = u.totalCacheWrite;
       let backendModelLine = "";
-      let backendContextLine = "";
+      let contextWindow = u.contextWindow;
       ctx.renderer.writeln();
       const nameStr = info.sessionName ? `"${info.sessionName}"  ·  ` : "";
 
@@ -313,12 +321,30 @@ export function registerBuiltinCommands(): void {
         if (modelInfo) {
           backendModelLine = `  ${pc.bold(label)}  ${modelInfo.displayName}  ·  ${modelInfo.providerName}${modelInfo.free ? " · free" : ""}`;
           if (modelInfo.contextWindow) {
-            backendContextLine = cache
-              ? `  ${pc.dim(`context window ${modelInfo.contextWindow.toLocaleString()}  ·  cache ${cache.read.toLocaleString()} / ${cache.write.toLocaleString()}`)}`
-              : `  ${pc.dim(`context window ${modelInfo.contextWindow.toLocaleString()}`)}`;
+            contextWindow ||= modelInfo.contextWindow;
           }
         }
       }
+
+      const context = buildContextDisplay({
+        contextTokens: u.contextTokens,
+        lastPromptTokens: u.lastPromptTokens,
+        contextWindow,
+      });
+      const contextUsed = context.known
+        ? formatTokenCount(context.used)
+        : "unknown";
+      const contextMax = context.max
+        ? formatTokenCount(context.max)
+        : "unknown";
+      const avgResponseMs =
+        info.turns > 0 && u.totalResponseMs
+          ? Math.round(u.totalResponseMs / info.turns)
+          : 0;
+      const fastestResponseMs =
+        Number.isFinite(u.fastestResponseMs) && u.fastestResponseMs > 0
+          ? u.fastestResponseMs
+          : 0;
 
       ctx.renderer.writeln(
         `  ${pc.bold("Session")}  ${nameStr}turns ${info.turns}${cache ? `  ·  ${cache.hitPct}% cache` : ""}`,
@@ -326,12 +352,24 @@ export function registerBuiltinCommands(): void {
       ctx.renderer.writeln(
         `  ${pc.dim(`in ${displayInputTokens.toLocaleString()}  ·  out ${displayOutputTokens.toLocaleString()} tokens`)}`,
       );
+      ctx.renderer.writeln();
+      ctx.renderer.writeln(
+        `  ${pc.bold("Context")}  ${contextUsed} / ${contextMax} (${context.known ? `${context.pct}%` : "unknown"})${context.warn ? pc.yellow("  nearing limit") : ""}`,
+      );
+      ctx.renderer.writeln(
+        `  ${context.warn ? pc.yellow(context.bar) : pc.dim(context.bar)}`,
+      );
+      ctx.renderer.writeln(
+        `  ${pc.dim(`response last ${u.lastResponseMs ? formatDuration(u.lastResponseMs) : "—"}  ·  avg ${avgResponseMs ? formatDuration(avgResponseMs) : "—"}  ·  best ${fastestResponseMs ? formatDuration(fastestResponseMs) : "—"}`)}`,
+      );
+      if (u.estimatedCostUsd > 0) {
+        ctx.renderer.writeln(
+          `  ${pc.dim(`estimated session cost ${formatUsd(u.estimatedCostUsd)}`)}`,
+        );
+      }
       if (backendModelLine) {
         ctx.renderer.writeln();
         ctx.renderer.writeln(backendModelLine);
-        if (backendContextLine) {
-          ctx.renderer.writeln(backendContextLine);
-        }
       }
 
       const plugins = getLoadedPlugins();

--- a/src/frontend/terminal/input.ts
+++ b/src/frontend/terminal/input.ts
@@ -3,7 +3,7 @@
  *
  * Input is a list of parts: text segments and collapsed paste blocks.
  * You can type, paste, type more, paste again. Backspace removes from the end.
- * Enter submits everything. Ctrl+U clears all.
+ * Enter submits everything. Ctrl+U clears all. Up/Down walk prompt history.
  */
 
 import pc from "picocolors";
@@ -19,9 +19,10 @@ export type InputHandler = {
   resume(): void;
 };
 
-type TextPart = { type: "text"; content: string };
-type PastePart = { type: "paste"; content: string };
-type Part = TextPart | PastePart;
+export type InputPart =
+  { type: "text"; content: string } | { type: "paste"; content: string };
+type TextPart = Extract<InputPart, { type: "text" }>;
+type PastePart = Extract<InputPart, { type: "paste" }>;
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -29,6 +30,79 @@ const PASTE_COLLAPSE_LINES = 3;
 const PASTE_COLLAPSE_CHARS = 150;
 const PASTE_START = "\x1b[200~";
 const PASTE_END = "\x1b[201~";
+const MAX_HISTORY_ITEMS = 100;
+
+function cloneParts(parts: readonly InputPart[]): InputPart[] {
+  return parts.map((part) => ({ ...part }));
+}
+
+function partsText(parts: readonly InputPart[]): string {
+  return parts
+    .map((part) => part.content)
+    .join("\n")
+    .trim();
+}
+
+/**
+ * In-process prompt history. Keeping this out of the persistent stores avoids
+ * creating a second plaintext transcript while still giving terminal users
+ * the expected Up/Down workflow.
+ */
+export class PromptHistory {
+  private readonly entries: InputPart[][] = [];
+  private cursor = 0;
+  private draft: InputPart[] | null = null;
+
+  constructor(private readonly maxItems = MAX_HISTORY_ITEMS) {}
+
+  add(parts: readonly InputPart[]): void {
+    const text = partsText(parts);
+    if (!text) return;
+
+    const latest = this.entries.at(-1);
+    if (!latest || partsText(latest) !== text) {
+      this.entries.push(cloneParts(parts));
+      if (this.entries.length > this.maxItems) this.entries.shift();
+    }
+    this.resetNavigation();
+  }
+
+  move(
+    direction: "previous" | "next",
+    current: readonly InputPart[],
+  ): InputPart[] | undefined {
+    if (this.entries.length === 0) return undefined;
+
+    if (direction === "previous") {
+      if (this.cursor === this.entries.length) {
+        this.draft = cloneParts(current);
+      }
+      if (this.cursor > 0) this.cursor--;
+      return cloneParts(this.entries[this.cursor]!);
+    }
+
+    if (this.cursor === this.entries.length) return undefined;
+    if (this.cursor < this.entries.length - 1) {
+      this.cursor++;
+      return cloneParts(this.entries[this.cursor]!);
+    }
+
+    this.cursor = this.entries.length;
+    return cloneParts(this.draft ?? [{ type: "text", content: "" }]);
+  }
+
+  /** Preserve an edited recalled prompt as the current draft. */
+  detach(parts: readonly InputPart[]): void {
+    if (this.cursor === this.entries.length) return;
+    this.cursor = this.entries.length;
+    this.draft = cloneParts(parts);
+  }
+
+  resetNavigation(): void {
+    this.cursor = this.entries.length;
+    this.draft = null;
+  }
+}
 
 // ── Factory ──────────────────────────────────────────────────────────────────
 
@@ -38,7 +112,8 @@ export function createInput(promptStr: string): InputHandler {
   let paused = false;
 
   // Input is an ordered list of parts
-  let parts: Part[] = [{ type: "text", content: "" }];
+  let parts: InputPart[] = [{ type: "text", content: "" }];
+  const history = new PromptHistory();
 
   // Bracketed paste accumulation
   let inPaste = false;
@@ -46,7 +121,7 @@ export function createInput(promptStr: string): InputHandler {
 
   // ── Helpers ──
 
-  function lastPart(): Part {
+  function lastPart(): InputPart {
     return parts[parts.length - 1]!;
   }
 
@@ -99,18 +174,17 @@ export function createInput(promptStr: string): InputHandler {
   }
 
   function getFullText(): string {
-    return parts
-      .map((p) => p.content)
-      .join("\n")
-      .trim();
+    return partsText(parts);
   }
 
   function clear(): void {
     parts = [{ type: "text", content: "" }];
+    history.resetNavigation();
   }
 
   function submit(): void {
     const text = getFullText();
+    if (!pendingResolve) history.add(parts);
     clear();
     process.stdout.write("\n");
 
@@ -135,6 +209,7 @@ export function createInput(promptStr: string): InputHandler {
       // Short paste — inline into current text part
       ensureTrailingText().content += text.replace(/\n/g, " ");
     }
+    history.detach(parts);
     redraw();
   }
 
@@ -160,6 +235,14 @@ export function createInput(promptStr: string): InputHandler {
       if (parts.length === 0) parts.push({ type: "text", content: "" });
       ensureTrailingText();
     }
+    history.detach(parts);
+    redraw();
+  }
+
+  function navigateHistory(direction: "previous" | "next"): void {
+    const recalled = history.move(direction, parts);
+    if (!recalled) return;
+    parts = recalled;
     redraw();
   }
 
@@ -236,9 +319,22 @@ export function createInput(promptStr: string): InputHandler {
 
       if (code === 0x1b) {
         if (i + 1 < chunk.length && chunk[i + 1] === "[") {
-          // ANSI escape sequence (arrows, etc.) — skip
+          // CSI escape sequence. Up/Down navigate history; the rest are
+          // ignored until cursor editing is implemented.
+          let end = i + 2;
+          while (end < chunk.length && chunk.charCodeAt(end) < 0x40) end++;
+          const final = chunk[end];
+          if (final === "A") navigateHistory("previous");
+          if (final === "B") navigateHistory("next");
+          i = end;
+        } else if (
+          i + 2 < chunk.length &&
+          chunk[i + 1] === "O" &&
+          (chunk[i + 2] === "A" || chunk[i + 2] === "B")
+        ) {
+          // Some terminals use application-cursor sequences (ESC O A/B).
+          navigateHistory(chunk[i + 2] === "A" ? "previous" : "next");
           i += 2;
-          while (i < chunk.length && chunk.charCodeAt(i) < 0x40) i++;
         } else if (pendingResolve) {
           // Bare Escape during waitForInput — cancel
           const resolve = pendingResolve;
@@ -253,6 +349,7 @@ export function createInput(promptStr: string): InputHandler {
       if (code === 0x09) {
         // Tab
         ensureTrailingText().content += "  ";
+        history.detach(parts);
         redraw();
         continue;
       }
@@ -261,6 +358,7 @@ export function createInput(promptStr: string): InputHandler {
 
       // Printable char
       ensureTrailingText().content += ch;
+      history.detach(parts);
       redraw();
     }
   });

--- a/src/frontend/terminal/renderer.ts
+++ b/src/frontend/terminal/renderer.ts
@@ -7,6 +7,7 @@
  */
 
 import pc from "picocolors";
+import { formatUsd } from "../shared/format.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -193,6 +194,7 @@ export function createRenderer(cols?: number, displayName = "Talon"): Renderer {
     if (typeof info.cacheHitPct === "number") {
       p.push(`${info.cacheHitPct}% cache`);
     }
+    if (info.costUsd > 0) p.push(formatUsd(info.costUsd));
     if (tools > 0) p.push(`${tools} tool${tools > 1 ? "s" : ""}`);
     writeln();
     writeln(`  ${pc.dim(p.join("  ·  "))}`);


### PR DESCRIPTION
## Summary

- add in-process Up/Down prompt history with draft restoration, deduplication, and collapsed-paste preservation
- enrich terminal `/status` with context utilization, limit warnings, response latency, and estimated session cost
- show non-zero estimated cost in the compact post-turn status line
- cover prompt history, context warnings, and cost rendering with focused tests

Prompt history intentionally remains process-local so Talon does not create a second plaintext prompt transcript.

## Verification

- `npx vitest run src/__tests__/terminal-input-history.test.ts src/__tests__/terminal-commands.test.ts src/__tests__/terminal-renderer.test.ts` — 100 passed
- `npm run typecheck`
- `npm run lint` — clean apart from two existing generated/native warnings
- `npm run ratchets`
- full Vitest run completed all 241 files: 4,053 passed, 42 skipped; the runner was interrupted after completion because one worker remained open
