### PR TITLE
feat(mesh): node provisioning — binary resolver, bridge-served installers, arch-aware update_node

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -45,18 +45,24 @@ jobs:
       - name: Test
         run: go test ./...
 
+      # PR-only drift guard. On release events package.json IS the tag
+      # (publish.yml verifies that) and the build tool below regenerates
+      # version.txt from it — failing the release build over a version.txt
+      # that release-please raced past just left releases with no node
+      # binaries at all (v3.2.0, v3.3.0).
       - name: version.txt in sync with package.json
+        if: github.event_name == 'pull_request'
         run: |
           want=$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' ../../package.json | head -1)
           # version.txt is "<semver> # x-release-please-version"; take the first field.
           got=$(awk 'NF{print $1; exit}' version.txt)
           if [ "$want" != "$got" ]; then
-            echo "version.txt ($got) != package.json ($want) — release-please bumps it on the release PR; run scripts/build-all.sh to refresh manually" >&2
+            echo "version.txt ($got) != package.json ($want) — release-please bumps it on the release PR; run 'go run ./tools/build' to refresh manually" >&2
             exit 1
           fi
 
       - name: Cross-compile all targets
-        run: ./scripts/build-all.sh
+        run: go run ./tools/build
 
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v6

--- a/apps/node/README.md
+++ b/apps/node/README.md
@@ -22,8 +22,15 @@ works out of the box.
 
 ## Quick start
 
+The fastest path needs nothing on this list: ask the Talon model for an
+install link (`make_node_install_link`) and run the returned one-liner on
+the host — it fetches a digest-verified binary from the daemon's bridge,
+installs it, pins the TLS fingerprint, and registers the boot service.
+
+Manual setup:
+
 ```sh
-# Build (or grab a release binary):
+# Build (or grab a release binary, or `get_node_binary` via the daemon):
 cd apps/node && go build -o talon-node .
 
 # First run — mints a device id, pins the bridge cert on first connect:
@@ -81,11 +88,16 @@ apps pair with). No daemon-side changes are required for headless nodes.
 ## Building all targets
 
 ```sh
-./scripts/build-all.sh          # → build/talon-node-<os>-<arch>[.exe]
+go run ./tools/build            # → build/talon-node-<os>-<arch>[.exe]
+                                #   + build/talon-node-SHA256SUMS
+./scripts/build-all.sh          # same thing, POSIX wrapper
 ```
 
-The `Headless Node` workflow builds the same matrix in CI and attaches the
-binaries to published releases.
+The builder is a Go program so it runs anywhere Go does (Windows included).
+It also emits the `talon-node-SHA256SUMS` manifest the daemon's node-binary
+resolver verifies release downloads against. The `Headless Node` workflow
+builds the same matrix in CI and attaches binaries + manifest to published
+releases.
 
 ## Versioning
 
@@ -93,21 +105,23 @@ The reported version tracks the **Talon release the binary was compiled
 against**, so a node's `appVersion` in the mesh tells you exactly which Talon
 it matches:
 
-- Release/CI and `scripts/build-all.sh` builds report `<talon-version>+<sha>`
+- Release/CI and `go run ./tools/build` builds report `<talon-version>+<sha>`
   (e.g. `3.1.1+c8c7437c`), stamped via `-ldflags -X main.ldflagsVersion=…`.
 - A bare `go build .` reports the embedded Talon version (`version.txt`,
   kept in sync with the root `package.json` — CI fails if it drifts).
 
 ## Remote self-update
 
-`update_node` (daemon-side mesh tool) streams a freshly-built binary to the
+`update_node` (daemon-side mesh tool) streams a replacement binary to the
 node, which re-hashes it, atomically swaps its own binary, and restarts into
 it — an in-place `execve` on Linux/macOS (same pid, no supervisor
 crash-accounting), a rename-aside + relaunch on Windows. A truncated or
 mismatched binary is refused before the swap, so the running node is never
-left broken. Build the replacement for the node's OS/arch first
-(`talon-node-<os>-<arch>`), then confirm with `get_device_status` once
-`appVersion` changes.
+left broken. With no `binary_path` the daemon resolves the right build
+itself from the node's registered platform/arch (nodes advertise
+`runtime.GOARCH`) — source build in a dev checkout, else the digest-verified
+release download. Confirm with `get_device_status` once `appVersion`
+changes.
 
 On Unix, `SIGHUP` also reloads the node into whatever binary is on disk —
 handy for `systemctl reload`-style restarts after an out-of-band swap.

--- a/apps/node/bridge.go
+++ b/apps/node/bridge.go
@@ -186,9 +186,13 @@ func (n *Node) Health() (map[string]any, error) {
 // one, and the registry treats absence correctly.
 func (n *Node) Register(ctx context.Context) error {
 	err := n.postJSON(ctx, "/devices/register", map[string]any{
-		"id":           n.DeviceID,
-		"name":         n.cfg.Name,
-		"platform":     meshPlatform(),
+		"id":       n.DeviceID,
+		"name":     n.cfg.Name,
+		"platform": meshPlatform(),
+		// The Go arch (amd64/arm64/arm) — matched against release binary
+		// names (talon-node-<os>-<arch>) so the daemon can auto-resolve the
+		// right replacement for update_node.
+		"arch":         runtime.GOARCH,
 		"appVersion":   version,
 		"capabilities": nodeCapabilities,
 	}, nil)

--- a/apps/node/scripts/build-all.sh
+++ b/apps/node/scripts/build-all.sh
@@ -1,52 +1,9 @@
 #!/usr/bin/env bash
-# Cross-compile talon-node for every supported target.
+# Thin wrapper for POSIX muscle memory — the real builder is the
+# platform-neutral Go tool (works on Windows too):
 #
-#   ./scripts/build-all.sh [version] [outdir]
+#   go run ./tools/build [-version <v>] [-out <dir>] [-targets os/arch,...]
 #
-# version defaults to the root package.json version + short SHA; outdir
-# defaults to ./build. Produces talon-node-<os>-<arch>[.exe] — fully static
-# binaries (CGO_ENABLED=0), no runtime dependencies on the target host.
-#
-# The node's reported version always tracks the Talon version it was
-# compiled against: version.txt (embedded fallback) is refreshed from
-# package.json here, and the ldflags stamp carries "<version>+<sha>".
 set -euo pipefail
-
 cd "$(dirname "$0")/.."
-
-PKG_VERSION=$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' ../../package.json | head -1)
-SHA=$(git rev-parse --short HEAD 2>/dev/null || echo dev)
-VERSION="${1:-${PKG_VERSION:-0.0.0}+${SHA}}"
-OUT="${2:-build}"
-
-# Keep the embedded Talon version (bare-build fallback) in sync. The trailing
-# annotation lets release-please bump this file on the release PR; consumers
-# (main.go, CI) read only the first field.
-printf '%s # x-release-please-version\n' "${PKG_VERSION:-0.0.0}" > version.txt
-
-TARGETS=(
-  linux/amd64
-  linux/arm64
-  linux/arm
-  darwin/amd64
-  darwin/arm64
-  windows/amd64
-)
-
-mkdir -p "$OUT"
-for target in "${TARGETS[@]}"; do
-  os="${target%/*}"
-  arch="${target#*/}"
-  ext=""
-  [[ "$os" == "windows" ]] && ext=".exe"
-  out="$OUT/talon-node-${os}-${arch}${ext}"
-  echo "→ $out"
-  CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build \
-    -trimpath \
-    -ldflags "-s -w -X main.ldflagsVersion=${VERSION}" \
-    -o "$out" .
-done
-
-echo
-echo "Built $(ls "$OUT" | wc -l) binaries (version ${VERSION}):"
-ls -lh "$OUT"
+exec go run ./tools/build "$@"

--- a/apps/node/tools/build/main.go
+++ b/apps/node/tools/build/main.go
@@ -1,0 +1,167 @@
+// Cross-compile talon-node for every supported target — the platform-neutral
+// replacement for the old build-all.sh (which required a POSIX shell).
+//
+//	go run ./tools/build [-version <v>] [-out <dir>] [-targets os/arch,...]
+//
+// Run from apps/node (the directory holding go.mod). Produces
+// talon-node-<os>-<arch>[.exe] plus a talon-node-SHA256SUMS manifest — the
+// digests the daemon verifies when it fetches a binary from a release.
+//
+// The node's reported version always tracks the Talon version it was
+// compiled against: version.txt (the embedded fallback) is refreshed from
+// the root package.json here, and the ldflags stamp carries "<version>+<sha>".
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// sumsFile is the checksum manifest name; release assets carry it so
+// downloaders (the daemon's node-binary resolver) can verify integrity.
+const sumsFile = "talon-node-SHA256SUMS"
+
+var defaultTargets = []string{
+	"linux/amd64",
+	"linux/arm64",
+	"linux/arm",
+	"darwin/amd64",
+	"darwin/arm64",
+	"windows/amd64",
+}
+
+func main() {
+	versionFlag := flag.String("version", "", `full version stamp (default "<package.json version>+<git sha>")`)
+	out := flag.String("out", "build", "output directory")
+	targets := flag.String("targets", strings.Join(defaultTargets, ","), "comma-separated os/arch list")
+	flag.Parse()
+
+	if _, err := os.Stat("go.mod"); err != nil {
+		fatalf("run from apps/node (go.mod not found): %v", err)
+	}
+
+	pkgVersion, err := packageVersion("../../package.json")
+	if err != nil {
+		fatalf("read package.json version: %v", err)
+	}
+	version := *versionFlag
+	if version == "" {
+		version = pkgVersion + "+" + gitShortSHA()
+	}
+
+	// Keep the embedded Talon version (bare-build fallback) in sync. The
+	// trailing annotation lets release-please bump this file on the release
+	// PR; consumers (main.go, CI) read only the first field.
+	if err := os.WriteFile(
+		"version.txt",
+		[]byte(pkgVersion+" # x-release-please-version\n"),
+		0o644,
+	); err != nil {
+		fatalf("write version.txt: %v", err)
+	}
+
+	if err := os.MkdirAll(*out, 0o755); err != nil {
+		fatalf("mkdir %s: %v", *out, err)
+	}
+
+	sums := make(map[string]string)
+	for _, target := range strings.Split(*targets, ",") {
+		goos, goarch, ok := strings.Cut(strings.TrimSpace(target), "/")
+		if !ok || goos == "" || goarch == "" {
+			fatalf("bad target %q (want os/arch)", target)
+		}
+		name := "talon-node-" + goos + "-" + goarch
+		if goos == "windows" {
+			name += ".exe"
+		}
+		dest := filepath.Join(*out, name)
+		fmt.Printf("→ %s\n", dest)
+		cmd := exec.Command(
+			"go", "build",
+			"-trimpath",
+			"-ldflags", "-s -w -X main.ldflagsVersion="+version,
+			"-o", dest, ".",
+		)
+		cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS="+goos, "GOARCH="+goarch)
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+		if err := cmd.Run(); err != nil {
+			fatalf("build %s: %v", target, err)
+		}
+		sum, err := fileSHA256(dest)
+		if err != nil {
+			fatalf("hash %s: %v", dest, err)
+		}
+		sums[name] = sum
+	}
+
+	if err := writeSums(filepath.Join(*out, sumsFile), sums); err != nil {
+		fatalf("write %s: %v", sumsFile, err)
+	}
+	fmt.Printf("\nBuilt %d binaries (version %s) + %s\n", len(sums), version, sumsFile)
+}
+
+func packageVersion(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	var pkg struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &pkg); err != nil {
+		return "", err
+	}
+	if pkg.Version == "" {
+		return "", fmt.Errorf("no version field in %s", path)
+	}
+	return pkg.Version, nil
+}
+
+func gitShortSHA() string {
+	out, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return "dev"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// writeSums emits the standard "<hex>  <name>" format `sha256sum -c` and the
+// daemon's resolver both parse, sorted for a deterministic manifest.
+func writeSums(path string, sums map[string]string) error {
+	names := make([]string, 0, len(sums))
+	for name := range sums {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	for _, name := range names {
+		fmt.Fprintf(&b, "%s  %s\n", sums[name], name)
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o644)
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/apps/node/version.txt
+++ b/apps/node/version.txt
@@ -1,1 +1,1 @@
-3.2.0 # x-release-please-version
+3.3.0 # x-release-please-version

--- a/docs/headless-node.md
+++ b/docs/headless-node.md
@@ -51,8 +51,26 @@ unmodified bridge.
 
 ## Deploying a node
 
-See `apps/node/README.md` for flags, config, and service install
-(systemd/launchd/scheduled task). The short version:
+The one-command path — ask the model for an install link
+(`make_node_install_link(os, arch)`), then run the returned command on the
+new host:
+
+```sh
+curl -fsSk "https://<daemon>:19880/node/install?provision=<token>" | sh
+```
+
+The bridge serves a generated installer over a single-use, expiring grant
+token (`src/core/mesh/node-provision.ts`): it downloads the matching
+talon-node binary from the same bridge, verifies its sha256 against the
+digest baked into the script, installs it, pre-pins the bridge TLS
+fingerprint, embeds the bearer token, and registers the boot service.
+Windows grants produce a PowerShell installer with the same flow. The two
+routes (`GET /node/install`, `GET /node/binary`) are deliberately pre-auth —
+the fresh host holds no credential yet; the grant token is the entire
+authorization, exactly like streamed-transfer tokens.
+
+Manual alternative — see `apps/node/README.md` for flags, config, and
+service install (systemd/launchd/scheduled task):
 
 ```sh
 talon-node install --bridge https://<daemon>:19880 --token <bridge-token> --name my-server
@@ -62,8 +80,32 @@ Remote nodes are best pointed at the daemon over a tailnet/VPN address —
 the bridge token grants the full bridge API, so avoid exposing the port
 publicly. Scoping per-device tokens is a known follow-up.
 
+## Where node binaries come from
+
+`src/core/mesh/node-binaries.ts` materializes a binary for any supported
+target regardless of how the daemon was installed, trying in order:
+
+1. **source build** — a dev checkout with Go on PATH cross-compiles
+   `apps/node` for the target (rebuilt every resolve, stamped
+   `<version>+<sha>`);
+2. **cache** — `~/.talon/node-bin/<talon-version>/`, digest-re-verified on
+   every hit;
+3. **release download** — the GitHub release matching the daemon's own
+   version, verified against its `talon-node-SHA256SUMS` manifest. This is
+   what lets prebuilt installs (npm, deb, standalone binary) provision and
+   update nodes with no toolchain.
+
+Everything rides that resolver: `get_node_binary` (stage a binary on the
+daemon host), `make_node_install_link` (bridge-served installer), and
+`update_node` with no `binary_path` (auto-picks the target's registered
+platform/arch — nodes advertise `runtime.GOARCH` at registration).
+
 ## Release artifacts
 
 `.github/workflows/node.yml` vets, tests, and cross-compiles
 linux/amd64+arm64+arm, darwin/amd64+arm64, and windows/amd64 on every PR
-touching `apps/node`, and attaches the binaries to published releases.
+touching `apps/node` (via the platform-neutral `go run ./tools/build`), and
+attaches the binaries plus `talon-node-SHA256SUMS` to published releases.
+The version.txt drift guard runs on PRs only — release builds stamp from
+the tag, so a stale release PR can no longer ship a release with no node
+binaries.

--- a/src/__tests__/mesh-service.test.ts
+++ b/src/__tests__/mesh-service.test.ts
@@ -68,6 +68,9 @@ describe("mesh tool availability", () => {
         "device_pull_file",
         "device_push_file",
         "update_device",
+        "update_node",
+        "get_node_binary",
+        "make_node_install_link",
         "remove_device",
       ]) {
         expect(names).toContain(tool);
@@ -1224,5 +1227,150 @@ describe("MeshService.pingAll", () => {
   it("returns an empty list when nothing has registered", async () => {
     const service = await tempService();
     expect(await service.pingAll()).toEqual([]);
+  });
+});
+
+describe("MeshService node provisioning", () => {
+  /** A resolver seam standing in for source-build/cache/release tiers. */
+  async function stubResolver(): Promise<{
+    resolver: NonNullable<
+      ConstructorParameters<typeof MeshService>[1]
+    >["nodeBinaryResolver"];
+    binaryPath: string;
+    calls: string[];
+  }> {
+    const dir = await mkdtemp(join(tmpdir(), "talon-node-resolve-"));
+    const binaryPath = join(dir, "talon-node-linux-arm64");
+    await fsWriteFile(binaryPath, "fake node binary");
+    const calls: string[] = [];
+    return {
+      resolver: async (goos, goarch) => {
+        calls.push(`${goos}/${goarch}`);
+        return {
+          path: binaryPath,
+          version: "3.4.0",
+          sha256: "ab".repeat(32),
+          size: 16,
+          source: "cache",
+        };
+      },
+      binaryPath,
+      calls,
+    };
+  }
+
+  async function registerNode(
+    service: MeshService,
+    extra: Record<string, unknown> = {},
+  ): Promise<void> {
+    await service.register({
+      id: "srv",
+      name: "Build Server",
+      platform: "linux",
+      arch: "arm64",
+      appVersion: "3.3.0",
+      capabilities: ["update_node", "write_file"],
+      ...extra,
+    });
+  }
+
+  it("registers and lists a node's arch alongside its platform", async () => {
+    const service = await tempService();
+    await registerNode(service);
+    const listed = await service.describeDevices();
+    expect(listed.text).toContain("(linux/arm64)");
+  });
+
+  it("auto-resolves the update binary from the node's platform/arch", async () => {
+    const { resolver, calls } = await stubResolver();
+    const service = await tempService({ nodeBinaryResolver: resolver });
+    await registerNode(service);
+    service.registerTransport({
+      locate: () => {},
+      command: (cmd) =>
+        queueMicrotask(() =>
+          service.completeCommand({
+            commandId: cmd.id,
+            deviceId: cmd.deviceId,
+            ok: true,
+            ...(cmd.name === "update_node"
+              ? { message: "Swapping and restarting." }
+              : {}),
+          }),
+        ),
+    });
+
+    const result = await service.updateNodeBinary("srv");
+    expect(result.ok).toBe(true);
+    expect(result.text).toContain("auto-resolved 3.4.0 for linux/arm64");
+    expect(calls).toEqual(["linux/arm64"]);
+  });
+
+  it("asks for an explicit binary when the node never advertised arch", async () => {
+    const service = await tempService();
+    await registerNode(service, { arch: undefined });
+    const result = await service.updateNodeBinary("srv");
+    expect(result.ok).toBe(false);
+    expect(result.text).toContain("CPU architecture");
+  });
+
+  it("refuses update_node aimed at a mobile companion", async () => {
+    const service = await tempService();
+    await service.register({
+      id: "phone",
+      name: "Pixel 9",
+      platform: "android",
+      appVersion: "1.0.0",
+      capabilities: ["update_node"],
+    });
+    const result = await service.updateNodeBinary("phone");
+    expect(result.ok).toBe(false);
+    expect(result.text).toContain("headless nodes only");
+  });
+
+  it("mints a single-use install link and serves both legs through the bridge routes", async () => {
+    const { resolver, binaryPath } = await stubResolver();
+    const service = await tempService({ nodeBinaryResolver: resolver });
+    service.setBridgeInfo({
+      scheme: "https",
+      host: "100.64.0.7",
+      port: 19880,
+      token: "bearer-secret",
+      fingerprint: "cd".repeat(32),
+    });
+
+    const minted = await service.makeNodeInstallLink("macos", "aarch64");
+    expect(minted.ok).toBe(true);
+    expect(minted.text).toContain(
+      'curl -fsSk "https://100.64.0.7:19880/node/install?provision=',
+    );
+
+    const token = /provision=([A-Za-z0-9_-]+)/.exec(minted.text)![1]!;
+    const install = service.openNodeInstall(token);
+    expect(install?.filename).toBe("install-talon-node.sh");
+    expect(install?.script).toContain("bearer-secret");
+    expect(service.openNodeInstall(token)).toBeNull();
+    expect(service.openNodeBinary(token)).toEqual({
+      path: binaryPath,
+      size: 16,
+    });
+    expect(service.openNodeBinary(token)).toBeNull();
+  });
+
+  it("refuses install links when the bridge is loopback-only or absent", async () => {
+    const service = await tempService();
+    const none = await service.makeNodeInstallLink("linux", "amd64");
+    expect(none.ok).toBe(false);
+    expect(none.text).toContain("bridge isn't running");
+
+    service.setBridgeInfo({
+      scheme: "http",
+      host: "127.0.0.1",
+      port: 19880,
+      token: "tok",
+    });
+    const loopback = await service.makeNodeInstallLink("linux", "amd64");
+    expect(loopback.ok).toBe(false);
+    expect(loopback.text).toContain("loopback");
   });
 });

--- a/src/__tests__/native-frontend.test.ts
+++ b/src/__tests__/native-frontend.test.ts
@@ -451,6 +451,8 @@ describe("native mesh bridge routes", () => {
       completeCommand: () => false,
       acceptFileUpload: (t, body) => transfers.acceptUpload(t, body),
       openFileDownload: (t) => transfers.openDownload(t),
+      openNodeInstall: () => null,
+      openNodeBinary: () => null,
     };
     const server = new BridgeServer(
       { host: "127.0.0.1", port: 0, token, startedAt: "now" },

--- a/src/__tests__/native-server-security.test.ts
+++ b/src/__tests__/native-server-security.test.ts
@@ -58,6 +58,8 @@ const handlers: BridgeServerHandlers = {
   completeCommand: () => false,
   acceptFileUpload: async () => ({ ok: false, error: "unused" }),
   openFileDownload: async () => null,
+  openNodeInstall: () => null,
+  openNodeBinary: () => null,
 };
 
 describe("bridge server security posture", () => {
@@ -160,5 +162,29 @@ describe("bridge server security posture", () => {
     ]) {
       expect(res.headers.get("x-content-type-options")).toBe("nosniff");
     }
+  });
+
+  it("gates the pre-auth node provisioning routes on the grant token alone", async () => {
+    // Deliberately pre-auth (a fresh host holds no bearer yet) — so a bad or
+    // missing provision token must 404, and a valid one must serve without
+    // any Authorization header.
+    server = new BridgeServer(
+      { host: "127.0.0.1", port: 0, token: "secret", startedAt: "boot" },
+      {
+        ...handlers,
+        openNodeInstall: (token) =>
+          token === "good-grant"
+            ? { script: "#!/bin/sh\necho install", filename: "install.sh" }
+            : null,
+      },
+    );
+    const port = await server.start();
+
+    expect((await get(port, "/node/install")).status).toBe(404);
+    expect((await get(port, "/node/install?provision=wrong")).status).toBe(404);
+    const ok = await get(port, "/node/install?provision=good-grant");
+    expect(ok.status).toBe(200);
+    expect(await ok.text()).toContain("echo install");
+    expect((await get(port, "/node/binary?provision=wrong")).status).toBe(404);
   });
 });

--- a/src/__tests__/native-tls.test.ts
+++ b/src/__tests__/native-tls.test.ts
@@ -154,6 +154,8 @@ describe("bridge server over TLS", () => {
     completeCommand: () => false,
     acceptFileUpload: async () => ({ ok: false, error: "unused" }),
     openFileDownload: async () => null,
+    openNodeInstall: () => null,
+    openNodeBinary: () => null,
   };
 
   /** GET over HTTPS trusting exactly the bridge's own certificate. */

--- a/src/__tests__/node-binaries.test.ts
+++ b/src/__tests__/node-binaries.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Node-binary resolver — target matrix, name normalization, and the tiered
+ * resolution flow (cache verify, digest-checked release download). The
+ * source-build tier is exercised only for its "disabled" path — a real
+ * `go build` needs a toolchain the CI matrix already covers in apps/node.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  NODE_TARGETS,
+  nodeAssetName,
+  normalizeGoarch,
+  normalizeGoos,
+  platformToGoos,
+  resolveNodeBinary,
+} from "../core/mesh/node-binaries.js";
+
+const VERSION = "9.9.9";
+
+function sha256(data: Buffer | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+async function tempCache(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "talon-node-bin-"));
+}
+
+/** A fetch stub serving a release's sums manifest + one binary. */
+function releaseFetch(
+  binary: Buffer,
+  asset: string,
+  opts: { sums?: string } = {},
+): typeof fetch {
+  const sums = opts.sums ?? `${sha256(binary)}  ${asset}\n`;
+  return (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.endsWith("/talon-node-SHA256SUMS")) return new Response(sums);
+    if (url.endsWith(`/${asset}`)) return new Response(new Uint8Array(binary));
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+}
+
+describe("target naming + normalization", () => {
+  it("names assets exactly like the build tool (windows gets .exe)", () => {
+    expect(nodeAssetName("linux", "arm64")).toBe("talon-node-linux-arm64");
+    expect(nodeAssetName("windows", "amd64")).toBe(
+      "talon-node-windows-amd64.exe",
+    );
+  });
+
+  it("normalizes user spellings onto Go names", () => {
+    expect(normalizeGoos("macOS")).toBe("darwin");
+    expect(normalizeGoos("Linux")).toBe("linux");
+    expect(normalizeGoos("android")).toBeUndefined();
+    expect(normalizeGoarch("x86_64")).toBe("amd64");
+    expect(normalizeGoarch("aarch64")).toBe("arm64");
+    expect(normalizeGoarch("armv7l")).toBe("arm");
+    expect(normalizeGoarch("riscv64")).toBeUndefined();
+  });
+
+  it("maps mesh platforms onto GOOS, excluding mobile", () => {
+    expect(platformToGoos("macos")).toBe("darwin");
+    expect(platformToGoos("linux")).toBe("linux");
+    expect(platformToGoos("windows")).toBe("windows");
+    expect(platformToGoos("android")).toBeUndefined();
+    expect(platformToGoos("ios")).toBeUndefined();
+  });
+
+  it("rejects targets outside the matrix without touching any tier", async () => {
+    await expect(
+      resolveNodeBinary("linux", "riscv64", { repoRoot: null }),
+    ).rejects.toThrow(/No talon-node target/);
+    expect(NODE_TARGETS.length).toBe(6);
+  });
+});
+
+describe("release download tier", () => {
+  it("downloads, digest-verifies, caches (0755), and serves from cache after", async () => {
+    const cacheRoot = await tempCache();
+    const binary = Buffer.from("#!fake-elf talon-node payload");
+    const asset = nodeAssetName("linux", "arm64");
+    let fetches = 0;
+    const fetchImpl = (async (
+      input: string | URL | Request,
+      init?: unknown,
+    ) => {
+      fetches++;
+      return releaseFetch(binary, asset)(
+        String(input) as string,
+        init as never,
+      );
+    }) as typeof fetch;
+
+    const first = await resolveNodeBinary("linux", "arm64", {
+      cacheRoot,
+      repoRoot: null,
+      fetchImpl,
+      version: VERSION,
+    });
+    expect(first.source).toBe("release");
+    expect(first.version).toBe(VERSION);
+    expect(first.sha256).toBe(sha256(binary));
+    expect(first.path).toBe(join(cacheRoot, VERSION, asset));
+    expect(await readFile(first.path)).toEqual(binary);
+
+    const again = await resolveNodeBinary("linux", "arm64", {
+      cacheRoot,
+      repoRoot: null,
+      fetchImpl: (() => {
+        throw new Error("network must not be touched on a cache hit");
+      }) as unknown as typeof fetch,
+      version: VERSION,
+    });
+    expect(again.source).toBe("cache");
+    expect(again.sha256).toBe(first.sha256);
+    expect(fetches).toBe(2); // sums + binary, once
+  });
+
+  it("refuses a download whose digest does not match the manifest", async () => {
+    const cacheRoot = await tempCache();
+    const binary = Buffer.from("payload");
+    const asset = nodeAssetName("linux", "amd64");
+    await expect(
+      resolveNodeBinary("linux", "amd64", {
+        cacheRoot,
+        repoRoot: null,
+        fetchImpl: releaseFetch(binary, asset, {
+          sums: `${sha256("something else")}  ${asset}\n`,
+        }),
+        version: VERSION,
+      }),
+    ).rejects.toThrow(/digest mismatch/);
+  });
+
+  it("fails clearly when the release has no entry for the asset", async () => {
+    const cacheRoot = await tempCache();
+    await expect(
+      resolveNodeBinary("darwin", "arm64", {
+        cacheRoot,
+        repoRoot: null,
+        fetchImpl: releaseFetch(Buffer.from("x"), "talon-node-linux-amd64"),
+        version: VERSION,
+      }),
+    ).rejects.toThrow(/no entry/);
+  });
+
+  it("re-downloads over a corrupted cache entry instead of serving it", async () => {
+    const cacheRoot = await tempCache();
+    const asset = nodeAssetName("linux", "amd64");
+    const good = Buffer.from("good build");
+    const dir = join(cacheRoot, VERSION);
+    await mkdir(dir, { recursive: true });
+    // Recorded digest says "good build", but the bytes on disk are damaged.
+    await writeFile(join(dir, asset), "damaged");
+    await writeFile(join(dir, `${asset}.sha256`), `${sha256(good)}\n`);
+
+    const resolved = await resolveNodeBinary("linux", "amd64", {
+      cacheRoot,
+      repoRoot: null,
+      fetchImpl: releaseFetch(good, asset),
+      version: VERSION,
+    });
+    expect(resolved.source).toBe("release");
+    expect(await readFile(resolved.path)).toEqual(good);
+  });
+
+  it("prunes cached matrices from other Talon versions after a download", async () => {
+    const cacheRoot = await tempCache();
+    const staleDir = join(cacheRoot, "1.0.0");
+    await mkdir(staleDir, { recursive: true });
+    await writeFile(join(staleDir, "talon-node-linux-amd64"), "stale");
+    const devDir = join(cacheRoot, "dev");
+    await mkdir(devDir, { recursive: true });
+    await writeFile(join(devDir, "talon-node-linux-amd64"), "dev build");
+
+    const binary = Buffer.from("fresh");
+    const asset = nodeAssetName("linux", "amd64");
+    await resolveNodeBinary("linux", "amd64", {
+      cacheRoot,
+      repoRoot: null,
+      fetchImpl: releaseFetch(binary, asset),
+      version: VERSION,
+    });
+    await expect(readFile(join(staleDir, asset))).rejects.toThrow();
+    // Dev builds are working-tree artifacts, not version-keyed — kept.
+    expect(String(await readFile(join(devDir, asset)))).toBe("dev build");
+  });
+});

--- a/src/__tests__/node-provision.test.ts
+++ b/src/__tests__/node-provision.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Node provisioning grants — single-use legs, expiry, and the generated
+ * installer scripts (POSIX sh for linux/darwin, PowerShell for windows).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  installOneLiner,
+  NodeProvisionStore,
+} from "../core/mesh/node-provision.js";
+
+const BASE = {
+  goos: "linux" as const,
+  goarch: "arm64",
+  binaryPath: "/tmp/talon-node-linux-arm64",
+  sha256: "ab".repeat(32),
+  size: 6_000_000,
+  version: "3.4.0",
+  bridgeUrl: "https://100.64.0.7:19880",
+  bearerToken: "bearer-secret",
+  fingerprint: "cd".repeat(32),
+};
+
+describe("NodeProvisionStore", () => {
+  it("serves each leg exactly once", () => {
+    const store = new NodeProvisionStore();
+    const grant = store.create(BASE);
+    expect(store.openScript(grant.token)?.filename).toBe(
+      "install-talon-node.sh",
+    );
+    expect(store.openScript(grant.token)).toBeNull();
+    expect(store.openBinary(grant.token)).toEqual({
+      path: BASE.binaryPath,
+      size: BASE.size,
+    });
+    expect(store.openBinary(grant.token)).toBeNull();
+  });
+
+  it("rejects unknown tokens and expires unclaimed grants", () => {
+    const store = new NodeProvisionStore(-1); // everything already expired
+    const grant = store.create(BASE);
+    expect(store.openScript("nope")).toBeNull();
+    expect(store.openScript(grant.token)).toBeNull();
+  });
+
+  it("sanitizes device names against quote breakouts", () => {
+    const store = new NodeProvisionStore();
+    const grant = store.create({ ...BASE, name: 'evil"; rm -rf / #box 1' });
+    expect(grant.name).toBe("evil rm -rf  box 1");
+  });
+});
+
+describe("installer scripts", () => {
+  it("sh installer wires bridge, digest, token, and fingerprint through", () => {
+    const store = new NodeProvisionStore();
+    const grant = store.create({ ...BASE, name: "build-box" });
+    const { script, filename } = store.openScript(grant.token)!;
+    expect(filename).toBe("install-talon-node.sh");
+    expect(script).toContain(`BRIDGE="${BASE.bridgeUrl}"`);
+    expect(script).toContain(`SHA="${BASE.sha256}"`);
+    expect(script).toContain(`/node/binary?provision=${grant.token}`);
+    expect(script).toContain(`--token "${BASE.bearerToken}"`);
+    expect(script).toContain(`--fingerprint "${BASE.fingerprint}"`);
+    expect(script).toContain(`--name "build-box"`);
+    // The digest check must gate the install, not decorate it.
+    expect(script).toContain("refusing to install");
+  });
+
+  it("windows grants produce a PowerShell installer and one-liner", () => {
+    const store = new NodeProvisionStore();
+    const grant = store.create({ ...BASE, goos: "windows", goarch: "amd64" });
+    const { script, filename } = store.openScript(grant.token)!;
+    expect(filename).toBe("install-talon-node.ps1");
+    expect(script).toContain("Get-FileHash");
+    expect(script).toContain(BASE.sha256);
+    expect(installOneLiner(grant)).toContain("powershell");
+  });
+
+  it("unix one-liner pipes the install route into sh", () => {
+    const store = new NodeProvisionStore();
+    const grant = store.create(BASE);
+    expect(installOneLiner(grant)).toBe(
+      `curl -fsSk "${BASE.bridgeUrl}/node/install?provision=${grant.token}" | sh`,
+    );
+  });
+
+  it("omits fingerprint and name flags when absent", () => {
+    const store = new NodeProvisionStore();
+    const { fingerprint: _drop, ...rest } = BASE;
+    const grant = store.create(rest);
+    const { script } = store.openScript(grant.token)!;
+    expect(script).not.toContain("--fingerprint");
+    expect(script).not.toContain("--name");
+  });
+});

--- a/src/core/engine/gateway-actions/mesh.ts
+++ b/src/core/engine/gateway-actions/mesh.ts
@@ -58,11 +58,23 @@ export const meshHandlers: SharedActionHandlers = {
       body.remote_path,
     ),
   // Remote self-update for a headless talon-node: push a new binary and have
-  // the node verify, swap, and restart into it.
+  // the node verify, swap, and restart into it. binary_path is optional —
+  // omitted, the daemon resolves the right build for the node's
+  // platform/arch itself (source build or verified release download).
   update_node: (body) =>
     getMeshService().updateNodeBinary(
       body.device,
       body.binary_path,
       body.remote_path,
+    ),
+  // Node provisioning: materialize a talon-node binary for any arch, and
+  // mint single-use bridge-served install links for fresh hosts.
+  get_node_binary: (body) => getMeshService().getNodeBinary(body.os, body.arch),
+  make_node_install_link: (body) =>
+    getMeshService().makeNodeInstallLink(
+      body.os,
+      body.arch,
+      body.name,
+      body.bridge_url,
     ),
 };

--- a/src/core/mesh/node-binaries.ts
+++ b/src/core/mesh/node-binaries.ts
@@ -1,0 +1,393 @@
+/**
+ * Node-binary resolver — materializes a talon-node binary for any supported
+ * platform/arch, whatever shape this daemon was installed in.
+ *
+ * The old flow required a source checkout plus a Go toolchain (`update_node`
+ * only took a path the caller had built). This resolver keeps that path and
+ * adds two more, tried in order:
+ *
+ *   1. source build — running from a git checkout with Go on PATH: cross-
+ *      compile apps/node for the requested target (always rebuilt, so a dev
+ *      daemon ships its working-tree code, stamped <version>+<sha>).
+ *   2. cache — ~/.talon/node-bin/<talon-version>/talon-node-<os>-<arch>,
+ *      re-verified against its recorded digest on every hit.
+ *   3. release download — the GitHub release matching THIS daemon's version
+ *      publishes the full binary matrix plus a talon-node-SHA256SUMS
+ *      manifest (built by .github/workflows/node.yml); fetch, verify the
+ *      digest, and cache. This is what makes prebuilt installs (npm, deb,
+ *      standalone binary) able to provision nodes at all.
+ *
+ * Version lock is structural: cache keys and release URLs both derive from
+ * `talonVersion()`, so a resolved binary always matches the daemon exactly.
+ */
+
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { TalonError } from "../errors.js";
+import { getRepoRoot } from "../update/self-update.js";
+import { dirs } from "../../util/paths.js";
+import { talonVersion } from "../../util/version.js";
+import type { DevicePlatform } from "./types.js";
+
+/** A cross-compile target, named exactly as Go (and the release assets) do. */
+export type NodeTarget = {
+  goos: "linux" | "darwin" | "windows";
+  goarch: string;
+};
+
+/** The supported matrix — mirrors apps/node/tools/build/main.go. */
+export const NODE_TARGETS: readonly NodeTarget[] = [
+  { goos: "linux", goarch: "amd64" },
+  { goos: "linux", goarch: "arm64" },
+  { goos: "linux", goarch: "arm" },
+  { goos: "darwin", goarch: "amd64" },
+  { goos: "darwin", goarch: "arm64" },
+  { goos: "windows", goarch: "amd64" },
+];
+
+const SUMS_ASSET = "talon-node-SHA256SUMS";
+const RELEASE_BASE = "https://github.com/dylanneve1/talon/releases/download";
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+const BUILD_TIMEOUT_MS = 300_000;
+
+export type ResolvedNodeBinary = {
+  path: string;
+  /** Full stamp the binary reports (release: the semver; build: semver+sha). */
+  version: string;
+  sha256: string;
+  size: number;
+  /** Which tier produced it. */
+  source: "source-build" | "cache" | "release";
+};
+
+export type ResolveNodeBinaryOptions = {
+  /** Cache root (default ~/.talon/node-bin). */
+  cacheRoot?: string;
+  /** Source checkout root; null disables the build tier (default: detect). */
+  repoRoot?: string | null;
+  /** Release download (test seam). */
+  fetchImpl?: typeof fetch;
+  /** Daemon version override (test seam). */
+  version?: string;
+};
+
+/** The resolver's function shape — the seam MeshService accepts in tests. */
+export type NodeBinaryResolver = (
+  goos: string,
+  goarch: string,
+  opts?: ResolveNodeBinaryOptions,
+) => Promise<ResolvedNodeBinary>;
+
+/** Release asset / on-disk name for one target. */
+export function nodeAssetName(goos: string, goarch: string): string {
+  return `talon-node-${goos}-${goarch}${goos === "windows" ? ".exe" : ""}`;
+}
+
+/**
+ * Normalize a caller-supplied OS ("macos", "darwin", "Linux") to a matrix
+ * GOOS, or undefined for anything outside it.
+ */
+export function normalizeGoos(value: unknown): NodeTarget["goos"] | undefined {
+  const v = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (v === "macos" || v === "darwin" || v === "osx") return "darwin";
+  if (v === "linux") return "linux";
+  if (v === "windows" || v === "win32") return "windows";
+  return undefined;
+}
+
+/** Normalize a caller-supplied arch ("x86_64", "aarch64") to a Go arch. */
+export function normalizeGoarch(value: unknown): string | undefined {
+  const v = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (v === "amd64" || v === "x86_64" || v === "x64") return "amd64";
+  if (v === "arm64" || v === "aarch64") return "arm64";
+  if (v === "arm" || v === "armv7" || v === "armv7l") return "arm";
+  return undefined;
+}
+
+/** Map a mesh platform onto a node GOOS (mobile platforms have no node). */
+export function platformToGoos(
+  platform: DevicePlatform,
+): NodeTarget["goos"] | undefined {
+  return normalizeGoos(platform === "macos" ? "darwin" : platform);
+}
+
+function isSupported(goos: string, goarch: string): boolean {
+  return NODE_TARGETS.some((t) => t.goos === goos && t.goarch === goarch);
+}
+
+/**
+ * Resolve a node binary for `goos`/`goarch`. Throws with an operator-facing
+ * message when every tier fails — callers surface it verbatim.
+ */
+export async function resolveNodeBinary(
+  goos: string,
+  goarch: string,
+  opts: ResolveNodeBinaryOptions = {},
+): Promise<ResolvedNodeBinary> {
+  if (!isSupported(goos, goarch)) {
+    throw new TalonError(
+      `No talon-node target for ${goos}/${goarch}. Supported: ${NODE_TARGETS.map(
+        (t) => `${t.goos}/${t.goarch}`,
+      ).join(", ")}.`,
+      { reason: "bad_request" },
+    );
+  }
+  const version = opts.version ?? talonVersion();
+  const cacheRoot = opts.cacheRoot ?? resolve(dirs.root, "node-bin");
+  const repoRoot = opts.repoRoot === undefined ? getRepoRoot() : opts.repoRoot;
+
+  const errors: string[] = [];
+
+  if (repoRoot) {
+    try {
+      return await buildFromSource(repoRoot, goos, goarch, version, cacheRoot);
+    } catch (err) {
+      errors.push(`source build: ${(err as Error).message}`);
+    }
+  }
+
+  const cached = await fromCache(cacheRoot, version, goos, goarch);
+  if (cached) return cached;
+
+  try {
+    return await downloadFromRelease(
+      version,
+      goos,
+      goarch,
+      cacheRoot,
+      opts.fetchImpl ?? fetch,
+    );
+  } catch (err) {
+    errors.push(`release download: ${(err as Error).message}`);
+  }
+
+  throw new TalonError(
+    `Could not obtain talon-node ${goos}/${goarch} for Talon ${version} — ${errors.join("; ")}`,
+    { reason: "unknown" },
+  );
+}
+
+// ── Tier 1: source build ────────────────────────────────────────────────────
+
+async function buildFromSource(
+  repoRoot: string,
+  goos: string,
+  goarch: string,
+  version: string,
+  cacheRoot: string,
+): Promise<ResolvedNodeBinary> {
+  const nodeDir = join(repoRoot, "apps", "node");
+  await stat(join(nodeDir, "go.mod"));
+  // Dev builds land under their own key: they track the working tree, not a
+  // release, and are rebuilt on every resolve so they can never go stale.
+  const outDir = join(cacheRoot, "dev");
+  await mkdir(outDir, { recursive: true });
+  const dest = join(outDir, nodeAssetName(goos, goarch));
+  const stamp = `${version}+${await gitShortSha(repoRoot)}`;
+  await run(
+    "go",
+    [
+      "build",
+      "-trimpath",
+      "-ldflags",
+      `-s -w -X main.ldflagsVersion=${stamp}`,
+      "-o",
+      dest,
+      ".",
+    ],
+    nodeDir,
+    { CGO_ENABLED: "0", GOOS: goos, GOARCH: goarch },
+    BUILD_TIMEOUT_MS,
+  );
+  const { sha256, size } = await hashFile(dest);
+  return { path: dest, version: stamp, sha256, size, source: "source-build" };
+}
+
+async function gitShortSha(repoRoot: string): Promise<string> {
+  try {
+    return (
+      await run("git", ["rev-parse", "--short", "HEAD"], repoRoot, {}, 10_000)
+    ).trim();
+  } catch {
+    return "dev";
+  }
+}
+
+function run(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  env: Record<string, string>,
+  timeoutMs: number,
+): Promise<string> {
+  return new Promise((res, rej) => {
+    execFile(
+      cmd,
+      args,
+      { cwd, env: { ...process.env, ...env }, timeout: timeoutMs },
+      (err, stdout, stderr) => {
+        if (err) {
+          rej(
+            new Error(
+              `${cmd} ${args[0]} failed: ${String(stderr || err.message)
+                .trim()
+                .slice(0, 500)}`,
+            ),
+          );
+        } else {
+          res(String(stdout));
+        }
+      },
+    );
+  });
+}
+
+// ── Tier 2: cache ───────────────────────────────────────────────────────────
+
+async function fromCache(
+  cacheRoot: string,
+  version: string,
+  goos: string,
+  goarch: string,
+): Promise<ResolvedNodeBinary | null> {
+  const path = join(cacheRoot, version, nodeAssetName(goos, goarch));
+  let recorded: string;
+  try {
+    recorded = (await readFile(`${path}.sha256`, "utf8")).trim();
+  } catch {
+    return null;
+  }
+  try {
+    const { sha256, size } = await hashFile(path);
+    if (size > 0 && sha256 === recorded) {
+      return { path, version, sha256, size, source: "cache" };
+    }
+  } catch {
+    // Fall through — a corrupt entry is re-downloaded, not fatal.
+  }
+  await rm(path, { force: true }).catch(() => {});
+  await rm(`${path}.sha256`, { force: true }).catch(() => {});
+  return null;
+}
+
+// ── Tier 3: release download ────────────────────────────────────────────────
+
+async function downloadFromRelease(
+  version: string,
+  goos: string,
+  goarch: string,
+  cacheRoot: string,
+  fetchImpl: typeof fetch,
+): Promise<ResolvedNodeBinary> {
+  const asset = nodeAssetName(goos, goarch);
+  const base = `${RELEASE_BASE}/v${version}`;
+  const sums = parseSums(await fetchText(fetchImpl, `${base}/${SUMS_ASSET}`));
+  const expected = sums.get(asset);
+  if (!expected) {
+    throw new TalonError(
+      `${SUMS_ASSET} for v${version} has no entry for ${asset}`,
+      { reason: "bad_request" },
+    );
+  }
+  const body = await fetchBytes(fetchImpl, `${base}/${asset}`);
+  const sha256 = createHash("sha256").update(body).digest("hex");
+  if (sha256 !== expected) {
+    throw new TalonError(
+      `digest mismatch for ${asset} (expected ${expected.slice(0, 12)}…, got ${sha256.slice(0, 12)}…) — refusing to cache`,
+      { reason: "unknown" },
+    );
+  }
+  const dir = join(cacheRoot, version);
+  await mkdir(dir, { recursive: true });
+  const dest = join(dir, asset);
+  const tmp = `${dest}.tmp-${process.pid}`;
+  await writeFile(tmp, body);
+  await chmod(tmp, 0o755);
+  await rename(tmp, dest);
+  await writeFile(`${dest}.sha256`, `${sha256}\n`);
+  await pruneStaleVersions(cacheRoot, version);
+  return { path: dest, version, sha256, size: body.length, source: "release" };
+}
+
+/** Parse "<hex>  <name>" manifest lines (the `sha256sum` format). */
+function parseSums(text: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const line of text.split("\n")) {
+    const m = /^([0-9a-f]{64})\s+\*?(\S+)\s*$/.exec(line.trim());
+    if (m) out.set(m[2]!, m[1]!);
+  }
+  return out;
+}
+
+async function fetchText(
+  fetchImpl: typeof fetch,
+  url: string,
+): Promise<string> {
+  const res = await fetchImpl(url, {
+    redirect: "follow",
+    signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new TalonError(`GET ${url}: HTTP ${res.status}`, {
+      reason: "network",
+      retryable: true,
+      status: res.status,
+    });
+  }
+  return res.text();
+}
+
+async function fetchBytes(
+  fetchImpl: typeof fetch,
+  url: string,
+): Promise<Buffer> {
+  const res = await fetchImpl(url, {
+    redirect: "follow",
+    signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new TalonError(`GET ${url}: HTTP ${res.status}`, {
+      reason: "network",
+      retryable: true,
+      status: res.status,
+    });
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+/** Drop cached matrices for other Talon versions — they can never be used
+ *  again (the resolver only serves version-exact binaries). Best-effort. */
+async function pruneStaleVersions(
+  cacheRoot: string,
+  keep: string,
+): Promise<void> {
+  try {
+    for (const entry of await readdir(cacheRoot)) {
+      if (entry === keep || entry === "dev") continue;
+      await rm(join(cacheRoot, entry), { recursive: true, force: true });
+    }
+  } catch {
+    // Cache hygiene only — never fail a resolve over it.
+  }
+}
+
+async function hashFile(
+  path: string,
+): Promise<{ sha256: string; size: number }> {
+  const data = await readFile(path);
+  return {
+    sha256: createHash("sha256").update(data).digest("hex"),
+    size: data.length,
+  };
+}

--- a/src/core/mesh/node-provision.ts
+++ b/src/core/mesh/node-provision.ts
@@ -1,0 +1,190 @@
+/**
+ * NodeProvisionStore — one-time grants that turn a fresh host into a mesh
+ * node with a single command.
+ *
+ * The daemon mints a grant bound to one resolved binary (path + digest) and
+ * one target platform; the bridge serves two UNAUTHENTICATED but
+ * token-gated routes against it:
+ *
+ *   GET /node/install?provision=<token>   → installer script (once)
+ *   GET /node/binary?provision=<token>    → the binary itself (once)
+ *
+ * The routes must work pre-auth — the whole point is a host that holds no
+ * bridge credential yet — so the grant token IS the authorization, exactly
+ * like streamed-transfer tokens (transfers.ts): random 192-bit, single-use
+ * per leg, expiring unused. The script carries the bridge bearer token and
+ * pinned TLS fingerprint into the node's config, verifies the downloaded
+ * binary against the grant's digest (integrity is the script's own sha256
+ * check, not TLS), installs it, and registers the boot service via
+ * `talon-node install`.
+ */
+
+import { randomBytes } from "node:crypto";
+
+/** Unclaimed grants die after this long. */
+const GRANT_TTL_MS = 30 * 60 * 1000;
+
+export type NodeProvisionGrant = {
+  token: string;
+  goos: "linux" | "darwin" | "windows";
+  goarch: string;
+  /** Device name baked into the installer (optional — defaults to hostname). */
+  name?: string;
+  /** The resolved binary this grant serves. */
+  binaryPath: string;
+  sha256: string;
+  size: number;
+  version: string;
+  /** Bridge base URL as reachable from the target host. */
+  bridgeUrl: string;
+  /** Bridge bearer token the node will authenticate with. */
+  bearerToken: string;
+  /** Bridge TLS certificate fingerprint to pre-pin (absent over plain HTTP). */
+  fingerprint?: string;
+  createdAt: number;
+  scriptUsed: boolean;
+  binaryUsed: boolean;
+};
+
+export class NodeProvisionStore {
+  private readonly grants = new Map<string, NodeProvisionGrant>();
+
+  constructor(private readonly ttlMs = GRANT_TTL_MS) {}
+
+  create(
+    grant: Omit<
+      NodeProvisionGrant,
+      "token" | "createdAt" | "scriptUsed" | "binaryUsed"
+    >,
+  ): NodeProvisionGrant {
+    this.sweep();
+    const full: NodeProvisionGrant = {
+      ...grant,
+      // Device names are injected into generated shell/PowerShell text —
+      // keep them to characters that can't break out of a quoted string.
+      ...(grant.name
+        ? { name: grant.name.replace(/[^\w .-]+/g, "").slice(0, 64) }
+        : {}),
+      token: randomBytes(24).toString("base64url"),
+      createdAt: Date.now(),
+      scriptUsed: false,
+      binaryUsed: false,
+    };
+    this.grants.set(full.token, full);
+    return full;
+  }
+
+  /** Serve the installer script for a live grant — once. */
+  openScript(token: string): { script: string; filename: string } | null {
+    const grant = this.claim(token, "scriptUsed");
+    if (!grant) return null;
+    return grant.goos === "windows"
+      ? {
+          script: powershellInstaller(grant),
+          filename: "install-talon-node.ps1",
+        }
+      : { script: shellInstaller(grant), filename: "install-talon-node.sh" };
+  }
+
+  /** Resolve the binary leg of a live grant — once. */
+  openBinary(token: string): { path: string; size: number } | null {
+    const grant = this.claim(token, "binaryUsed");
+    if (!grant) return null;
+    return { path: grant.binaryPath, size: grant.size };
+  }
+
+  /** Expire-check + single-use latch for one leg of a grant. */
+  private claim(
+    token: string,
+    leg: "scriptUsed" | "binaryUsed",
+  ): NodeProvisionGrant | null {
+    this.sweep();
+    const grant = this.grants.get(token);
+    if (!grant || grant[leg]) return null;
+    grant[leg] = true;
+    if (grant.scriptUsed && grant.binaryUsed) this.grants.delete(token);
+    return grant;
+  }
+
+  private sweep(): void {
+    const cutoff = Date.now() - this.ttlMs;
+    for (const [token, grant] of this.grants) {
+      if (grant.createdAt < cutoff) this.grants.delete(token);
+    }
+  }
+}
+
+/** The command a human (or the model over SSH) runs on the target host. */
+export function installOneLiner(grant: NodeProvisionGrant): string {
+  const url = `${grant.bridgeUrl}/node/install?provision=${grant.token}`;
+  if (grant.goos === "windows") {
+    // -k has no iwr flag; trust-all callback covers the self-signed bridge
+    // cert for the two fetches — the binary itself is digest-verified. The
+    // one-liner is meant for cmd.exe / PowerShell, where $true survives the
+    // outer double quotes verbatim.
+    return (
+      `powershell -ExecutionPolicy Bypass -Command "` +
+      `[Net.ServicePointManager]::ServerCertificateValidationCallback={$true}; ` +
+      `iwr -UseBasicParsing '${url}' | Select-Object -ExpandProperty Content | iex"`
+    );
+  }
+  return `curl -fsSk "${url}" | sh`;
+}
+
+/**
+ * POSIX installer: fetch the binary over the same grant, verify its digest,
+ * install it next to the node's config, and register the boot service. -k on
+ * the fetches is deliberate — the bridge cert is self-signed; integrity
+ * comes from the embedded sha256 and the fingerprint is pre-pinned into the
+ * node's config for every connection after install.
+ */
+function shellInstaller(grant: NodeProvisionGrant): string {
+  const nameFlag = grant.name ? ` --name "${grant.name}"` : "";
+  const fpFlag = grant.fingerprint
+    ? ` --fingerprint "${grant.fingerprint}"`
+    : "";
+  return `#!/bin/sh
+# talon-node installer — generated by Talon ${grant.version} for ${grant.goos}/${grant.goarch}
+set -eu
+BRIDGE="${grant.bridgeUrl}"
+SHA="${grant.sha256}"
+if [ "$(id -u)" = "0" ]; then DEST_DIR="\${TALON_NODE_DIR:-/usr/local/bin}"; else DEST_DIR="\${TALON_NODE_DIR:-$HOME/.talon-node/bin}"; fi
+mkdir -p "$DEST_DIR"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+echo "Downloading talon-node ${grant.version} (${grant.goos}/${grant.goarch})..."
+curl -fsSk "$BRIDGE/node/binary?provision=${grant.token}" -o "$TMP"
+if command -v sha256sum >/dev/null 2>&1; then GOT="$(sha256sum "$TMP" | cut -d' ' -f1)"; else GOT="$(shasum -a 256 "$TMP" | cut -d' ' -f1)"; fi
+if [ "$GOT" != "$SHA" ]; then echo "talon-node download failed its checksum — refusing to install" >&2; exit 1; fi
+BIN="$DEST_DIR/talon-node"
+mv "$TMP" "$BIN"
+chmod 0755 "$BIN"
+trap - EXIT
+echo "Installed $BIN"
+"$BIN" install --bridge "$BRIDGE" --token "${grant.bearerToken}"${fpFlag}${nameFlag}
+echo "Done — this host is now on the mesh. Check with: $BIN status"
+`;
+}
+
+/** PowerShell installer (Windows PowerShell 5+ compatible). */
+function powershellInstaller(grant: NodeProvisionGrant): string {
+  const nameArg = grant.name ? `, "--name", "${grant.name}"` : "";
+  const fpArg = grant.fingerprint
+    ? `, "--fingerprint", "${grant.fingerprint}"`
+    : "";
+  return `# talon-node installer — generated by Talon ${grant.version} for ${grant.goos}/${grant.goarch}
+$ErrorActionPreference = "Stop"
+[Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+$bridge = "${grant.bridgeUrl}"
+$dest = Join-Path $env:LOCALAPPDATA "talon-node"
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+$bin = Join-Path $dest "talon-node.exe"
+Write-Host "Downloading talon-node ${grant.version} (${grant.goos}/${grant.goarch})..."
+Invoke-WebRequest -UseBasicParsing "$bridge/node/binary?provision=${grant.token}" -OutFile $bin
+$got = (Get-FileHash $bin -Algorithm SHA256).Hash.ToLower()
+if ($got -ne "${grant.sha256}") { Remove-Item $bin; throw "talon-node download failed its checksum - refusing to install" }
+Write-Host "Installed $bin"
+& $bin install --bridge $bridge --token "${grant.bearerToken}"${fpArg}${nameArg}
+Write-Host "Done - this host is now on the mesh. Check with: $bin status"
+`;
+}

--- a/src/core/mesh/registry.ts
+++ b/src/core/mesh/registry.ts
@@ -237,10 +237,12 @@ function sanitizeDevice(
   ) {
     return null;
   }
+  const arch = stringField(body.arch)?.toLowerCase().slice(0, 16);
   return {
     id: id ?? "",
     name: name ?? "",
     platform: platform ?? "linux",
+    ...(arch ? { arch } : {}),
     appVersion: appVersion ?? "",
     online: body.online === true,
     lastSeen: numberField(body.lastSeen) ?? now,

--- a/src/core/mesh/service.ts
+++ b/src/core/mesh/service.ts
@@ -30,11 +30,20 @@ import { randomUUID } from "node:crypto";
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { networkInterfaces, tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import type { Readable } from "node:stream";
 import { clampExecOutput } from "../../util/exec-output.js";
 import { dirs } from "../../util/paths.js";
+import {
+  NODE_TARGETS,
+  normalizeGoarch,
+  normalizeGoos,
+  platformToGoos,
+  resolveNodeBinary,
+  type NodeBinaryResolver,
+} from "./node-binaries.js";
+import { installOneLiner, NodeProvisionStore } from "./node-provision.js";
 import { MeshRegistry } from "./registry.js";
 import { TransferStore } from "./transfers.js";
 import type {
@@ -72,6 +81,25 @@ export type MeshServiceOptions = {
   pollIntervalMs?: number;
   /** How long a device command waits for its result before timing out. */
   commandTimeoutMs?: number;
+  /** Node-binary resolver override (tests — the real one builds/downloads). */
+  nodeBinaryResolver?: NodeBinaryResolver;
+};
+
+/**
+ * What the native bridge tells the mesh about itself once it's listening —
+ * everything a generated node installer needs to point a fresh host here.
+ * Registered by the native frontend after server start; null when the
+ * bridge isn't running (provisioning tools then fail with a clear reason).
+ */
+export type MeshBridgeInfo = {
+  scheme: "http" | "https";
+  /** The bind host from config — may be a wildcard (0.0.0.0/::). */
+  host: string;
+  port: number;
+  /** Bearer token clients authenticate with (absent on open loopback). */
+  token?: string;
+  /** TLS certificate SHA-256 (absent over plain HTTP). */
+  fingerprint?: string;
 };
 
 const DEFAULT_FRESH_FIX_TIMEOUT_MS = 8_000;
@@ -144,6 +172,10 @@ export class MeshService {
   private readonly receivedAt = new Map<string, number>();
   /** One-time tokens arranging streamed (single-HTTP-request) transfers. */
   private readonly transfers = new TransferStore();
+  /** One-time grants for bridge-served node installers. */
+  private readonly provision = new NodeProvisionStore();
+  private readonly resolveNode: NodeBinaryResolver;
+  private bridgeInfo: MeshBridgeInfo | null = null;
   private readonly freshFixTimeoutMs: number;
   private readonly pollIntervalMs: number;
   private readonly commandTimeoutMs: number;
@@ -158,6 +190,12 @@ export class MeshService {
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.commandTimeoutMs =
       options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+    this.resolveNode = options.nodeBinaryResolver ?? resolveNodeBinary;
+  }
+
+  /** The native bridge reports its reachable identity here (null on stop). */
+  setBridgeInfo(info: MeshBridgeInfo | null): void {
+    this.bridgeInfo = info;
   }
 
   /** Hydrate persisted devices/locations. Idempotent — safe to await from
@@ -923,19 +961,17 @@ export class MeshService {
    *
    * The binary is hashed here and the digest travels with the command; the
    * node re-hashes the pushed file and refuses to swap on a mismatch, so a
-   * truncated transfer can never be installed. Build the replacement for the
-   * node's platform/arch (talon-node-<os>-<arch>) before calling.
+   * truncated transfer can never be installed.
+   *
+   * With no binary_path, the replacement is auto-resolved for the node's
+   * registered platform/arch (source build in a dev checkout, else the
+   * version-matched release download — see node-binaries.ts).
    */
   async updateNodeBinary(
     query: unknown,
-    localBinaryPath: unknown,
+    localBinaryPath?: unknown,
     remotePath?: unknown,
   ): Promise<MeshToolResult> {
-    const local =
-      typeof localBinaryPath === "string" && localBinaryPath.trim()
-        ? resolve(dirs.workspace, localBinaryPath.trim())
-        : "";
-    if (!local) return { ok: false, text: "A local binary path is required." };
     await this.load();
     const resolved = this.resolveDevice(query);
     if ("error" in resolved) return { ok: false, text: resolved.error };
@@ -945,6 +981,34 @@ export class MeshService {
         ok: false,
         text: `${target.name} can't self-update — it needs the update_node capability (a talon-node headless device).`,
       };
+    }
+
+    let local: string;
+    let provenance = "";
+    if (typeof localBinaryPath === "string" && localBinaryPath.trim()) {
+      local = resolve(dirs.workspace, localBinaryPath.trim());
+    } else {
+      const goos = platformToGoos(target.platform);
+      if (!goos) {
+        return {
+          ok: false,
+          text: `${target.name} is a ${target.platform} device — update_node targets headless nodes only.`,
+        };
+      }
+      const goarch = normalizeGoarch(target.arch);
+      if (!goarch) {
+        return {
+          ok: false,
+          text: `${target.name} has not advertised its CPU architecture (a node build from before arch reporting). Pass binary_path explicitly for this update — after it, the node advertises arch and future updates auto-resolve.`,
+        };
+      }
+      try {
+        const bin = await this.resolveNode(goos, goarch);
+        local = bin.path;
+        provenance = ` (auto-resolved ${bin.version} for ${goos}/${goarch} via ${bin.source})`;
+      } catch (err) {
+        return { ok: false, text: (err as Error).message };
+      }
     }
 
     let sha256: string;
@@ -989,10 +1053,143 @@ export class MeshService {
     return {
       ok: true,
       text:
-        `Pushed ${formatBytes(size)} and staged the update on ${target.name}. ` +
+        `Pushed ${formatBytes(size)}${provenance} and staged the update on ${target.name}. ` +
         `${dispatched.result.message ?? "Restarting now."} ` +
         `Confirm with get_device_status once it reconnects (appVersion should change).`,
     };
+  }
+
+  // ── Node provisioning ──────────────────────────────────────────────────────
+
+  /**
+   * `get_node_binary`: materialize a talon-node binary for any supported
+   * platform/arch on the daemon host — source build in a dev checkout, else
+   * the digest-verified release download (cached under ~/.talon/node-bin).
+   */
+  async getNodeBinary(os: unknown, arch: unknown): Promise<MeshToolResult> {
+    const goos = normalizeGoos(os);
+    const goarch = normalizeGoarch(arch);
+    if (!goos || !goarch) {
+      return { ok: false, text: unknownTargetText(os, arch) };
+    }
+    try {
+      const bin = await this.resolveNode(goos, goarch);
+      return {
+        ok: true,
+        text: `talon-node ${bin.version} for ${goos}/${goarch}: ${bin.path} (${formatBytes(bin.size)}, sha256 ${bin.sha256}, via ${bin.source})`,
+      };
+    } catch (err) {
+      return { ok: false, text: (err as Error).message };
+    }
+  }
+
+  /**
+   * `make_node_install_link`: mint a single-use provisioning URL on the
+   * bridge and return the one command that turns a fresh host into a mesh
+   * node — it fetches the installer script, which downloads the (digest-
+   * verified) binary from the same bridge, installs it, pre-pins the bridge
+   * certificate, and registers the boot service.
+   */
+  async makeNodeInstallLink(
+    os: unknown,
+    arch: unknown,
+    name?: unknown,
+    bridgeUrl?: unknown,
+  ): Promise<MeshToolResult> {
+    const goos = normalizeGoos(os);
+    const goarch = normalizeGoarch(arch);
+    if (!goos || !goarch) {
+      return { ok: false, text: unknownTargetText(os, arch) };
+    }
+    const info = this.bridgeInfo;
+    if (!info) {
+      return {
+        ok: false,
+        text: "The native bridge isn't running, so there is nothing for a new node to connect to. Enable the native frontend first.",
+      };
+    }
+    if (!info.token) {
+      return {
+        ok: false,
+        text: "The bridge has no bearer token (loopback-only bind), and nodes authenticate with one. Set native.host to a reachable address (a token is auto-minted) and restart.",
+      };
+    }
+    const base = this.bridgeBaseUrl(info, bridgeUrl);
+    if (typeof base !== "string") return { ok: false, text: base.error };
+    let bin;
+    try {
+      bin = await this.resolveNode(goos, goarch);
+    } catch (err) {
+      return { ok: false, text: (err as Error).message };
+    }
+    const grant = this.provision.create({
+      goos,
+      goarch,
+      ...(typeof name === "string" && name.trim() ? { name: name.trim() } : {}),
+      binaryPath: bin.path,
+      sha256: bin.sha256,
+      size: bin.size,
+      version: bin.version,
+      bridgeUrl: base,
+      bearerToken: info.token,
+      ...(info.fingerprint ? { fingerprint: info.fingerprint } : {}),
+    });
+    return {
+      ok: true,
+      text: [
+        `Run this on the new ${goos}/${goarch} host:`,
+        "",
+        `  ${installOneLiner(grant)}`,
+        "",
+        `It installs talon-node ${bin.version} (sha256-verified against ${grant.sha256.slice(0, 12)}…), pins the bridge certificate, and registers a boot service — the host appears on the mesh within a minute.`,
+        `Single-use link, expires in 30 minutes. The host must be able to reach ${base}.`,
+      ].join("\n"),
+    };
+  }
+
+  /** GET /node/install — serve a grant's installer script (single-use). */
+  openNodeInstall(token: string): { script: string; filename: string } | null {
+    return this.provision.openScript(token);
+  }
+
+  /** GET /node/binary — serve a grant's binary (single-use). */
+  openNodeBinary(token: string): { path: string; size: number } | null {
+    return this.provision.openBinary(token);
+  }
+
+  /**
+   * The bridge base URL a NEW host should dial: an explicit override wins;
+   * otherwise derive from the bridge's bind. A wildcard bind maps to this
+   * host's first external IPv4; a loopback bind is unreachable from other
+   * machines, so it's an error rather than a link that can't work.
+   */
+  private bridgeBaseUrl(
+    info: MeshBridgeInfo,
+    explicit?: unknown,
+  ): string | { error: string } {
+    if (typeof explicit === "string" && explicit.trim()) {
+      const url = explicit.trim().replace(/\/+$/, "");
+      if (!/^https?:\/\/\S+$/.test(url)) {
+        return { error: `bridge_url must be an http(s) URL, got "${url}".` };
+      }
+      return url;
+    }
+    let host = info.host;
+    if (host === "0.0.0.0" || host === "::") {
+      const external = firstExternalIPv4();
+      if (!external) {
+        return {
+          error:
+            "Could not determine this host's external address — pass bridge_url explicitly (the URL the new node should dial).",
+        };
+      }
+      host = external;
+    } else if (isLoopbackAddress(host)) {
+      return {
+        error: `The bridge is bound to loopback (${host}), which other machines can't reach. Set native.host to a reachable address, or pass bridge_url if a tunnel exposes it.`,
+      };
+    }
+    return `${info.scheme}://${host}:${info.port}`;
   }
 
   /**
@@ -1243,7 +1440,7 @@ export class MeshService {
 
   private deviceLine(device: DeviceInfo): string {
     const parts = [
-      `${device.name} [id: ${device.id}] (${device.platform})`,
+      `${device.name} [id: ${device.id}] (${device.platform}${device.arch ? `/${device.arch}` : ""})`,
       device.online ? "online" : "offline",
       `last seen ${age(Date.now() - device.lastSeen)}`,
     ];
@@ -1443,6 +1640,28 @@ function clampExecTimeout(value: unknown): number {
 /** Trim a string path param, returning undefined when blank. */
 function requirePath(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** Error text for an os/arch pair outside the talon-node build matrix. */
+function unknownTargetText(os: unknown, arch: unknown): string {
+  return `No talon-node target for os="${String(os)}", arch="${String(arch)}". Supported: ${NODE_TARGETS.map(
+    (t) => `${t.goos}/${t.goarch}`,
+  ).join(", ")} (macos ≡ darwin, x86_64 ≡ amd64, aarch64 ≡ arm64).`;
+}
+
+/** First non-internal IPv4 on this host — the wildcard-bind fallback. */
+function firstExternalIPv4(): string | undefined {
+  for (const list of Object.values(networkInterfaces())) {
+    for (const iface of list ?? []) {
+      if (!iface.internal && iface.family === "IPv4") return iface.address;
+    }
+  }
+  return undefined;
+}
+
+function isLoopbackAddress(host: string): boolean {
+  const h = host.toLowerCase();
+  return h === "localhost" || h === "::1" || h.startsWith("127.");
 }
 
 /** Render an exec result: exit code headline + stdout/stderr blocks. */

--- a/src/core/mesh/types.ts
+++ b/src/core/mesh/types.ts
@@ -15,6 +15,13 @@ export type DeviceInfo = {
   id: string;
   name: string;
   platform: DevicePlatform;
+  /**
+   * CPU architecture in Go spelling (amd64/arm64/arm), as talon-node
+   * advertises it. Lets the daemon pick the right release binary for
+   * update_node without being told. Absent for companion apps and node
+   * builds that predate arch reporting.
+   */
+  arch?: string;
   appVersion: string;
   online: boolean;
   /** Epoch milliseconds. */
@@ -83,6 +90,7 @@ export function toDeviceInfo(
     id: value.id,
     name: value.name,
     platform: value.platform,
+    ...(value.arch ? { arch: value.arch } : {}),
     appVersion: value.appVersion,
     online: now - value.lastSeen <= offlineAfterMs && value.online,
     lastSeen: value.lastSeen,

--- a/src/core/tools/mesh.ts
+++ b/src/core/tools/mesh.ts
@@ -188,13 +188,14 @@ export const meshTools: ToolDefinition[] = [
   {
     name: "update_node",
     description:
-      "Remotely update a headless talon-node (Linux/macOS/Windows server on the mesh): stream a new node binary from the daemon and have the node verify its hash, atomically swap its own binary, and restart into it. On Linux/macOS this is an in-place execve so the mesh connection returns within seconds; the node re-hashes the pushed file and refuses a truncated or mismatched binary. Build the replacement for the node's platform/arch first (talon-node-<os>-<arch>). Confirm success with get_device_status afterwards (appVersion should change). This is the node counterpart of update_device — use update_device for Android companions.",
+      "Remotely update a headless talon-node (Linux/macOS/Windows server on the mesh): stream a new node binary from the daemon and have the node verify its hash, atomically swap its own binary, and restart into it. On Linux/macOS this is an in-place execve so the mesh connection returns within seconds; the node re-hashes the pushed file and refuses a truncated or mismatched binary. With no binary_path, the daemon auto-resolves the right build for the node's registered platform/arch (source build in a dev checkout, else the digest-verified release download matching this Talon version) — the normal call is just update_node(device). Confirm success with get_device_status afterwards (appVersion should change). This is the node counterpart of update_device — use update_device for Android companions.",
     schema: {
       device: deviceParam,
       binary_path: z
         .string()
+        .optional()
         .describe(
-          "Path to the new talon-node binary, relative to the workspace (or absolute), built for the node's OS/arch.",
+          "Optional explicit binary, relative to the workspace (or absolute), built for the node's OS/arch. Omit to auto-resolve.",
         ),
       remote_path: z
         .string()
@@ -204,6 +205,44 @@ export const meshTools: ToolDefinition[] = [
         ),
     },
     execute: (params, bridge) => bridge("update_node", params),
+    tag: "mesh",
+  },
+  {
+    name: "get_node_binary",
+    description:
+      "Materialize a talon-node binary (the headless mesh device) for any supported platform/arch on the daemon host and return its path, version, and sha256. Resolution order: built from source when running in a dev checkout with Go, else the cached copy, else the digest-verified download from this Talon version's GitHub release — so it works on prebuilt installs with no toolchain. Use it to stage a binary for manual deployment (scp, device_push_file); for onboarding a fresh host prefer make_node_install_link, and for updating an existing node just call update_node (which resolves automatically).",
+    schema: {
+      os: z.string().describe("Target OS: linux, macos/darwin, or windows."),
+      arch: z
+        .string()
+        .describe("Target arch: amd64/x86_64, arm64/aarch64, or arm."),
+    },
+    execute: (params, bridge) => bridge("get_node_binary", params),
+    tag: "mesh",
+  },
+  {
+    name: "make_node_install_link",
+    description:
+      "Mint a single-use install link served by this daemon's bridge and return the one command that attaches a fresh Linux/macOS/Windows host to the mesh as a headless talon-node. Running it on the host downloads the installer script and binary from the bridge (sha256-verified), installs talon-node, pre-pins the bridge TLS certificate, embeds the bearer token, and registers a boot service — no toolchain, package manager, or manual config on the host. The link expires in 30 minutes and each leg serves exactly once; the host only needs to reach the bridge URL. Requires the native bridge running on a non-loopback bind with a token.",
+    schema: {
+      os: z.string().describe("Host OS: linux, macos/darwin, or windows."),
+      arch: z
+        .string()
+        .describe("Host arch: amd64/x86_64, arm64/aarch64, or arm."),
+      name: z
+        .string()
+        .optional()
+        .describe(
+          "Device name to register with (default: the host's hostname).",
+        ),
+      bridge_url: z
+        .string()
+        .optional()
+        .describe(
+          "Bridge base URL as reachable FROM the new host (e.g. https://100.64.0.7:19880). Default: derived from the bridge bind (wildcard binds use this host's first external IPv4).",
+        ),
+    },
+    execute: (params, bridge) => bridge("make_node_install_link", params),
     tag: "mesh",
   },
 ];

--- a/src/frontend/native/index.ts
+++ b/src/frontend/native/index.ts
@@ -1194,6 +1194,8 @@ export function createNativeFrontend(
     completeCommand: (body) => mesh.completeCommand(body),
     acceptFileUpload: (token, body) => mesh.acceptFileUpload(token, body),
     openFileDownload: (token) => mesh.openFileDownload(token),
+    openNodeInstall: (token) => mesh.openNodeInstall(token),
+    openNodeBinary: (token) => mesh.openNodeBinary(token),
   };
 
   const nativeCfg = config.native ?? { port: 19880, host: "127.0.0.1" };
@@ -1278,6 +1280,15 @@ export function createNativeFrontend(
       chats.restore();
       await server.start();
       const fingerprint = server.getFingerprint();
+      // Tell the mesh how this bridge is reachable — everything a generated
+      // node installer needs (make_node_install_link fails cleanly without it).
+      mesh.setBridgeInfo({
+        scheme: server.getScheme(),
+        host: bridgeHost,
+        port: server.getPort(),
+        ...(bridgeToken ? { token: bridgeToken } : {}),
+        ...(fingerprint ? { fingerprint } : {}),
+      });
       await writeBridgeDiscovery({
         port: server.getPort(),
         token: bridgeToken,
@@ -1297,6 +1308,7 @@ export function createNativeFrontend(
     async stop() {
       unregisterMeshTransport?.();
       unregisterMeshTransport = null;
+      mesh.setBridgeInfo(null);
       await removeBridgeDiscovery();
       await server.stop();
       await gateway.stop();

--- a/src/frontend/native/server.ts
+++ b/src/frontend/native/server.ts
@@ -142,6 +142,10 @@ export type BridgeServerHandlers = {
   openFileDownload(
     token: string,
   ): Promise<{ path: string; size: number } | null>;
+  /** Resolve a node-provisioning token to its installer script, or null. */
+  openNodeInstall(token: string): { script: string; filename: string } | null;
+  /** Resolve a node-provisioning token to the binary to stream, or null. */
+  openNodeBinary(token: string): { path: string; size: number } | null;
 };
 
 const SSE_PING_MS = 25_000;
@@ -375,6 +379,45 @@ export class BridgeServer {
         activeChats: s.activeChats,
         capabilities: ["mesh", "mesh-commands", "mesh-file-stream"],
       });
+    }
+
+    // Node provisioning runs PRE-AUTH by design: the target host holds no
+    // bridge credential yet — the single-use grant token (minted by
+    // make_node_install_link, expiring, one serve per leg) is the entire
+    // authorization, the same trust model as streamed-transfer tokens.
+    if (
+      method === "GET" &&
+      (path === "/node/install" || path === "/node/binary")
+    ) {
+      const token = url.searchParams.get("provision") ?? "";
+      const unknown = () =>
+        this.json(res, 404, {
+          ok: false,
+          error: "Unknown, expired, or already-used provisioning token",
+        });
+      if (!token) return unknown();
+      if (path === "/node/install") {
+        const install = this.handlers.openNodeInstall(token);
+        if (!install) return unknown();
+        res.writeHead(200, {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${install.filename}"`,
+          ...this.corsHeaders(),
+        });
+        res.end(install.script);
+        return;
+      }
+      const binary = this.handlers.openNodeBinary(token);
+      if (!binary) return unknown();
+      res.writeHead(200, {
+        "Content-Type": "application/octet-stream",
+        "Content-Length": String(binary.size),
+        ...this.corsHeaders(),
+      });
+      const stream = createReadStream(binary.path);
+      stream.on("error", () => res.destroy());
+      stream.pipe(res);
+      return;
     }
 
     if (auth !== "ok") {

--- a/src/util/version.ts
+++ b/src/util/version.ts
@@ -1,0 +1,16 @@
+/**
+ * The daemon's own release version, as a runtime value.
+ *
+ * A JSON import (not an fs read) so every packaging shape agrees: tsx and
+ * Node resolve the file, and `bun build --compile` inlines it into the
+ * standalone binary, where no package.json exists on disk. This is the
+ * version the node-binary resolver keys caches and release-asset URLs on,
+ * so it must exactly match the published tag (publish.yml verifies that).
+ */
+
+import pkg from "../../package.json" with { type: "json" };
+
+/** Talon's semver (e.g. "3.3.0") — the release identity of this build. */
+export function talonVersion(): string {
+  return pkg.version;
+}


### PR DESCRIPTION
## Why

Prebuilt Talon installs (npm / deb / standalone) could not deploy or update headless mesh nodes: `update_node` required a binary the operator had cross-compiled from a source checkout with a Go toolchain, and there was no onboarding story for fresh hosts at all. Worse, the release pipeline that was supposed to attach `talon-node-*` binaries to every release has been silently broken — **both v3.2.0 and v3.3.0 shipped with zero node assets** because the `version.txt` drift guard killed the release-triggered build (the stale-release-PR race: the release PR was cut before the sync mechanism landed).

## What

**Daemon — binary resolver (`core/mesh/node-binaries.ts`)**
Materializes a talon-node binary for any supported target (6-target matrix), trying in order:
1. **source build** — dev checkout + Go on PATH: cross-compile `apps/node`, stamped `<version>+<sha>` (keeps today's bot flow, always fresh);
2. **cache** — `~/.talon/node-bin/<talon-version>/`, digest-re-verified on every hit, stale versions pruned;
3. **release download** — the GitHub release matching the daemon's own version, verified against the new `talon-node-SHA256SUMS` asset.

Version lock is structural: cache keys and asset URLs derive from `talonVersion()` (new `util/version.ts`, JSON-imported so bun-compiled binaries agree with the tag).

**Daemon — tool surface**
- `update_node(device)` — `binary_path` now optional; the daemon auto-resolves from the node's registered platform/arch.
- `get_node_binary(os, arch)` — stage a binary on the daemon host (for scp / `device_push_file`).
- `make_node_install_link(os, arch, name?, bridge_url?)` — mints a single-use, 30-min grant and returns a one-liner:
  ```sh
  curl -fsSk "https://<bridge>:19880/node/install?provision=<token>" | sh
  ```
  The bridge serves a generated installer (sh, or PowerShell for windows grants) over new **pre-auth** routes `GET /node/install` + `GET /node/binary` — the fresh host holds no credential yet, so the grant token is the entire authorization, same trust model as streamed-transfer tokens (random 192-bit, single-use per leg, expiring). The script downloads the binary from the same bridge, verifies its sha256 against the digest baked into the script, installs, pre-pins the bridge TLS fingerprint, embeds the bearer token, and registers the boot service.

**Node (Go)**
- Registration advertises `runtime.GOARCH`; the registry stores/surfaces it (`(linux/arm64)` in `list_devices`) — this is what makes auto-resolve possible.
- `tools/build` — platform-neutral Go replacement for the unix-only `build-all.sh` (now a thin wrapper): same matrix + ldflags stamp, plus the `talon-node-SHA256SUMS` manifest. Works on Windows.

**CI (`node.yml`)**
- `version.txt` drift guard is **PR-only** — on release events `package.json` IS the tag (publish.yml verifies it) and the build tool regenerates `version.txt` from it, so a raced release PR can never again ship a release with no node binaries.
- Release assets now include the checksum manifest the resolver verifies against.
- `apps/node/version.txt` refreshed 3.2.0 → 3.3.0 (the exact drift that broke both release builds).

## Notes

- The installer embeds the bridge bearer token (same trust level as companion pairing); per-device scoped tokens remain the known follow-up already noted in `docs/headless-node.md`.
- v3.3.0's missing release assets can be backfilled after this merges (build + `gh release upload v3.3.0`), or simply picked up by the next release.

## Verification

- `tsc --noEmit`, oxlint, dependency-cruiser (no new violations), ratchets (throws classified as `TalonError`), prettier, knip — all clean.
- Full vitest suite: **236 files / 4073 tests passed** (6 files / 42 tests skipped — the usual live-network suites).
- New suites: resolver tiers (cache verify, digest-checked download, corrupt-cache recovery, prune), provisioning grants (single-use legs, expiry, script content, name sanitization), bridge route security (pre-auth routes 404 on bad/missing tokens, serve on valid grant), mesh-service auto-resolve (+ arch registration, mobile refusal, loopback/no-bridge errors).
- Go: `gofmt`, `go vet`, `go test` clean; `go run ./tools/build` smoke-built linux+windows targets, binary reports `3.3.0+ec4ee0c`, manifest verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)