### PR TITLE
fix(ci): stop release-please ignoring its config file (release-type input override)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,10 +28,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # NO `release-type` input here, deliberately: release-please-action
+      # ignores config-file whenever release-type is passed (its code does
+      # `if (inputs.releaseType) Manifest.fromConfig(...)`), which silently
+      # disabled everything in release-please-config.json — including the
+      # extra-files bump of apps/node/version.txt — from the day the config
+      # was added. release-type lives in the config file instead.
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          release-type: node
           token: ${{ secrets.PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/apps/node/version.txt
+++ b/apps/node/version.txt
@@ -1,1 +1,1 @@
-3.3.0 # x-release-please-version
+3.4.0 # x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
   "draft-pull-request": false,
   "packages": {
     ".": {
-      "package-name": "talon",
+      "package-name": "talon-agent",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "generic", "path": "apps/node/version.txt" }


### PR DESCRIPTION
## Why

3.4.0 released without bumping `apps/node/version.txt` even though #608 configured an `extra-files` generic bump. Root cause found in the action source: **release-please-action ignores `config-file` entirely whenever the `release-type` input is set** (`if (inputs.releaseType) { Manifest.fromConfig(...) }` — [src/index.ts L92](https://github.com/googleapis/release-please-action/blob/v5/src/index.ts)). Our workflow passed both, so `release-please-config.json` has been dead config since it was added.

Proof from the 3.4.0 release-PR run log: it fetched only the default node-strategy files (package.json, package-lock, CHANGELOG, npm-shrinkwrap, samples/package.json) — never `apps/node/version.txt` — and searched releases under prefix `talon-agent` (package.json name), not the config's `package-name: "talon"`.

## What

- Remove the `release-type: node` action input (with a comment explaining why it must never come back); the config file already declares `release-type`.
- `package-name` `"talon"` → `"talon-agent"` so newly-active manifest mode keeps the exact component/branch/tag naming the action was already using (`release-please--branches--main--components--talon-agent`, plain `vX.Y.Z` tags) — zero behavioral drift beyond the config actually taking effect.
- Sync `apps/node/version.txt` to 3.4.0 (the bump release-please would have made), keeping the PR-time drift guard truthful until the next release PR exercises the now-active updater.

## Verification

The next release PR after this merges is the end-to-end test: it should now include an `apps/node/version.txt` bump alongside package.json. Side effect of the config taking effect: changelogs gain the configured sections (chore/docs/refactor/etc.) — that was #608's intent all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)