### PR TITLE
feat(frontend): frontend SDK — capability contract + self-registering frontend registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ index.ts                    Composition root
   +-- util/                 Config, logging, workspace, paths, time
 ```
 
-**Dependency rule:** `core/` imports nothing from `frontend/` or `backend/`. Frontends and backends depend on core types, never on each other. All five backends (Claude SDK, Kilo, OpenCode, Codex, OpenAI Agents) implement the same `Backend` capability interface from `core/agent-runtime/capabilities.ts`. Kilo and OpenCode additionally share the `remote-server/` infrastructure because they wrap forks of the same upstream HTTP agent server.
+**Dependency rule:** `core/` imports nothing from `frontend/` or `backend/`. Frontends and backends depend on core types, never on each other. All five backends (Claude SDK, Kilo, OpenCode, Codex, OpenAI Agents) implement the same `Backend` capability interface from `core/agent-runtime/capabilities.ts`. Frontends mirror this: each implements the `Frontend` contract from `core/frontend-runtime/capabilities.ts` and self-registers in the frontend registry (identity + chat-id routing in a descriptor, lazy `create` in a per-frontend `factory.ts`) — see [docs/frontends.md](docs/frontends.md). Kilo and OpenCode additionally share the `remote-server/` infrastructure because they wrap forks of the same upstream HTTP agent server.
 
 **Prompts:** everything the model reads at session start is assembled by `core/prompt/` from the files in `prompts/` — see [prompts/README.md](prompts/README.md) for the assembly order, file ownership (user-editable vs package-owned templates), and the per-backend delivery contracts.
 

--- a/docs/frontends.md
+++ b/docs/frontends.md
@@ -1,0 +1,126 @@
+# Frontend SDK — capability contract + registry
+
+> Status: **implemented**. The contract and registry landed as a
+> behavior-preserving refactor; every built-in frontend registers through
+> it. Plugin-loaded frontends use the same API (see "External frontends"
+> below for what still gates them).
+
+## Why
+
+Backends have had a real SDK shape for a while: one `Backend` capability
+interface (`core/agent-runtime/capabilities.ts`) and a self-registration
+registry (`core/agent-runtime/backend-registry.ts`) — adding a backend is
+one `factory.ts`, no bootstrap churn.
+
+Frontends had the interface (the `Frontend` type, formerly in
+`bootstrap.ts`) but not the registry. Frontend *identity* was smeared
+across four hand-maintained copies of the same if/else chain:
+
+| Concern | Lived in |
+| --- | --- |
+| Creation switch | `app.ts` (`switch (name)` over dynamic imports) |
+| Dispatch routing (chat id → live frontend) | `bootstrap.ts` `resolveFrontendName` |
+| Gateway action routing | `core/engine/gateway.ts` `resolveOwnedFrontendName` |
+| MCP tool scoping | `backend/shared/frontends.ts` `frontendForChatId` + literal `"terminal"` filters |
+
+Adding a frontend meant touching all four, and they could silently drift.
+
+## The model
+
+`core/frontend-runtime/` is the frontend counterpart of
+`core/agent-runtime`:
+
+```
+capabilities.ts   Frontend (runtime contract: init/start/stop, context,
+                  sendMessage/sendTyping, getBridgePort) and
+                  FrontendCreate ((config, gateway) → Frontend)
+registry.ts       id → FrontendDescriptor map + chat-id resolution.
+                  Self-contained: create functions are stored opaquely
+                  so routing-only consumers never import engine types.
+builtins.ts       The five built-in descriptors (identity only — no
+                  frontend implementation is imported from core).
+create.ts         The typed create seam: attachFrontendCreate,
+                  registerFrontend (plugin path), createFrontendById.
+routing.ts        Import surface for routing-only consumers (gateway,
+                  backend MCP scoping) — guarantees builtins are
+                  registered without pulling in the create seam.
+index.ts          Everything, for composition roots and factories.
+```
+
+A **descriptor** is cheap, static identity:
+
+```ts
+{
+  id: "discord",                    // matches config.frontend entries
+  label: "Discord",                 // logs / status output
+  ownsChatId: isDiscordChatId,      // chat-id shape convention
+  routePriority: 40,                // lower checks first; broad matchers last
+  messaging: true,                  // gets a per-frontend MCP tool server
+  sharesStdin: false,               // start() blocks on stdin (terminal only)
+}
+```
+
+The **create** half is attached separately by
+`src/frontend/<id>/factory.ts`, which dynamically imports the
+implementation — an unconfigured frontend costs nothing at boot:
+
+```ts
+attachFrontendCreate("discord", async (config, gateway) => {
+  const { createDiscordFrontend } = await import("./index.js");
+  return createDiscordFrontend(config, gateway);
+});
+```
+
+`src/frontend/factories.ts` is the side-effect barrel the composition
+roots import once.
+
+The split exists for layering: `core/` never imports `frontend/`, so
+descriptors register from core while create functions attach from the
+frontend layer. Everything that only needs "whose chat id is this?"
+works from descriptors alone.
+
+## Routing semantics (preserved from the old chains)
+
+- `resolveOwnerFrontendId(chatId)` — the messaging frontend owning a
+  chat id by shape, else null (heartbeat sentinel, one-shots, terminal).
+  This is the MCP-scoping flavour (`frontendForChatId`).
+- `resolveOwnerFrontendId(chatId, { includeNonMessaging: true })` — full
+  routing, terminal included (gateway flavour).
+- `resolveFrontendIdAmong(chatId, candidates)` — pick the live frontend
+  that serves a chat: single candidate wins; else the owner if
+  live; else the first messaging candidate, else the first (bootstrap
+  flavour).
+
+Two historical tie-breaks are encoded in `routePriority`: telegram's
+numeric matcher accepts almost anything so it runs last (90), and the
+terminal claims the legacy chat id `"1"` ahead of telegram (10).
+
+## Adding a built-in frontend
+
+1. Implement `createMyFrontend(config, gateway): Frontend` under
+   `src/frontend/my/`.
+2. Register the descriptor in `core/frontend-runtime/builtins.ts` (id,
+   label, chat-id matcher — add the predicate to `util/chat-id.ts`).
+3. Drop a `factory.ts` beside the implementation and list it in
+   `src/frontend/factories.ts`.
+4. Add the id to the config `frontendEnum` in `util/config.ts`.
+
+No changes to `app.ts`, `bootstrap.ts`, the gateway, or backend scoping.
+
+## External frontends
+
+`registerFrontend({ ...descriptor, create })` registers a complete
+frontend at runtime — the intended path for plugin frontends (Slack,
+Matrix, …). The registry, routing, creation, MCP tool scoping, and
+gateway all handle unknown ids already (the registry tests pin this
+with a synthetic `slack` frontend). What still gates a real frontend
+plugin:
+
+- the config schema's `frontendEnum` only admits built-in ids;
+- the plugin loader has no lifecycle step that imports frontend modules
+  before frontends are created;
+- per-frontend prompt flavours (`prompts/system/<id>.md`) and the
+  `FrontendScope` tool tags are still built-in-only vocabularies.
+
+Those are deliberate follow-ups — the seam they plug into is now one
+registry instead of four switch statements.

--- a/src/__tests__/frontend-registry.test.ts
+++ b/src/__tests__/frontend-registry.test.ts
@@ -81,7 +81,7 @@ describe("chat-id ownership (resolveOwnerFrontendId)", () => {
     ).toBe("terminal");
   });
 
-  it("terminal beats telegram for the legacy chat id \"1\"", () => {
+  it('terminal beats telegram for the legacy chat id "1"', () => {
     // "1" matches both the terminal's legacy id and telegram's numeric
     // matcher — routePriority must keep the historical terminal-first
     // order.

--- a/src/__tests__/frontend-registry.test.ts
+++ b/src/__tests__/frontend-registry.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Frontend registry — identity, chat-id routing, and the create seam.
+ *
+ * The registry replaces four hand-maintained copies of the frontend
+ * if/else chain (bootstrap resolution, gateway action routing, backend
+ * MCP scoping, app.ts creation switch); these tests pin the semantics
+ * those call sites relied on, including the two historical tie-breaks:
+ * telegram's numeric matcher runs last, and the terminal claims the
+ * legacy chat id "1".
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+
+import {
+  attachFrontendCreate,
+  createFrontendById,
+  getFrontendDescriptor,
+  hasFrontend,
+  listFrontends,
+  registerFrontend,
+  resetFrontendRegistry,
+  resolveFrontendIdAmong,
+  resolveOwnerFrontendId,
+  type Frontend,
+} from "../core/frontend-runtime/index.js";
+import {
+  frontendForChatId,
+  frontendsForChat,
+  nonTerminalFrontends,
+} from "../backend/shared/frontends.js";
+import type { TalonConfig } from "../util/config.js";
+import type { Gateway } from "../core/engine/gateway.js";
+
+afterEach(() => resetFrontendRegistry());
+
+describe("built-in descriptors", () => {
+  it("registers all five built-ins on import", () => {
+    expect(listFrontends().map((f) => f.id)).toEqual([
+      "discord",
+      "native",
+      "teams",
+      "telegram",
+      "terminal",
+    ]);
+  });
+
+  it("only the terminal is non-messaging and stdin-sharing", () => {
+    for (const f of listFrontends()) {
+      expect(f.messaging).toBe(f.id !== "terminal");
+      expect(f.sharesStdin === true).toBe(f.id === "terminal");
+    }
+  });
+
+  it("rejects duplicate registration", () => {
+    expect(() =>
+      registerFrontend({
+        id: "telegram",
+        label: "Imposter",
+        ownsChatId: () => true,
+        routePriority: 1,
+        messaging: true,
+        create: () => ({}) as Frontend,
+      }),
+    ).toThrow(/already registered/);
+  });
+});
+
+describe("chat-id ownership (resolveOwnerFrontendId)", () => {
+  it("classifies each built-in id shape", () => {
+    expect(resolveOwnerFrontendId("d_1751640000000_ab12cd")).toBe("native");
+    expect(resolveOwnerFrontendId("teams_chat_19:abc@thread.v2")).toBe("teams");
+    expect(resolveOwnerFrontendId("discord_guild_123_456")).toBe("discord");
+    expect(resolveOwnerFrontendId("-1001426819337")).toBe("telegram");
+    expect(resolveOwnerFrontendId("123456789")).toBe("telegram");
+  });
+
+  it("resolves terminal ids to null unless non-messaging is included", () => {
+    expect(resolveOwnerFrontendId("t_1751640000000")).toBeNull();
+    expect(
+      resolveOwnerFrontendId("t_1751640000000", { includeNonMessaging: true }),
+    ).toBe("terminal");
+  });
+
+  it("terminal beats telegram for the legacy chat id \"1\"", () => {
+    // "1" matches both the terminal's legacy id and telegram's numeric
+    // matcher — routePriority must keep the historical terminal-first
+    // order.
+    expect(resolveOwnerFrontendId("1", { includeNonMessaging: true })).toBe(
+      "terminal",
+    );
+    expect(resolveOwnerFrontendId("1")).toBe("telegram");
+  });
+
+  it("returns null for cross-surface contexts", () => {
+    expect(resolveOwnerFrontendId("heartbeat")).toBeNull();
+    expect(
+      resolveOwnerFrontendId("heartbeat", { includeNonMessaging: true }),
+    ).toBeNull();
+  });
+});
+
+describe("candidate resolution (resolveFrontendIdAmong)", () => {
+  it("a single candidate always wins", () => {
+    expect(resolveFrontendIdAmong("d_123", ["telegram"])).toBe("telegram");
+  });
+
+  it("the owning candidate wins", () => {
+    expect(resolveFrontendIdAmong("d_123", ["telegram", "native"])).toBe(
+      "native",
+    );
+    expect(resolveFrontendIdAmong("-100", ["telegram", "native"])).toBe(
+      "telegram",
+    );
+    expect(resolveFrontendIdAmong("1", ["telegram", "terminal"])).toBe(
+      "terminal",
+    );
+  });
+
+  it("falls back to the first messaging candidate", () => {
+    expect(
+      resolveFrontendIdAmong(undefined, ["terminal", "telegram", "native"]),
+    ).toBe("telegram");
+    expect(resolveFrontendIdAmong("heartbeat", ["terminal", "native"])).toBe(
+      "native",
+    );
+  });
+
+  it("falls back to the first candidate when none are messaging", () => {
+    expect(resolveFrontendIdAmong(undefined, ["terminal", "terminal"])).toBe(
+      "terminal",
+    );
+  });
+});
+
+describe("create seam", () => {
+  const config = {} as TalonConfig;
+  const gateway = {} as Gateway;
+
+  it("creates through an attached factory", async () => {
+    const instance = { name: "terminal" } as Frontend;
+    attachFrontendCreate("terminal", () => instance);
+    await expect(createFrontendById("terminal", config, gateway)).resolves.toBe(
+      instance,
+    );
+  });
+
+  it("rejects unknown ids with the known list", async () => {
+    await expect(createFrontendById("slack", config, gateway)).rejects.toThrow(
+      /Unknown frontend "slack".*discord, native, teams, telegram, terminal/,
+    );
+  });
+
+  it("rejects a descriptor with no factory attached", async () => {
+    await expect(
+      createFrontendById("telegram", config, gateway),
+    ).rejects.toThrow(/no factory attached/);
+  });
+
+  it("rejects attaching to an unknown id or twice", () => {
+    expect(() => attachFrontendCreate("slack", () => ({}) as Frontend)).toThrow(
+      /not registered/,
+    );
+    attachFrontendCreate("native", () => ({}) as Frontend);
+    expect(() =>
+      attachFrontendCreate("native", () => ({}) as Frontend),
+    ).toThrow(/already has a factory/);
+  });
+
+  it("registers a plugin frontend (descriptor + create in one call)", async () => {
+    const instance = { name: "slack" } as Frontend;
+    registerFrontend({
+      id: "slack",
+      label: "Slack",
+      ownsChatId: (id) => id.startsWith("slack_"),
+      routePriority: 50,
+      messaging: true,
+      create: () => instance,
+    });
+    expect(hasFrontend("slack")).toBe(true);
+    expect(resolveOwnerFrontendId("slack_C042")).toBe("slack");
+    expect(getFrontendDescriptor("slack")?.label).toBe("Slack");
+    await expect(createFrontendById("slack", config, gateway)).resolves.toBe(
+      instance,
+    );
+    // Built-in matchers still win by shape, unaffected by the addition.
+    expect(resolveOwnerFrontendId("d_123")).toBe("native");
+  });
+});
+
+describe("backend/shared/frontends.ts stays a thin view of the registry", () => {
+  it("nonTerminalFrontends filters by the messaging trait, keeps unknowns", () => {
+    expect(
+      nonTerminalFrontends(["telegram", "terminal", "native", "mystery"]),
+    ).toEqual(["telegram", "native", "mystery"]);
+    expect(nonTerminalFrontends("terminal")).toEqual([]);
+    expect(nonTerminalFrontends(undefined)).toEqual([]);
+  });
+
+  it("frontendForChatId matches registry ownership", () => {
+    expect(frontendForChatId("d_1")).toBe("native");
+    expect(frontendForChatId("t_1")).toBeNull();
+    expect(frontendForChatId("heartbeat")).toBeNull();
+  });
+
+  it("frontendsForChat scopes to a registered plugin frontend too", () => {
+    registerFrontend({
+      id: "slack",
+      label: "Slack",
+      ownsChatId: (id) => id.startsWith("slack_"),
+      routePriority: 50,
+      messaging: true,
+      create: () => ({}) as Frontend,
+    });
+    expect(frontendsForChat("slack_C042", ["telegram", "slack"])).toEqual([
+      "slack",
+    ]);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -31,7 +31,15 @@ import {
 } from "./core/vfs/index.js";
 import { bootstrap, initBackendAndDispatcher } from "./bootstrap.js";
 import { Gateway } from "./core/engine/gateway.js";
+import {
+  createFrontendById,
+  getFrontendDescriptor,
+} from "./core/frontend-runtime/index.js";
 import type { Frontend } from "./bootstrap.js";
+// Attach every built-in frontend's create() to its registry descriptor.
+// Adding a frontend is strictly additive: drop a factory.ts under the
+// new frontend dir and list it in frontend/factories.ts.
+import "./frontend/factories.js";
 
 // ── Bootstrap ────────────────────────────────────────────────────────────────
 
@@ -55,45 +63,13 @@ gateway.onStarted((port) =>
 );
 gateway.onShutdownRequest((reason) => void gracefulShutdown(reason));
 
-const configuredFrontends = [
-  ...new Set(getFrontends(config)),
-] as Frontend["name"][];
-
-async function createFrontend(name: Frontend["name"]): Promise<Frontend> {
-  switch (name) {
-    case "terminal": {
-      const { createTerminalFrontend } =
-        await import("./frontend/terminal/index.js");
-      return createTerminalFrontend(config, gateway);
-    }
-    case "teams": {
-      const { createTeamsFrontend } = await import("./frontend/teams/index.js");
-      return createTeamsFrontend(config, gateway);
-    }
-    case "discord": {
-      const { createDiscordFrontend } =
-        await import("./frontend/discord/index.js");
-      return createDiscordFrontend(config, gateway);
-    }
-    case "native": {
-      const { createNativeFrontend } =
-        await import("./frontend/native/index.js");
-      return createNativeFrontend(config, gateway);
-    }
-    case "telegram":
-    default: {
-      const { createTelegramFrontend } =
-        await import("./frontend/telegram/index.js");
-      return createTelegramFrontend(config, gateway);
-    }
-  }
-}
+const configuredFrontends = [...new Set(getFrontends(config))];
 
 const frontends: Frontend[] = [];
 for (const name of configuredFrontends) {
-  const frontend = await createFrontend(name);
+  const frontend = await createFrontendById(name, config, gateway);
   frontends.push(frontend);
-  log("bot", `Frontend: ${name[0].toUpperCase()}${name.slice(1)}`);
+  log("bot", `Frontend: ${getFrontendDescriptor(name)?.label ?? name}`);
 }
 
 // ── Create backend + wire dispatcher ─────────────────────────────────────────
@@ -249,20 +225,22 @@ async function main(): Promise<void> {
   startWatchdog(config.workspace);
   startUploadCleanup(config.workspace);
 
-  const terminalFrontends = frontends.filter(
-    (frontend) => frontend.name === "terminal",
+  // A stdin-reading frontend (terminal) blocks in start() for the
+  // process lifetime — run it without awaiting alongside the others.
+  const stdinFrontends = frontends.filter(
+    (frontend) => getFrontendDescriptor(frontend.name)?.sharesStdin === true,
   );
   const blockingFrontends = frontends.filter(
-    (frontend) => frontend.name !== "terminal",
+    (frontend) => !stdinFrontends.includes(frontend),
   );
-  if (terminalFrontends.length > 0 && frontends.length > 1) {
+  if (stdinFrontends.length > 0 && frontends.length > 1) {
     log(
       "bot",
       "Terminal frontend shares stdin with the other frontends; it will run alongside them without blocking startup.",
     );
   }
   await Promise.all(blockingFrontends.map((frontend) => frontend.start()));
-  for (const frontend of terminalFrontends) {
+  for (const frontend of stdinFrontends) {
     void frontend
       .start()
       .catch((err) =>

--- a/src/backend/shared/frontends.ts
+++ b/src/backend/shared/frontends.ts
@@ -2,44 +2,41 @@
  * Frontend-list helpers shared across backends.
  *
  * Every backend needs "which frontends get an MCP tool server?" at
- * spawn time; before this helper, claude-sdk, openai-agents, and codex
- * each carried their own copy of the same normalise-and-filter logic.
+ * spawn time. Identity, chat-id ownership, and the messaging trait are
+ * owned by the frontend registry (`core/frontend-runtime`) — these
+ * helpers are thin views over it, kept for their call-site-friendly
+ * shapes.
  */
 
 import {
-  isNativeChatId,
-  isTeamsChatId,
-  isDiscordChatId,
-  isTelegramChatId,
-} from "../../util/chat-id.js";
+  getFrontendDescriptor,
+  resolveOwnerFrontendId,
+} from "../../core/frontend-runtime/routing.js";
 
 /**
  * Normalise a config `frontend` value (string or array, possibly
  * undefined) to the list of messaging frontends — i.e. those that
  * need an MCP tool server spawned. `terminal` is excluded: it has no
- * outbound messaging surface (the agent runs to stdout).
+ * outbound messaging surface (the agent runs to stdout). Unknown ids
+ * are kept — an unregistered frontend must fail loudly downstream,
+ * not silently lose its tools.
  */
 export function nonTerminalFrontends(
   frontend: string | readonly string[] | undefined,
 ): readonly string[] {
   if (!frontend) return [];
   const all = Array.isArray(frontend) ? frontend : [frontend as string];
-  return all.filter((f) => f !== "terminal");
+  return all.filter((f) => getFrontendDescriptor(f)?.messaging !== false);
 }
 
 /**
  * The messaging frontend that owns a chat, inferred from the chat-id
- * shape (the same convention the gateway uses to route actions):
- * native `d_*`, teams `teams_chat_*`, discord `discord_*`, telegram
- * numeric. Returns null for cross-surface contexts — the heartbeat
+ * shape (the same registry matchers the gateway uses to route
+ * actions). Returns null for cross-surface contexts — the heartbeat
  * sentinel, isolated one-shots, terminal sessions.
  */
 export function frontendForChatId(chatId: string): string | null {
-  if (isNativeChatId(chatId)) return "native";
-  if (isTeamsChatId(chatId)) return "teams";
-  if (isDiscordChatId(chatId)) return "discord";
-  if (isTelegramChatId(chatId)) return "telegram";
-  return null;
+  return resolveOwnerFrontendId(chatId);
 }
 
 /**

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -34,70 +34,37 @@ import { initDream, maybeStartDream } from "./core/background/dream.js";
 import { initHeartbeat } from "./core/background/heartbeat/index.js";
 import { log, logWarn, logDebug } from "./util/log.js";
 import type { TalonConfig } from "./util/config.js";
-import {
-  isNativeChatId,
-  isDiscordChatId,
-  isTelegramChatId,
-  isTerminalChatId,
-  isTeamsChatId,
-} from "./util/chat-id.js";
+import { resolveFrontendIdAmong } from "./core/frontend-runtime/routing.js";
+import type { Frontend } from "./core/frontend-runtime/index.js";
 import type { ContextManager } from "./core/types.js";
 import type { Backend } from "./core/agent-runtime/capabilities.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-export type Frontend = {
-  name: "telegram" | "terminal" | "teams" | "discord" | "native";
-  context: ContextManager;
-  sendTyping: (chatId: number) => Promise<void>;
-  sendMessage: (chatId: number, text: string) => Promise<void>;
-  getBridgePort: () => number;
-  init: () => Promise<void>;
-  start: () => Promise<void>;
-  stop: () => Promise<void>;
-};
+// The Frontend contract moved to core/frontend-runtime/capabilities.ts
+// (the frontend counterpart of agent-runtime). Re-exported so existing
+// importers keep working.
+export type { Frontend } from "./core/frontend-runtime/index.js";
 
 type FrontendSelection = Frontend | Frontend[];
 
 function normalizeFrontends(frontend: FrontendSelection): Frontend[] {
   const list = Array.isArray(frontend) ? frontend : [frontend];
-  const byName = new Map<Frontend["name"], Frontend>();
+  const byName = new Map<string, Frontend>();
   for (const item of list) byName.set(item.name, item);
   return [...byName.values()];
-}
-
-function resolveFrontendName(
-  chatId: string | undefined,
-  frontends: Frontend[],
-): Frontend["name"] {
-  if (frontends.length === 1) return frontends[0].name;
-  if (chatId) {
-    if (
-      isTerminalChatId(chatId) &&
-      frontends.some((f) => f.name === "terminal")
-    )
-      return "terminal";
-    if (isNativeChatId(chatId) && frontends.some((f) => f.name === "native"))
-      return "native";
-    if (isTeamsChatId(chatId) && frontends.some((f) => f.name === "teams"))
-      return "teams";
-    if (isDiscordChatId(chatId) && frontends.some((f) => f.name === "discord"))
-      return "discord";
-    if (
-      isTelegramChatId(chatId) &&
-      frontends.some((f) => f.name === "telegram")
-    )
-      return "telegram";
-  }
-  const firstNonTerminal = frontends.find((f) => f.name !== "terminal");
-  return firstNonTerminal?.name ?? frontends[0].name;
 }
 
 function resolveFrontend(
   chatId: string | undefined,
   frontends: Frontend[],
 ): Frontend {
-  const name = resolveFrontendName(chatId, frontends);
+  // Chat-id ownership and fallback order live in the frontend registry
+  // (one source of truth shared with gateway routing and MCP scoping).
+  const name = resolveFrontendIdAmong(
+    chatId,
+    frontends.map((f) => f.name),
+  );
   const resolved = frontends.find((frontend) => frontend.name === name);
   if (!resolved) {
     throw new Error(`No frontend available for ${chatId ?? "unknown chat"}`);

--- a/src/cli/chat.ts
+++ b/src/cli/chat.ts
@@ -9,8 +9,9 @@ export async function startChat(): Promise<void> {
   const { bootstrap, initBackendAndDispatcher } =
     await import("../bootstrap.js");
   const { flushDatabase } = await import("../storage/db.js");
-  const { createTerminalFrontend } =
-    await import("../frontend/terminal/index.js");
+  const { createFrontendById } =
+    await import("../core/frontend-runtime/index.js");
+  await import("../frontend/terminal/factory.js");
   const { Gateway } = await import("../core/engine/gateway.js");
 
   const { config } = await bootstrap({ frontendNames: ["terminal"] });
@@ -25,7 +26,7 @@ export async function startChat(): Promise<void> {
   rebuildSystemPrompt(config, getPluginPromptAdditions());
 
   const gateway = new Gateway("chat");
-  const frontend = createTerminalFrontend(config, gateway);
+  const frontend = await createFrontendById("terminal", config, gateway);
   await frontend.init();
   const { backend } = await initBackendAndDispatcher(config, frontend);
   gateway.backend = backend;

--- a/src/core/agent-runtime/backend-registry.ts
+++ b/src/core/agent-runtime/backend-registry.ts
@@ -34,9 +34,13 @@ import type { TalonConfig } from "../../util/config.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
-/** Frontend identifiers that can be passed to a backend's init step. */
-export type FrontendName =
-  "telegram" | "terminal" | "teams" | "discord" | "native";
+/**
+ * Frontend identifier passed to a backend's init step. An open set:
+ * ids come from the frontend registry (`core/frontend-runtime`), where
+ * the built-ins (telegram, terminal, teams, discord, native) register
+ * their descriptors and plugin frontends can add more.
+ */
+export type FrontendName = string;
 
 /** Per-init context — runtime dependencies the backend may need at startup. */
 export interface BackendInitContext {

--- a/src/core/engine/gateway.ts
+++ b/src/core/engine/gateway.ts
@@ -32,13 +32,7 @@ import { taskTable } from "../tasks/index.js";
 import type { FrontendActionHandler } from "../types.js";
 import { BOT_MESSAGE_ACTIONS, noteBotMessage } from "../soul/taps.js";
 import type { Backend } from "../agent-runtime/capabilities.js";
-import {
-  isNativeChatId,
-  isDiscordChatId,
-  isTelegramChatId,
-  isTerminalChatId,
-  isTeamsChatId,
-} from "../../util/chat-id.js";
+import { resolveOwnerFrontendId } from "../frontend-runtime/routing.js";
 
 // ── Retry helper (stateless — standalone export) ─────────────────────────────
 
@@ -169,12 +163,9 @@ export class Gateway {
   ): string | null {
     const owned = this.chatFrontendOwners.get(chatId);
     if (owned) return owned;
-    if (isTerminalChatId(rawChatId)) return "terminal";
-    if (isNativeChatId(rawChatId)) return "native";
-    if (isTeamsChatId(rawChatId)) return "teams";
-    if (isDiscordChatId(rawChatId)) return "discord";
-    if (isTelegramChatId(rawChatId)) return "telegram";
-    return null;
+    // Shape-convention fallback — the frontend registry owns chat-id
+    // matchers, including any registered at runtime.
+    return resolveOwnerFrontendId(rawChatId, { includeNonMessaging: true });
   }
 
   private resolveFrontendHandler(

--- a/src/core/frontend-runtime/builtins.ts
+++ b/src/core/frontend-runtime/builtins.ts
@@ -1,0 +1,69 @@
+/**
+ * Built-in frontend descriptors.
+ *
+ * Identity only — no frontend implementation is imported here (core
+ * never imports frontend/). The heavy `create` half of each built-in is
+ * attached by `src/frontend/<id>/factory.ts` when the composition root
+ * imports `src/frontend/factories.ts`.
+ *
+ * Chat-id shapes are the long-standing conventions from
+ * `util/chat-id.ts`. Priorities encode the historical resolution order
+ * (terminal, native, teams, discord, telegram) — load-bearing in two
+ * places: telegram's numeric matcher is a near-catch-all so it must run
+ * last, and the terminal claims the legacy chat id "1" that telegram's
+ * matcher would also accept.
+ */
+
+import {
+  registerFrontendDescriptor as registerFrontend,
+  setBuiltinRegistrar,
+} from "./registry.js";
+import {
+  isDiscordChatId,
+  isNativeChatId,
+  isTeamsChatId,
+  isTelegramChatId,
+  isTerminalChatId,
+} from "../../util/chat-id.js";
+
+function registerBuiltinFrontends(): void {
+  registerFrontend({
+    id: "terminal",
+    label: "Terminal",
+    ownsChatId: isTerminalChatId,
+    routePriority: 10,
+    messaging: false,
+    sharesStdin: true,
+  });
+  registerFrontend({
+    id: "native",
+    label: "Native",
+    ownsChatId: isNativeChatId,
+    routePriority: 20,
+    messaging: true,
+  });
+  registerFrontend({
+    id: "teams",
+    label: "Teams",
+    ownsChatId: isTeamsChatId,
+    routePriority: 30,
+    messaging: true,
+  });
+  registerFrontend({
+    id: "discord",
+    label: "Discord",
+    ownsChatId: isDiscordChatId,
+    routePriority: 40,
+    messaging: true,
+  });
+  registerFrontend({
+    id: "telegram",
+    label: "Telegram",
+    ownsChatId: isTelegramChatId,
+    routePriority: 90,
+    messaging: true,
+  });
+}
+
+setBuiltinRegistrar(registerBuiltinFrontends);
+registerBuiltinFrontends();

--- a/src/core/frontend-runtime/capabilities.ts
+++ b/src/core/frontend-runtime/capabilities.ts
@@ -1,0 +1,62 @@
+/**
+ * Frontend capability contract — the frontend counterpart of
+ * `core/agent-runtime/capabilities.ts`.
+ *
+ * A frontend is a chat surface (Telegram, Discord, Teams, the terminal,
+ * the native client bridge, …) that receives user messages and delivers
+ * the agent's replies. Every frontend implements the same `Frontend`
+ * runtime interface and describes itself with a `FrontendDescriptor` in
+ * the frontend registry (`registry.ts`), so the engine can create, route
+ * to, and reason about frontends without knowing any concrete one.
+ *
+ * The contract is split in two on purpose:
+ *
+ *   - `FrontendDescriptor` (defined in `registry.ts`) — cheap, static
+ *     identity: id, label, chat-id ownership, routing traits.
+ *     Descriptors for the built-ins register from core (`builtins.ts`)
+ *     so every subsystem that only needs "whose chat id is this?"
+ *     (gateway routing, MCP tool scoping, dispatcher context) can
+ *     consult the registry without loading any frontend implementation.
+ *   - `FrontendCreate` — the heavy part. Attached separately by each
+ *     frontend's `factory.ts` (frontend layer), which dynamically
+ *     imports the implementation only when that frontend is actually
+ *     configured. Plugin frontends register a descriptor and create
+ *     function together at runtime (`registerFrontend` in `create.ts`).
+ */
+
+import type { ContextManager } from "../types.js";
+import type { TalonConfig } from "../../util/config.js";
+import type { Gateway } from "../engine/gateway.js";
+import type { FrontendDescriptor } from "./registry.js";
+
+/**
+ * The runtime interface every frontend implements (moved here from
+ * `bootstrap.ts`; `bootstrap.ts` re-exports it for existing importers).
+ * Lifecycle: `create → init → start → stop`.
+ */
+export type Frontend = {
+  /** Registry id of the frontend that created this instance. */
+  name: string;
+  context: ContextManager;
+  sendTyping: (chatId: number) => Promise<void>;
+  sendMessage: (chatId: number, text: string) => Promise<void>;
+  getBridgePort: () => number;
+  init: () => Promise<void>;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+};
+
+/**
+ * Creates the runtime instance for a frontend. Implementations should
+ * dynamically import their heavy dependencies here so an unconfigured
+ * frontend costs nothing at boot.
+ */
+export type FrontendCreate = (
+  config: TalonConfig,
+  gateway: Gateway,
+) => Frontend | Promise<Frontend>;
+
+/** A fully-registered frontend: identity plus the factory. */
+export type FrontendFactory = FrontendDescriptor & { create: FrontendCreate };
+
+export type { FrontendDescriptor } from "./registry.js";

--- a/src/core/frontend-runtime/create.ts
+++ b/src/core/frontend-runtime/create.ts
@@ -1,0 +1,65 @@
+/**
+ * The typed create seam of the frontend registry.
+ *
+ * `registry.ts` stores create functions opaquely so routing-only
+ * consumers (gateway, backend MCP scoping) never import engine types;
+ * this module narrows them back to the `FrontendCreate` contract for
+ * the two parties that do care: frontend `factory.ts` modules
+ * (attach) and the composition roots (create).
+ */
+
+import type {
+  Frontend,
+  FrontendCreate,
+  FrontendFactory,
+} from "./capabilities.js";
+import { TalonError } from "../errors.js";
+import {
+  attachOpaqueCreate,
+  getOpaqueCreate,
+  hasFrontend,
+  knownIds,
+  registerFrontendDescriptor,
+} from "./registry.js";
+
+/**
+ * Attach the create function to an already-registered descriptor. Each
+ * built-in frontend's `factory.ts` calls this; importing that module is
+ * what makes the frontend creatable.
+ */
+export function attachFrontendCreate(id: string, create: FrontendCreate): void {
+  attachOpaqueCreate(id, create);
+}
+
+/**
+ * Register a complete frontend — descriptor and create together. The
+ * one-call path for plugin frontends.
+ */
+export function registerFrontend(factory: FrontendFactory): void {
+  const { create, ...descriptor } = factory;
+  registerFrontendDescriptor(descriptor, create);
+}
+
+/**
+ * Create a frontend instance by id. Throws when the id is unknown or
+ * its factory module was never imported — both are wiring bugs worth a
+ * loud, early failure.
+ */
+export async function createFrontendById(
+  id: string,
+  ...args: Parameters<FrontendCreate>
+): Promise<Frontend> {
+  if (!hasFrontend(id)) {
+    throw new TalonError(`Unknown frontend "${id}" (known: ${knownIds()})`, {
+      reason: "bad_request",
+    });
+  }
+  const create = getOpaqueCreate(id) as FrontendCreate | undefined;
+  if (!create) {
+    throw new TalonError(
+      `Frontend "${id}" has no factory attached — is its factory module imported?`,
+      { reason: "bad_request" },
+    );
+  }
+  return create(...args);
+}

--- a/src/core/frontend-runtime/index.ts
+++ b/src/core/frontend-runtime/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Frontend runtime — capability contract + registry (the frontend
+ * counterpart of `core/agent-runtime`). Import THIS module, not
+ * `registry.js` directly: loading it guarantees the built-in
+ * descriptors are registered. Routing-only consumers inside the engine
+ * import `routing.js` instead, which offers the same guarantee without
+ * the engine-typed create seam.
+ */
+
+import "./builtins.js";
+
+export type {
+  Frontend,
+  FrontendCreate,
+  FrontendDescriptor,
+  FrontendFactory,
+} from "./capabilities.js";
+export {
+  getFrontendDescriptor,
+  hasFrontend,
+  listFrontends,
+  resetFrontendRegistry,
+  resolveFrontendIdAmong,
+  resolveOwnerFrontendId,
+} from "./registry.js";
+export {
+  attachFrontendCreate,
+  createFrontendById,
+  registerFrontend,
+} from "./create.js";

--- a/src/core/frontend-runtime/registry.ts
+++ b/src/core/frontend-runtime/registry.ts
@@ -1,0 +1,223 @@
+/**
+ * Frontend registry — the frontend counterpart of
+ * `core/agent-runtime/backend-registry.ts`.
+ *
+ * One typed `id → descriptor` map that owns two things the codebase
+ * used to hardcode in parallel chains (bootstrap dispatch routing,
+ * gateway action routing, backend MCP tool scoping, the composition
+ * root's creation switch):
+ *
+ *   1. **Identity + chat-id ownership.** "Whose chat id is this?" is
+ *      answered once, here, from the registered descriptors' matchers in
+ *      `routePriority` order — instead of five copies of the same
+ *      if/else chain drifting apart.
+ *   2. **Creation.** The composition root looks a frontend up by id and
+ *      calls its attached create — adding a frontend means one new
+ *      `factory.ts`, no switch churn.
+ *
+ * Registration is split to respect layering (core never imports
+ * frontend/): built-in *descriptors* register from core
+ * (`builtins.ts`), and each frontend's `factory.ts` attaches the heavy
+ * create via `attachFrontendCreate` (`create.ts`). External plugin
+ * frontends register descriptor + create in one call with
+ * `registerFrontend`.
+ *
+ * This module is deliberately self-contained (no imports from
+ * `capabilities.ts` or the engine): the create function is stored
+ * opaquely here and typed at the `create.ts` seam, so routing-only
+ * consumers (gateway, backend MCP scoping) never pull the engine types
+ * into an import cycle.
+ *
+ * The registry is module-scoped; `resetFrontendRegistry()` restores the
+ * built-in descriptors for test isolation.
+ */
+
+import { TalonError } from "../errors.js";
+
+/**
+ * Static identity + routing traits for one frontend. Registered before
+ * config is even loaded, so it must stay dependency-light: no SDK
+ * imports, no I/O — predicates and flags only.
+ */
+export type FrontendDescriptor = {
+  /** Stable identifier — matches `config.frontend` entries. */
+  id: string;
+  /** Display label for logs and status output (e.g. "Telegram"). */
+  label: string;
+  /**
+   * Whether this frontend owns a chat id, by its id-shape convention
+   * (native `d_*`, teams `teams_chat_*`, discord `discord_*`, telegram
+   * numeric, terminal `t_*`). Shapes should be disjoint; where two
+   * matchers could overlap, `routePriority` breaks the tie.
+   */
+  ownsChatId: (chatId: string) => boolean;
+  /**
+   * Tie-break order for chat-id resolution — lower checks first. Broad
+   * matchers (telegram accepts any numeric id) belong at the high end
+   * so specific shapes always win.
+   */
+  routePriority: number;
+  /**
+   * Has an outbound messaging surface — i.e. gets a per-frontend MCP
+   * tool server (`<id>-tools`) so the model can address the surface
+   * explicitly. False for the terminal: the agent runs to stdout and
+   * has nothing to deliver out-of-band.
+   */
+  messaging: boolean;
+  /**
+   * Reads stdin interactively, so `start()` blocks for the process
+   * lifetime. The composition root starts such frontends without
+   * awaiting them when they run alongside others.
+   */
+  sharesStdin?: boolean;
+};
+
+/**
+ * The create function as stored here: opaque. `create.ts` narrows it
+ * back to the typed `FrontendCreate` — keeping engine types out of
+ * this module so routing-only importers stay cycle-free.
+ */
+type OpaqueCreate = (...args: never[]) => unknown;
+
+type Entry = FrontendDescriptor & { create?: OpaqueCreate };
+
+const frontends = new Map<string, Entry>();
+
+/**
+ * Register a frontend descriptor (optionally with a create function
+ * already attached, as plugin frontends do via `registerFrontend` in
+ * `create.ts`). Throws on duplicate id — fail at startup rather than
+ * silently shadowing an implementation.
+ */
+export function registerFrontendDescriptor(
+  descriptor: FrontendDescriptor,
+  create?: OpaqueCreate,
+): void {
+  if (frontends.has(descriptor.id)) {
+    throw new TalonError(
+      `Frontend "${descriptor.id}" already registered — duplicate registration`,
+      { reason: "bad_request" },
+    );
+  }
+  frontends.set(descriptor.id, { ...descriptor, create });
+}
+
+/** @internal typed seam in create.ts — use `attachFrontendCreate`. */
+export function attachOpaqueCreate(id: string, create: OpaqueCreate): void {
+  const entry = frontends.get(id);
+  if (!entry) {
+    throw new TalonError(
+      `Cannot attach factory: frontend "${id}" is not registered ` +
+        `(known: ${knownIds()})`,
+      { reason: "bad_request" },
+    );
+  }
+  if (entry.create) {
+    throw new TalonError(`Frontend "${id}" already has a factory attached`, {
+      reason: "bad_request",
+    });
+  }
+  entry.create = create;
+}
+
+/** @internal typed seam in create.ts — use `createFrontendById`. */
+export function getOpaqueCreate(id: string): OpaqueCreate | undefined {
+  return frontends.get(id)?.create;
+}
+
+/** Look up a frontend descriptor by id. */
+export function getFrontendDescriptor(
+  id: string,
+): FrontendDescriptor | undefined {
+  return frontends.get(id);
+}
+
+/** Whether a frontend with this id is registered. */
+export function hasFrontend(id: string): boolean {
+  return frontends.has(id);
+}
+
+/** All registered descriptors, sorted by id for deterministic output. */
+export function listFrontends(): FrontendDescriptor[] {
+  return [...frontends.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** @internal error-message helper shared with create.ts. */
+export function knownIds(): string {
+  return [...frontends.keys()].sort().join(", ") || "none";
+}
+
+/**
+ * The frontend that owns a chat id by shape convention, or null for
+ * cross-surface contexts (the heartbeat sentinel, isolated one-shots).
+ * Matchers run in `routePriority` order so specific shapes beat broad
+ * ones (telegram's numeric matcher accepts almost anything).
+ *
+ * By default only messaging frontends are considered — the historical
+ * `frontendForChatId` contract used for MCP tool scoping, where
+ * terminal sessions deliberately resolve to null. Pass
+ * `includeNonMessaging: true` for full routing (gateway actions,
+ * dispatch), where terminal ids resolve to the terminal.
+ */
+export function resolveOwnerFrontendId(
+  chatId: string,
+  opts: { includeNonMessaging?: boolean } = {},
+): string | null {
+  for (const entry of byPriority()) {
+    if (!opts.includeNonMessaging && !entry.messaging) continue;
+    if (entry.ownsChatId(chatId)) return entry.id;
+  }
+  return null;
+}
+
+/**
+ * Pick the frontend that should serve a chat from a set of live
+ * candidates (the configured frontends of this process). Semantics
+ * preserved from the old bootstrap chain: a single candidate always
+ * wins; otherwise the chat id's owner wins when it is a candidate;
+ * otherwise fall back to the first messaging candidate (a stdin
+ * frontend must not swallow cross-surface work), else the first.
+ */
+export function resolveFrontendIdAmong(
+  chatId: string | undefined,
+  candidates: readonly string[],
+): string | undefined {
+  if (candidates.length === 0) return undefined;
+  if (candidates.length === 1) return candidates[0];
+  if (chatId) {
+    for (const entry of byPriority()) {
+      if (!candidates.includes(entry.id)) continue;
+      if (entry.ownsChatId(chatId)) return entry.id;
+    }
+  }
+  const messaging = candidates.find(
+    (id) => frontends.get(id)?.messaging !== false,
+  );
+  return messaging ?? candidates[0];
+}
+
+/**
+ * Restore the registry to just the built-in descriptors. Test-only
+ * utility — production code should never call this.
+ */
+export function resetFrontendRegistry(): void {
+  frontends.clear();
+  registerBuiltinFrontendsInternal();
+}
+
+// ── Internal ────────────────────────────────────────────────────────────────
+
+function byPriority(): Entry[] {
+  return [...frontends.values()].sort(
+    (a, b) => a.routePriority - b.routePriority,
+  );
+}
+
+// Injected by builtins.ts at module-load time (avoids an import cycle:
+// builtins imports registerFrontendDescriptor from here).
+let registerBuiltinFrontendsInternal: () => void = () => {};
+
+/** @internal wiring for builtins.ts — not part of the public API. */
+export function setBuiltinRegistrar(fn: () => void): void {
+  registerBuiltinFrontendsInternal = fn;
+}

--- a/src/core/frontend-runtime/routing.ts
+++ b/src/core/frontend-runtime/routing.ts
@@ -1,0 +1,16 @@
+/**
+ * Chat-id routing view of the frontend registry, for consumers that
+ * only need "whose chat id is this?" (gateway action routing, backend
+ * MCP tool scoping, dispatch resolution). Importing this module — not
+ * `registry.js` directly — guarantees the built-in descriptors are
+ * registered, without pulling in the engine-typed create seam.
+ */
+
+import "./builtins.js";
+
+export {
+  getFrontendDescriptor,
+  resolveFrontendIdAmong,
+  resolveOwnerFrontendId,
+  type FrontendDescriptor,
+} from "./registry.js";

--- a/src/frontend/discord/factory.ts
+++ b/src/frontend/discord/factory.ts
@@ -1,0 +1,12 @@
+/**
+ * Discord frontend factory — attaches the create half of the
+ * registry entry (descriptor registered in core/frontend-runtime).
+ * The implementation (discord.js) loads only when created.
+ */
+
+import { attachFrontendCreate } from "../../core/frontend-runtime/index.js";
+
+attachFrontendCreate("discord", async (config, gateway) => {
+  const { createDiscordFrontend } = await import("./index.js");
+  return createDiscordFrontend(config, gateway);
+});

--- a/src/frontend/factories.ts
+++ b/src/frontend/factories.ts
@@ -1,0 +1,15 @@
+/**
+ * Side-effect barrel: attaches the create function for every built-in
+ * frontend to its registry descriptor. The composition roots (app.ts,
+ * cli/chat.ts) import this once; adding a frontend is strictly
+ * additive — drop a `factory.ts` under the new frontend dir and import
+ * it here. Factory modules are dependency-light: each one dynamically
+ * imports its implementation only when the frontend is actually
+ * created.
+ */
+
+import "./telegram/factory.js";
+import "./discord/factory.js";
+import "./teams/factory.js";
+import "./native/factory.js";
+import "./terminal/factory.js";

--- a/src/frontend/native/factory.ts
+++ b/src/frontend/native/factory.ts
@@ -1,0 +1,12 @@
+/**
+ * Native (client bridge) frontend factory — attaches the create half
+ * of the registry entry (descriptor registered in core/frontend-runtime).
+ * The bridge server implementation loads only when created.
+ */
+
+import { attachFrontendCreate } from "../../core/frontend-runtime/index.js";
+
+attachFrontendCreate("native", async (config, gateway) => {
+  const { createNativeFrontend } = await import("./index.js");
+  return createNativeFrontend(config, gateway);
+});

--- a/src/frontend/teams/factory.ts
+++ b/src/frontend/teams/factory.ts
@@ -1,0 +1,12 @@
+/**
+ * Teams frontend factory — attaches the create half of the registry
+ * entry (descriptor registered in core/frontend-runtime). The
+ * implementation (Bot Framework + Graph) loads only when created.
+ */
+
+import { attachFrontendCreate } from "../../core/frontend-runtime/index.js";
+
+attachFrontendCreate("teams", async (config, gateway) => {
+  const { createTeamsFrontend } = await import("./index.js");
+  return createTeamsFrontend(config, gateway);
+});

--- a/src/frontend/telegram/factory.ts
+++ b/src/frontend/telegram/factory.ts
@@ -1,0 +1,12 @@
+/**
+ * Telegram frontend factory — attaches the create half of the
+ * registry entry (descriptor registered in core/frontend-runtime).
+ * The implementation (grammy + GramJS) loads only when created.
+ */
+
+import { attachFrontendCreate } from "../../core/frontend-runtime/index.js";
+
+attachFrontendCreate("telegram", async (config, gateway) => {
+  const { createTelegramFrontend } = await import("./index.js");
+  return createTelegramFrontend(config, gateway);
+});

--- a/src/frontend/terminal/factory.ts
+++ b/src/frontend/terminal/factory.ts
@@ -1,0 +1,11 @@
+/**
+ * Terminal frontend factory — attaches the create half of the
+ * registry entry (descriptor registered in core/frontend-runtime).
+ */
+
+import { attachFrontendCreate } from "../../core/frontend-runtime/index.js";
+
+attachFrontendCreate("terminal", async (config, gateway) => {
+  const { createTerminalFrontend } = await import("./index.js");
+  return createTerminalFrontend(config, gateway);
+});


### PR DESCRIPTION
## What

Backends have had an SDK shape for a while: one `Backend` capability interface (`core/agent-runtime/capabilities.ts`) and a self-registration registry, so adding a backend is one `factory.ts` with no bootstrap churn. Frontends had the interface (the `Frontend` type in `bootstrap.ts`) but not the registry — frontend *identity* was smeared across four hand-maintained copies of the same if/else chain:

| Concern | Lived in |
| --- | --- |
| Creation switch | `app.ts` (`switch (name)` over dynamic imports) |
| Dispatch routing (chat id → live frontend) | `bootstrap.ts` `resolveFrontendName` |
| Gateway action routing | `core/engine/gateway.ts` `resolveOwnedFrontendName` |
| MCP tool scoping | `backend/shared/frontends.ts` + literal `"terminal"` filters |

This PR adds `core/frontend-runtime/` — the frontend counterpart of `core/agent-runtime` — and routes all four through it. Behavior-preserving. See `docs/frontends.md` for the full design doc.

## Design

- **`capabilities.ts`** — the `Frontend` runtime contract (moved from `bootstrap.ts`, which re-exports it) and `FrontendCreate`.
- **`registry.ts`** — `id → FrontendDescriptor` map: label, `ownsChatId` matcher, `routePriority`, `messaging`/`sharesStdin` traits, plus the two resolution flavours (`resolveOwnerFrontendId`, `resolveFrontendIdAmong`). Deliberately self-contained: create functions are stored opaquely so routing-only consumers (gateway, backend scoping) never pull engine types into an import cycle.
- **`builtins.ts`** — the five built-in descriptors, registered from core (identity only; core still imports nothing from `frontend/`).
- **`create.ts`** — the typed create seam: `attachFrontendCreate` (built-in `factory.ts` modules), `registerFrontend` (the one-call plugin-frontend path), `createFrontendById` (composition roots).
- **`src/frontend/<id>/factory.ts`** ×5 + `src/frontend/factories.ts` barrel — each attaches its create via dynamic import, so unconfigured frontends still cost nothing at boot.

The historical tie-breaks are now explicit `routePriority` data instead of chain order: telegram's broad numeric matcher runs last (90), and the terminal claims the legacy chat id `"1"` ahead of telegram (10).

## Consumers converted

- `app.ts`: creation switch → `createFrontendById`; terminal special-case → the `sharesStdin` trait; labels from descriptors. (An unknown configured frontend now fails loudly instead of silently falling back to telegram — unreachable in practice, the config schema already rejects unknown names.)
- `bootstrap.ts`: `resolveFrontendName` chain → `resolveFrontendIdAmong`.
- `core/engine/gateway.ts`: shape-fallback chain → `resolveOwnerFrontendId(…, { includeNonMessaging: true })`.
- `backend/shared/frontends.ts`: now a thin view over the registry (same exported shapes); a runtime-registered frontend gets correct MCP tool scoping for free.
- `cli/chat.ts`: terminal creation through the registry.
- `FrontendName` in `agent-runtime` widens to `string` — ids are an open set owned by the registry.

## What still gates external frontend plugins (deliberate follow-ups)

The config schema's `frontendEnum`, a plugin-loader lifecycle step to import frontend modules, and per-frontend prompt flavours / `FrontendScope` tool tags. The seam they plug into is now one registry — `docs/frontends.md` tracks these.

## Validation

- `tsc`, oxlint, dependency-cruiser (0 errors — the new module respects `core-not-to-frontend` and `no-circular`), ratchets at baseline (registry throws are classified `TalonError`s)
- Full vitest suite green (4109 passed); new `frontend-registry.test.ts` pins routing semantics, the tie-breaks, error paths, and the plugin-frontend path end to end (synthetic `slack` frontend through registration → routing → creation → MCP scoping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)