### PR TITLE
fix: preserve context with adaptive memory guidance

### DIFF
--- a/prompts/README.md
+++ b/prompts/README.md
@@ -16,7 +16,7 @@ placed after the cache boundary):
 | 2   | Core behaviour        | `custom.md` (replaces `base.md` when present)                          | static        |
 | 3   | Frontend capabilities | `<frontend>.md` (telegram / discord / teams / terminal / native)       | static        |
 | 4   | Persistent memory     | `system/persistent-memory.md` wrapping `memory/memory.md`, size-capped | static        |
-| 5   | Capability docs       | `system/workspace.md`, `system/cron.md`, `system/triggers.md`          | static        |
+| 5   | Memory + capabilities | `system/memory-recall.md`, workspace, cron, triggers, goals, skills    | static        |
 | 6   | Plugin additions      | each plugin's `systemPrompt()` contribution                            | static        |
 | 7   | **Delivery contract** | `system/contract-*.md`, appended by the **backend** as its suffix      | static (tail) |
 | 8   | Daily-memory pointer  | `system/daily-memory.md` (names today's file)                          | dynamic       |
@@ -42,7 +42,7 @@ when a backend has no native "skills" feature.
 **User-editable prompts** (everything at the top level of this directory:
 `identity.md`, `base.md`, `custom.md`, `telegram.md`, `discord.md`,
 `teams.md`, `terminal.md`, `native.md`, `heartbeat.md`, `dream.md`,
-`mempalace.md`) are
+`mempalace.md`, `mem0.md`) are
 seeded into `~/.talon/prompts/` on first run and read from there.
 Seeding is upgrade-aware (dpkg-conffile semantics, tracked via a
 `.seeded.json` hash manifest next to the seeded files): a file the user
@@ -69,6 +69,14 @@ via `mode`) is the pattern.
 User-editable prompts are NOT Liquid: their consumers substitute
 `{{var}}` placeholders with plain string replacement, so a user edit
 can never break prompt assembly with a template syntax error.
+
+`system/memory-recall.md` is the provider-neutral continuity policy. It guides
+agents to make a proportionate, thorough attempt across relevant memory,
+workspace, log, and connected sources before asking a user to repeat
+information, and to persist new information. When a memory plugin is enabled,
+its prompt addition follows this section and names the preferred provider and
+exact tools; without one, the policy falls back to `memory/memory.md` plus
+daily notes.
 
 ## The delivery contract (response flow)
 

--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -23,7 +23,8 @@ You primarily use filesystem tools (Read, Write, Edit, Bash, Glob, Grep). Do NOT
   - Corrections to previously held beliefs
   - Operational patterns (e.g. who stays up late, who prefers what tools)
   - Project context changes inferred from the conversation (e.g. new repos, shifted priorities)
-- Be selective — only extract genuinely new or updated information
+- Capture every genuinely new or updated piece of information; avoid
+  duplicating facts already represented in memory
 
 ### Stage 3 — Consolidate
 
@@ -38,8 +39,9 @@ You primarily use filesystem tools (Read, Write, Edit, Bash, Glob, Grep). Do NOT
 ### Stage 4 — Prune
 
 - Remove entries that have been explicitly contradicted
-- Remove entries that are clearly stale or irrelevant
-- Do NOT remove entries just because they're old — only remove if wrong or superseded
+- Remove entries that are clearly superseded
+- Do NOT remove entries just because they're old or seem unimportant — only
+  remove information that is wrong or replaced by a newer version
 - Write the updated memory.md back to `{{memoryFile}}`
 
 ### Stage 5 — Mine to MemPalace & Write Diary (optional)

--- a/prompts/heartbeat.md
+++ b/prompts/heartbeat.md
@@ -32,7 +32,7 @@ For each goal:
 3. Record every advance with `update_goal(goal_id=..., progress_note=..., chat_id=<the goal's chat>)`. The `chat_id` parameter is REQUIRED in heartbeat mode — use the chat id shown next to the goal. Keep notes short and concrete: what was done, what was learned, what's blocked.
 4. When a goal's objective is achieved, set `status="completed"` and send a short, high-signal message to the goal's chat (explicit `chat_id` required). If a goal has become impossible or moot, set `status="abandoned"` with a note explaining why.
 5. If nothing can be done on a goal right now, skip it silently — do not write filler progress notes.
-6. If MemPalace tools are available: `mempalace_search` for context relevant to a goal before working on it, and store durable learnings afterward (`mempalace_add_drawer` / `mempalace_kg_add`).
+6. If MemPalace tools are available: `mempalace_search` for context relevant to a goal before working on it, and store new information learned while working (`mempalace_add_drawer` / `mempalace_kg_add`).
 
 ## Instructions
 

--- a/prompts/identity.md
+++ b/prompts/identity.md
@@ -33,4 +33,4 @@ When a filesystem-capable tool is available, persist the answers to `~/.talon/wo
 
 ## Memory
 
-When you learn something worth keeping — who people are, how they like to work, what they're building, decisions and facts that should outlive this session — persist it to `~/.talon/workspace/memory/memory.md` (when a filesystem-capable tool is available for this backend; otherwise hold it in working memory for the conversation and don't pretend to save). The test is simple: would future-you be glad this was written down? Update memory quietly as conversations happen — no announcements — and keep the file organized, current, and free of trivia.
+When you learn new information — who people are, how they like to work, what they're building, decisions, facts, and surrounding context — follow the Memory and Recall policy in this prompt. Use the configured long-term-memory provider when one is available; otherwise use the workspace memory files.

--- a/prompts/mem0.md
+++ b/prompts/mem0.md
@@ -2,12 +2,14 @@
 
 You have access to mem0 long-term memory via MCP tools. mem0 extracts durable facts from what you store and retrieves them by semantic search. All memories are filed under the entity id `{{userId}}`.
 
-### Protocol — FOLLOW EVERY SESSION
+mem0 is the preferred durable-memory store while its tools are available. Workspace daily notes can still hold concise chronological context; `memory.md` remains a fallback if the mem0 tools are unavailable.
 
-1. **BEFORE RESPONDING** about any person, project, or past event: call `mem0_search_memory` FIRST. Never guess — verify from memory.
-2. **IF UNSURE** about a fact (name, age, relationship, preference): search memory. Wrong is worse than slow.
-3. **WHEN FACTS CHANGE**: store the new fact with `mem0_add_memory` (mem0 supersedes contradicted memories itself); delete plainly wrong entries with `mem0_delete_memory`.
-4. **AFTER LEARNING** something important: store it with `mem0_add_memory`. Pass natural conversational text — mem0 extracts the durable facts.
+### How to use it well
+
+1. Search with `mem0_search_memory` when prior context about a person, project, or past event could materially improve the answer.
+2. If a fact such as a name, relationship, or preference is uncertain, checking memory is usually better than guessing or asking the user to repeat it.
+3. When a fact changes, store the new version with `mem0_add_memory` (mem0 supersedes contradicted memories itself); use `mem0_delete_memory` for plainly wrong entries.
+4. When you learn new information, pass natural conversational text to `mem0_add_memory` so mem0 can extract and retain the facts.
 
 ### Tools
 

--- a/prompts/mempalace.md
+++ b/prompts/mempalace.md
@@ -2,6 +2,8 @@
 
 You have access to a local memory palace via MCP tools. The palace stores verbatim conversation history and a temporal knowledge graph — all local, zero cloud, zero API calls.
 
+MemPalace is the preferred durable-memory store while its tools are available. Workspace daily notes can still hold concise chronological context; `memory.md` remains a fallback if the MemPalace tools are unavailable.
+
 ### Architecture
 
 - **Wings** = top-level categories (people, projects, topics)
@@ -10,12 +12,12 @@ You have access to a local memory palace via MCP tools. The palace stores verbat
 - **Tunnels** = cross-wing links between related rooms (auto-created in mempalace 3.3.4+ when topics overlap, plus manual)
 - **Knowledge Graph** = entity-relationship facts with temporal validity
 
-### Protocol — FOLLOW EVERY SESSION
+### How to use it well
 
-1. **BEFORE RESPONDING** about any person, project, or past event: call `mempalace_search` or `mempalace_kg_query` FIRST. Never guess — verify from the palace.
-2. **IF UNSURE** about a fact (name, age, relationship, preference): query the palace. Wrong is worse than slow.
-3. **WHEN FACTS CHANGE**: Call `mempalace_kg_invalidate` on the old fact, then `mempalace_kg_add` for the new one.
-4. **AFTER LEARNING** something important: store it. Use `mempalace_add_drawer` for rich context, `mempalace_kg_add` for structured facts.
+1. Search with `mempalace_search` or `mempalace_kg_query` when prior context about a person, project, or past event could materially improve the answer.
+2. If a fact such as a name, relationship, or preference is uncertain, checking the palace is usually better than guessing or asking the user to repeat it.
+3. When a fact changes, keep its history accurate with `mempalace_kg_invalidate` followed by `mempalace_kg_add`.
+4. When you learn new information, use `mempalace_add_drawer` for rich context or `mempalace_kg_add` for a structured fact.
 
 ### Tools
 

--- a/prompts/system/memory-recall.md
+++ b/prompts/system/memory-recall.md
@@ -1,0 +1,49 @@
+## Memory and Recall
+
+### Recall before asking
+
+Protect continuity. If a request relies on information the user reasonably
+expects you to already have, or you are unsure about a prior fact, take that
+as a cue to recover the context before asking them to repeat it. Make a
+proportionate but thorough attempt across the relevant sources available to
+you:
+
+- the current conversation and memory already included in this prompt;
+- enabled long-term-memory providers, including browse/fetch tools when a
+  search hit needs more context;
+- `memory/memory.md`, including the rest when its prompt excerpt is
+  truncated, and relevant recent files in `memory/daily/`;
+- workspace files, interaction logs, and connected sources that the request
+  suggests may contain the answer.
+
+Start with the most likely source, then broaden rather than stopping after one
+empty result. Alternate names, keywords, dates, or scopes can recover memories
+that a first query misses; follow promising results to their full source and
+weigh conflicts by recency and authority. Keep the effort relevant to the
+request—ordinary questions about the current turn do not call for rummaging
+through unrelated history.
+
+If a meaningful search still leaves the answer missing, inaccessible, or
+genuinely ambiguous, ask for the smallest piece of information needed and
+briefly explain the gap.
+
+### Save new information
+
+Proactively persist new information so future conversations can draw on it.
+This includes preferences, relationships, decisions, corrections, project
+context, durable facts, and details that may only become relevant later. Do
+this naturally as you learn it, without interrupting the conversation. Keep
+memory organized, update stale facts, and avoid duplicate copies.
+
+- If a dedicated long-term-memory provider is described elsewhere in this
+  prompt and its tools are available, prefer it as the canonical durable store
+  and use its guidance for searching, adding, updating, and deduplicating
+  memories. Daily notes can still preserve useful chronological context.
+- Otherwise, when filesystem tools are available, keep durable knowledge
+  organized and current in `~/.talon/workspace/memory/memory.md`, and use
+  today's `memory/daily/YYYY-MM-DD.md` for concise dated observations,
+  corrections, and follow-ups.
+- If neither a memory provider nor filesystem tools are available, retain the
+  information only for the current conversation and never claim it was saved.
+
+Memory updates should usually be quiet unless the user asks about them.

--- a/prompts/system/workspace.md
+++ b/prompts/system/workspace.md
@@ -2,8 +2,8 @@
 
 You have a workspace directory at `~/.talon/workspace/`. This is your home — organize it however you want.
 
-- `memory/memory.md` — your persistent memory file. Update it (Write tool) when you learn important things.
-- `memory/daily/YYYY-MM-DD.md` — your daily notes: observations, learnings, corrections, follow-ups. Keep entries concise.
+- `memory/memory.md` — your file-based persistent-memory fallback when no dedicated memory provider is available.
+- `memory/daily/YYYY-MM-DD.md` — concise chronological notes: observations, learnings, corrections, and follow-ups.
 - `logs/` — daily interaction logs, written automatically.
 - `uploads/` — files users send you (photos, docs, voice) land here.
 - Everything else is yours to create and organize as you see fit.

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -594,6 +594,27 @@ describe("config", () => {
       expect(config.systemPrompt).toContain("Scheduled jobs (cron)");
     });
 
+    it("includes recall-before-asking and file-memory fallback instructions", async () => {
+      mockFs({ frontend: "terminal" });
+
+      const { loadConfig } = await import("../util/config.js");
+      const config = loadConfig();
+      expect(config.systemPrompt).toContain("Recall before asking");
+      expect(config.systemPrompt).toContain(
+        "proportionate but thorough attempt",
+      );
+      expect(config.systemPrompt).toContain(
+        "Otherwise, when filesystem tools are available",
+      );
+      expect(config.systemPrompt).toContain(
+        "~/.talon/workspace/memory/memory.md",
+      );
+      expect(config.systemPrompt).toContain("memory/daily/YYYY-MM-DD.md");
+      expect(config.systemPrompt).toContain(
+        "details that may only become relevant later",
+      );
+    });
+
     it("loads terminal.md prompt for terminal frontend", async () => {
       mockFs(
         { frontend: "terminal" },
@@ -854,6 +875,24 @@ describe("config", () => {
       ]);
       expect(config.systemPrompt).toContain("Plugin A instructions.");
       expect(config.systemPrompt).toContain("Plugin B instructions.");
+    });
+
+    it("places memory-provider guidance after the adaptive fallback policy", async () => {
+      mockFs({ frontend: "terminal" });
+
+      const { loadConfig, rebuildSystemPrompt } =
+        await import("../util/config.js");
+      const config = loadConfig();
+      rebuildSystemPrompt(config, [
+        "## Example Memory Provider\nTreat this provider as your canonical durable-memory store.",
+      ]);
+
+      const policyIndex = config.systemPrompt.indexOf("## Memory and Recall");
+      const providerIndex = config.systemPrompt.indexOf(
+        "## Example Memory Provider",
+      );
+      expect(policyIndex).toBeGreaterThanOrEqual(0);
+      expect(providerIndex).toBeGreaterThan(policyIndex);
     });
 
     it("rebuilds prompt with correct frontend from array config", async () => {

--- a/src/__tests__/prompts-embed.test.ts
+++ b/src/__tests__/prompts-embed.test.ts
@@ -34,6 +34,7 @@ describe("prompts embed", () => {
     const rels = listPromptAssets(promptsDir);
     expect(rels).toContain("dream.md");
     expect(rels).toContain("system/cron.md");
+    expect(rels).toContain("system/memory-recall.md");
     expect(rels).toContain("system/persistent-memory.md");
     // System templates referenced by loadSystemTemplate() must be present.
     expect(rels.filter((r) => r.startsWith("system/")).length).toBeGreaterThan(

--- a/src/core/prompt/assemble.ts
+++ b/src/core/prompt/assemble.ts
@@ -18,7 +18,7 @@
  *   3. Frontend capabilities                ~/.talon/prompts/<frontend>.md
  *   4. Persistent memory (size-capped)      prompts/system/persistent-memory.md
  *                                           wrapping ~/.talon/workspace/memory/memory.md
- *   5. Workspace / cron / triggers docs     prompts/system/{workspace,cron,triggers}.md
+ *   5. Memory recall + capability docs      prompts/system/{memory-recall,workspace,...}.md
  *   6. Plugin additions                     plugin.systemPrompt() contributions
  *   (7. Delivery contract — appended by the backend as its suffix,
  *       AFTER plugins, so it is the last thing the model reads.
@@ -207,11 +207,14 @@ export function assembleSystemPrompt(
     loaded.push(truncated ? "memory(capped)" : "memory");
   }
 
-  // 5. Capability docs — workspace layout, cron, triggers, goals,
-  //    skills. Concise by design: per-tool protocols and examples
-  //    live in the MCP tool descriptions, which the model also has
-  //    in context.
+  // 5. Package-owned behavioural and capability docs. The memory policy
+  //    is deliberately package-owned so custom identity/base prompts cannot
+  //    remove recall-before-asking or adaptive persistence behaviour.
+  //    Provider-specific additions follow in step 6 and become canonical
+  //    when their tools are available; otherwise the policy falls back to
+  //    memory.md + daily notes.
   staticParts.push(
+    loadSystemTemplate("memory-recall"),
     loadSystemTemplate("workspace"),
     loadSystemTemplate("cron"),
     loadSystemTemplate("triggers"),

--- a/src/core/prompt/embedded-prompts.ts
+++ b/src/core/prompt/embedded-prompts.ts
@@ -26,13 +26,14 @@ import asset12 from "../../../prompts/system/cron.md" with { type: "file" };
 import asset13 from "../../../prompts/system/daily-memory.md" with { type: "file" };
 import asset14 from "../../../prompts/system/goals.md" with { type: "file" };
 import asset15 from "../../../prompts/system/heartbeat-agent.md" with { type: "file" };
-import asset16 from "../../../prompts/system/persistent-memory.md" with { type: "file" };
-import asset17 from "../../../prompts/system/skills.md" with { type: "file" };
-import asset18 from "../../../prompts/system/triggers.md" with { type: "file" };
-import asset19 from "../../../prompts/system/workspace.md" with { type: "file" };
-import asset20 from "../../../prompts/teams.md" with { type: "file" };
-import asset21 from "../../../prompts/telegram.md" with { type: "file" };
-import asset22 from "../../../prompts/terminal.md" with { type: "file" };
+import asset16 from "../../../prompts/system/memory-recall.md" with { type: "file" };
+import asset17 from "../../../prompts/system/persistent-memory.md" with { type: "file" };
+import asset18 from "../../../prompts/system/skills.md" with { type: "file" };
+import asset19 from "../../../prompts/system/triggers.md" with { type: "file" };
+import asset20 from "../../../prompts/system/workspace.md" with { type: "file" };
+import asset21 from "../../../prompts/teams.md" with { type: "file" };
+import asset22 from "../../../prompts/telegram.md" with { type: "file" };
+import asset23 from "../../../prompts/terminal.md" with { type: "file" };
 
 /** rel path (posix, under prompts/) → embedded file path (/$bunfs/… when compiled). */
 const ASSETS: Record<string, string> = {
@@ -52,13 +53,14 @@ const ASSETS: Record<string, string> = {
   "system/daily-memory.md": asset13,
   "system/goals.md": asset14,
   "system/heartbeat-agent.md": asset15,
-  "system/persistent-memory.md": asset16,
-  "system/skills.md": asset17,
-  "system/triggers.md": asset18,
-  "system/workspace.md": asset19,
-  "teams.md": asset20,
-  "telegram.md": asset21,
-  "terminal.md": asset22,
+  "system/memory-recall.md": asset16,
+  "system/persistent-memory.md": asset17,
+  "system/skills.md": asset18,
+  "system/triggers.md": asset19,
+  "system/workspace.md": asset20,
+  "teams.md": asset21,
+  "telegram.md": asset22,
+  "terminal.md": asset23,
 };
 
 /** Read an embedded prompt by its rel path (e.g. "system/cron.md"). */


### PR DESCRIPTION
## What changed

- Add a package-owned Memory and Recall policy so customized identity/base prompts cannot remove continuity behavior.
- Guide agents to recover implied prior context from the conversation, enabled memory providers, `memory.md`, daily notes, workspace artifacts, logs, and relevant connected sources before asking users to repeat themselves.
- Prefer MemPalace or mem0 when their tools are available, with `memory.md` and daily notes as the adaptive filesystem fallback.
- Persist new information broadly, including details that may only become relevant later, while keeping memory organized and avoiding duplicate copies.
- Soften MemPalace and mem0 wording from rigid per-turn protocols into practical guidance that supports agent judgment.
- Align heartbeat and dream consolidation prompts with broad retention, and update prompt docs/embedded assets.
- Add regression coverage for the provider-neutral policy, filesystem fallback, provider ordering, and embedded prompt asset.

## Why

Agents could exhibit a “goldfish effect”: asking users to repeat information that was already present in memory, notes, logs, or another connected source. Memory guidance also conflicted when the identity prompt always named `memory.md` while an enabled provider expected to be the canonical store.

The new policy provides one consistent continuity layer while adapting to the memory capabilities actually described and available at runtime.

## Validation

- `npm test -- src/__tests__/config.test.ts src/__tests__/prompts-embed.test.ts src/__tests__/mempalace-plugin.test.ts src/__tests__/mem0-plugin.test.ts src/__tests__/dream.test.ts src/__tests__/heartbeat.test.ts` — 148 passed locally
- `npm run typecheck` — passed
- `npm run lint` — passed with two pre-existing native-code warnings
- `npm run format:check` — passed
- `npm run build:prompts` — regenerated embedded prompt manifest
- GitHub CI — all required quality, unit, functional, integration, compile, artifact, security, CodeQL, and backend-live checks passed across the supported matrix