### PR TITLE
fix(prompt): rank memory sections instead of head-slicing

### DIFF
--- a/docs/memory-persona-plan.md
+++ b/docs/memory-persona-plan.md
@@ -1,0 +1,432 @@
+# Memory & Persona — architecture plan
+
+Status: proposal. Supersedes the Phase-A/Phase-B memory notes and settles the
+question of what happens to the Soul Kernel.
+
+---
+
+## 1. What is actually broken
+
+Not speculation — this is the live deployment's `~/.talon/workspace/memory/memory.md`
+(23,633 chars, 113 lines) read against `assemble.ts`.
+
+**1.1 The model never sees the useful half.** `MEMORY_INJECT_MAX_CHARS = 12_000`
+slices the *head* of the file. On the live file that cut lands at **line 46 of 113**.
+Above the line: one user-facts block, one infra-health block, and three
+near-duplicate `## Inbox / CI Watch (as of …, Run #N)` snapshots. Below the line,
+invisible: `## Active Investigations` (including a root-cause analysis), `##
+Revisions`, `## Branches to clean up`. Truncation is positional; content is not
+priority-ordered. So the *least* durable content systematically evicts the most
+durable.
+
+**1.2 Ephemeral state is stored in the durable layer.** Those three CI-watch
+sections are hourly status snapshots with a shelf life of ~60 minutes, ~4 KB each,
+describing the same recurring failures. They are a feed, not a memory. Nothing in
+the system distinguishes "true forever" from "true right now."
+
+**1.3 Reconciliation is annotation, not supersession.** One real bullet, abridged:
+
+> v1.29.4 FAILED 07-03 … **RESOLVED 07-08 (Run #235)** … **CONFIRMED reliable
+> 07-08 10:27Z (Run #236)** …
+
+Three layers of amendment on a single line, ~700 chars, describing a *closed*
+issue. Facts get annotated because there is no unit of memory that can be
+*replaced*: no id, no timestamp, no source, no confidence — just prose in a file.
+An LLM asked to "merge" 23 KB of prose will always append and annotate; deleting
+is the risky move from its position. The dream prompt even mandates it: *"Do NOT
+remove entries just because they're old."* Combined with append-only growth, that
+guarantees monotonic bloat.
+
+**1.4 Three uncoordinated writers, one file, no protocol.** The live chat agent
+(`Write`, mid-conversation), the dream agent (12 h), and the heartbeat agent
+(hourly) all read-modify-write the same file with different instructions and no
+schema, lock, or ownership. Last writer wins, silently.
+
+**1.5 Daily notes are write-only.** 323 KB across 16 files (~20 KB/day), surfaced
+only as *"Use the Read tool to check recent daily notes when you need context"* —
+with no index, so in practice never read. They are also the **only** surviving
+record of 07-04 → 07-10 (raw logs rotated). Write-only memory is worse than none:
+it costs tokens and creates the illusion of continuity.
+
+**1.6 Retrieval never landed.** `core/memory/retrieval.ts` is a clean, trust-aware,
+fail-closed seam wired end-to-end into the Weaver and both backends — populated
+with `noopMemoryRetriever`. The doc it cites
+(`docs/memory-phase-b-pre-retrieval.md`) no longer exists. MemPalace and mem0 are
+real but *model-invoked*: their prompts open with "BEFORE RESPONDING … call search
+FIRST, every session," which is the least reliable mechanism available and costs a
+round trip per turn. Net effect: the model's entire memory is the truncated head of
+one markdown file.
+
+**1.7 Persona is an adjective list.** `prompts/identity.md` opens with "Sharp,
+witty, and warm." That describes ten thousand assistants. It never changes, never
+differs per person, and — decisively — is not connected to memory. The evolving
+file that *could* personalize (`workspace/identity.md`) is six lines of NPUW facts
+with no voice at all. Meanwhile voice is duplicated and drifting across
+`telegram.md` / `discord.md` / `teams.md` / `terminal.md` / `native.md`.
+
+---
+
+## 2. Verdict on the Soul Kernel: repurpose ~10%, delete the rest
+
+**The ideas are right. The implementation is ~30× oversized for the signal it is
+fed.** That is the whole judgement, and it is measurable.
+
+What it is: 4,797 lines across 31 modules, 30 test files — content-addressed Merkle
+DAG, Hebbian value lattice, salience with a predictive-coding delta rule, FSRS/DSR
+forgetting, ADWIN drift detection, PageRank centrality, modern-Hopfield associative
+recall, VSA/HDC compositional episodic memory, per-interlocutor lens compilation,
+frozen critic classifiers, a governance approval queue.
+
+What it is fed: **three taps, Telegram only.** Emoji reactions on bot messages;
+eight regexes for "directive" (`/\bfrom now on\b/`…); eight for "correction"
+(`/^\s*(no|nope|nah)\b/`…). That is the entire input stream.
+
+So: Hebbian co-activation needs many co-activations to mean anything — it gets one
+event per emoji. ADWIN needs a stream — it gets maybe a directive a week. PageRank
+over ~15 nodes is noise. And the *best case* output of the whole pipeline is
+
+```
+- [conf +0.42] "verbatim quote"
+```
+
+— a few things Dylan once said, ranked by an arithmetic score, formatted as a
+debug dump. `SELECT text FROM directives ORDER BY recency * weight LIMIT 8` gets
+you 95% of that in one line.
+
+It is also **off by default** (`TALON_SOUL_ENABLED`), and its two best entry points
+are unreachable: `SoulService.renderPromptSection()` calls bare `kernel.project()`,
+so `projectFor(embedder, {context, lens})` — relevance conditioning and
+per-interlocutor refraction, the genuinely valuable parts — never runs in
+production. This is precisely the failure mode already recorded as a project rule:
+*native bricks need runtime consumers in the same PR, not just tests.* The soul is
+the canonical violation of it.
+
+**The structural argument for merging rather than either keeping or ripping:** the
+soul is a *parallel memory system*. Its content — directives, corrections,
+per-person relationship — is memory of a particular kind. It has its own store, its
+own decay, its own projector, its own persistence, fed by its own pipe. Once a real
+typed memory store exists, "the soul" is a **view over rows of kind
+`directive`/`correction`/`preference` filtered by subject, rendered by the same
+ranker that renders facts.** Merging it is a net *deletion of concepts*, not a
+migration.
+
+### Keep (≈460 lines, absorbed into the memory subsystem)
+
+| Keep | Why |
+| --- | --- |
+| **The thesis** — "the model never writes its own soul" | The best idea in the repo. Generalize it to *all* memory: the model **proposes** claims, the harness **decides** what survives. |
+| **Selection, never generation** (`projector.ts` principle) | Prompt surfaces assembled by ranking + verbatim quoting. Directly fixes 1.1 and 1.3. Keep the principle; the 240-line implementation becomes a ranked SQL query. |
+| `critic.ts` (162 lines) | Model-free wall-of-text / sycophancy / emoji-overload classifiers. The only mechanical voice enforcement anywhere in Talon — and currently dead code. |
+| `taps.ts` (199 lines) | Crude but real, and it is the *input* to everything. Keep, move out of Telegram, extend to every frontend. |
+| `lens.ts` (110 lines) | Per-interlocutor refraction — the highest-value persona feature. Re-express as ~60 lines of query. |
+| Decay math (~40 of `salience.ts`) | One exponential decay + a reinforcement counter. Everything else in that file is unfeedable. |
+
+### Delete (≈4,300 lines + ~26 test files)
+
+`dag` · `hash` · `delta` · `hdc` · `associative` · `centrality` · `forgetting` ·
+`drift` · `valence` · `emergent-critic` · `governance` · `cluster` · `consolidate` ·
+`reflect` · `compiler` · `kernel` · `lattice` · `retrieve` · `embedder` ·
+`talon-embedder` · `projector` · `service` · `reflex` · `signals` · `types` ·
+`settings` · `index`, and the `TALON_SOUL_ENABLED` gate.
+
+Content addressing to dedup ~50 rows, and a Merkle commit chain to version them,
+is work SQLite already does. Reflexes overlap the critic-as-guard and go with it.
+
+**Teardown lands last** (Phase 6) — the old thing is removed only once the new
+thing does its job. But the *decision* is now: no further investment in the kernel.
+
+---
+
+## 3. Target architecture
+
+Five ideas, in dependency order.
+
+### 3.1 One typed store; markdown becomes a view
+
+The substrate already exists and is good: SQLite at `~/.talon/data/talon.db`,
+`sql/<store>.sql` → `statements.generated.ts` → `repositories/<store>-repo.ts` →
+`<store>.ts` (zero SQL above the repo), FTS5 available, `node:sqlite`/`bun:sqlite`
+with no native addon. There is no `memory` table. Add one.
+
+Every row: `id, kind, subject, key?, text, source{frontend,chat,actor,turn}, trust,
+confidence, created_at, last_seen_at, hit_count, salience, pinned, superseded_by`.
+
+**Kinds are lifecycles, not labels** — this is the fix for 1.1 and 1.2:
+
+| kind | lifecycle | injection |
+| --- | --- | --- |
+| `directive` | durable, human-authored intent | **pinned — never truncated away** |
+| `fact` | durable, supersedable, slow decay | ranked into the core view |
+| `state` | **keyed; a write REPLACES the row for that key**, has an explicit staleness horizon | injected while fresh, queryable after |
+| `episode` | timestamped, fast decay, consolidates into `fact` or drops | retrieval only |
+| `relationship` | per-subject: tone, working style, history | persona layer, subject-scoped |
+| `reflection` | first-person diary; **never a fact source** | persona layer only, bounded |
+
+The keyed-`state` rule alone kills the CI-watch accretion: `heartbeat.health` is
+one row, overwritten, not a new dated section per run.
+
+`memory.md` stops being the source of truth and becomes a **rendered projection** —
+regenerated after each reconcile, still human-readable and `Read`-able. Because the
+store is ranked, truncation becomes *selection under a budget* instead of slicing.
+Hand-edits to the file are treated as an inbox and folded back on change, so it
+stays human-editable without being authoritative.
+
+### 3.2 Writes are cheap, in-band, single-claim
+
+Today, learning something means either the model calling `Write` on a 23 KB file
+mid-conversation (expensive, race-prone — so it doesn't) or waiting up to 12 hours
+for the dream. Add `remember` / `forget` / `recall`: one typed claim, ~50 tokens,
+transactional. On `assert`, FTS-match against existing rows of the same
+`kind`+`subject`; a near-duplicate becomes a **supersede candidate** rather than a
+second row. That is MemPalace's `check_duplicate` idea moved into the write path
+and made automatic — mechanically, the highest-leverage reconciliation in the plan.
+
+The live agent stops writing `memory.md` directly. That resolves 1.4 by
+construction.
+
+### 3.3 Reconciliation is mechanical ops, model-proposed
+
+The dream agent stops re-authoring prose and emits **operations only**:
+
+```
+assert(kind, subject, key?, text, confidence)   supersede(id, text, reason)
+merge(ids[], text)                              drop(id, reason)
+promote(episode_ids[] → fact)                   pin(id) / unpin(id)
+```
+
+The harness validates (ids exist, budget respected, pinned rows need an explicit
+reason), applies transactionally, and writes a `memory_history` row for every
+change; drops go to a graveyard, not oblivion. The model gets a **worklist** —
+contradiction candidates, over-budget tails, stale `state` rows — instead of the
+whole file. A bad model turn can no longer clobber 23 KB, and every change is
+diffable and revertible (`/memory diff`, `/memory undo`).
+
+Consolidation gets what it has never had: a **hard target size** and a **decay
+policy**. Over budget → lowest-ranked non-pinned rows are merged into a parent or
+dropped to the graveyard. Never annotated in place.
+
+### 3.4 Retrieval is harness-driven
+
+Fill the seam that already exists. A real `MemoryRetriever` over the store: FTS5
+match on the incoming message + recency decay + salience + `hit_count`, trust-
+filtered (the #373 policy is already written and enforced in two places). No model
+call, no MCP round trip — sub-millisecond. MemPalace/mem0 stay as *optional deep
+archives*; they stop being the primary path.
+
+Two tiers, and the boundary between them is a prompt-cache invariant:
+
+- **Core view** — pinned directives + top facts/relationship for the current
+  interlocutor + fresh relevant `state`, computed **once per session build** and
+  living in `staticText` (~1.5–2 k tokens, budgeted).
+- **Turn retrieval** — keyed to the incoming message, injected via the existing
+  `formatPromptWithRetrievedMemory` in the *user turn*, never in
+  `prepareSystemPrompt()`. The 3 k-char cap is already implemented.
+
+### 3.5 Persona is three layers, and the first one is memory
+
+Persona-without-memory is cosplay; the strongest personality signal available is
+unprompted, accurate callback ("you said the same thing about the last refactor").
+That is why memory ships before persona, not beside it.
+
+- **Voice** — authored, human-owned, stable. `identity.md` rewritten from
+  adjectives into *concrete stances on concrete situations*: what you do when
+  someone's plan is bad, when you don't know, when someone is upset, when the same
+  question arrives a third time. With **anti-examples** — "don't do X, here's what
+  X looks like" constrains far harder than any positive adjective. One file, shared
+  by every frontend; the frontend prompts keep capability docs only, ending the
+  voice drift in 1.7.
+- **Relationship** — derived, per-subject, mechanical. The lens as a query over
+  `relationship` + `directive` + `preference` rows for whoever is talking, rendered
+  verbatim. "How I show up with Dylan" ≠ "how I show up with a stranger in a
+  group."
+- **Stance** — per-turn, enforced. Run `critic.ts` on drafted output: log-only
+  telemetry first, then a single targeted retry on the strongest classifier.
+  Mechanical restraint does more for perceived personality than any adjective, and
+  the classifiers already exist.
+- **Continuity** — a bounded slice of recent `reflection` rows, explicitly marked
+  as self-reflection. A diary that is written and never read is a log, not
+  interiority. Hard rule: **the diary is never a retrieval source for facts.**
+
+### 3.6 The prompt-cache invariant
+
+This is already solved, and the plan must not un-solve it.
+
+`prepareSystemPrompt` (`backend/shared/system-prompt.ts`) freezes the **entire**
+prepared prompt — static *and* dynamic — per `(chatId, sessionEpoch)`. So within a
+session the system prompt is byte-stable, and `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` makes
+the static prefix cacheable *across* sessions on top of that. The docstring records
+what getting this wrong cost: **60–90 k cache-write tokens on turns that should
+write 2–8 k.** Only plugin reload and native-extension changes invalidate
+(`notifyPromptInputsChanged`), which is correct — both are rare and deliberate.
+
+**Invariant: nothing on the memory write path may ever call
+`notifyPromptInputsChanged()`.** A `remember` that invalidated snapshots would
+force a full-prompt cache write across every live session, on every learned fact.
+This is the single most expensive mistake available in this plan, and it is also the
+*obvious* one — someone will notice that a mid-session `remember` doesn't appear in
+the core view and reach straight for invalidation.
+
+**The consequence is a design constraint, not a bug to fix.** A fact learned at
+turn 3 cannot enter that session's core view; it reaches the model through **turn
+retrieval**, which runs per turn and lands in the user message *after* all cached
+history. So: core view = frozen, session-scoped. Anything learned mid-session =
+retrieval-only until the next session. That is the cache-correct design, and it is
+exactly what the Phase-B seam already does.
+
+**Investigated 2026-07-30 — the TTL lever does not exist.** The hypothesis was that
+the dominant cost is the 5-minute cache TTL versus a chat bot's minutes-to-hours
+cadence, fixable with a 1-hour TTL. It is not fixable from here:
+`@anthropic-ai/claude-agent-sdk@0.3.212` exposes **no cache-control surface at
+all** — a full grep of `sdk.d.ts` + `agentSdkTypes.d.ts` for cache/ttl identifiers
+returns only `cacheCreationInputTokens` / `cacheReadInputTokens` (read-only usage
+reporting). The SDK owns `cache_control` placement internally. A 1-hour TTL is an
+**upstream ask**, not a config change.
+
+Two things the SDK docs do settle:
+
+- **Talon's static/dynamic split is correct**, per `sdk.d.ts` on `systemPrompt`:
+  *"include `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` as a standalone element to mark the
+  split between the static (globally-cacheable) prefix and the dynamic
+  (session-specific) suffix. Blocks before the marker are eligible for
+  cross-session prompt caching; blocks after it are not."* That is exactly what
+  `toSdkSystemPrompt` builds.
+- **`excludeDynamicSections` doesn't apply to us.** It strips per-user dynamic
+  sections for cross-user cache hits, but *"has no effect when `systemPrompt` is a
+  string (custom prompt)"* — Talon always passes a custom array.
+
+**Measured, from the live DB's `sessions` rows:**
+
+| session | cache_read | cache_write | ratio | hit |
+| --- | --- | --- | --- | --- |
+| sonnet, 1 API call | 242,847 | 30,326 | **8.01** | 100% |
+| default, 4 API calls | 111,959 | 43,635 | 2.57 | 94.9% |
+| haiku, 1 API call | 19,091 | 20,384 | **0.94** | 97.2% |
+| (one session) | 0 | 0 | — | 0% |
+
+**Within a turn, caching works well** — the 8:1 row is ~11 model requests inside one
+user turn all reading the same ~22 k prefix. **Across turns is where it goes** — the
+0.94 row is the cold-start shape: write the prefix, read it once, pay ~1.25× for the
+write. Caveat: four short sessions on a dev instance, and 93% of the log's 696
+usage lines are test-harness chats. This characterises the *shape*; it does not
+quantify production cost. That is what PR 3 is for.
+
+**So the only lever Talon controls is prompt size** — which reframes this plan's
+economics in its favour. If most turns miss the cross-turn cache, cost is
+`cache-write volume × prompt size`, and every write here is 20–44 k tokens at
+1.25×. Cutting ~10 k chars of stale CI-watch content out of the static prompt
+(§1.1) saves ~2.5 k tokens × 1.25 on **every cold turn** — a bigger, more reliable
+win than hit-rate tuning, and it lands in PR 1.
+
+Remaining suspects, in order:
+
+- **The 20-block lookback window.** A cache breakpoint walks back at most 20
+  content blocks to find a prior entry. Talon's agentic turns emit many
+  tool_use/tool_result pairs, so a turn with >20 blocks can silently stop the
+  *next* turn's breakpoint from finding the prior cache. The 8:1 row shows
+  within-turn is fine; cross-turn after a tool-heavy turn is unverified.
+- **Tool-definition churn.** Tools render *before* the system prompt, so any change
+  to the tool array invalidates everything after it. Lazily-discovered plugin tools
+  (see `base.md`) are exactly that shape. A stable prompt behind an unstable tool
+  list buys nothing.
+- **The cacheable minimum is model-dependent and non-monotonic** — 512 tokens
+  (Opus 5), 1024 (Opus 4.8 / Sonnet 5 / 4.6), 2048 (Opus 4.7), **4096 (Opus 4.6,
+  Haiku 4.5)**. Below it, nothing caches and there is no error. Talon's ~20 k chat
+  prompts clear every threshold, but the one-shot paths (dream, heartbeat, cron) may
+  not — and the zero-cache session above is consistent with exactly that.
+- **Compaction** rewrites history and re-writes cache (visible via
+  `notificationHook`); **restarts** cost one re-freeze per session (accepted).
+
+**This plan's own cache cost**, stated plainly: core view ≈ 2 k tokens in
+`staticText` — one write per session, then free reads. Turn retrieval ≤ 3 k chars in
+the user turn — **uncached by definition, every turn** (~750 tokens). That recurring
+cost is the price of retrieval that actually works, and it should be budgeted
+deliberately rather than discovered later.
+
+One future option worth knowing: **mid-conversation system messages**
+(`{"role": "system"}` inside `messages[]`) are supported on Opus 5 / Opus 4.8 /
+Fable 5 with no beta header, sit *after* the cached history, and carry
+non-spoofable operator authority — the ideal channel for a directive learned
+mid-session. Whether the Agent SDK will let Talon inject one is unverified; noting
+it, not planning on it.
+
+---
+
+## 4. Phases
+
+PR-by-PR execution plan: **`memory-persona-rollout.md`**.
+
+**Phase 0 — Stop the bleeding.** Small diffs, no new architecture, ships this week.
+Rank-based truncation in `assemble.ts` (priority-ordered sections, newest-only per
+`state`-family heading) instead of head-slicing. Rewrite the dream/heartbeat
+prompts: forbid a new dated section for an existing topic, require replace-in-place
+for status, set a hard size target, and replace *"do not remove entries just
+because they're old"* with a real decay rule. Route status snapshots to a
+separately-owned `memory/state.md` that is fully rewritten each run. Split writer
+ownership: heartbeat → state + daily note; dream → memory; live agent → an inbox
+file. Rotate/consolidate daily notes and give them an index. **This roughly doubles
+effective memory quality for a few hundred lines.**
+
+Also in Phase 0, independent of memory: **instrument the cache read:write ratio per
+turn** from the figures `stream.ts` already captures, and check whether the tool
+array is byte-stable per session. Both are prerequisites for reasoning about usage —
+see 3.6. Do this before any structural change, or the plan's cost will be
+indistinguishable from the TTL problem it sits next to.
+
+**Phase 1 — The store.** `memory.sql` + `memory-repo.ts` + `memory.ts` + FTS5.
+One-time idempotent importer for the existing `memory.md` and daily notes (file
+kept as backup). Render `memory.md` from the store. Tests.
+
+**Phase 2 — Write path.** `remember` / `forget` / `recall`. Auto-dupe-check on
+assert. Move directive/correction classification out of the Telegram frontend into
+a shared engine seam so every frontend feeds it; generalize reaction attribution to
+every frontend that has reactions (telegram, native, discord).
+
+**Phase 3 — Read path.** Real `MemoryRetriever` against the store; core view
+replaces the head-slice; per-interlocutor block. Measure token cost against the
+prompt-cache invariant in 3.4.
+
+**Phase 4 — Reconciliation.** Op-based dream, worklists, history + graveyard,
+budget enforcement, `/memory` inspect/diff/undo.
+
+**Phase 5 — Persona.** Rewrite `identity.md` as voice + stances + anti-examples.
+Relationship block. Critic as guard (log-only → enforce). Bounded diary read-back.
+De-duplicate voice out of the frontend prompts.
+
+**Phase 6 — Soul teardown.** One mostly-deletion PR: ~4,300 lines and ~26 test
+files out, `TALON_SOUL_ENABLED` removed, the six survivors already living in the
+memory subsystem.
+
+**Phase 7 — Surfaces (optional).** `talon://` mount for memory (fits the existing
+VFS namespace) and a Companion memory view. A memory you can see and correct by
+hand is a memory you will trust.
+
+---
+
+## 5. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| **Prompt-cache regression** — the trap most likely to bite. See 3.6 in full. | Core view computed once per session build, in `staticText`. Turn retrieval only ever enters via the user-turn wrapper. **A test that fails if the memory write path reaches `notifyPromptInputsChanged`.** |
+| **Memory poisoning** in group chats — a poisoned pinned row is a permanent prompt injection. | #373 trust levels enforced **at the store**, not just the retriever. `user_claim` / `group_chat` can never reach the pinned or core tier. |
+| **Token cost** | Core view budgeted (~2 k), retrieval capped (3 k chars, already implemented). Both measured. |
+| **Model doesn't call `remember`** | Cheap single-claim tool + explicit norm; instrument call rate and iterate on the prompt, not the schema. |
+| **Over-eager forgetting** | Graveyard + `memory_history` + `/memory undo`. Nothing is unrecoverable. |
+| **Diary contaminating facts** | Structural: `reflection` rows are excluded from the fact retriever, not merely discouraged. |
+
+## 6. How we will know it worked
+
+- **Reachable memory**: share of durable content that actually enters the prompt.
+  Today ≈ 51% by chars — and the wrong 51%.
+- **Store size over time**: must plateau. Today it grows monotonically.
+- **Supersessions per reconcile**: currently zero; annotation instead.
+- **Duplicate/stale rate** in the store.
+- **Callback rate**: unprompted, accurate references per week (sampled).
+- **Critic flag rate** on Talon's own output: should fall once the guard is live.
+- **Daily-note read rate**: should approach zero — retrieval replaces it.
+
+## 7. Non-goals
+
+No cloud memory. No vector database (FTS5 + recency + salience is enough, and the
+local-only constraint is deliberate). No second identity system — the soul's
+function is absorbed, not reimplemented. The model is never the reconciler of
+record. No per-frontend persona.

--- a/docs/memory-persona-rollout.md
+++ b/docs/memory-persona-rollout.md
@@ -1,0 +1,291 @@
+# Memory & Persona — rollout
+
+Execution plan for `memory-persona-plan.md`. Fifteen PRs in seven stages. Each PR
+is independently shippable, lands its own runtime consumer (no repeats of the soul's
+mistake), and is reviewable on its own.
+
+**Net line count: roughly +3,400 / −4,700.** The codebase gets *smaller* while
+gaining a memory system that works.
+
+Repo conventions every PR here obeys:
+
+- Storage: `sql/<store>.sql` → `npm run build:sql` → committed
+  `statements.generated.ts` (`sql-embed.test.ts` fails on drift) →
+  `repositories/<store>-repo.ts` (execution + row↔domain mapping, no SQL) →
+  `storage/<store>.ts` (domain API, **zero SQL**). DDL goes in `schema.sql`,
+  idempotent, applied on every open.
+- `storage/` never imports `core/`, `backend/`, or `frontend/` (dependency-cruiser
+  `storage-below-the-engine`). **So: the store lives in `storage/`, the policy —
+  ranking, retrieval, projection — lives in `core/memory/`.** That split is already
+  anticipated by the existing `core/memory/retrieval.ts` seam.
+- Prompt text lives in `prompts/`, never in TS. New prompt assets need
+  `npm run build:prompts` (`prompts-embed.test.ts` fails on drift).
+- Tools are two files: `core/tools/<area>.ts` (zod schema + `bridge("action")`) and
+  `core/engine/gateway-actions/<area>.ts` (the action).
+- Every PR ships consumers, or `knip` flags the unused exports. That gate is doing
+  real work here — respect it rather than suppressing it.
+- Validation is CI, not local (`gh pr checks`): `test`, `typecheck`, `lint`,
+  `depcruise`, `ratchets`, `knip`, `format:check`.
+- Engine-touching PRs (6, 7, 9, 10) need Discord verified — it breaks quietly.
+
+One flag gates the whole new path: **`TALON_MEMORY_STORE`**, default off until
+PR 9 is measured. Removed during Stage 6.
+
+---
+
+## Stage 0 — Measure, and stop the bleeding
+
+No new architecture. Ships this week. Independent of everything below, and worth
+doing even if the rest is deferred.
+
+### PR 1 — `fix(prompt): rank memory sections instead of head-slicing`
+
+The single highest value-per-line change in the plan.
+
+- **New** `core/prompt/memory-view.ts`: split `memory.md` on `##` headings;
+  classify each section into a priority tier; collapse "state families" (headings
+  sharing a prefix before `(as of` / `(Run #`) to the newest member only; order by
+  tier; then cap.
+- Tier order: directives/preferences → people & facts → active investigations and
+  open items → newest state snapshot → remainder.
+- **Edit** `assemble.ts` §4: `capMemory(memory)` → `renderMemoryView(memory)`.
+- Tests: a sanitized fixture of the live file, asserting `## Active Investigations`
+  survives the cap and exactly one `Inbox / CI Watch` section is retained. Plus:
+  **output is byte-identical when the file is under the cap** — keeps the
+  prompt-cache tests honest.
+- Not wasted work when PR 5 lands: this parser becomes the importer.
+
+### PR 2 — `fix(prompts): write discipline + state/memory split`
+
+- `prompts/heartbeat.md`: heartbeat **stops writing `memory.md`**. It writes
+  `memory/state.md` — fully rewritten each run, one keyed section per domain — plus
+  today's daily note. This is where "heartbeat dead since 07-10" belongs.
+- `prompts/dream.md`: replace-in-place for status topics; a new dated section for an
+  existing topic is forbidden; hard size target for `memory.md` (~10 k chars);
+  replace *"do NOT remove entries just because they're old"* with a decay rule;
+  removals append to `memory/archive/YYYY-MM.md` rather than vanishing. New stage:
+  daily notes older than 14 days collapse into a monthly summary and the originals
+  are deleted.
+- `assemble.ts`: inject `state.md` as its own capped section (~2 k).
+- `prompts/system/workspace.md` + `persistent-memory.md`: document the split and
+  who owns which file.
+- `npm run build:prompts`, commit the regenerated embed.
+
+### PR 3 — `feat(metrics): per-turn cache read:write telemetry`
+
+Prerequisite for the whole usage conversation — see plan §3.6, which now records
+what the 2026-07-30 investigation settled: **the Agent SDK exposes no cache-TTL
+knob**, so the 1-hour TTL is an upstream ask and prompt size is the only lever
+Talon controls. No behavior change in this PR.
+
+- `stream.ts` already captures `cache_read_input_tokens` /
+  `cache_creation_input_tokens`, and `sessions` already persists the totals. Surface
+  the **per-turn** ratio in the post-turn accounting line and persist to `turn_meta`
+  (table exists, currently 0 rows).
+- Distinguish **within-turn** from **cross-turn** hits — the measured 8:1 ratio is
+  ~11 model requests inside one user turn, which tells you nothing about whether the
+  *next* turn hit. Cross-turn is the number that matters.
+- Log a hash of the registered tool-name array per turn; warn when it changes
+  *within* a session.
+- Count content blocks per turn and flag turns over 20 — that is the cache
+  lookback-window limit, and Talon's tool-heavy turns are the shape that trips it.
+- Check the one-shot paths (dream, heartbeat, cron) against the model's cacheable
+  minimum — 4096 tokens on Opus 4.6 / Haiku 4.5. Below it nothing caches, silently.
+
+---
+
+## Stage 1 — The store
+
+### PR 4 — `feat(storage): typed memory store with FTS5`
+
+- `sql/schema.sql`: `memory` table; `memory_fts` (external-content FTS5 + the three
+  `ai`/`ad`/`au` triggers — copy `history_fts` exactly, it is the established
+  pattern); `memory_history`; indexes on `(kind, subject)`, `(key)`, `(salience)`.
+- `sql/memory.sql`: named statements.
+- `repositories/memory-repo.ts`: statement execution, row↔domain mapping.
+- `storage/memory-store.ts`: `assert`, `supersede`, `drop`, `merge`, `pin`,
+  `search`, `listByKind`, `replaceStateKey`. Validation. Zero SQL, no core imports.
+- `npm run build:sql`; commit both files.
+- Tests: CRUD; FTS search; **keyed-state replacement semantics**; supersede writes
+  history; drop lands in the graveyard; `TALON_DB_PATH` isolation.
+- Fold PR 5 in if `knip` objects to the API landing without consumers.
+
+### PR 5 — `feat(memory): import memory.md, render it back`
+
+- `core/memory/import.ts`: `memory.md` + daily notes → rows, reusing PR 1's parser.
+  Idempotent via content hash. Original files preserved.
+- `core/memory/render.ts`: rows → `memory.md`, ranked and budgeted. Supersedes PR 1's
+  ranker as the production path.
+- CLI: `talon memory import` / `talon memory render`.
+- `/memory` (telegram + native): top rows, search, `/memory why <id>` for provenance.
+- With the flag on, the store is authoritative and `memory.md` is rendered output.
+  Hand-edits to the file are folded back as an inbox on next import.
+
+---
+
+## Stage 2 — Write path
+
+### PR 6 — `feat(tools): remember / forget / recall`
+
+- `core/tools/memory.ts` + `core/engine/gateway-actions/memory.ts`.
+- `remember(kind, text, subject?, key?)` — on assert, FTS near-dupe check turns a
+  near-match into a **supersede candidate** instead of a second row. Mechanically the
+  highest-leverage reconciliation in the plan, and it lives in the write path.
+- `recall(query)` — explicit pull when the model wants more than was auto-injected.
+- `forget(id, reason)` — to the graveyard.
+- `prompts/system/memory.md`: the norm only (when to remember, what never to store).
+  No protocol prose duplicating tool descriptions.
+- **Required test: the memory gateway actions never reach
+  `notifyPromptInputsChanged`.** This is the cache invariant from plan §3.6, and it
+  is the mistake someone will otherwise make on purpose.
+- Verify Discord.
+
+### PR 7 — `refactor(soul): taps into the shared engine seam`
+
+The PR that makes persona learning frontend-agnostic — what the soul never got.
+
+- Move directive/correction classification out of
+  `frontend/telegram/handlers/messages.ts` into the engine's inbound path, so every
+  frontend feeds it.
+- Generalize reaction attribution beyond Telegram to native and discord.
+- Taps write `directive` / `correction` rows to the store. The soul kernel call
+  stays behind its own flag until Stage 6.
+- Verify Discord.
+
+---
+
+## Stage 3 — Read path
+
+### PR 8 — `feat(memory): real retriever behind the Phase B seam`
+
+**The PR where memory starts working.**
+
+- `core/memory/store-retriever.ts` implements the existing `MemoryRetriever`: FTS
+  match on the inbound message + recency decay + salience + `hit_count`. Sub-
+  millisecond, no model call, no MCP round trip.
+- Wire in bootstrap: flag on → store retriever; off → `noopMemoryRetriever`.
+  `filterAutoInjectable` stays exactly as written; trust policy unchanged.
+- Retrieved rows bump `hit_count` / `last_seen_at` — the ranking feedback loop.
+- Tests: relevance; trust filtering; **fail-closed on any db error**; budget cap;
+  prompt byte-identical when nothing is retrieved.
+
+### PR 9 — `feat(prompt): core view replaces the head-slice`
+
+- `assemble.ts` §4 renders the store's core view: pinned directives + top facts for
+  the chat's subject + fresh `state`. Budgeted ~2 k tokens.
+- Assert the core view is only ever computed inside the session-frozen build.
+- Record the prompt-size delta before/after, against PR 3's baseline.
+- Flag flips to default-on here, once the numbers are in.
+- Verify Discord.
+
+---
+
+## Stage 4 — Reconciliation
+
+### PR 10 — `feat(memory): op-based reconciliation`
+
+- `core/memory/ops.ts`: op types, validator, transactional applier. Every op writes
+  a `memory_history` row.
+- Guards: unknown id rejected; dropping a pinned row needs an explicit reason;
+  budget enforced; ops per run capped.
+- `prompts/dream.md` rewritten: the dream **emits ops** and never rewrites files. It
+  receives a *worklist* — FTS near-dupe candidates, stale state keys, the
+  over-budget tail — instead of 23 KB of prose to re-author.
+- Tests: every op; each rejection case; rollback on partial failure.
+- Verify Discord.
+
+### PR 11 — `feat(memory): diff / undo / audit`
+
+The trust layer. You will only let it forget things once you can see and revert what
+it forgot.
+
+- `/memory diff` (last reconcile), `/memory undo <op_id>`, `/memory graveyard`.
+- Each dream run reports what it changed.
+
+---
+
+## Stage 5 — Persona
+
+### PR 12 — `feat(prompts): identity.md as voice + stances`
+
+Prompt-only; independent of every other PR; could ship at any point.
+
+- Replace the adjective list with concrete stances on concrete situations — bad
+  plan, don't know, someone's upset, third time the same question — each with
+  **anti-examples**.
+- Strip voice out of `telegram.md` / `discord.md` / `teams.md` / `native.md` /
+  `terminal.md`; they keep capability docs only.
+- `identity.md` stays **seeded and user-editable** — a shipped rewrite updates the
+  package default; a local edit wins and is never clobbered. (Settled: Dylan does not
+  need the live NPUW-Agent copy preserved.)
+
+### PR 13 — `feat(persona): relationship block`
+
+- The lens as a query: `relationship` / `directive` / `preference` rows for the
+  current subject, ranked, quoted verbatim. ~60 lines replacing `soul/lens.ts`.
+- Rendered inside the session-frozen core view.
+- Group chats: subject is whoever is speaking; trust rules keep subjects from
+  contaminating each other.
+
+### PR 14 — `feat(persona): critic as an output guard`
+
+- `soul/critic.ts` → `core/persona/critic.ts`, logic unchanged; its tests come with
+  it.
+- Wire post-draft: **log-only first** (flag rate per failure mode), then a single
+  targeted retry on the strongest classifier, behind a flag.
+- Optional: bounded diary read-back, marked as self-reflection, structurally
+  excluded from the fact retriever.
+
+---
+
+## Stage 6 — Teardown
+
+### PR 15 — `refactor(soul): remove the kernel`
+
+Pure deletion, easy review. Everything worth keeping was relocated by PRs 7, 13, 14.
+
+- Delete ~4,300 lines and ~26 test files: `dag` `hash` `delta` `hdc` `associative`
+  `centrality` `forgetting` `drift` `valence` `emergent-critic` `governance`
+  `cluster` `consolidate` `reflect` `compiler` `kernel` `lattice` `retrieve`
+  `embedder` `talon-embedder` `projector` `service` `reflex` `signals` `types`
+  `settings` `index`.
+- Remove `TALON_SOUL_ENABLED`, the `assemble.ts` soul section, `getSoul().dream()`
+  in `background/dream.ts`, and the `/soul` admin command (repoint at `/memory`).
+- Remove the `TALON_MEMORY_STORE` flag in the same window.
+- `knip` + `depcruise` + `ratchets` confirm nothing dangles.
+
+---
+
+## Stage 7 — Surfaces (optional)
+
+`talon://memory/` mount on the existing VFS namespace; a Companion memory view.
+A memory you can see and correct by hand is a memory you will trust.
+
+---
+
+## Sequencing
+
+**Critical path:** 4 → 5 → 8 → 9. That is the spine; everything else hangs off it.
+
+**Ships immediately, in parallel, no dependencies:** PR 1, 2, 3, and 12.
+
+**Start here:** PR 1 and PR 3 together. PR 1 is the biggest quality win per line in
+the whole plan, and PR 3 buys the week of cache data needed before anyone reasons
+about usage. Neither touches architecture, so neither can be invalidated by a later
+design change.
+
+Rough sizing: Stage 0 ≈ 600 lines · Stage 1 ≈ 900 · Stage 2 ≈ 500 · Stage 3 ≈ 400 ·
+Stage 4 ≈ 600 · Stage 5 ≈ 400 · Stage 6 ≈ −4,300.
+
+## Decisions
+
+1. ~~`identity.md` reseed policy~~ — **settled.** Stays user-editable; local edits
+   win, package default updates. PR 12 unblocked.
+2. ~~1-hour cache TTL~~ — **settled by investigation.** The Agent SDK
+   (`0.3.212`) exposes no cache-control surface, so this is an upstream ask, not a
+   config change. Prompt size is the lever we control. See plan §3.6.
+3. **`state.md` — file or kind?** *(open)* PR 2 makes it a file (cheap, immediate);
+   PR 4 could absorb it as a `state` kind instead. Recommend the file first, absorb
+   later — it de-risks Stage 0 from Stage 1's schedule.
+4. **Default-on timing for `TALON_MEMORY_STORE`** *(open)* — proposed at PR 9, after
+   the prompt-size delta is measured against PR 3's baseline.

--- a/docs/memory-persona-rollout.md
+++ b/docs/memory-persona-rollout.md
@@ -4,7 +4,7 @@ Execution plan for `memory-persona-plan.md`. Fifteen PRs in seven stages. Each P
 is independently shippable, lands its own runtime consumer (no repeats of the soul's
 mistake), and is reviewable on its own.
 
-**Net line count: roughly +3,400 / −4,700.** The codebase gets *smaller* while
+**Net line count: roughly +3,400 / −4,700.** The codebase gets _smaller_ while
 gaining a memory system that works.
 
 Repo conventions every PR here obeys:
@@ -38,9 +38,16 @@ PR 9 is measured. Removed during Stage 6.
 No new architecture. Ships this week. Independent of everything below, and worth
 doing even if the rest is deferred.
 
-### PR 1 — `fix(prompt): rank memory sections instead of head-slicing`
+### PR 1 — `fix(prompt): rank memory sections instead of head-slicing` ✅ done
 
 The single highest value-per-line change in the plan.
+
+**Landed.** On the live 23,396-char file the view emits 9,461 chars: every live
+section present (`## Active Investigations` with its root-cause analysis,
+`## Revisions`, `## Branches to clean up` — all previously below the cut), the
+newest CI-watch snapshot kept, the two stale duplicates dropped and named. That
+is 21% _smaller_ than the old 12k head-slice, so it also cuts the per-turn
+cache-write cost. 14 tests; full suite green.
 
 - **New** `core/prompt/memory-view.ts`: split `memory.md` on `##` headings;
   classify each section into a priority tier; collapse "state families" (headings
@@ -62,7 +69,7 @@ The single highest value-per-line change in the plan.
   today's daily note. This is where "heartbeat dead since 07-10" belongs.
 - `prompts/dream.md`: replace-in-place for status topics; a new dated section for an
   existing topic is forbidden; hard size target for `memory.md` (~10 k chars);
-  replace *"do NOT remove entries just because they're old"* with a decay rule;
+  replace _"do NOT remove entries just because they're old"_ with a decay rule;
   removals append to `memory/archive/YYYY-MM.md` rather than vanishing. New stage:
   daily notes older than 14 days collapse into a monthly summary and the originals
   are deleted.
@@ -71,12 +78,24 @@ The single highest value-per-line change in the plan.
   who owns which file.
 - `npm run build:prompts`, commit the regenerated embed.
 
-### PR 3 — `feat(metrics): per-turn cache read:write telemetry`
+### PR 3 — `feat(metrics): per-turn cache read:write telemetry` ✅ done
 
 Prerequisite for the whole usage conversation — see plan §3.6, which now records
 what the 2026-07-30 investigation settled: **the Agent SDK exposes no cache-TTL
 knob**, so the 1-hour TTL is an upstream ask and prompt size is the only lever
-Talon controls. No behavior change in this PR.
+Talon controls. No behaviour change in this PR.
+
+**Landed** as `backend/shared/cache-telemetry.ts` (25 tests). The accounting line
+now carries `xturn=hit|miss|none reqs=N rw=R`, derived from the result message's
+per-request `usage.iterations` — `xturn` is the field that tracks cost, since the
+turn's first request is the only one that reports whether the previous turn's
+prefix survived. Plus mid-session tool-set change warnings that name the delta,
+a lookback-window flag, and a sub-minimum check on the one-shot paths.
+
+**Read `xturn` first when the data comes in.** Mostly `miss` → the prefix is
+dying between turns and the fix is a smaller prefix (or the upstream TTL ask);
+mostly `hit` → caching is working and the cost is elsewhere; any `none` → that
+prompt isn't cacheable at all.
 
 - `stream.ts` already captures `cache_read_input_tokens` /
   `cache_creation_input_tokens`, and `sessions` already persists the totals. Surface
@@ -84,9 +103,9 @@ Talon controls. No behavior change in this PR.
   (table exists, currently 0 rows).
 - Distinguish **within-turn** from **cross-turn** hits — the measured 8:1 ratio is
   ~11 model requests inside one user turn, which tells you nothing about whether the
-  *next* turn hit. Cross-turn is the number that matters.
+  _next_ turn hit. Cross-turn is the number that matters.
 - Log a hash of the registered tool-name array per turn; warn when it changes
-  *within* a session.
+  _within_ a session.
 - Count content blocks per turn and flag turns over 20 — that is the cache
   lookback-window limit, and Talon's tool-heavy turns are the shape that trips it.
 - Check the one-shot paths (dream, heartbeat, cron) against the model's cacheable
@@ -189,7 +208,7 @@ The PR that makes persona learning frontend-agnostic — what the soul never got
 - Guards: unknown id rejected; dropping a pinned row needs an explicit reason;
   budget enforced; ops per run capped.
 - `prompts/dream.md` rewritten: the dream **emits ops** and never rewrites files. It
-  receives a *worklist* — FTS near-dupe candidates, stale state keys, the
+  receives a _worklist_ — FTS near-dupe candidates, stale state keys, the
   over-budget tail — instead of 23 KB of prose to re-author.
 - Tests: every op; each rejection case; rollback on partial failure.
 - Verify Discord.
@@ -267,12 +286,17 @@ A memory you can see and correct by hand is a memory you will trust.
 
 **Critical path:** 4 → 5 → 8 → 9. That is the spine; everything else hangs off it.
 
-**Ships immediately, in parallel, no dependencies:** PR 1, 2, 3, and 12.
+**Ships immediately, in parallel, no dependencies:** ~~PR 1~~, PR 2, ~~PR 3~~, and
+PR 12.
 
-**Start here:** PR 1 and PR 3 together. PR 1 is the biggest quality win per line in
-the whole plan, and PR 3 buys the week of cache data needed before anyone reasons
-about usage. Neither touches architecture, so neither can be invalidated by a later
-design change.
+**Done:** PR 1 and PR 3. PR 1 was the biggest quality win per line in the plan;
+PR 3 buys the week of cache data needed before anyone reasons about usage.
+Neither touched architecture, so neither can be invalidated by a later design
+change.
+
+**Next:** PR 2 (writer discipline — heartbeat stops writing `memory.md`, dream
+gets a size target and permission to forget) and PR 12 (identity.md as voice +
+stances), both still dependency-free. Then the spine, 4 → 5 → 8 → 9.
 
 Rough sizing: Stage 0 ≈ 600 lines · Stage 1 ≈ 900 · Stage 2 ≈ 500 · Stage 3 ≈ 400 ·
 Stage 4 ≈ 600 · Stage 5 ≈ 400 · Stage 6 ≈ −4,300.
@@ -284,8 +308,8 @@ Stage 4 ≈ 600 · Stage 5 ≈ 400 · Stage 6 ≈ −4,300.
 2. ~~1-hour cache TTL~~ — **settled by investigation.** The Agent SDK
    (`0.3.212`) exposes no cache-control surface, so this is an upstream ask, not a
    config change. Prompt size is the lever we control. See plan §3.6.
-3. **`state.md` — file or kind?** *(open)* PR 2 makes it a file (cheap, immediate);
+3. **`state.md` — file or kind?** _(open)_ PR 2 makes it a file (cheap, immediate);
    PR 4 could absorb it as a `state` kind instead. Recommend the file first, absorb
    later — it de-risks Stage 0 from Stage 1's schedule.
-4. **Default-on timing for `TALON_MEMORY_STORE`** *(open)* — proposed at PR 9, after
+4. **Default-on timing for `TALON_MEMORY_STORE`** _(open)_ — proposed at PR 9, after
    the prompt-size delta is measured against PR 3's baseline.

--- a/prompts/system/persistent-memory.md
+++ b/prompts/system/persistent-memory.md
@@ -3,6 +3,8 @@
 The following is your memory file. Reference it naturally. Update it via the Write tool when you learn important new information.
 File: ~/.talon/workspace/memory/memory.md
 
-{{content}}{% if truncated %}
+{{content}}{% if omitted %}
+
+Sections held back to keep session start lean — Read the file above when you need them: {{omitted}}{% elsif truncated %}
 
 …(memory file truncated here to keep session start lean — Read the file above for the rest){% endif %}

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -704,7 +704,7 @@ describe("config", () => {
 
       const { loadConfig } = await import("../util/config.js");
       const { MEMORY_INJECT_MAX_CHARS } =
-        await import("../core/prompt/assemble.js");
+        await import("../core/prompt/memory-view.js");
       const config = loadConfig();
       expect(config.systemPrompt).toContain("Persistent Memory");
       expect(config.systemPrompt).toContain("truncated");

--- a/src/__tests__/memory-view.test.ts
+++ b/src/__tests__/memory-view.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the persistent-memory view — ranked selection of `memory.md`
+ * under a char budget.
+ *
+ * The fixture mirrors the shape that motivated the module: a real
+ * deployment's memory file where three near-duplicate status snapshots sat
+ * above the head-slice cut and the durable knowledge (`## Active
+ * Investigations`, with a root-cause analysis in it) sat below and never
+ * reached the prompt at all.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  MEMORY_INJECT_MAX_CHARS,
+  renderMemoryView,
+} from "../core/prompt/memory-view.js";
+
+/** Filler that makes a section big enough to matter against the budget. */
+const bulk = (n: number): string => `- ${"detail ".repeat(n)}\n`;
+
+/**
+ * A memory file in the observed pathological shape: status snapshots first
+ * and largest, durable knowledge last and smallest.
+ */
+function liveShapedMemory(): string {
+  return [
+    "# Agent Memory",
+    "",
+    "## User: Dylan",
+    "- Creator and primary user",
+    "- Based in Dublin",
+    "",
+    "## Inbox / CI Watch (as of 2026-07-03 ~23:15Z, Run #134)",
+    bulk(900),
+    "## Inbox / CI Watch (as of 2026-07-03 ~10:56Z, Run #122)",
+    bulk(1300),
+    "## Inbox / CI Watch (as of 2026-07-01 ~15:03Z, Run #121)",
+    bulk(1800),
+    "## Active Investigations",
+    "",
+    "### Qwen3-Embedding int4 Failure — ROOT CAUSE",
+    "- The compile step drops the quantized weights",
+    "",
+    "## Branches to clean up",
+    "- dneve-isolate-qwen3embed",
+  ].join("\n");
+}
+
+describe("renderMemoryView", () => {
+  describe("under the budget", () => {
+    it("returns the input byte-identically", () => {
+      const content = "# Memory\n\n## User: Dylan\n- Lives in Dublin";
+      const view = renderMemoryView(content);
+      expect(view.text).toBe(content);
+      expect(view.truncated).toBe(false);
+      expect(view.omitted).toBe("");
+    });
+
+    it("does not collapse duplicate status families", () => {
+      // Reordering only earns its risk when the alternative is losing
+      // content — a file that fits is passed through untouched.
+      const content = [
+        "## Watch (Run #2)",
+        "- b",
+        "",
+        "## Watch (Run #1)",
+        "- a",
+      ].join("\n");
+      expect(renderMemoryView(content).text).toBe(content);
+    });
+  });
+
+  describe("over the budget", () => {
+    it("keeps durable knowledge that head-slicing would have evicted", () => {
+      const content = liveShapedMemory();
+      expect(content.length).toBeGreaterThan(MEMORY_INJECT_MAX_CHARS);
+
+      // The old behaviour: a positional cut that never reaches the tail.
+      expect(content.slice(0, MEMORY_INJECT_MAX_CHARS)).not.toContain(
+        "## Active Investigations",
+      );
+
+      const view = renderMemoryView(content);
+      expect(view.truncated).toBe(true);
+      expect(view.text).toContain("## Active Investigations");
+      expect(view.text).toContain("ROOT CAUSE");
+      expect(view.text).toContain("## Branches to clean up");
+      expect(view.text).toContain("## User: Dylan");
+    });
+
+    it("collapses a status family to its newest member", () => {
+      const view = renderMemoryView(liveShapedMemory());
+      const watches = view.text.match(/^## Inbox \/ CI Watch/gm) ?? [];
+      expect(watches).toHaveLength(1);
+      expect(view.text).toContain("Run #134");
+      expect(view.text).not.toContain("Run #122");
+      expect(view.text).not.toContain("Run #121");
+    });
+
+    it("names the sections it held back", () => {
+      const view = renderMemoryView(liveShapedMemory());
+      expect(view.omitted).toContain("Run #122");
+      expect(view.omitted).toContain("Run #121");
+      expect(view.omitted).not.toContain("Active Investigations");
+    });
+
+    it("stays within the budget", () => {
+      const view = renderMemoryView(liveShapedMemory());
+      expect(view.text.length).toBeLessThanOrEqual(MEMORY_INJECT_MAX_CHARS);
+    });
+
+    it("emits surviving sections in file order, not tier order", () => {
+      const view = renderMemoryView(liveShapedMemory());
+      const iUser = view.text.indexOf("## User: Dylan");
+      const iWatch = view.text.indexOf("## Inbox / CI Watch");
+      const iActive = view.text.indexOf("## Active Investigations");
+      // `status` ranks below `active`, but the emitted body preserves the
+      // author's ordering so the prompt prefix doesn't churn on retier.
+      expect(iUser).toBeLessThan(iWatch);
+      expect(iWatch).toBeLessThan(iActive);
+    });
+
+    it("prefers a dated snapshot over an undated sibling", () => {
+      const content = [
+        "## Status",
+        bulk(400),
+        "## Status (as of 2026-07-09)",
+        bulk(400),
+      ].join("\n");
+      const view = renderMemoryView(content, 3_000);
+      expect(view.text).toContain("2026-07-09");
+    });
+
+    it("ranks directives above status when the budget is tight", () => {
+      const content = [
+        "## Inbox status (Run #9)",
+        bulk(300),
+        "## Standing rules",
+        "- Never put credentials in the repo",
+      ].join("\n");
+      const view = renderMemoryView(content, 1_000);
+      expect(view.text).toContain("Never put credentials in the repo");
+      expect(view.text).not.toContain("## Inbox status");
+      expect(view.omitted).toContain("Inbox status (Run #9)");
+    });
+
+    it("ranks historical sections last", () => {
+      const content = [
+        "## Historical: merge flurry",
+        bulk(300),
+        "## Deploy notes",
+        "- staging mirrors prod",
+      ].join("\n");
+      const view = renderMemoryView(content, 1_000);
+      expect(view.text).toContain("staging mirrors prod");
+      expect(view.text).not.toContain("## Historical");
+    });
+  });
+
+  describe("degenerate input", () => {
+    it("head-slices a file with no section headings", () => {
+      const content = `# Memory\n${bulk(500)}`;
+      const view = renderMemoryView(content, 1_000);
+      expect(view.truncated).toBe(true);
+      expect(view.text.length).toBeLessThanOrEqual(1_000);
+      expect(view.text.length).toBeGreaterThan(0);
+    });
+
+    it("head-slices when a single section exceeds the whole budget", () => {
+      const content = `## One huge section\n${bulk(500)}`;
+      const view = renderMemoryView(content, 500);
+      expect(view.truncated).toBe(true);
+      expect(view.text.length).toBeGreaterThan(0);
+      expect(view.text.length).toBeLessThanOrEqual(500);
+      expect(view.omitted).toBe("");
+    });
+
+    it("handles content that starts at a section heading", () => {
+      const content = ["## A", bulk(200), "## B", bulk(200)].join("\n");
+      const view = renderMemoryView(content, 1_500);
+      expect(view.text).toMatch(/^## /);
+    });
+
+    it("elides a long omitted tail", () => {
+      const content = Array.from(
+        { length: 20 },
+        (_, i) => `## Watch ${i} (Run #${i})\n${bulk(60)}`,
+      ).join("\n");
+      const view = renderMemoryView(content, 1_000);
+      expect(view.omitted).toMatch(/and \d+ more$/);
+    });
+  });
+});

--- a/src/core/prompt/assemble.ts
+++ b/src/core/prompt/assemble.ts
@@ -16,8 +16,9 @@
  *   2. Core behaviour                       ~/.talon/prompts/custom.md,
  *                                           else base.md, else fallback
  *   3. Frontend capabilities                ~/.talon/prompts/<frontend>.md
- *   4. Persistent memory (size-capped)      prompts/system/persistent-memory.md
+ *   4. Persistent memory (ranked, capped)   prompts/system/persistent-memory.md
  *                                           wrapping ~/.talon/workspace/memory/memory.md
+ *                                           via memory-view.ts
  *   5. Memory recall + capability docs      prompts/system/{memory-recall,workspace,...}.md
  *   6. Plugin additions                     plugin.systemPrompt() contributions
  *   (7. Delivery contract — appended by the backend as its suffix,
@@ -57,6 +58,7 @@ import { dirs, files as pathFiles } from "../../util/paths.js";
 import { todayAndYesterday } from "../../util/time.js";
 import { log } from "../../util/log.js";
 import { loadSystemTemplate } from "./templates.js";
+import { renderMemoryView } from "./memory-view.js";
 import { renderWorkspaceListing } from "./workspace-listing.js";
 import { renderSkillsPrompt } from "../../storage/skill-store.js";
 import { renderStickerLibraryPrompt } from "../../storage/sticker-store.js";
@@ -92,17 +94,6 @@ export function joinSystemPromptParts(parts: SystemPromptParts): string {
   return `${parts.staticText}\n\n---\n\n${parts.dynamicText}`;
 }
 
-// ── Tunables ────────────────────────────────────────────────────────────────
-
-/**
- * Cap on how much of `memory.md` is injected into the static prompt.
- * Memory files grow without bound over months of use; injecting all
- * of it bloats EVERY session from its very first turn. 12k chars is
- * roughly 3k tokens — past that, the model gets the head of the file
- * plus a truncation pointer and can Read the rest on demand.
- */
-export const MEMORY_INJECT_MAX_CHARS = 12_000;
-
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function readOptionalFile(path: string): string {
@@ -112,23 +103,6 @@ function readOptionalFile(path: string): string {
     /* ignore */
   }
   return "";
-}
-
-/**
- * Truncate memory content at the cap, snapping back to the previous
- * newline so the cut never lands mid-sentence. Returns the (possibly
- * shortened) content and whether truncation happened.
- */
-function capMemory(content: string): { text: string; truncated: boolean } {
-  if (content.length <= MEMORY_INJECT_MAX_CHARS) {
-    return { text: content, truncated: false };
-  }
-  const head = content.slice(0, MEMORY_INJECT_MAX_CHARS);
-  const lastNewline = head.lastIndexOf("\n");
-  return {
-    text: (lastNewline > 0 ? head.slice(0, lastNewline) : head).trimEnd(),
-    truncated: true,
-  };
 }
 
 let lastLoggedPromptKey = "";
@@ -194,17 +168,21 @@ export function assembleSystemPrompt(
   }
 
   // 4. Persistent memory — size-capped so a memory file that has grown
-  //    for months can't bloat every session from turn 0.
+  //    for months can't bloat every session from turn 0. Over the cap the
+  //    view ranks sections rather than head-slicing, so durable knowledge
+  //    isn't evicted by whatever happens to sit at the top of the file
+  //    (see prompt/memory-view.ts).
   const memory = readOptionalFile(pathFiles.memory);
   if (memory) {
-    const { text, truncated } = capMemory(memory);
+    const { text, truncated, omitted } = renderMemoryView(memory);
     staticParts.push(
       loadSystemTemplate("persistent-memory", {
         content: text,
         truncated: truncated ? "yes" : undefined,
+        omitted: omitted || undefined,
       }),
     );
-    loaded.push(truncated ? "memory(capped)" : "memory");
+    loaded.push(truncated ? "memory(ranked)" : "memory");
   }
 
   // 5. Package-owned behavioural and capability docs. The memory policy

--- a/src/core/prompt/index.ts
+++ b/src/core/prompt/index.ts
@@ -3,6 +3,7 @@
  *
  * One stop for everything system-prompt:
  *   - `assemble`          — section pipeline + static/dynamic split
+ *   - `memory-view`       — ranked selection of `memory.md` under a budget
  *   - `templates`         — package-owned `prompts/system/*.md` loader
  *   - `workspace-listing` — lazy workspace tree for the dynamic tail
  *

--- a/src/core/prompt/memory-view.ts
+++ b/src/core/prompt/memory-view.ts
@@ -1,0 +1,304 @@
+/**
+ * Persistent-memory view — what the model actually sees of `memory.md`.
+ *
+ * `memory.md` grows without bound and only the first
+ * `MEMORY_INJECT_MAX_CHARS` reach the prompt. Head-slicing that file makes
+ * the cut positional while the content is not priority-ordered, so the
+ * *least* durable material evicts the most durable. Observed on the live
+ * deployment: a 23.6k-char file cut at line 46 of 113, where everything
+ * above the line was one facts block plus three near-duplicate
+ * `## Inbox / CI Watch (as of …, Run #N)` status snapshots, and
+ * `## Active Investigations` — with the root-cause analysis in it — fell
+ * below the cut and was never injected at all.
+ *
+ * So this module makes truncation a *selection* problem:
+ *
+ *   1. Split the file into `## ` sections (an `h3` stays with its parent).
+ *   2. Collapse "state families" — sections whose headings differ only by a
+ *      trailing timestamp / run number — down to the newest member. Three
+ *      CI-watch snapshots describing the same recurring failures are one
+ *      fact, not three.
+ *   3. Order by tier (directives → people → active work → general → status
+ *      → historical), stable within a tier.
+ *   4. Emit whole sections until the budget is spent, and name the ones
+ *      that didn't make it so the model knows to `Read` for them.
+ *
+ * Three deliberate constraints:
+ *
+ *   - **Under the cap, output is byte-identical to the input.** Reordering
+ *     only happens when the alternative is losing content, so deployments
+ *     whose memory still fits see no behaviour change and no prompt-cache
+ *     churn.
+ *   - **Surviving sections are emitted in file order**, not tier order. The
+ *     ranking decides *what* survives, not how it reads — and a
+ *     tier-ordered body would rewrite the prompt prefix every time a
+ *     section's heading changed tier.
+ *   - **If nothing fits, fall back to head-slicing.** A single section
+ *     larger than the whole budget must still give the model something
+ *     rather than an empty memory block.
+ */
+
+// ── Tunables ────────────────────────────────────────────────────────────────
+
+/**
+ * Cap on how much of `memory.md` is injected into the static prompt.
+ * Memory files grow without bound over months of use; injecting all of it
+ * bloats EVERY session from its very first turn. 12k chars is roughly 3k
+ * tokens — past that, the model gets the ranked selection below plus a
+ * pointer, and can Read the file on demand.
+ */
+export const MEMORY_INJECT_MAX_CHARS = 12_000;
+
+/** Cap on how many omitted section titles are named before eliding the rest. */
+const MAX_OMITTED_NAMED = 8;
+
+// ── Tiers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Section priority, most-durable first. `status` sits second-to-last because
+ * a snapshot is true *now* and false later — it is the content most safely
+ * dropped and most cheaply re-derived. `historical` is last for the mirror
+ * reason: it will never change again, so it is the least urgent to carry.
+ */
+const TIER_ORDER = [
+  "directive",
+  "people",
+  "active",
+  "general",
+  "status",
+  "historical",
+] as const;
+
+type Tier = (typeof TIER_ORDER)[number];
+
+const tier = (name: Tier): number => TIER_ORDER.indexOf(name);
+
+/**
+ * Heading classifiers. First match wins, so order is the policy: a heading
+ * reading "Active investigation status" is active work, not a snapshot.
+ * `general` is the unmatched default and ranks above `status` — a section
+ * nobody labelled is more likely durable knowledge than a dated snapshot.
+ */
+const MATCHERS: readonly { readonly tier: Tier; readonly match: RegExp }[] = [
+  {
+    tier: "historical",
+    match:
+      /\b(historical|history|archived?|superseded|resolved|closed|completed|past|old)\b/i,
+  },
+  {
+    tier: "directive",
+    match: /\b(directives?|preferences?|instructions?|rules?)\b/i,
+  },
+  {
+    tier: "active",
+    match:
+      /\b(active|current|investigations?|open|pending|todo|follow.?ups?|blocked|in.progress|priorit(?:y|ies)|goals?)\b/i,
+  },
+  {
+    tier: "people",
+    match: /\b(users?|people|person|contacts?|team|about)\b/i,
+  },
+  {
+    tier: "status",
+    match: /\b(as of|run #|status|health|watch|inbox|snapshot|report)\b/i,
+  },
+];
+
+const STATUS_TIER = tier("status");
+const GENERAL_TIER = tier("general");
+
+function classify(title: string): number {
+  for (const m of MATCHERS) {
+    if (m.match.test(title)) return tier(m.tier);
+  }
+  return GENERAL_TIER;
+}
+
+// ── Parsing ─────────────────────────────────────────────────────────────────
+
+type Section = {
+  /** Heading with markup and trailing qualifiers stripped — the display name. */
+  readonly title: string;
+  /** Whole section including its heading and any `###` children. */
+  readonly body: string;
+  /** Index in the original file, for stable ordering within a tier. */
+  readonly order: number;
+  readonly tier: number;
+  /** Key shared by every member of a state family (see `familyKey`). */
+  readonly family: string;
+  /** Recency score used to pick a family's survivor; higher is newer. */
+  readonly recency: string;
+};
+
+/** Strip `## ` markup and bold markers from a heading line. */
+function headingTitle(heading: string): string {
+  return heading
+    .replace(/^#+\s*/, "")
+    .replace(/\*\*/g, "")
+    .trim();
+}
+
+/**
+ * The family a section belongs to: its title minus temporal qualifiers.
+ * `Inbox / CI Watch (as of 2026-07-03, Run #134)` → `inbox / ci watch`. That
+ * parenthetical is exactly what makes each snapshot look unique while the
+ * underlying topic repeats, so removing it is what lets a family collapse.
+ */
+function familyKey(title: string): string {
+  return title
+    .replace(/\s*\([^)]*\)\s*$/, "")
+    .replace(/\s*[—–-]\s*(?:as of|run #).*$/i, "")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * A sortable recency key: `<date>|<run>`, both fixed-width so a plain string
+ * compare orders correctly. Both fields are zero-filled when absent rather
+ * than left empty — an empty field would make the `|` separator the first
+ * character compared, and `|` sorts *above* every digit, which would rank an
+ * undated section as newer than a dated one. A heading with neither field
+ * scores lowest and falls back to file order, where the dream agent puts the
+ * newest section first.
+ */
+function recencyKey(heading: string): string {
+  const date = /(\d{4}-\d{2}-\d{2})/.exec(heading)?.[1] ?? "0000-00-00";
+  const run = /\brun\s*#\s*(\d+)/i.exec(heading)?.[1] ?? "0";
+  return `${date}|${run.padStart(10, "0")}`;
+}
+
+/**
+ * Split content into a leading preamble (the `#` title and anything before
+ * the first `## `) plus one entry per `## ` section. The split is on `## `
+ * only, so an `h3` travels with the section it belongs to.
+ */
+function parseSections(content: string): {
+  preamble: string;
+  sections: Section[];
+} {
+  const parts = content.split(/^(?=## )/m);
+  const first = parts[0] ?? "";
+  const preamble = first.startsWith("## ") ? "" : (parts.shift() ?? "");
+  const sections: Section[] = [];
+  for (const body of parts) {
+    if (!body.trim()) continue;
+    const heading = body.split("\n", 1)[0] ?? "";
+    const title = headingTitle(heading);
+    sections.push({
+      title,
+      body,
+      order: sections.length,
+      tier: classify(title),
+      family: familyKey(title),
+      recency: recencyKey(heading),
+    });
+  }
+  return { preamble, sections };
+}
+
+/**
+ * Keep one section per state family: the newest by `recency`, and on a tie
+ * the one that appeared first. Only the `status` tier collapses — two
+ * sections about people are two different people, not two snapshots of one.
+ */
+function collapseFamilies(sections: readonly Section[]): {
+  kept: Section[];
+  dropped: Section[];
+} {
+  const winners = new Map<string, Section>();
+  for (const s of sections) {
+    if (s.tier !== STATUS_TIER) continue;
+    const held = winners.get(s.family);
+    if (!held || s.recency > held.recency) winners.set(s.family, s);
+  }
+  const kept: Section[] = [];
+  const dropped: Section[] = [];
+  for (const s of sections) {
+    if (s.tier !== STATUS_TIER || winners.get(s.family) === s) kept.push(s);
+    else dropped.push(s);
+  }
+  return { kept, dropped };
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/** The memory block to inject, plus what had to be left out of it. */
+export type MemoryView = {
+  /** Text to render into the persistent-memory prompt section. */
+  text: string;
+  /** True when the file did not fit whole — drives the "Read for more" note. */
+  truncated: boolean;
+  /** Human-readable list of ranked-out sections, or "" when none. */
+  omitted: string;
+};
+
+/** Head-slice at the cap, snapping back to a newline so the cut isn't mid-line. */
+function headSlice(content: string, budget: number): string {
+  const head = content.slice(0, budget);
+  const lastNewline = head.lastIndexOf("\n");
+  return (lastNewline > 0 ? head.slice(0, lastNewline) : head).trimEnd();
+}
+
+/** Render omitted titles as one prose list, eliding a long tail. */
+function formatOmitted(titles: readonly string[]): string {
+  if (titles.length === 0) return "";
+  if (titles.length <= MAX_OMITTED_NAMED) return titles.join("; ");
+  const named = titles.slice(0, MAX_OMITTED_NAMED).join("; ");
+  return `${named}; and ${titles.length - MAX_OMITTED_NAMED} more`;
+}
+
+/**
+ * Render the injectable view of `memory.md`.
+ *
+ * Under the cap this is the identity function — same bytes in, same bytes
+ * out. Over the cap, sections are collapsed and ranked as described in the
+ * module docstring, and anything that didn't fit is named in `omitted`.
+ */
+export function renderMemoryView(
+  content: string,
+  budget: number = MEMORY_INJECT_MAX_CHARS,
+): MemoryView {
+  if (content.length <= budget) {
+    return { text: content, truncated: false, omitted: "" };
+  }
+
+  const { preamble, sections } = parseSections(content);
+  const { kept, dropped } = collapseFamilies(sections);
+
+  // Tier first, then original file order — stable within a tier so the
+  // author's own ordering survives wherever priority doesn't decide.
+  const ranked = [...kept].sort((a, b) => a.tier - b.tier || a.order - b.order);
+
+  const head = preamble.trimEnd();
+  let spent = head.length;
+  const chosen: Section[] = [];
+  const omitted: Section[] = [...dropped];
+  for (const s of ranked) {
+    const cost = s.body.trimEnd().length + 2; // body + section separator
+    if (spent + cost <= budget) {
+      spent += cost;
+      chosen.push(s);
+    } else {
+      omitted.push(s);
+    }
+  }
+
+  // Nothing fit — a single section is bigger than the whole budget. Degrade
+  // to the old behaviour rather than injecting an empty memory block.
+  if (chosen.length === 0) {
+    return { text: headSlice(content, budget), truncated: true, omitted: "" };
+  }
+
+  chosen.sort((a, b) => a.order - b.order);
+  const body = chosen.map((s) => s.body.trimEnd()).join("\n\n");
+
+  return {
+    text: head ? `${head}\n\n${body}` : body,
+    truncated: true,
+    omitted: formatOmitted(
+      omitted
+        .sort((a, b) => a.tier - b.tier || a.order - b.order)
+        .map((s) => s.title),
+    ),
+  };
+}


### PR DESCRIPTION
## The bug

Only the first `MEMORY_INJECT_MAX_CHARS` of `memory.md` reach the prompt, and head-slicing made that cut **positional** while the content is not priority-ordered — so the least durable material evicted the most durable.

Measured on the live deployment: a **23,396-char file, 12k cap, cut landing at line 46 of 113**. Above the line sat one facts block and three near-duplicate `## Inbox / CI Watch (as of …, Run #N)` status snapshots. Below it, **never injected at all**, sat `## Active Investigations` with its root-cause analysis, plus `## Revisions` and `## Branches to clean up`.

## The fix

`core/prompt/memory-view.ts` makes truncation a *selection* problem:

1. Split into `## ` sections (an `h3` stays with its parent).
2. Collapse **state families** — sections whose headings differ only by a trailing timestamp or run number — down to the newest member. Three CI-watch snapshots describing the same recurring failures are one fact, not three.
3. Order by tier: directive → people → active → general → status → historical.
4. Emit whole sections until the budget is spent, and **name the ones held back** so the model knows to `Read` for them.

## Result on that same file

`23,396 → 9,461 chars`. Every live section present; only the two redundant stale snapshots dropped. That is **21% smaller than the old 12k head-slice**, so it also cuts the per-turn cache-write cost — which matters more than usual, because the Agent SDK exposes no cache-TTL knob and prompt size is the only lever we control (see `docs/memory-persona-plan.md` §3.6).

## Three deliberate constraints

- **Under the cap, output is byte-identical to the input.** Reordering only happens when the alternative is losing content, so deployments whose memory still fits see no behaviour change and no prompt-cache churn.
- **Surviving sections are emitted in file order, not tier order.** The ranking decides *what* survives, not how it reads — a tier-ordered body would rewrite the prompt prefix whenever a heading changed tier.
- **If nothing fits, fall back to head-slicing** rather than injecting an empty memory block.

## Also in this PR

`docs/memory-persona-plan.md` and `docs/memory-persona-rollout.md` — the architecture plan this is step 1 of, and the 15-PR rollout. The plan settles what happens to the Soul Kernel (absorb ~460 lines, delete ~4,300) and records the prompt-cache invariant the design has to respect.

## Verification

14 new tests in `memory-view.test.ts`; full suite green (4,140 passed); typecheck, lint, ratchets clean; no new dependency-cruiser violations (20 warnings before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)