### PR TITLE
feat(metrics): per-turn prompt-cache telemetry

### DIFF
--- a/src/__tests__/cache-telemetry.test.ts
+++ b/src/__tests__/cache-telemetry.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for prompt-cache telemetry.
+ *
+ * The behaviour under test exists because the aggregate `cache=NN%` on the
+ * accounting line is compatible with every turn re-writing the whole prefix:
+ * an agentic turn makes many model requests and all but the first read the
+ * prefix the first one paid for. Measured on the live deployment, one session
+ * read 242,847 cached tokens against 30,326 written — an 8:1 ratio that is
+ * entirely within-turn and says nothing about cross-turn reuse.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as logModule from "../util/log.js";
+import {
+  CACHE_LOOKBACK_BLOCKS,
+  cacheMinimumTokens,
+  crossTurnVerdict,
+  estimateTurnBlocks,
+  exceedsLookbackWindow,
+  formatTurnCache,
+  noteToolFingerprint,
+  resetToolFingerprints,
+  toolFingerprint,
+  turnCacheStats,
+  warnIfBelowCacheMinimum,
+  type CacheIteration,
+} from "../backend/shared/cache-telemetry.js";
+
+const iter = (read: number, write: number): CacheIteration => ({
+  cache_read_input_tokens: read,
+  cache_creation_input_tokens: write,
+});
+
+/** Spy on the real warn seam — `logWarn` goes through pino, not console. */
+function spyWarn(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(logModule, "logWarn").mockImplementation(() => {});
+}
+
+describe("turnCacheStats", () => {
+  it("returns undefined when the provider reported no iterations", () => {
+    expect(turnCacheStats(undefined)).toBeUndefined();
+    expect(turnCacheStats([])).toBeUndefined();
+  });
+
+  it("separates the first request from the turn totals", () => {
+    // The shape of a real agentic turn: pay once, then read repeatedly.
+    const stats = turnCacheStats([
+      iter(0, 22_000),
+      iter(22_000, 0),
+      iter(22_000, 0),
+    ])!;
+    expect(stats.modelRequests).toBe(3);
+    expect(stats.firstRead).toBe(0);
+    expect(stats.firstWrite).toBe(22_000);
+    expect(stats.totalRead).toBe(44_000);
+    expect(stats.totalWrite).toBe(22_000);
+  });
+
+  it("treats absent token fields as zero", () => {
+    const stats = turnCacheStats([{}, { cache_read_input_tokens: 5 }])!;
+    expect(stats.firstRead).toBe(0);
+    expect(stats.totalRead).toBe(5);
+    expect(stats.totalWrite).toBe(0);
+  });
+});
+
+describe("crossTurnVerdict", () => {
+  it("reports a miss when the turn paid to re-write the prefix", () => {
+    // A 2:1 aggregate read:write ratio still means the previous turn's
+    // prefix was gone — this is the case a short cache TTL produces.
+    const stats = turnCacheStats([iter(0, 20_000), iter(40_000, 0)])!;
+    expect(crossTurnVerdict(stats)).toBe("miss");
+  });
+
+  it("reports a hit when the first request read a cache", () => {
+    const stats = turnCacheStats([iter(20_000, 0), iter(20_000, 0)])!;
+    expect(crossTurnVerdict(stats)).toBe("hit");
+  });
+
+  it("reports none when nothing was cached either way", () => {
+    // Below the model's cacheable floor, or a provider that doesn't cache.
+    const stats = turnCacheStats([iter(0, 0)])!;
+    expect(crossTurnVerdict(stats)).toBe("none");
+  });
+});
+
+describe("formatTurnCache", () => {
+  it("emits a parseable space-delimited suffix", () => {
+    const stats = turnCacheStats([iter(0, 10_000), iter(80_000, 0)])!;
+    expect(formatTurnCache(stats)).toBe("xturn=miss reqs=2 rw=8.0");
+  });
+
+  it("omits the ratio when nothing was written", () => {
+    const stats = turnCacheStats([iter(500, 0)])!;
+    expect(formatTurnCache(stats)).toBe("xturn=hit reqs=1");
+  });
+});
+
+describe("lookback window", () => {
+  it("counts two blocks per tool call plus surrounding text", () => {
+    expect(estimateTurnBlocks(0)).toBe(1);
+    expect(estimateTurnBlocks(3)).toBe(7);
+  });
+
+  it("flags a turn that plausibly outran the lookback window", () => {
+    expect(exceedsLookbackWindow(9)).toBe(false); // 19 blocks
+    expect(exceedsLookbackWindow(10)).toBe(true); // 21 blocks
+    expect(estimateTurnBlocks(10)).toBeGreaterThan(CACHE_LOOKBACK_BLOCKS);
+  });
+
+  it("treats a negative tool count as zero", () => {
+    expect(estimateTurnBlocks(-5)).toBe(1);
+  });
+});
+
+describe("cacheMinimumTokens", () => {
+  it("knows the floor is not monotonic across generations", () => {
+    // The whole reason for a table rather than a version comparison.
+    expect(cacheMinimumTokens("claude-opus-5")).toBe(512);
+    expect(cacheMinimumTokens("claude-opus-4-8")).toBe(1024);
+    expect(cacheMinimumTokens("claude-opus-4-7")).toBe(2048);
+    expect(cacheMinimumTokens("claude-opus-4-6")).toBe(4096);
+    expect(cacheMinimumTokens("claude-haiku-4-5")).toBe(4096);
+  });
+
+  it("prefers the longest matching key", () => {
+    // "sonnet-4-6" must not be resolved by a bare "sonnet" entry.
+    expect(cacheMinimumTokens("claude-sonnet-4-6")).toBe(1024);
+    expect(cacheMinimumTokens("claude-haiku-4-5")).toBe(4096);
+  });
+
+  it("resolves SDK model strings with suffixes", () => {
+    expect(cacheMinimumTokens("sonnet-5[1m]")).toBe(1024);
+    expect(cacheMinimumTokens("haiku")).toBe(4096);
+  });
+
+  it("returns undefined for ambiguous aliases rather than guessing", () => {
+    // A warning that fires on the wrong model teaches people to ignore it.
+    expect(cacheMinimumTokens("default")).toBeUndefined();
+    expect(cacheMinimumTokens("opus")).toBeUndefined();
+    expect(cacheMinimumTokens("sonnet")).toBeUndefined();
+    expect(cacheMinimumTokens("gpt-5")).toBeUndefined();
+  });
+});
+
+describe("warnIfBelowCacheMinimum", () => {
+  it("warns when a prompt is under the model's floor", () => {
+    const warn = spyWarn();
+    warnIfBelowCacheMinimum("dream", "claude-haiku-4-5", "x".repeat(400));
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0]?.[1])).toContain("cacheable minimum");
+    warn.mockRestore();
+  });
+
+  it("stays quiet when the prompt clears the floor", () => {
+    const warn = spyWarn();
+    warnIfBelowCacheMinimum("dream", "claude-haiku-4-5", "x".repeat(40_000));
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("stays quiet when the model's floor is unknown", () => {
+    const warn = spyWarn();
+    warnIfBelowCacheMinimum("dream", "default", "x");
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe("tool fingerprint", () => {
+  beforeEach(() => {
+    resetToolFingerprints();
+  });
+
+  it("is order-insensitive and deduped", () => {
+    expect(toolFingerprint(["Bash", "Read"], ["talon"])).toEqual(
+      toolFingerprint(["Read", "Bash", "Read"], ["talon"]),
+    );
+  });
+
+  it("namespaces MCP servers so they can't collide with built-ins", () => {
+    expect(toolFingerprint([], ["Bash"])).toEqual(["mcp:Bash"]);
+  });
+
+  it("does not warn on the first turn of a chat", () => {
+    const warn = spyWarn();
+    const changed = noteToolFingerprint(
+      "chat-1",
+      toolFingerprint(["Bash"], []),
+    );
+    expect(changed).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("does not warn when the tool set is stable", () => {
+    const warn = spyWarn();
+    noteToolFingerprint("chat-1", toolFingerprint(["Bash", "Read"], ["talon"]));
+    const changed = noteToolFingerprint(
+      "chat-1",
+      toolFingerprint(["Read", "Bash"], ["talon"]),
+    );
+    expect(changed).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("warns and names the delta when a plugin server appears", () => {
+    const warn = spyWarn();
+    noteToolFingerprint("chat-1", toolFingerprint(["Bash"], ["talon"]));
+    const changed = noteToolFingerprint(
+      "chat-1",
+      toolFingerprint(["Bash"], ["talon", "mempalace"]),
+    );
+    expect(changed).toBe(true);
+    const message = String(warn.mock.calls[0]?.[1]);
+    expect(message).toContain("tool set changed mid-session");
+    expect(message).toContain("mcp:mempalace");
+    warn.mockRestore();
+  });
+
+  it("names removals too", () => {
+    const warn = spyWarn();
+    noteToolFingerprint("chat-1", toolFingerprint(["Bash", "Read"], []));
+    noteToolFingerprint("chat-1", toolFingerprint(["Bash"], []));
+    expect(String(warn.mock.calls[0]?.[1])).toContain("-Read");
+    warn.mockRestore();
+  });
+
+  it("tracks chats independently", () => {
+    const warn = spyWarn();
+    noteToolFingerprint("chat-1", toolFingerprint(["Bash"], []));
+    const changed = noteToolFingerprint(
+      "chat-2",
+      toolFingerprint(["Read"], []),
+    );
+    expect(changed).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -64,6 +64,10 @@ import {
   recordTurnMetrics,
   recordFailedTurnAccounting,
   recordFlowViolation,
+  formatTurnCache,
+  exceedsLookbackWindow,
+  estimateTurnBlocks,
+  CACHE_LOOKBACK_BLOCKS,
 } from "../shared/index.js";
 
 // ── Post-result watchdog ────────────────────────────────────────────────────
@@ -577,6 +581,19 @@ export async function* runChatTurn(
 
   state.allResponseText += state.currentBlockText;
 
+  // The aggregate `cache=NN%` can't distinguish a turn that reused the
+  // previous turn's prefix from one that re-wrote it — see
+  // shared/cache-telemetry.ts. Append the cross-turn verdict when the
+  // provider gave us per-request usage to derive it from.
+  if (state.cacheStats && exceedsLookbackWindow(state.toolCalls)) {
+    logWarn(
+      "agent",
+      `[${chatId}] turn emitted ~${estimateTurnBlocks(state.toolCalls)} content ` +
+        `blocks (> ${CACHE_LOOKBACK_BLOCKS} lookback) — the next turn's cache ` +
+        `breakpoint may not find this turn's prefix`,
+    );
+  }
+
   log(
     "agent",
     `[${chatId}] -> (${summarizeUsage(
@@ -586,7 +603,13 @@ export async function* runChatTurn(
         cacheRead: state.sdkCacheRead,
         cacheWrite: state.sdkCacheWrite,
       },
-      { durationMs, toolCalls: state.toolCalls },
+      {
+        durationMs,
+        toolCalls: state.toolCalls,
+        ...(state.cacheStats
+          ? { suffix: formatTurnCache(state.cacheStats) }
+          : {}),
+      },
     )})`,
   );
   traceMessage(chatId, "out", state.allResponseText, {

--- a/src/backend/claude-sdk/one-shot.ts
+++ b/src/backend/claude-sdk/one-shot.ts
@@ -19,6 +19,7 @@ import { log, logWarn } from "../../util/log.js";
 import { ALLOWED_TOOLS_BACKGROUND } from "../../core/constants.js";
 import { EFFORT_MAP } from "./constants.js";
 import { buildMcpServers, buildPluginMcpServers } from "./options.js";
+import { warnIfBelowCacheMinimum } from "../shared/cache-telemetry.js";
 
 const DEFAULT_SUBPROCESS_KILL_GRACE_MS = 5 * 1000;
 
@@ -110,6 +111,11 @@ export async function runOneShotAgent(
       `[${contextLabel}] Claude one-shot effort: ${reasoningEffort}`,
     );
   }
+
+  // Background runs are the one path whose prompt can be small enough to
+  // fall under the model's cacheable floor — where nothing is cached and the
+  // API reports no error at all. Chat prompts always clear it.
+  warnIfBelowCacheMinimum(contextLabel, model, `${systemPrompt}\n${prompt}`);
 
   const qi = query({
     prompt,

--- a/src/backend/claude-sdk/options.ts
+++ b/src/backend/claude-sdk/options.ts
@@ -26,6 +26,10 @@ import {
   hubPluginServerNames,
 } from "../../core/mcp-hub/index.js";
 import { nonTerminalFrontends, frontendsForChat } from "../shared/frontends.js";
+import {
+  noteToolFingerprint,
+  toolFingerprint,
+} from "../shared/cache-telemetry.js";
 import { log, logError } from "../../util/log.js";
 import { getConfig, getBridgePort } from "./state.js";
 import { ALLOWED_TOOLS_CHAT, EFFORT_MAP } from "./constants.js";
@@ -378,6 +382,24 @@ export function buildSdkOptions(
   const { postToolUseFailureHook, postToolBatchHook } =
     buildTurnTerminatorHooks();
 
+  const builtinTools = config.nativeTools
+    ? ALLOWED_TOOLS_CHAT.filter((t) => !NATIVE_REPLACED_BUILTINS.has(t))
+    : [...ALLOWED_TOOLS_CHAT];
+
+  const mcpServers = {
+    ...buildMcpServers(chatId),
+    ...buildPluginMcpServers(chatId),
+  };
+
+  // Tool definitions render BEFORE the system prompt, so a set that shifts
+  // mid-session invalidates the system prompt and every cached message after
+  // it — the most expensive cache event there is, and one the aggregate
+  // hit-rate can't show. Plugin-provided MCP servers are the mutable part.
+  noteToolFingerprint(
+    chatId,
+    toolFingerprint(builtinTools, Object.keys(mcpServers)),
+  );
+
   const options: Options = {
     model: resolvedActiveModel,
     // Prefer the caller's frozen per-session prompt; fall back to the
@@ -424,16 +446,9 @@ export function buildSdkOptions(
     // teleport onto companion devices), and Agent (sub-agent dispatch) is
     // removed too — the owner prefers the native surface without nested
     // agents. Flip the flag back off to restore the built-ins instantly.
-    tools: config.nativeTools
-      ? ALLOWED_TOOLS_CHAT.filter(
-          (t) => !NATIVE_REPLACED_BUILTINS.has(t as string),
-        )
-      : [...ALLOWED_TOOLS_CHAT],
+    tools: builtinTools,
     ...thinkingConfig,
-    mcpServers: {
-      ...buildMcpServers(chatId),
-      ...buildPluginMcpServers(chatId),
-    },
+    mcpServers,
     hooks: {
       PostToolUseFailure: [{ hooks: [postToolUseFailureHook] }],
       PostToolBatch: [{ hooks: [postToolBatchHook] }],

--- a/src/backend/claude-sdk/stream.ts
+++ b/src/backend/claude-sdk/stream.ts
@@ -19,6 +19,10 @@ import type { BetaRawContentBlockDeltaEvent } from "@anthropic-ai/sdk/resources/
 import { STREAM_INTERVAL } from "./constants.js";
 import { log } from "../../util/log.js";
 import { checkModelDrift } from "./model-drift.js";
+import {
+  turnCacheStats,
+  type TurnCacheStats,
+} from "../shared/cache-telemetry.js";
 
 // ── Stream state accumulator ────────────────────────────────────────────────
 
@@ -35,6 +39,14 @@ export type StreamState = {
   sdkOutputTokens: number;
   sdkCacheRead: number;
   sdkCacheWrite: number;
+  /**
+   * Per-turn cache behaviour derived from the result message's per-request
+   * `usage.iterations`. Undefined when the provider reported none — the
+   * aggregate totals above cannot distinguish a turn that read the previous
+   * turn's prefix from one that re-wrote it, and that distinction is the
+   * whole cost signal (see shared/cache-telemetry.ts).
+   */
+  cacheStats: TurnCacheStats | undefined;
   lastStreamUpdate: number;
   /**
    * Trailing text from the most recent assistant message — text after all
@@ -101,6 +113,7 @@ export function createStreamState(): StreamState {
     sdkOutputTokens: 0,
     sdkCacheRead: 0,
     sdkCacheWrite: 0,
+    cacheStats: undefined,
     lastStreamUpdate: 0,
     lastTrailingText: "",
     deliveredTextNorms: [],
@@ -332,6 +345,9 @@ export function processResultMessage(
       (last.input_tokens ?? 0) +
       (last.cache_read_input_tokens ?? 0) +
       (last.cache_creation_input_tokens ?? 0);
+    // The same array answers a question the per-turn totals can't: whether
+    // the FIRST request of this turn read a cache or paid to write one.
+    state.cacheStats = turnCacheStats(usage.iterations);
   }
 
   // Read token counts from the ACTIVE model's usage only.

--- a/src/backend/shared/cache-telemetry.ts
+++ b/src/backend/shared/cache-telemetry.ts
@@ -1,0 +1,297 @@
+/**
+ * Prompt-cache telemetry — the numbers needed to tell whether Talon's
+ * prompt cache is actually working, and why not when it isn't.
+ *
+ * Motivation (see docs/memory-persona-plan.md §3.6): the obvious lever for a
+ * sparse-traffic chat bot would be a 1-hour cache TTL, but
+ * `@anthropic-ai/claude-agent-sdk` exposes no cache-control surface at all —
+ * it owns `cache_control` placement internally. So the only levers Talon has
+ * are (a) keeping the prompt prefix byte-stable and (b) keeping it small,
+ * and the only way to know which one is costing money is to measure.
+ *
+ * Four things are measured here, each answering a question the aggregate
+ * `cache=NN%` on the accounting line cannot:
+ *
+ *   1. **Cross-turn vs within-turn hits.** An agentic turn makes many model
+ *      requests; every one after the first reads the prefix the first one
+ *      just paid for. So a 97% aggregate hit rate is compatible with *every
+ *      turn* re-writing the whole prefix. The turn's FIRST request is the
+ *      only one that reports whether the previous turn's cache survived —
+ *      that is the number that tracks cost.
+ *   2. **Tool-set churn.** Tool definitions render BEFORE the system prompt,
+ *      so any change to the tool array invalidates the system prompt and the
+ *      whole message history with it. A stable prompt behind an unstable
+ *      tool list buys nothing, and Talon's per-chat MCP servers are exactly
+ *      the shape that can shift mid-session.
+ *   3. **Lookback-window risk.** A cache breakpoint searches back at most
+ *      `CACHE_LOOKBACK_BLOCKS` content blocks for a prior entry. A turn that
+ *      emits more blocks than that can leave the *next* turn's breakpoint
+ *      unable to find anything — a silent miss with no error.
+ *   4. **Sub-minimum prompts.** Below a model-specific token floor nothing
+ *      caches, and the API reports no error. Talon's chat prompts clear every
+ *      floor; its one-shot prompts (dream, heartbeat, cron) may not.
+ *
+ * Everything here is pure except `noteToolFingerprint`, which keeps a small
+ * per-chat map so it can name what changed rather than just that something
+ * did.
+ */
+
+import { logWarn } from "../../util/log.js";
+
+// ── Per-turn cache stats ────────────────────────────────────────────────────
+
+/**
+ * One model request's usage, as the SDK reports it in
+ * `result.usage.iterations`. Fields are optional because a given provider
+ * may omit any of them; absent is treated as zero.
+ */
+export type CacheIteration = {
+  readonly input_tokens?: number;
+  readonly cache_read_input_tokens?: number;
+  readonly cache_creation_input_tokens?: number;
+};
+
+/** Cache behaviour for one user-visible turn. */
+export type TurnCacheStats = {
+  /** Model requests the SDK made inside this turn. */
+  readonly modelRequests: number;
+  /** Cache read on the turn's FIRST request — did the last turn's prefix live? */
+  readonly firstRead: number;
+  /** Cache written by the turn's first request. */
+  readonly firstWrite: number;
+  /** Cache read across every request in the turn. */
+  readonly totalRead: number;
+  /** Cache written across every request in the turn. */
+  readonly totalWrite: number;
+};
+
+/**
+ * What the turn's first request says about the previous turn's cache.
+ *
+ *   - `hit`  — the prefix survived; this turn read it instead of paying for it.
+ *   - `miss` — the prefix was gone and had to be re-written. The expensive case,
+ *              and the one a TTL shorter than the gap between turns produces.
+ *   - `none` — nothing was cached either way: below the model's cacheable
+ *              minimum, or a provider that doesn't cache at all.
+ */
+export type CrossTurnVerdict = "hit" | "miss" | "none";
+
+/**
+ * Fold a turn's per-request usage into cache stats. Returns undefined when
+ * the provider reported no iterations — the caller then logs nothing rather
+ * than inventing a verdict from aggregate totals it can't attribute.
+ */
+export function turnCacheStats(
+  iterations: readonly CacheIteration[] | undefined,
+): TurnCacheStats | undefined {
+  if (!iterations || iterations.length === 0) return undefined;
+  const first = iterations[0]!;
+  let totalRead = 0;
+  let totalWrite = 0;
+  for (const it of iterations) {
+    totalRead += it.cache_read_input_tokens ?? 0;
+    totalWrite += it.cache_creation_input_tokens ?? 0;
+  }
+  return {
+    modelRequests: iterations.length,
+    firstRead: first.cache_read_input_tokens ?? 0,
+    firstWrite: first.cache_creation_input_tokens ?? 0,
+    totalRead,
+    totalWrite,
+  };
+}
+
+/** Classify the turn's first request. See {@link CrossTurnVerdict}. */
+export function crossTurnVerdict(stats: TurnCacheStats): CrossTurnVerdict {
+  if (stats.firstRead > 0) return "hit";
+  if (stats.firstWrite > 0) return "miss";
+  return "none";
+}
+
+/**
+ * Compact suffix for the per-turn accounting line, e.g.
+ * `xturn=miss reqs=11 rw=8.0`. Deliberately terse and space-delimited so a
+ * week of logs can be parsed without a schema:
+ *
+ *   - `xturn` — the cross-turn verdict; the field that tracks cost.
+ *   - `reqs`  — model requests in the turn; explains a high aggregate hit
+ *               rate that isn't saving anything.
+ *   - `rw`    — total read ÷ total write. Above ~1 the turn amortised its
+ *               write; at or below it, the write dominated.
+ */
+export function formatTurnCache(stats: TurnCacheStats): string {
+  const parts = [
+    `xturn=${crossTurnVerdict(stats)}`,
+    `reqs=${stats.modelRequests}`,
+  ];
+  if (stats.totalWrite > 0) {
+    parts.push(`rw=${(stats.totalRead / stats.totalWrite).toFixed(1)}`);
+  }
+  return parts.join(" ");
+}
+
+// ── Lookback window ────────────────────────────────────────────────────────
+
+/**
+ * How far back a cache breakpoint searches for a prior entry, in content
+ * blocks. A turn that emits more than this can prevent the NEXT turn from
+ * finding any cache to read.
+ */
+export const CACHE_LOOKBACK_BLOCKS = 20;
+
+/**
+ * Rough content-block count for a turn from its tool-call count. Each tool
+ * call is a `tool_use` block plus a `tool_result` block, and the assistant
+ * text around them adds at least one more — so `2n + 1` is a floor, not an
+ * estimate. Used only to decide whether to warn, never to report a number.
+ */
+export function estimateTurnBlocks(toolCalls: number): number {
+  return Math.max(0, toolCalls) * 2 + 1;
+}
+
+/** True when a turn plausibly emitted more blocks than a breakpoint looks back. */
+export function exceedsLookbackWindow(toolCalls: number): boolean {
+  return estimateTurnBlocks(toolCalls) > CACHE_LOOKBACK_BLOCKS;
+}
+
+// ── Cacheable minimum ──────────────────────────────────────────────────────
+
+/**
+ * Minimum cacheable prefix, in tokens, by model. Below this nothing is
+ * cached and the API reports no error — `cache_creation_input_tokens` is
+ * simply 0.
+ *
+ * The floor is NOT monotonic across generations (512 on the newest models,
+ * 4096 on Opus 4.6 and Haiku 4.5), so it can't be inferred from a version
+ * number. Longest match wins, so `sonnet-4-6` is checked before `sonnet`.
+ *
+ * Bare aliases resolve only where Talon's catalog leaves no ambiguity:
+ * `haiku` is Haiku 4.5 (and carries the largest floor, making it the most
+ * likely to silently not cache). Ambiguous aliases — `opus`, `sonnet`,
+ * `default` — deliberately return undefined: a warning that fires on the
+ * wrong model teaches people to ignore warnings.
+ */
+const CACHE_MINIMUMS: readonly (readonly [string, number])[] = [
+  ["fable-5", 512],
+  ["mythos-5", 512],
+  ["opus-5", 512],
+  ["opus-4-8", 1024],
+  ["sonnet-5", 1024],
+  ["sonnet-4-6", 1024],
+  ["sonnet-4-5", 1024],
+  ["opus-4-1", 1024],
+  ["opus-4-7", 2048],
+  ["mythos-preview", 2048],
+  ["opus-4-6", 4096],
+  ["opus-4-5", 4096],
+  ["haiku-4-5", 4096],
+  ["haiku", 4096],
+];
+
+/**
+ * The cacheable-prefix floor for a model, or undefined when the model string
+ * doesn't unambiguously identify one.
+ */
+export function cacheMinimumTokens(model: string): number | undefined {
+  const m = model.toLowerCase();
+  let best: { key: string; min: number } | undefined;
+  for (const [key, min] of CACHE_MINIMUMS) {
+    if (!m.includes(key)) continue;
+    if (!best || key.length > best.key.length) best = { key, min };
+  }
+  return best?.min;
+}
+
+/** Cheap tokenizer-free estimate (~4 chars/token), matching soul/projector. */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Warn when a prompt is too small to be cacheable on its model. No-op when
+ * the model's floor is unknown or the prompt clears it. `label` names the
+ * caller (e.g. `"dream"`) so the warning points somewhere.
+ */
+export function warnIfBelowCacheMinimum(
+  label: string,
+  model: string,
+  prompt: string,
+): void {
+  const min = cacheMinimumTokens(model);
+  if (min === undefined) return;
+  const estimated = estimateTokens(prompt);
+  if (estimated >= min) return;
+  logWarn(
+    "agent",
+    `[${label}] prompt ~${estimated} tokens is below ${model}'s ${min}-token ` +
+      `cacheable minimum — nothing will be cached for this run`,
+  );
+}
+
+// ── Tool-set fingerprint ───────────────────────────────────────────────────
+
+/**
+ * Per-chat fingerprint of the last tool set seen. Bounded so a long-lived
+ * process with many chats can't grow it without limit; eviction is
+ * insertion-ordered, and a false "changed" warning after eviction is
+ * cheaper than unbounded retention.
+ */
+const MAX_TRACKED_CHATS = 256;
+const lastToolSets = new Map<string, readonly string[]>();
+
+/** Stable fingerprint for a tool set: sorted, deduped names. */
+export function toolFingerprint(
+  builtinTools: readonly string[],
+  mcpServerNames: readonly string[],
+): readonly string[] {
+  return [
+    ...new Set([...builtinTools, ...mcpServerNames.map((n) => `mcp:${n}`)]),
+  ].sort();
+}
+
+/**
+ * Record this turn's tool set for a chat and warn when it differs from the
+ * previous turn's. Returns true when a change was detected.
+ *
+ * Tools render before the system prompt, so a mid-session change invalidates
+ * the system prompt and every cached message after it — the most expensive
+ * cache event available, and invisible in aggregate hit-rate numbers.
+ */
+export function noteToolFingerprint(
+  chatId: string,
+  fingerprint: readonly string[],
+): boolean {
+  const previous = lastToolSets.get(chatId);
+
+  if (lastToolSets.size >= MAX_TRACKED_CHATS && !previous) {
+    const oldest = lastToolSets.keys().next().value;
+    if (oldest !== undefined) lastToolSets.delete(oldest);
+  }
+  lastToolSets.set(chatId, fingerprint);
+
+  if (!previous) return false;
+  if (
+    previous.length === fingerprint.length &&
+    previous.every((t, i) => t === fingerprint[i])
+  ) {
+    return false;
+  }
+
+  const before = new Set(previous);
+  const after = new Set(fingerprint);
+  const added = fingerprint.filter((t) => !before.has(t));
+  const removed = previous.filter((t) => !after.has(t));
+  logWarn(
+    "agent",
+    `[${chatId}] tool set changed mid-session — invalidates the whole prompt ` +
+      `cache for this chat` +
+      (added.length ? ` (+${added.join(",")})` : "") +
+      (removed.length ? ` (-${removed.join(",")})` : ""),
+  );
+  return true;
+}
+
+/** Drop all tracked fingerprints (tests / explicit reset). */
+export function resetToolFingerprints(): void {
+  lastToolSets.clear();
+}

--- a/src/backend/shared/index.ts
+++ b/src/backend/shared/index.ts
@@ -68,6 +68,16 @@ export {
   type TokenUsageSnapshot,
 } from "./usage.js";
 
+// Only what is consumed THROUGH the barrel. Everything else in
+// cache-telemetry.ts is imported from the module directly, matching the
+// barrel discipline the prompt/ barrel was just trimmed to.
+export {
+  formatTurnCache,
+  estimateTurnBlocks,
+  exceedsLookbackWindow,
+  CACHE_LOOKBACK_BLOCKS,
+} from "./cache-telemetry.js";
+
 export {
   prepareSystemPrompt,
   appendBackendSuffix,


### PR DESCRIPTION
## Why

The aggregate `cache=NN%` on the accounting line **cannot tell a turn that reused the previous turn's prefix from one that re-wrote it.** An agentic turn makes many model requests and every one after the first reads the prefix the first one paid for, so a 97% hit rate is compatible with every turn paying full price.

Measured on the live deployment: one session read **242,847** cached tokens against **30,326** written — an 8:1 ratio that is entirely *within-turn* and says nothing about cross-turn reuse.

This matters because the obvious lever turns out to be unavailable. A full grep of `sdk.d.ts` + `agentSdkTypes.d.ts` in `@anthropic-ai/claude-agent-sdk@0.3.212` for cache/ttl identifiers returns only the read-only `cacheCreationInputTokens` / `cacheReadInputTokens` — **the SDK exposes no cache-control surface at all.** So a 1-hour TTL is an upstream ask rather than a config change, and the only levers left are keeping the prefix byte-stable and keeping it small. Which one is costing money is an empirical question, and nothing currently measures it.

## What lands

`backend/shared/cache-telemetry.ts` measures four things, each answering a question the aggregate can't:

- **Cross-turn vs within-turn hits**, from the result message's per-request `usage.iterations`. The turn's *first* request is the only one that reports whether the previous turn's cache survived. Emitted on the existing accounting line as `xturn=hit|miss|none reqs=N rw=R` — space-delimited so a week of logs parses without a schema.
- **Tool-set churn.** Tool definitions render *before* the system prompt, so a set that shifts mid-session invalidates the system prompt and every cached message after it — the most expensive cache event available, and invisible in hit-rate numbers. Talon's per-chat plugin MCP servers are exactly that shape. Warns once per change and names the added/removed entries.
- **Lookback-window risk.** A cache breakpoint searches back at most 20 content blocks; a turn that emits more can leave the *next* turn unable to find anything. Flagged from the tool-call count (`2n+1` blocks is a floor, not an estimate).
- **Sub-minimum prompts.** Below a model-specific token floor nothing caches and the API reports no error. The floor is **not monotonic** across generations (512 on Opus 5, 4096 on Opus 4.6 and Haiku 4.5), so it's a table rather than a version comparison. Ambiguous aliases (`opus`, `sonnet`, `default`) return undefined rather than risk a warning that fires on the wrong model. Checked on the one-shot paths (dream, heartbeat, cron), whose prompts are the only ones small enough to trip it.

## How to read it

`xturn` is the field that tracks cost:

- mostly `miss` → the prefix is dying between turns; the fix is a smaller prefix, or the upstream TTL ask
- mostly `hit` → caching is working and the spend is elsewhere
- any `none` → that prompt isn't cacheable at all

## Scope

No behaviour change — telemetry and warnings only. The only refactor is hoisting `builtinTools` / `mcpServers` out of the `options` literal so the fingerprint can see them.

## Verification

25 new tests in `cache-telemetry.test.ts`; full suite green (4,151 passed); typecheck, lint, ratchets clean; no new dependency-cruiser violations (20 warnings before and after).

Depends on nothing; stacks cleanly with #686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)