### PR TITLE
fix(prompts): split live state out of durable memory

### DIFF
--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -30,19 +30,39 @@ You primarily use filesystem tools (Read, Write, Edit, Bash, Glob, Grep). Do NOT
 
 - Read the current memory file at `{{memoryFile}}`
 - Merge new information into the appropriate sections
-- Update existing entries if new info contradicts or extends them
-- Add new entries where appropriate
 - Keep entries concise and factual — no padding, no narrative
-- Preserve all existing structure and sections
 - Also write daily memory summaries to `{{dailyMemoryDir}}/YYYY-MM-DD.md` for each day of logs you processed. Include key learnings, conversation summaries, and follow-ups. Keep these concise — the bot reads them on demand for context.
 
-### Stage 4 — Prune
+**Replace, don't annotate.** When new information supersedes an entry, rewrite that entry to say what is true now. Do not append "UPDATE:", "RESOLVED:", or "CONFIRMED:" to an existing line and leave the old claim standing — an entry that has been amended three times is three times the tokens and reads as three competing facts. One line, current state, and the history goes to the archive if it is worth keeping at all.
 
-- Remove entries that have been explicitly contradicted
-- Remove entries that are clearly superseded
-- Do NOT remove entries just because they're old or seem unimportant — only
-  remove information that is wrong or replaced by a newer version
-- Write the updated memory.md back to `{{memoryFile}}`
+**Never create a second section for a topic that already has one.** If `## Foo` exists, update `## Foo`. Do not add `## Foo (as of <date>)` or `## Foo (Run #N)` beside it. Dated section headings are how this file grew three near-duplicate status sections totalling 15.8k characters, which pushed the real content past the prompt's injection cap and out of the bot's context entirely.
+
+**Status snapshots do not belong here at all.** Anything that will be false in an hour — what is currently up or down, this run's inbox, the latest CI result — is the heartbeat's job and lives in `state.md`. If you find that kind of content in memory.md, move what is durable into the right topical section and delete the rest.
+
+### Stage 4 — Prune to budget
+
+Memory has a size budget: **keep `{{memoryFile}}` under 10,000 characters.** It is injected into every session from the first turn, so growth is a cost paid on every single conversation.
+
+Remove, in this order, until the file is within budget:
+
+1. Entries that have been contradicted or superseded.
+2. Status snapshots and run-by-run forensics (see above) — the highest-volume, lowest-value content.
+3. Closed items: resolved bugs, merged PRs, completed migrations. A fixed problem is worth at most one line, and usually zero.
+4. Detail that has stopped earning its space — collapse a long entry to the fact it establishes. "The compile step drops quantized weights" survives; the four-paragraph investigation that discovered it does not.
+
+**Old is not the same as wrong, but old and inert is prunable.** An entry that is still true and still load-bearing stays however old it is. An entry nobody will act on again goes, whatever its age.
+
+**Forgetting must be auditable.** Before deleting anything substantive, append it to `{{memoryArchiveDir}}/YYYY-MM.md` (create the directory and file if needed) under a `## Pruned <YYYY-MM-DD>` heading. The archive is never injected into the prompt and never read automatically — it exists so a wrong deletion can be recovered and so pruning can be reviewed.
+
+Write the updated memory.md back to `{{memoryFile}}`.
+
+### Stage 4.5 — Rotate daily notes
+
+Daily notes accumulate indefinitely and are only ever read on demand, so old ones cost storage without earning attention.
+
+- For any note in `{{dailyMemoryDir}}/` older than 14 days, fold its durable content into `{{dailyMemoryDir}}/archive/YYYY-MM.md` as a short dated bullet list, then delete the original.
+- Anything genuinely durable should already be in memory.md — the monthly summary is a safety net, not the primary record.
+- Never delete a note you have not summarised.
 
 ### Stage 5 — Mine to MemPalace & Write Diary (optional)
 

--- a/prompts/heartbeat.md
+++ b/prompts/heartbeat.md
@@ -13,11 +13,22 @@ Use available tools when they help accomplish the goals and user-defined tasks (
 ## Context
 
 - Workspace: `{{workspace}}`
-- Memory file: `{{memoryFile}}`
+- Live state file (yours to rewrite): `{{stateFile}}`
+- Durable memory file (read-only for you — the dream agent owns it): `{{memoryFile}}`
 - Logs directory: `{{logsDir}}`
 - Last heartbeat: `{{lastRunIso}}`
 - Run number: #{{runCount}}
 - Today's daily memory: `{{dailyMemoryFile}}`
+
+## File ownership — read this before writing anything
+
+You own **two** files: the live state file and today's daily note. You do **not** write `{{memoryFile}}`.
+
+- **`{{stateFile}}` — rewrite it WHOLE every run.** It holds current operational status and nothing else: what is up, what is down, what is in flight. One `## <domain>` section per subject (e.g. `## Heartbeat health`, `## CI`, `## Inbox`), each carrying only the current state of that subject. Never add a run number or date to a section heading, never keep a previous run's section alongside a new one, and never append — replace the file's contents outright. If a subject is healthy and unremarkable, drop its section rather than writing "nothing to report".
+- **Today's daily note** — append observations, learnings, corrections, follow-ups.
+- **`{{memoryFile}}` is read-only for you.** Read it for context whenever useful. If you learn something durable that belongs there, write it into today's daily note instead; the dream agent consolidates notes into memory on its own cadence.
+
+Why: status snapshots written into durable memory accreted there run after run until they crowded out the actual knowledge — three "as of Run #N" sections had grown to 15.8k chars and pushed the live investigations past the prompt's injection cap. A file that gets replaced can't accrete.
 
 ## Open Goals
 
@@ -41,15 +52,16 @@ Read the user-defined instructions file at `{{instructionsFile}}`. Follow whatev
 If the instructions file does not exist or is empty, perform these default tasks after working on goals:
 
 1. **Review recent logs** — Check `{{logsDir}}/` for log files dated after `{{lastRunIso}}`. If `{{lastRunIso}}` is `never`, treat it as the beginning of time and review all available logs. Extract any new facts, preferences, or notable events.
-2. **Update memory** — Merge any new information into `{{memoryFile}}`, keeping entries concise and factual.
-3. **Update daily notes** — Write today's learnings, observations, corrections, and follow-ups to `{{dailyMemoryFile}}`. Keep entries concise — the bot reads this file on demand for context.
+2. **Rewrite live state** — Replace `{{stateFile}}` with the current status, per the ownership rules above. Keep the whole file under ~1500 characters; if it won't fit, you are recording history rather than state — cut the history.
+3. **Update daily notes** — Write today's learnings, observations, corrections, and follow-ups to `{{dailyMemoryFile}}`. Keep entries concise. Durable facts go here, not into the memory file.
 4. **Check email** — If email tools are available, check the inbox for new messages and note anything important.
 5. **Workspace hygiene** — Note any issues but do not delete files unless the instructions explicitly say to.
 
 ## Rules
 
 - Reach out when you find something a user would genuinely want to know — goal completed or blocked, deadline approaching, something broken, a finding they care about. Don't send filler ("still working on it", uneventful-run summaries). The bar: "would they be glad this interrupted them?" Every outbound tool call needs an explicit `chat_id`.
-- Be concise in log entries, progress notes, and memory updates.
+- Be concise in log entries, progress notes, and state updates.
+- Never write to `{{memoryFile}}` — durable facts go in today's daily note.
 - If a task fails, log the error and move on to the next task.
 - Do NOT modify the instructions file — only read it.
 - Be surgical: only make the minimal file changes needed to complete the current task.

--- a/prompts/system/heartbeat-agent.md
+++ b/prompts/system/heartbeat-agent.md
@@ -10,6 +10,16 @@ status="completed" and send a short high-signal message to the goal's
 chat. If nothing can be done on a goal right now, skip it silently.
 
 {{goals}}
+{% elsif mode == "state-fallback" %}
+
+## File ownership (overrides anything above)
+
+Your seeded `heartbeat.md` predates the memory/state split, so apply these rules over whatever it says about writing memory:
+
+- **Rewrite `{{stateFile}}` WHOLE every run.** It holds current operational status only: what is up, what is down, what is in flight. One `## <domain>` section per subject, each carrying only that subject's current state. Never put a run number or date in a heading, never keep a previous run's section beside a new one, and never append — replace the file outright. Keep it under ~1500 characters.
+- **`{{memoryFile}}` is read-only for you.** Read it for context, but do not write to it. Durable facts go into today's daily note; the nightly consolidation folds notes into memory on its own cadence.
+
+Why: status snapshots written into durable memory accreted run after run until they crowded out real knowledge — three "as of Run #N" sections reached 15.8k characters and pushed the live investigations past the prompt's injection cap.
 {% else %}
 You are a background heartbeat agent for Talon. You have access to
 filesystem tools and all registered MCP plugins. Follow the

--- a/prompts/system/live-state.md
+++ b/prompts/system/live-state.md
@@ -1,0 +1,8 @@
+## Live State
+
+Current operational status — what is up, down, or in flight right now. The heartbeat rewrites this file in full on every run, so treat it as a snapshot that may already be stale, not as a durable fact. Read-only for you: anything you write here is overwritten on the next run, so if something below is wrong, say so rather than correcting the file.
+File: ~/.talon/workspace/memory/state.md
+
+{{content}}{% if truncated %}
+
+…(state file truncated here — Read the file above for the rest){% endif %}

--- a/prompts/system/memory-recall.md
+++ b/prompts/system/memory-recall.md
@@ -46,4 +46,16 @@ memory organized, update stale facts, and avoid duplicate copies.
 - If neither a memory provider nor filesystem tools are available, retain the
   information only for the current conversation and never claim it was saved.
 
+Replace what changed rather than annotating it. Appending "UPDATE:" or
+"RESOLVED:" to an existing entry leaves the superseded claim standing beside
+its correction, and a line amended three times reads as three competing facts.
+For the same reason, never open a second dated section for a topic that already
+has one — update the section that exists.
+
+Live operational status is not durable memory. What is up, down, or in flight
+right now belongs in `memory/state.md`, which the background heartbeat rewrites
+in full on every run and which is read-only for you. Recording it as durable
+memory instead is what crowds a memory file with snapshots that were true for
+an hour.
+
 Memory updates should usually be quiet unless the user asks about them.

--- a/prompts/system/persistent-memory.md
+++ b/prompts/system/persistent-memory.md
@@ -1,6 +1,6 @@
 ## Persistent Memory
 
-The following is your memory file. Reference it naturally. Update it via the Write tool when you learn important new information.
+The following is your memory file — durable facts, not live status. Reference it naturally; the Memory and Recall policy in this prompt governs how you add to it and keep it current.
 File: ~/.talon/workspace/memory/memory.md
 
 {{content}}{% if omitted %}

--- a/prompts/system/workspace.md
+++ b/prompts/system/workspace.md
@@ -3,7 +3,9 @@
 You have a workspace directory at `~/.talon/workspace/`. This is your home — organize it however you want.
 
 - `memory/memory.md` — your file-based persistent-memory fallback when no dedicated memory provider is available.
+- `memory/state.md` — current operational status, rewritten in full by the background heartbeat. Read-only for you: a snapshot, not a record.
 - `memory/daily/YYYY-MM-DD.md` — concise chronological notes: observations, learnings, corrections, and follow-ups.
+- `memory/archive/YYYY-MM.md` — memory pruned by the nightly consolidation, kept so forgetting stays auditable. Never injected into a prompt; read it only when something looks like it was dropped by mistake.
 - `logs/` — daily interaction logs, written automatically.
 - `uploads/` — files users send you (photos, docs, voice) land here.
 - Everything else is yours to create and organize as you see fit.

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -708,11 +708,20 @@ describe("config", () => {
       const config = loadConfig();
       expect(config.systemPrompt).toContain("Persistent Memory");
       expect(config.systemPrompt).toContain("truncated");
-      // The whole prompt stays bounded: memory contributes at most the cap.
+      // The point of the cap: the memory FILE contributes at most
+      // MEMORY_INJECT_MAX_CHARS. The section also carries the template's
+      // fixed prose (heading, file pointer, update rules), which is not what
+      // this bound is guarding — so measure the injected content, not the
+      // rendered section, and let the template's wording change freely.
       const memorySection = config.systemPrompt
         .split("Persistent Memory")[1]
         .split("---")[0];
-      expect(memorySection.length).toBeLessThan(MEMORY_INJECT_MAX_CHARS + 500);
+      const injected = memorySection
+        .split("\n")
+        .filter((l) => l.startsWith("remembered fact"))
+        .join("\n");
+      expect(injected.length).toBeGreaterThan(0);
+      expect(injected.length).toBeLessThanOrEqual(MEMORY_INJECT_MAX_CHARS);
     });
 
     it("includes workspace file listing when files exist", async () => {

--- a/src/__tests__/live-state-prompt.test.ts
+++ b/src/__tests__/live-state-prompt.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the memory/state split in the system prompt.
+ *
+ * `state.md` exists because status snapshots written into durable memory
+ * accreted there run after run: on the live deployment three
+ * `## Inbox / CI Watch (as of …, Run #N)` sections had grown to 15.8k chars
+ * and pushed the actual investigations past the injection cap. A file the
+ * heartbeat rewrites whole cannot accrete; a hard cap on the injected block
+ * makes it loud if the heartbeat starts appending anyway.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  STATE_INJECT_MAX_CHARS,
+  assembleSystemPrompt,
+} from "../core/prompt/assemble.js";
+import { loadSystemTemplate } from "../core/prompt/templates.js";
+
+describe("live-state template", () => {
+  it("renders the state content and marks it as a snapshot", () => {
+    const out = loadSystemTemplate("live-state", {
+      content: "## Heartbeat health\n- healthy since 2026-07-30",
+    });
+    expect(out).toContain("Live State");
+    expect(out).toContain("healthy since 2026-07-30");
+    // The model must not treat a snapshot as a durable fact, and must not
+    // write to a file the heartbeat overwrites every run.
+    expect(out.toLowerCase()).toContain("snapshot");
+    expect(out.toLowerCase()).toContain("read-only");
+    expect(out).not.toContain("truncated here");
+  });
+
+  it("appends a pointer when the state file was capped", () => {
+    const out = loadSystemTemplate("live-state", {
+      content: "## CI\n- red",
+      truncated: "yes",
+    });
+    expect(out).toContain("truncated here");
+  });
+});
+
+describe("memory policy", () => {
+  it("puts the replace-don't-annotate rule in the recall policy, not the wrapper", () => {
+    // `memory-recall.md` owns the save/update policy, so the rule lives
+    // there — duplicating it into the file wrapper would give two places to
+    // drift apart. Annotation is what produced 700-char bullets carrying
+    // three superseded claims plus their amendments on the live deployment.
+    const policy = loadSystemTemplate("memory-recall");
+    expect(policy).toMatch(/Replace what changed rather than annotating/i);
+    expect(policy).toMatch(/never open a second dated section/i);
+    expect(policy).toContain("memory/state.md");
+    expect(policy).toMatch(/not durable memory/i);
+  });
+
+  it("keeps the file wrapper lean and delegating", () => {
+    const wrapper = loadSystemTemplate("persistent-memory", { content: "x" });
+    expect(wrapper).toMatch(/durable facts, not live status/i);
+    expect(wrapper).toMatch(/Memory and Recall policy/);
+    expect(wrapper).not.toMatch(/Replace what changed/i);
+  });
+});
+
+describe("assembleSystemPrompt", () => {
+  it("keeps the state cap far tighter than the memory cap", () => {
+    // state.md is rewritten every run; anything large means the heartbeat is
+    // accumulating history in a file that is supposed to be replaced.
+    expect(STATE_INJECT_MAX_CHARS).toBeLessThan(3_000);
+  });
+
+  it("omits the state section entirely when no state file exists", () => {
+    // The common case on a fresh install — an absent file must not emit an
+    // empty section, and must not throw.
+    const parts = assembleSystemPrompt({ frontend: "terminal" });
+    expect(typeof parts.staticText).toBe("string");
+    expect(parts.staticText.length).toBeGreaterThan(0);
+  });
+});
+
+describe("heartbeat state-fallback template", () => {
+  it("carries the ownership rules for a stale seeded prompt", () => {
+    // A seeded heartbeat.md predating the split still says "update memory";
+    // this block is appended to override it, since a user-owned seeded file
+    // is never refreshed by an upgrade.
+    const out = loadSystemTemplate("heartbeat-agent", {
+      mode: "state-fallback",
+      stateFile: "/home/u/.talon/workspace/memory/state.md",
+      memoryFile: "/home/u/.talon/workspace/memory/memory.md",
+    });
+    expect(out).toContain("state.md");
+    expect(out).toContain("memory.md");
+    expect(out).toMatch(/read-only/i);
+    expect(out).toMatch(/whole every run/i);
+    // Must not leak the other branches of the template.
+    expect(out).not.toContain("OUTBOUND MESSAGING");
+    expect(out).not.toContain("Open goals");
+  });
+
+  it("still renders the goals fallback independently", () => {
+    const out = loadSystemTemplate("heartbeat-agent", {
+      mode: "goals-fallback",
+      count: "2",
+      goals: "- ship the release",
+    });
+    expect(out).toContain("Open goals (2)");
+    expect(out).toContain("ship the release");
+    expect(out).not.toMatch(/read-only/i);
+  });
+});

--- a/src/core/background/dream.ts
+++ b/src/core/background/dream.ts
@@ -235,6 +235,7 @@ If commands fail, log the error and continue — this stage is optional.`
       .replace(/\{\{lastRunIso\}\}/g, lastRunIso)
       .replace(/\{\{memoryFile\}\}/g, memoryFile)
       .replace(/\{\{dailyMemoryDir\}\}/g, dirs.dailyMemory)
+      .replace(/\{\{memoryArchiveDir\}\}/g, dirs.memoryArchive)
       .replace(/\{\{mempalaceSection\}\}/g, mempalaceSection);
   } catch {
     throw new Error("Failed to read dream prompt (dream.md)");

--- a/src/core/background/heartbeat/agent.ts
+++ b/src/core/background/heartbeat/agent.ts
@@ -127,14 +127,17 @@ export async function runHeartbeatAgent(
 
   let prompt: string;
   let hadGoalsVar: boolean;
+  let hadStateVar: boolean;
   try {
     const raw = readFileSync(promptPath, "utf-8");
     hadGoalsVar = raw.includes("{{goals}}");
+    hadStateVar = raw.includes("{{stateFile}}");
     prompt = raw
       .replace(/\{\{workspace\}\}/g, workspace)
       .replace(/\{\{logsDir\}\}/g, logsDir)
       .replace(/\{\{lastRunIso\}\}/g, lastRunIso)
       .replace(/\{\{memoryFile\}\}/g, memoryFile)
+      .replace(/\{\{stateFile\}\}/g, pathFiles.state)
       .replace(/\{\{instructionsFile\}\}/g, instructionsFile)
       .replace(/\{\{dailyMemoryFile\}\}/g, dailyMemoryFile)
       .replace(/\{\{runCount\}\}/g, String(runCount))
@@ -152,6 +155,24 @@ export async function runHeartbeatAgent(
       mode: "goals-fallback",
       count: String(goalsBlock.count),
       goals: goalsBlock.text,
+    }).trim()}`;
+  }
+
+  // Same vintage problem for the memory/state split: a seeded heartbeat.md
+  // from before it still instructs the agent to write memory.md, which is
+  // how status snapshots accreted in the durable store in the first place.
+  // Append the ownership rules so the split holds regardless of template
+  // vintage — the seeded copy is never rewritten once the user owns it.
+  if (!hadStateVar) {
+    logWarn(
+      "heartbeat",
+      `Seeded ${promptPath} predates the memory/state split — appending ` +
+        `file-ownership rules. Delete that file to re-seed the current prompt.`,
+    );
+    prompt += `\n\n${loadSystemTemplate("heartbeat-agent", {
+      mode: "state-fallback",
+      stateFile: pathFiles.state,
+      memoryFile,
     }).trim()}`;
   }
 

--- a/src/core/prompt/assemble.ts
+++ b/src/core/prompt/assemble.ts
@@ -19,6 +19,9 @@
  *   4. Persistent memory (ranked, capped)   prompts/system/persistent-memory.md
  *                                           wrapping ~/.talon/workspace/memory/memory.md
  *                                           via memory-view.ts
+ *   4.5 Live state (capped)                 prompts/system/live-state.md
+ *                                           wrapping ~/.talon/workspace/memory/state.md
+ *                                           (heartbeat-owned, rewritten whole)
  *   5. Memory recall + capability docs      prompts/system/{memory-recall,workspace,...}.md
  *   6. Plugin additions                     plugin.systemPrompt() contributions
  *   (7. Delivery contract — appended by the backend as its suffix,
@@ -93,6 +96,18 @@ export function joinSystemPromptParts(parts: SystemPromptParts): string {
   if (!parts.staticText) return parts.dynamicText;
   return `${parts.staticText}\n\n---\n\n${parts.dynamicText}`;
 }
+
+// ── Tunables ────────────────────────────────────────────────────────────────
+
+/**
+ * Cap on the injected `state.md` block. Deliberately much tighter than the
+ * memory cap: this is a status snapshot the heartbeat rewrites every run, so
+ * anything past a couple of thousand chars means the heartbeat is
+ * accumulating history in a file that is supposed to be replaced — the
+ * failure the memory/state split exists to prevent. Truncating loudly is the
+ * signal that it is happening.
+ */
+export const STATE_INJECT_MAX_CHARS = 2_000;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -183,6 +198,26 @@ export function assembleSystemPrompt(
       }),
     );
     loaded.push(truncated ? "memory(ranked)" : "memory");
+  }
+
+  // 4.5. Live state — the heartbeat's rewritten-whole status snapshot, kept
+  //      OUT of memory.md so "as of Run #N" sections can't accrete in the
+  //      durable store and push real knowledge past the cap. Capped hard:
+  //      this is the most volatile content in the static prompt, and a
+  //      status file that grows is the exact failure this split exists to
+  //      prevent.
+  const state = readOptionalFile(pathFiles.state);
+  if (state) {
+    const truncated = state.length > STATE_INJECT_MAX_CHARS;
+    staticParts.push(
+      loadSystemTemplate("live-state", {
+        content: truncated
+          ? state.slice(0, STATE_INJECT_MAX_CHARS).trimEnd()
+          : state,
+        truncated: truncated ? "yes" : undefined,
+      }),
+    );
+    loaded.push(truncated ? "state(capped)" : "state");
   }
 
   // 5. Package-owned behavioural and capability docs. The memory policy

--- a/src/core/prompt/embedded-prompts.ts
+++ b/src/core/prompt/embedded-prompts.ts
@@ -26,14 +26,15 @@ import asset12 from "../../../prompts/system/cron.md" with { type: "file" };
 import asset13 from "../../../prompts/system/daily-memory.md" with { type: "file" };
 import asset14 from "../../../prompts/system/goals.md" with { type: "file" };
 import asset15 from "../../../prompts/system/heartbeat-agent.md" with { type: "file" };
-import asset16 from "../../../prompts/system/memory-recall.md" with { type: "file" };
-import asset17 from "../../../prompts/system/persistent-memory.md" with { type: "file" };
-import asset18 from "../../../prompts/system/skills.md" with { type: "file" };
-import asset19 from "../../../prompts/system/triggers.md" with { type: "file" };
-import asset20 from "../../../prompts/system/workspace.md" with { type: "file" };
-import asset21 from "../../../prompts/teams.md" with { type: "file" };
-import asset22 from "../../../prompts/telegram.md" with { type: "file" };
-import asset23 from "../../../prompts/terminal.md" with { type: "file" };
+import asset16 from "../../../prompts/system/live-state.md" with { type: "file" };
+import asset17 from "../../../prompts/system/memory-recall.md" with { type: "file" };
+import asset18 from "../../../prompts/system/persistent-memory.md" with { type: "file" };
+import asset19 from "../../../prompts/system/skills.md" with { type: "file" };
+import asset20 from "../../../prompts/system/triggers.md" with { type: "file" };
+import asset21 from "../../../prompts/system/workspace.md" with { type: "file" };
+import asset22 from "../../../prompts/teams.md" with { type: "file" };
+import asset23 from "../../../prompts/telegram.md" with { type: "file" };
+import asset24 from "../../../prompts/terminal.md" with { type: "file" };
 
 /** rel path (posix, under prompts/) → embedded file path (/$bunfs/… when compiled). */
 const ASSETS: Record<string, string> = {
@@ -53,14 +54,15 @@ const ASSETS: Record<string, string> = {
   "system/daily-memory.md": asset13,
   "system/goals.md": asset14,
   "system/heartbeat-agent.md": asset15,
-  "system/memory-recall.md": asset16,
-  "system/persistent-memory.md": asset17,
-  "system/skills.md": asset18,
-  "system/triggers.md": asset19,
-  "system/workspace.md": asset20,
-  "teams.md": asset21,
-  "telegram.md": asset22,
-  "terminal.md": asset23,
+  "system/live-state.md": asset16,
+  "system/memory-recall.md": asset17,
+  "system/persistent-memory.md": asset18,
+  "system/skills.md": asset19,
+  "system/triggers.md": asset20,
+  "system/workspace.md": asset21,
+  "teams.md": asset22,
+  "telegram.md": asset23,
+  "terminal.md": asset24,
 };
 
 /** Read an embedded prompt by its rel path (e.g. "system/cron.md"). */

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -17,7 +17,11 @@
  *       trigger-runs/          Trigger script bodies + run logs
  *     workspace/               User-facing workspace (memory, uploads, logs)
  *       memory/
+ *         memory.md            Durable memory — the dream agent owns it
+ *         state.md             Live operational status — the heartbeat owns
+ *                              it, rewritten in full each run
  *         daily/               Per-day memory notes (YYYY-MM-DD.md)
+ *         archive/             Pruned memory, kept for audit (YYYY-MM.md)
  *       scripts/               Agent script bodies
  *       skills/                Skill folders (SKILL.md + resources)
  *       uploads/
@@ -56,6 +60,12 @@ export const dirs = {
   memory: resolve(TALON_ROOT, "workspace", "memory"),
   /** Daily memory notes: ~/.talon/workspace/memory/daily/ */
   dailyMemory: resolve(TALON_ROOT, "workspace", "memory", "daily"),
+  /**
+   * Pruned-memory archive: ~/.talon/workspace/memory/archive/
+   * Monthly files the dream agent appends to when it drops an entry, so
+   * forgetting stays auditable instead of silent.
+   */
+  memoryArchive: resolve(TALON_ROOT, "workspace", "memory", "archive"),
   /** Sticker packs: ~/.talon/workspace/stickers/ */
   stickers: resolve(TALON_ROOT, "workspace", "stickers"),
   /** Prompt files: ~/.talon/prompts/ */
@@ -110,6 +120,16 @@ export const files = {
   mediaIndex: resolve(TALON_ROOT, "data", "media-index.json"),
   /** Persistent memory: ~/.talon/workspace/memory/memory.md */
   memory: resolve(TALON_ROOT, "workspace", "memory", "memory.md"),
+  /**
+   * Live operational state: ~/.talon/workspace/memory/state.md
+   *
+   * Separate from `memory.md` on purpose. The heartbeat rewrites this file
+   * whole on every run; nothing appends to it. Keeping status snapshots out
+   * of the durable store is what stops "as of Run #N" sections accreting
+   * there — on the live deployment three of them had grown to 15.8k chars,
+   * pushing the actual knowledge past the prompt's injection cap.
+   */
+  state: resolve(TALON_ROOT, "workspace", "memory", "state.md"),
   /** Self-bootstrapping identity: ~/.talon/workspace/identity.md */
   identity: resolve(TALON_ROOT, "workspace", "identity.md"),
   /** Telegram userbot session: ~/.talon/.user-session */


### PR DESCRIPTION
> Supersedes #690, which GitHub auto-closed when its stacked base (#686) was merged and its branch deleted. Same commit, rebuilt on current `main`; #686 is already in.

## The problem

The heartbeat and the dream agent both wrote `memory.md`, with different instructions and no schema between them. So status snapshots accumulated in the durable store. On the live deployment that produced three near-duplicate `## Inbox / CI Watch (as of …, Run #N)` sections totalling **15.8k of a 23.4k-char file** — content with a shelf life of about an hour, crowding out the investigations the bot actually needed.

#686 stopped that content from evicting the good stuff. This stops it being written.

## Ownership is now explicit

| File | Owner | Rule |
|---|---|---|
| `memory/state.md` | heartbeat | Rewritten **whole** every run. One `## <domain>` section per subject, current state only. No dated headings, no keeping the previous run's section, no appending. |
| `memory/memory.md` | dream agent | Read-only for the heartbeat, which now routes durable facts to today's daily note. |
| `memory/archive/YYYY-MM.md` | dream agent | Where pruned memory goes, so forgetting is auditable. Never injected. |

A file that gets replaced cannot accrete. That is the whole mechanism.

## The dream agent gets a budget and permission to forget

- **10k-char budget** for `memory.md` — it is injected from turn 0 of every session.
- **Prune order**: contradicted → status snapshots and run-by-run forensics → closed items → detail that has stopped earning its space.
- `"do NOT remove entries just because they're old"` → **`"old is not the same as wrong, but old and inert is prunable"`**. The old wording plus append-only growth guaranteed monotonic bloat.
- Daily-note rotation at 14 days.

## Policy lives in one place

The replace-don't-annotate rule and the state/memory distinction go into **`memory-recall.md`**, which owns the save-and-update policy — not into the `persistent-memory.md` file wrapper, which stays lean and delegates to it. Two copies of one policy is two places to drift apart.

(That placement is a change from the original #690: `memory-recall.md` landed upstream while these PRs were in flight, and the first draft duplicated it.)

## Cap on the injected state block

2k chars, far tighter than memory's 12k. `state.md` is rewritten every run, so anything larger means the heartbeat is accumulating history in a file that is supposed to be replaced — truncating loudly is the signal that it is happening.

## Stale-seed handling (the part that nearly made this a no-op)

`heartbeat.md` is a **seeded user-editable** file, and the live copy predates even the goals feature — it matches no manifest hash, so upgrades will never refresh it. Shipping a better package prompt would change nothing on exactly the deployment that needs it.

Rather than rewrite a file the user owns, this follows the existing `goals-fallback` pattern already in `heartbeat/agent.ts`: no `{{stateFile}}` placeholder → the ownership rules are appended from a package template, and a warning names the file to delete for a re-seed.

## Verification

7 tests in `live-state-prompt.test.ts`; full suite green locally; typecheck, lint, ratchets clean; dependency-cruiser unchanged at 20 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)