### PR TITLE
feat(terminal): /context — context-window usage, broken down

### DIFF
--- a/src/__tests__/status-context.test.ts
+++ b/src/__tests__/status-context.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildCacheDisplay,
   buildContextDisplay,
+  buildContextBreakdown,
+  apportionCells,
+  estimateContextTokens,
 } from "../frontend/shared/status-context.js";
 
 describe("status context display", () => {
@@ -102,5 +105,135 @@ describe("cache display", () => {
         cacheWrite: 0,
       }),
     ).toEqual({ hitPct: 0, read: 0, write: 0, showsWrite: true });
+  });
+});
+
+describe("apportionCells", () => {
+  it("sums to exactly the bar width", () => {
+    const cells = apportionCells([6100, 18900, 3400, 171600], 42);
+    expect(cells.reduce((a, b) => a + b, 0)).toBe(42);
+  });
+
+  it("gives zero-weight segments zero cells", () => {
+    expect(apportionCells([0, 100, 0], 10)).toEqual([0, 10, 0]);
+  });
+
+  it("does not starve a small nonzero weight of a leftover cell before a large one", () => {
+    // Largest-remainder: 1 leftover cell goes to the largest fractional part.
+    // 3 equal weights over 10 cells → 3,3,3 floor + 1 leftover.
+    const cells = apportionCells([1, 1, 1], 10);
+    expect(cells.reduce((a, b) => a + b, 0)).toBe(10);
+    expect(cells.every((c) => c >= 3)).toBe(true);
+  });
+
+  it("returns all zeros for a zero-width bar or zero total", () => {
+    expect(apportionCells([1, 2, 3], 0)).toEqual([0, 0, 0]);
+    expect(apportionCells([0, 0], 42)).toEqual([0, 0]);
+  });
+});
+
+describe("estimateContextTokens", () => {
+  it("estimates ~4 chars per token, rounding up", () => {
+    expect(estimateContextTokens("")).toBe(0);
+    expect(estimateContextTokens("abc")).toBe(1);
+    expect(estimateContextTokens("a".repeat(4000))).toBe(1000);
+  });
+});
+
+describe("buildContextBreakdown", () => {
+  it("derives tools as the residual when a real fill is reported", () => {
+    const bd = buildContextBreakdown({
+      contextTokens: 28_400,
+      contextWindow: 200_000,
+      systemTokens: 6_100,
+      conversationTokens: 3_400,
+    });
+    expect(bd.known).toBe(true);
+    expect(bd.windowKnown).toBe(true);
+    expect(bd.used).toBe(28_400);
+    const byKey = Object.fromEntries(bd.segments.map((s) => [s.key, s.tokens]));
+    expect(byKey.system).toBe(6_100);
+    expect(byKey.conversation).toBe(3_400);
+    // Tools = used − system − conversation.
+    expect(byKey.tools).toBe(28_400 - 6_100 - 3_400);
+    expect(bd.free).toBe(200_000 - 28_400);
+  });
+
+  it("segments plus free sum to the window", () => {
+    const bd = buildContextBreakdown({
+      contextTokens: 742_000,
+      contextWindow: 1_000_000,
+      systemTokens: 9_200,
+      conversationTokens: 610_000,
+    });
+    const sum = bd.segments.reduce((a, s) => a + s.tokens, 0) + bd.free;
+    expect(sum).toBe(1_000_000);
+  });
+
+  it("clamps an overshooting conversation estimate to the real fill", () => {
+    // Stored history estimates 150k, but the model only actually holds 100k
+    // after compaction. Conversation must shrink; tools must not go negative.
+    const bd = buildContextBreakdown({
+      contextTokens: 100_000,
+      contextWindow: 200_000,
+      systemTokens: 8_000,
+      conversationTokens: 150_000,
+    });
+    const byKey = Object.fromEntries(bd.segments.map((s) => [s.key, s.tokens]));
+    expect(byKey.tools).toBe(0);
+    expect(byKey.conversation).toBe(100_000 - 8_000);
+    expect(bd.segments.reduce((a, s) => a + s.tokens, 0)).toBe(100_000);
+  });
+
+  it("omits tools and shows only measured parts when no fill is reported", () => {
+    const bd = buildContextBreakdown({
+      contextWindow: 200_000,
+      systemTokens: 6_100,
+      conversationTokens: 0,
+    });
+    expect(bd.segments.map((s) => s.key)).toEqual(["system", "conversation"]);
+    expect(bd.used).toBe(6_100);
+    expect(bd.free).toBe(200_000 - 6_100);
+  });
+
+  it("has no free space and no window percentages when the window is unknown", () => {
+    const bd = buildContextBreakdown({
+      contextTokens: 30_000,
+      systemTokens: 6_000,
+      conversationTokens: 4_000,
+    });
+    expect(bd.windowKnown).toBe(false);
+    expect(bd.free).toBe(0);
+    expect(bd.usedPct).toBe(0);
+    // Percentages fall back to share-of-used.
+    const sys = bd.segments.find((s) => s.key === "system")!;
+    expect(sys.pct).toBe(20); // 6000 / 30000
+  });
+
+  it("warns at ≥80% of the window", () => {
+    expect(
+      buildContextBreakdown({
+        contextTokens: 160_000,
+        contextWindow: 200_000,
+        systemTokens: 8_000,
+        conversationTokens: 100_000,
+      }).warn,
+    ).toBe(true);
+    expect(
+      buildContextBreakdown({
+        contextTokens: 100_000,
+        contextWindow: 200_000,
+        systemTokens: 8_000,
+        conversationTokens: 50_000,
+      }).warn,
+    ).toBe(false);
+  });
+
+  it("reports not-known when there is nothing to show", () => {
+    const bd = buildContextBreakdown({
+      systemTokens: 0,
+      conversationTokens: 0,
+    });
+    expect(bd.known).toBe(false);
   });
 });

--- a/src/__tests__/terminal-commands.test.ts
+++ b/src/__tests__/terminal-commands.test.ts
@@ -16,8 +16,19 @@ vi.mock("picocolors", () => ({
     red: (s: string) => s,
     bold: (s: string) => s,
     yellow: (s: string) => s,
+    blue: (s: string) => s,
+    magenta: (s: string) => s,
     underline: (s: string) => s,
   },
+}));
+
+const mockGetRecentHistory = vi.fn((_chatId: string, _limit?: number) => [
+  { text: "hello there" },
+  { text: "a reply" },
+]);
+vi.mock("../storage/history.js", () => ({
+  getRecentHistory: (chatId: string, limit?: number) =>
+    mockGetRecentHistory(chatId, limit),
 }));
 
 // Mock storage modules that commands import dynamically.
@@ -226,6 +237,7 @@ describe("built-in commands", () => {
     expect(names).toContain("model");
     expect(names).toContain("effort");
     expect(names).toContain("status");
+    expect(names).toContain("context");
     expect(names).toContain("reset");
     expect(names).toContain("resume");
     expect(names).toContain("rename");
@@ -630,6 +642,67 @@ describe("/status command", () => {
     expect(output).toContain("1,389,045");
     expect(output).toContain("3,675");
     expect(output).toContain("204.8k");
+  });
+});
+
+describe("/context command", () => {
+  beforeEach(() => {
+    clearCommands();
+    registerBuiltinCommands();
+    mockGetRecentHistory.mockClear();
+  });
+
+  it("breaks the window into System / Tools / Conversation + Free", async () => {
+    mockGetSessionInfo.mockReturnValueOnce({
+      turns: 4,
+      usage: {
+        contextTokens: 40_000,
+        contextWindow: 200_000,
+        lastPromptTokens: 40_000,
+      },
+    });
+    const ctx = makeMockContext({
+      config: {
+        model: "claude-sonnet-4-6",
+        // ~2k system tokens (8000 chars / 4).
+        systemPromptParts: { staticText: "s".repeat(8_000), dynamicText: "" },
+      } as unknown as CommandContext["config"],
+    });
+    await tryRunCommand("/context", ctx);
+    const output = (ctx.renderer.writeln as ReturnType<typeof vi.fn>).mock.calls
+      .flat()
+      .join(" ");
+    expect(output).toContain("Context");
+    expect(output).toContain("System");
+    expect(output).toContain("Tools");
+    expect(output).toContain("Conversation");
+    expect(output).toContain("Free");
+    expect(output).toContain("20% used"); // 40k / 200k
+    expect(mockGetRecentHistory).toHaveBeenCalled();
+    expect(ctx.reprompt).toHaveBeenCalled();
+  });
+
+  it("warns and omits Tools appropriately, and never throws before a first turn", async () => {
+    // No contextTokens reported yet: tools can't be derived, but System still
+    // shows and the command must not crash.
+    mockGetSessionInfo.mockReturnValueOnce({
+      turns: 0,
+      usage: { contextTokens: 0, contextWindow: 200_000 },
+    });
+    const ctx = makeMockContext({
+      config: {
+        model: "claude-sonnet-4-6",
+        systemPromptParts: { staticText: "s".repeat(4_000), dynamicText: "" },
+      } as unknown as CommandContext["config"],
+    });
+    await tryRunCommand("/context", ctx);
+    const output = (ctx.renderer.writeln as ReturnType<typeof vi.fn>).mock.calls
+      .flat()
+      .join(" ");
+    expect(output).toContain("System");
+    expect(output).toContain("Free");
+    expect(output).not.toContain("Tools");
+    expect(ctx.reprompt).toHaveBeenCalled();
   });
 });
 

--- a/src/frontend/shared/status-context.ts
+++ b/src/frontend/shared/status-context.ts
@@ -1,5 +1,166 @@
 import type { CacheMetricsSupport } from "../../core/types.js";
 
+// ── /context breakdown ────────────────────────────────────────────────────────
+
+/**
+ * Rough token estimate — ~4 chars/token, the house heuristic used everywhere
+ * (soul/projector, cache-telemetry). No real tokenizer is wired, so every
+ * measured figure in the breakdown below is an estimate at this fidelity.
+ */
+export function estimateContextTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+export type ContextSegmentKey = "system" | "tools" | "conversation";
+
+interface ContextSegment {
+  key: ContextSegmentKey;
+  label: string;
+  tokens: number;
+  /** Share of the window (0–100) when the window is known, else share of used. */
+  pct: number;
+}
+
+export interface ContextBreakdown {
+  /** True once there is anything to show (a system prompt or a reported fill). */
+  known: boolean;
+  /** True when the window size is known — only then can free space be shown. */
+  windowKnown: boolean;
+  used: number;
+  max: number;
+  usedPct: number;
+  free: number;
+  freePct: number;
+  /** Fixed → variable order: System, Tools, Conversation. */
+  segments: ContextSegment[];
+  warn: boolean;
+}
+
+function posInt(n: number | undefined): number {
+  return typeof n === "number" && Number.isFinite(n) && n > 0
+    ? Math.round(n)
+    : 0;
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+/**
+ * Decompose the context window into System / Tools / Conversation + free.
+ *
+ * The honesty this has to preserve: the backend reports exactly one
+ * authoritative number, `contextTokens` (the real last-turn fill). Nothing
+ * reports a per-category split, so:
+ *
+ *   - **System** is measured from the actual (frozen) system prompt — accurate,
+ *     and the part a user can act on.
+ *   - **Conversation** is estimated from stored history. It can overshoot what
+ *     is really in-window after compaction; when it does, it is clamped to fit.
+ *   - **Tools** is the residual: `used − system − conversation`. Tool schemas
+ *     (invisible to us — they live inside the SDK) dominate it, but it also
+ *     absorbs message-formatting overhead and estimation slack. Labelled as the
+ *     remainder, not claimed as exact.
+ *
+ * When the backend reports no fill, tools cannot be derived, so only the two
+ * measured/estimated parts are shown and the window's free space (if known) is
+ * whatever is left of it.
+ */
+export function buildContextBreakdown(input: {
+  contextTokens?: number;
+  contextWindow?: number;
+  systemTokens: number;
+  conversationTokens: number;
+}): ContextBreakdown {
+  const max = posInt(input.contextWindow);
+  const system = Math.max(0, Math.round(input.systemTokens));
+  let conversation = Math.max(0, Math.round(input.conversationTokens));
+  const fill = posInt(input.contextTokens);
+
+  const segments: ContextSegment[] = [];
+  let used: number;
+
+  if (fill > 0) {
+    used = fill;
+    // System is sent in full every turn; if our estimate exceeds the real fill
+    // that is estimation slack, not reality — clamp so parts never exceed used.
+    const sys = Math.min(system, used);
+    let tools = used - sys - conversation;
+    if (tools < 0) {
+      // Conversation overshot the real fill (compaction dropped in-window
+      // messages) — give the remainder back to conversation, zero the residual.
+      conversation = Math.max(0, used - sys);
+      tools = 0;
+    }
+    segments.push({ key: "system", label: "System", tokens: sys, pct: 0 });
+    segments.push({ key: "tools", label: "Tools", tokens: tools, pct: 0 });
+    segments.push({
+      key: "conversation",
+      label: "Conversation",
+      tokens: conversation,
+      pct: 0,
+    });
+  } else {
+    // No authoritative fill — show what we can measure; tools isn't derivable.
+    used = system + conversation;
+    segments.push({ key: "system", label: "System", tokens: system, pct: 0 });
+    segments.push({
+      key: "conversation",
+      label: "Conversation",
+      tokens: conversation,
+      pct: 0,
+    });
+  }
+
+  const windowKnown = max > 0;
+  const free = windowKnown ? Math.max(0, max - used) : 0;
+  const denom = windowKnown ? max : used;
+  for (const s of segments) {
+    s.pct = denom > 0 ? round1((s.tokens / denom) * 100) : 0;
+  }
+
+  return {
+    known: used > 0,
+    windowKnown,
+    used,
+    max,
+    usedPct: windowKnown ? Math.min(100, round1((used / max) * 100)) : 0,
+    free,
+    freePct: windowKnown ? round1((free / max) * 100) : 0,
+    segments,
+    warn: windowKnown && used / max >= 0.8,
+  };
+}
+
+/**
+ * Distribute `width` integer cells across `weights` proportionally, by the
+ * largest-remainder method — the cells sum to exactly `width` and no positive
+ * weight is systematically rounded to nothing before its peers. Zero weights
+ * get zero cells. Used to lay out the segmented bar so its coloured runs sum to
+ * the bar width regardless of rounding.
+ */
+export function apportionCells(
+  weights: readonly number[],
+  width: number,
+): number[] {
+  const total = weights.reduce((a, b) => a + b, 0);
+  if (total <= 0 || width <= 0) return weights.map(() => 0);
+  const exact = weights.map((w) => (Math.max(0, w) / total) * width);
+  const cells = exact.map((x) => Math.floor(x));
+  let remaining = width - cells.reduce((a, b) => a + b, 0);
+  const byRemainder = exact
+    .map((x, i) => ({ i, frac: x - Math.floor(x) }))
+    .sort((a, b) => b.frac - a.frac);
+  for (const { i } of byRemainder) {
+    if (remaining <= 0) break;
+    if (weights[i]! > 0) {
+      cells[i]!++;
+      remaining--;
+    }
+  }
+  return cells;
+}
+
 export interface ContextDisplay {
   known: boolean;
   used: number;

--- a/src/frontend/terminal/commands.ts
+++ b/src/frontend/terminal/commands.ts
@@ -18,7 +18,13 @@ import {
 import {
   buildCacheDisplay,
   buildContextDisplay,
+  buildContextBreakdown,
+  estimateContextTokens,
+  apportionCells,
+  type ContextBreakdown,
+  type ContextSegmentKey,
 } from "../shared/status-context.js";
+import { getRecentHistory } from "../../storage/history.js";
 import {
   formatDuration,
   formatTokenCount,
@@ -111,6 +117,63 @@ export function getCommands(): readonly Command[] {
 export function clearCommands(): void {
   commands.length = 0;
   nameIndex.clear();
+}
+
+// ── /context rendering ───────────────────────────────────────────────────────
+
+/** Each used segment gets its own colour; free is a dim hatch. */
+const CONTEXT_SEGMENT_COLOR: Record<ContextSegmentKey, (s: string) => string> =
+  {
+    system: pc.blue,
+    tools: pc.yellow,
+    conversation: pc.cyan,
+  };
+
+const CONTEXT_BAR_WIDTH = 42;
+
+/**
+ * The segmented bar: one coloured run per segment (proportional to the window),
+ * then the free space as a dim `░` hatch. Cell counts come from
+ * `apportionCells`, so the runs always sum to exactly the bar width.
+ */
+function renderContextBar(bd: ContextBreakdown): string {
+  const weights = bd.segments.map((s) => s.tokens);
+  if (bd.windowKnown) weights.push(bd.free);
+  const cells = apportionCells(weights, CONTEXT_BAR_WIDTH);
+  let bar = "";
+  bd.segments.forEach((s, i) => {
+    bar += CONTEXT_SEGMENT_COLOR[s.key]("█".repeat(cells[i] ?? 0));
+  });
+  if (bd.windowKnown) {
+    bar += pc.dim("░".repeat(cells[bd.segments.length] ?? 0));
+  }
+  return bar;
+}
+
+/** One aligned legend row per segment (and Free), colour-matched to the bar. */
+function renderContextLegend(bd: ContextBreakdown): string[] {
+  const rows = bd.segments.map((s) => ({
+    dot: CONTEXT_SEGMENT_COLOR[s.key]("●"),
+    label: s.label,
+    tokens: s.tokens,
+    pct: s.pct,
+  }));
+  if (bd.windowKnown) {
+    rows.push({
+      dot: pc.dim("░"),
+      label: "Free",
+      tokens: bd.free,
+      pct: bd.freePct,
+    });
+  }
+  const labelW = Math.max(...rows.map((r) => r.label.length));
+  const tokW = Math.max(...rows.map((r) => formatTokenCount(r.tokens).length));
+  return rows.map((r) => {
+    const label = r.label.padEnd(labelW);
+    const tok = formatTokenCount(r.tokens).padStart(tokW);
+    const pct = `${r.pct}%`.padStart(6);
+    return `${r.dot} ${label}  ${pc.dim(tok)}  ${pc.dim(pct)}`;
+  });
 }
 
 // ── Built-in commands ────────────────────────────────────────────────────────
@@ -389,6 +452,95 @@ export function registerBuiltinCommands(): void {
           );
         }
       }
+      ctx.reprompt();
+    },
+  });
+
+  registerCommand({
+    name: "context",
+    aliases: ["ctx"],
+    description: "Context-window usage, broken down",
+    async handler(_args, ctx) {
+      const chatId = ctx.chatId();
+      const u = getSessionInfo(chatId).usage;
+      const be = ctx.backend;
+      const activeModel = getChatSettings(chatId).model ?? ctx.config.model;
+
+      // Window + a friendly model name, enriched from the backend like /status.
+      let contextWindow = u.contextWindow;
+      let modelName = resolveModelName(activeModel);
+      if (be?.models?.getRawModelInfo) {
+        const mi = await be.models
+          .getRawModelInfo(activeModel)
+          .catch(() => undefined);
+        if (mi) {
+          if (mi.contextWindow) contextWindow ||= mi.contextWindow;
+          if (mi.displayName) modelName = mi.displayName;
+        }
+      }
+
+      // System = the actual frozen prompt the model is running with. Measure
+      // it directly rather than rebuilding, so the number matches what was
+      // really sent (the prompt is frozen per session by design).
+      const parts = ctx.config.systemPromptParts;
+      const systemText = parts
+        ? [parts.staticText, parts.dynamicText].filter(Boolean).join("\n")
+        : (ctx.config.systemPrompt ?? "");
+      const systemTokens = estimateContextTokens(systemText);
+
+      // Conversation = stored history for this chat. An estimate: the model's
+      // real in-window history may be smaller after compaction, which the
+      // breakdown clamps against the authoritative fill.
+      const history = getRecentHistory(chatId, 2000);
+      const conversationTokens = estimateContextTokens(
+        history.map((m) => m.text ?? "").join("\n"),
+      );
+
+      const bd = buildContextBreakdown({
+        contextTokens: u.contextTokens,
+        contextWindow,
+        systemTokens,
+        conversationTokens,
+      });
+
+      ctx.renderer.writeln();
+      if (!bd.known) {
+        ctx.renderer.writeln(
+          `  ${pc.bold("Context")}  ${pc.dim("no usage yet — send a message first")}`,
+        );
+        ctx.reprompt();
+        return;
+      }
+
+      const windowStr = bd.windowKnown
+        ? `${formatTokenCount(bd.max)} window`
+        : pc.dim("window unknown");
+      ctx.renderer.writeln(
+        `  ${pc.bold("Context")}  ${modelName}  ·  ${windowStr}`,
+      );
+
+      const usedStr = bd.windowKnown
+        ? `${formatTokenCount(bd.used)} / ${formatTokenCount(bd.max)}  ·  ${bd.usedPct}% used`
+        : `${formatTokenCount(bd.used)} used`;
+      ctx.renderer.writeln(
+        `  ${bd.warn ? pc.yellow(usedStr) : pc.dim(usedStr)}${bd.warn ? pc.yellow("  · nearing limit") : ""}`,
+      );
+      ctx.renderer.writeln();
+      ctx.renderer.writeln(`  ${renderContextBar(bd)}`);
+      ctx.renderer.writeln();
+      for (const line of renderContextLegend(bd)) {
+        ctx.renderer.writeln(`  ${line}`);
+      }
+      // Explain only what's on screen: Tools is derivable (and shown) only
+      // when the backend reported a real fill.
+      const hasTools = bd.segments.some((s) => s.key === "tools");
+      ctx.renderer.writeln(
+        `  ${pc.dim(
+          hasTools
+            ? "System measured; Conversation estimated; Tools is the remainder."
+            : "System measured; Conversation estimated from stored history.",
+        )}`,
+      );
       ctx.reprompt();
     },
   });


### PR DESCRIPTION
`/status` shows one context number. `/context` (alias `/ctx`) decomposes it.

## What it looks like

A segmented bar over the full window — one colour per category, free space as a dim hatch — then an aligned legend of tokens + percentages, with a warn state past 80%.

```
  Context  claude-sonnet-4-6  ·  200.0k window
  28.4k / 200.0k  ·  14.2% used

  ██████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   (System·blue Tools·yellow Conversation·cyan, ░ free)

  ● System         6.1k    3.1%
  ● Tools         18.9k    9.5%
  ● Conversation   3.4k    1.7%
  ░ Free         171.6k   85.8%
  System measured; Conversation estimated; Tools is the remainder.
```

## The honest part

The backend reports **one** authoritative figure — `contextTokens`, the real last-turn fill. Nothing reports a per-category split, and I refused to fabricate one:

| Segment | How it's derived |
|---|---|
| **System** | Measured from the actual *frozen* system prompt — accurate, and the part a user can act on. |
| **Conversation** | Estimated from stored history, and **clamped** when it overshoots the real fill (compaction can drop in-window messages, so stored ≠ in-window). |
| **Tools** | The residual: `used − system − conversation`. Tool schemas live inside the SDK and are invisible in-process, so this is derived, not measured — labelled as the remainder, never claimed exact. |

When the backend reports no fill yet, tools **can't** be derived — the command shows only the measured parts and the footnote says so, rather than inventing a number. That's the second `/context` test.

## Structure

The two pieces with real logic are pure functions in `shared/status-context.ts`, unit-tested independently of the terminal:

- `buildContextBreakdown` — the decomposition + clamping (fill known / unknown, overshoot, window unknown, warn threshold).
- `apportionCells` — largest-remainder bar layout, so the coloured runs sum to exactly the bar width and no positive segment is rounded away before its peers.

The terminal command is thin glue: gather inputs (frozen prompt, stored history, session usage, model window from the backend like `/status`), build, render.

## Scope

Terminal frontend only — where a colour bar makes sense. No core/backend changes; reuses the existing `getRawModelInfo` window enrichment `/status` already does.

## Verification

15 new unit tests (`status-context.test.ts`) + 2 command tests (`terminal-commands.test.ts`); full suite green (4,307 passed); typecheck, lint, ratchets, knip clean; dependency-cruiser unchanged (18 warnings / 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)