### PR TITLE
fix(runtime): harden model menu and restart handoff

### DIFF
--- a/src/__tests__/respawn.test.ts
+++ b/src/__tests__/respawn.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Respawn handoff ordering.
+ *
+ * Regression: `respawnSelf()` used to spawn the successor immediately
+ * and only then raise SIGTERM. Graceful shutdown drains in-flight
+ * queries (up to DRAIN_TIMEOUT_MS) before stopping the frontends, so
+ * the successor was long-polling `getUpdates` while the outgoing
+ * process still held the poll. Telegram answers one poller and
+ * re-delivers the unconfirmed updates to the other — a restart
+ * mid-turn logged a 409 Conflict on the way out and produced
+ * duplicate replies on the way in.
+ *
+ * The contract now: arming must not spawn. Only `spawnSuccessor()` —
+ * called at the tail of shutdown, after the frontends have stopped —
+ * may start the successor.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+let killSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(async () => {
+  vi.resetModules();
+  spawnMock.mockReset();
+  spawnMock.mockReturnValue({ pid: 4242, once: vi.fn(), unref: vi.fn() });
+  killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  killSpy.mockRestore();
+});
+
+describe("respawn handoff ordering", () => {
+  it("arms without spawning, and signals itself to shut down", async () => {
+    const { respawnSelf, respawnRequested } =
+      await import("../util/respawn.js");
+
+    expect(respawnRequested()).toBe(false);
+    respawnSelf("telegram /restart");
+
+    // The successor must NOT exist yet — the frontends are still up.
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(respawnRequested()).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(process.pid, "SIGTERM");
+  });
+
+  it("spawns the successor only once shutdown calls spawnSuccessor", async () => {
+    const { respawnSelf, spawnSuccessor } = await import("../util/respawn.js");
+
+    respawnSelf("telegram /restart");
+    expect(spawnMock).not.toHaveBeenCalled();
+
+    spawnSuccessor();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock.mock.calls[0]![0]).toBe(process.argv[0]);
+  });
+
+  it("does not spawn on a plain shutdown that never armed a respawn", async () => {
+    const { spawnSuccessor } = await import("../util/respawn.js");
+
+    spawnSuccessor();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("hands off at most once", async () => {
+    const { respawnSelf, spawnSuccessor, respawnRequested } =
+      await import("../util/respawn.js");
+
+    respawnSelf("telegram /update");
+    spawnSuccessor();
+    spawnSuccessor();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(respawnRequested()).toBe(false);
+  });
+
+  it("never throws when the successor cannot be spawned", async () => {
+    const { respawnSelf, spawnSuccessor } = await import("../util/respawn.js");
+    spawnMock.mockImplementation(() => {
+      throw new Error("EAGAIN");
+    });
+
+    respawnSelf("telegram /restart");
+    // A failed handoff must still let this process exit.
+    expect(() => spawnSuccessor()).not.toThrow();
+  });
+});

--- a/src/__tests__/telegram-model-menu.test.ts
+++ b/src/__tests__/telegram-model-menu.test.ts
@@ -274,6 +274,24 @@ describe("telegram /model — renderModelMenuText", () => {
     );
     expect(text.toLowerCase()).not.toContain("free-tier");
   });
+
+  // Regression: the OpenCode catalog emits the literal hint
+  // "Hint: use /model <name> to switch." as a status line. Rendered
+  // unescaped, Telegram parsed `<name>` as an HTML start tag and
+  // rejected the whole send with 400 "Unsupported start tag", so
+  // /model and the backend switcher silently did nothing.
+  it("escapes HTML metacharacters in status lines and display names", () => {
+    const text = renderModelMenuText(
+      baseState({
+        activeDisplay: "a<b>&c",
+        statusLines: ["Hint: use /model <name> to switch."],
+      }),
+    );
+    expect(text).toContain("Hint: use /model &lt;name&gt; to switch.");
+    expect(text).toContain("<code>a&lt;b&gt;&amp;c</code>");
+    // Only the tags this function itself emits may remain.
+    expect(text.replace(/<\/?(b|i|code)>/g, "")).not.toMatch(/[<>]/);
+  });
 });
 
 // ── renderModelBrowseKeyboard ──────────────────────────────────────────────

--- a/src/__tests__/telegram-settings-escaping.test.ts
+++ b/src/__tests__/telegram-settings-escaping.test.ts
@@ -1,0 +1,141 @@
+/**
+ * `/model <query>` error-reply escaping.
+ *
+ * Regression: the reply built from `backend.models.formatModelError()`
+ * was sent with `parse_mode: "HTML"` without escaping, while the
+ * fallback on the very next line escaped. Every backend implements
+ * formatModelError as plain text that interpolates the raw query, so
+ * any `<` in a failed lookup reached Telegram as a tag and the whole
+ * send failed with:
+ *
+ *   400: Bad Request: can't parse entities: Unsupported start tag "name"
+ *
+ * That is reachable by copying the hint OpenCode and Kilo print in the
+ * model menu — "Hint: use /model <name> to switch." — so the documented
+ * recovery path was itself the trigger, and the command looked inert.
+ *
+ * Same bug class as the model menu's status lines; this covers the
+ * other sink.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Bot } from "grammy";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+vi.mock("../storage/chat-settings.js", () => ({
+  getChatSettings: vi.fn(() => ({ effort: undefined })),
+  setChatModelForBackend: vi.fn(),
+  setChatBackend: vi.fn(),
+  setChatEffort: vi.fn(),
+  setChatPulseInterval: vi.fn(),
+}));
+vi.mock("../core/background/pulse.js", () => ({
+  registerChat: vi.fn(),
+  disablePulse: vi.fn(),
+  enablePulse: vi.fn(),
+  isPulseEnabled: vi.fn(() => false),
+}));
+vi.mock("../core/engine/backend-controller/index.js", () => ({
+  getBackendIdForChat: vi.fn(() => "opencode"),
+}));
+vi.mock("../core/models/active-model.js", () => ({
+  resolveActiveModelForChat: vi.fn(async () => ({ model: "glm-5" })),
+}));
+
+const resolveModelInfo = vi.hoisted(() => vi.fn());
+const formatModelError = vi.hoisted(() => vi.fn());
+
+vi.mock("../frontend/telegram/model-menu.js", () => ({
+  resolveBackendForChat: vi.fn(() => ({
+    models: { resolveModelInfo, formatModelError },
+  })),
+  buildModelMenuViewForChat: vi.fn(async () => null),
+}));
+
+import { registerSettingsCommands } from "../frontend/telegram/commands/settings.js";
+
+/** Collect the handlers `registerSettingsCommands` installs. */
+function captureCommands(): Map<string, (ctx: unknown) => Promise<void>> {
+  const handlers = new Map<string, (ctx: unknown) => Promise<void>>();
+  const bot = {
+    command: (name: string, handler: (ctx: unknown) => Promise<void>) => {
+      handlers.set(name, handler);
+    },
+  } as unknown as Bot;
+  registerSettingsCommands(bot, {
+    config: {},
+    gateway: {},
+  } as never);
+  return handlers;
+}
+
+/** Minimal grammy ctx double that records the outgoing reply. */
+function makeCtx(arg: string) {
+  const replies: Array<{ text: string; opts?: { parse_mode?: string } }> = [];
+  return {
+    ctx: {
+      chat: { id: -100123 },
+      match: arg,
+      reply: async (text: string, opts?: { parse_mode?: string }) => {
+        replies.push({ text, opts });
+      },
+    },
+    replies,
+  };
+}
+
+beforeEach(() => {
+  resolveModelInfo.mockReset();
+  formatModelError.mockReset();
+});
+
+describe("/model error replies are HTML-safe", () => {
+  it("escapes a backend model error containing angle brackets", async () => {
+    resolveModelInfo.mockResolvedValue({ kind: "missing" });
+    // Verbatim shape of the OpenCode/Kilo hint a user would copy.
+    formatModelError.mockReturnValue(
+      'No OpenCode model matched "<name>". Hint: use /model <name> to switch.',
+    );
+
+    const handlers = captureCommands();
+    const { ctx, replies } = makeCtx("<name>");
+    await handlers.get("model")!(ctx);
+
+    expect(replies).toHaveLength(1);
+    const [reply] = replies;
+    expect(reply!.opts?.parse_mode).toBe("HTML");
+    // No raw tag may survive into an HTML-parsed send.
+    expect(reply!.text).not.toContain("<name>");
+    expect(reply!.text).toContain("&lt;name&gt;");
+  });
+
+  it("escapes the built-in fallback when the backend supplies no formatter", async () => {
+    resolveModelInfo.mockResolvedValue({ kind: "missing" });
+    formatModelError.mockReturnValue(undefined);
+
+    const handlers = captureCommands();
+    const { ctx, replies } = makeCtx("<name>");
+    await handlers.get("model")!(ctx);
+
+    expect(replies[0]!.text).not.toContain("<name>");
+    expect(replies[0]!.text).toContain("&lt;name&gt;");
+  });
+
+  it("leaves an ordinary query readable", async () => {
+    resolveModelInfo.mockResolvedValue({ kind: "missing" });
+    formatModelError.mockReturnValue('No model matched "gpt-9".');
+
+    const handlers = captureCommands();
+    const { ctx, replies } = makeCtx("gpt-9");
+    await handlers.get("model")!(ctx);
+
+    // Quotes round-trip as `&quot;`, which Telegram renders back as `"`.
+    // The model id itself must survive untouched.
+    expect(replies[0]!.text).toContain("gpt-9");
+    expect(replies[0]!.text).toBe("No model matched &quot;gpt-9&quot;.");
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -122,6 +122,14 @@ async function gracefulShutdown(signal: string): Promise<void> {
 
   const forceTimer = setTimeout(() => {
     logError("shutdown", "Timeout exceeded, forcing exit");
+    // Hand off even on the forced path. A restart must survive a
+    // subsystem that won't stop (a wedged FUSE unmount, an MCP server
+    // ignoring SIGTERM, a backend child that never acks): without this
+    // the timeout exits without a successor and `/restart` silently
+    // takes the daemon down for good. The successor may briefly race
+    // the long-poll we failed to release, but grammy retries the 409 —
+    // a few seconds of overlap beats staying down.
+    spawnSuccessor();
     process.exit(1);
   }, SHUTDOWN_TIMEOUT_MS);
   forceTimer.unref();

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ import {
 import { shutdownTriggers } from "./core/background/triggers/index.js";
 import { pruneSettledTriggers } from "./storage/trigger-store.js";
 import { startWatchdog, stopWatchdog } from "./util/watchdog.js";
+import { spawnSuccessor } from "./util/respawn.js";
 import { log, logError, logWarn } from "./util/log.js";
 import {
   getVfs,
@@ -181,11 +182,15 @@ async function gracefulShutdown(signal: string): Promise<void> {
     await shutdownHub();
   });
   flushDatabase();
-  // Guarded removal: after a /restart handoff the successor has already
-  // written its own pid here — deleting unconditionally would orphan it
-  // (the bug that made `talon restart` spawn duplicate daemons).
+  // Guarded removal: only clear the record if it still names us. A
+  // successor that raced ahead and wrote its own pid here must not be
+  // orphaned (the bug that made `talon restart` spawn duplicate daemons).
   removePidRecordIfOwnedBy(process.pid);
   log("shutdown", "State saved");
+  // Hand off last: the frontends are stopped, so the successor binds
+  // Telegram's long-poll only after we have released it. No-op unless
+  // /restart or /update armed a respawn.
+  spawnSuccessor();
   process.exit(0);
 }
 

--- a/src/frontend/telegram/commands/settings.ts
+++ b/src/frontend/telegram/commands/settings.ts
@@ -112,10 +112,16 @@ export function registerSettingsCommands(
     if (be?.models?.resolveModelInfo) {
       const resolution = await be.models?.resolveModelInfo(arg);
       if (resolution.kind !== "exact") {
+        // Every backend's formatModelError returns plain text and
+        // interpolates the raw query, so escape at this boundary — the
+        // same fix as the model menu's status lines. `/model <name>`
+        // (which the OpenCode/Kilo hint literally tells you to type)
+        // otherwise reaches Telegram as an unsupported `<name>` tag and
+        // the whole reply 400s, leaving the command looking dead.
         const msg =
           be.models?.formatModelError?.(arg, resolution) ??
-          `No model matched "${escapeHtml(arg)}".`;
-        await ctx.reply(msg, { parse_mode: "HTML" });
+          `No model matched "${arg}".`;
+        await ctx.reply(escapeHtml(msg), { parse_mode: "HTML" });
         return;
       }
       if (!resolution.model.selectable) {

--- a/src/frontend/telegram/helpers/menu.ts
+++ b/src/frontend/telegram/helpers/menu.ts
@@ -370,9 +370,12 @@ export function renderModelMenuText(state: ModelMenuState): string {
       `<i>Use the picker below to choose one — sending a message before picking will be refused.</i>`,
     );
   } else {
-    lines.push(`<b>Model:</b> <code>${state.activeDisplay}</code>`);
+    lines.push(`<b>Model:</b> <code>${escapeHtml(state.activeDisplay)}</code>`);
   }
-  for (const l of state.statusLines) lines.push(l);
+  // Display names and status lines are plain text from backend catalogs —
+  // a literal `<name>` in a hint (or a `<` in a model id) is otherwise
+  // parsed as an HTML tag and Telegram rejects the whole send with 400.
+  for (const l of state.statusLines) lines.push(escapeHtml(l));
   if (state.freeOnly && state.showFreeToggle) {
     lines.push("<i>Filtering to free-tier models when browsing.</i>");
   }

--- a/src/util/respawn.ts
+++ b/src/util/respawn.ts
@@ -3,8 +3,7 @@
  *
  * Spawns a fresh copy of the current process — same Node binary,
  * same `execArgv` (preserving the tsx loader so `.ts` entrypoints
- * still resolve), same script + user args, same cwd + env — then
- * triggers a graceful shutdown of the current process. The new
+ * still resolve), same script + user args, same cwd + env. The new
  * child is detached with stdio:"ignore" so it survives the parent's
  * exit; calling `unref()` lets the parent exit without waiting on
  * it.
@@ -16,59 +15,88 @@
  * debugger. Respawning from our own `process.argv` works regardless
  * of launch method.
  *
- * Shutdown is done by raising SIGTERM on ourselves rather than
- * `process.exit(0)` so the existing graceful-shutdown handler runs
- * (`await frontend.stop()`, flush sessions, remove PID file). The
- * brief overlap between the new child binding Telegram's long-poll
- * and the old one releasing it is benign — grammy retries on 409
- * Conflict and the new child takes over within a few seconds.
+ * Ordering matters. `respawnSelf()` only *arms* the handoff and
+ * raises SIGTERM; the successor is spawned by `spawnSuccessor()` at
+ * the tail of graceful shutdown, once the frontends have stopped.
+ * Spawning up-front (the previous behaviour) left the successor
+ * long-polling `getUpdates` while the outgoing process was still
+ * draining in-flight queries — up to DRAIN_TIMEOUT_MS of two live
+ * pollers. Telegram answers only one of them and re-delivers the
+ * unconfirmed updates to the other, so a restart mid-turn produced
+ * a 409 Conflict on the way out and duplicate replies on the way in.
+ * Releasing the poll before the successor binds it removes the
+ * overlap rather than relying on grammy's 409 retry to paper over it.
  */
 
 import { spawn } from "node:child_process";
 import { log, logError } from "./log.js";
 
+let pendingReason: string | null = null;
+
 /**
- * Respawn the current process with identical argv + flags, then
- * raise SIGTERM on ourselves so the existing graceful-shutdown path
- * cleanly stops the frontend, flushes state, and exits.
+ * Arm a respawn and raise SIGTERM on ourselves so the existing
+ * graceful-shutdown path cleanly stops the frontends, flushes state,
+ * and hands off via `spawnSuccessor()`.
  *
  * `reason` is logged for operator visibility (e.g. "telegram
- * /restart"). The function returns immediately; the actual exit
- * happens asynchronously once the child has spawned (or failed).
+ * /restart"). The function returns immediately; the successor starts
+ * only after shutdown has released the Telegram long-poll.
  */
 export function respawnSelf(reason: string): void {
   log("shutdown", `Respawn requested (${reason})`);
+  pendingReason = reason;
+  // SIGTERM triggers the graceful-shutdown handler in src/app.ts,
+  // which stops the frontends, flushes state, spawns the successor,
+  // and calls process.exit(0). Don't exit here directly — that would
+  // skip the flush and leave the PID file dangling.
+  process.kill(process.pid, "SIGTERM");
+}
 
-  const child = spawn(
-    process.argv[0],
-    [...process.execArgv, ...process.argv.slice(1)],
-    {
-      cwd: process.cwd(),
-      detached: true,
-      stdio: "ignore",
-      env: { ...process.env },
-    },
-  );
+/** True when a `/restart` or `/update` armed a handoff. */
+export function respawnRequested(): boolean {
+  return pendingReason !== null;
+}
 
-  child.once("spawn", () => {
-    log("shutdown", `Respawn child started (pid ${child.pid}) — exiting self`);
+/**
+ * Spawn the successor process. Called at the end of graceful
+ * shutdown, after the frontends have stopped — so the incoming
+ * process binds Telegram's long-poll only once this one has let go
+ * of it. No-op unless `respawnSelf()` armed a handoff.
+ *
+ * Never throws: a failed handoff must not prevent this process from
+ * exiting. An external supervisor (systemd, pm2, the user's
+ * terminal) can pick things up.
+ */
+export function spawnSuccessor(): void {
+  if (pendingReason === null) return;
+  const reason = pendingReason;
+  pendingReason = null;
+
+  try {
+    const child = spawn(
+      process.argv[0],
+      [...process.execArgv, ...process.argv.slice(1)],
+      {
+        cwd: process.cwd(),
+        detached: true,
+        stdio: "ignore",
+        env: { ...process.env },
+      },
+    );
+    child.once("error", (err) => {
+      logError(
+        "shutdown",
+        `Respawn failed; exiting without a successor — restart manually`,
+        err,
+      );
+    });
     child.unref();
-    // SIGTERM triggers the existing graceful-shutdown handler in
-    // src/index.ts, which stops the frontend, flushes state, and
-    // calls process.exit(0). Don't exit here directly — that would
-    // skip the flush and leave the PID file dangling.
-    process.kill(process.pid, "SIGTERM");
-  });
-
-  child.once("error", (err) => {
+    log("shutdown", `Respawn child started (pid ${child.pid}) — ${reason}`);
+  } catch (err) {
     logError(
       "shutdown",
       `Respawn failed; exiting without a successor — restart manually`,
       err,
     );
-    // The child never started, so we can't hand off. Still exit so
-    // any external supervisor (systemd, pm2, the user's terminal)
-    // can pick things up.
-    process.kill(process.pid, "SIGTERM");
-  });
+  }
 }


### PR DESCRIPTION
## What changed

- Escape backend-provided model names and status lines before rendering Telegram HTML.
- Defer self-respawn until graceful shutdown has stopped all frontends.
- Add regression coverage for the OpenCode `<name>` hint and respawn ordering.

## Why

Two production failures exposed separate boundary bugs:

1. OpenCode reports `Hint: use /model <name> to switch.`. Telegram parsed `<name>` as an unsupported HTML tag, so the backend switch succeeded but the model menu failed to redraw and looked inert.
2. `/restart` spawned its successor before the outgoing Telegram long-poll stopped. During the drain window both processes polled `getUpdates`, producing 409 conflicts and duplicate replies.

The menu now treats catalog strings as plain text, and the successor starts only after frontend teardown releases Telegram polling.

## Validation

- `npx vitest run src/__tests__/telegram-model-menu.test.ts src/__tests__/respawn.test.ts` — 32 tests passed
- `npm run typecheck`
- targeted `oxlint`
- targeted `prettier --check`

## Follow-up: two gaps found while verifying against production logs

3. Moving the handoff to the tail of `gracefulShutdown` left the 15s force-exit
   timer (`process.exit(1)`) with no handoff at all. A subsystem that won't stop
   in time — wedged FUSE unmount, an MCP server ignoring SIGTERM, a backend child
   that never acks — turned `/restart` into a permanent outage rather than a
   restart. The forced path now hands off too. `spawnSuccessor()` is already
   idempotent ("hands off at most once"), so the normal tail call can't double-spawn.
4. `/model <query>` sent `formatModelError()` output as HTML unescaped, while the
   fallback one line below escaped. All five backends return plain text wrapped
   around the raw query, so `/model <name>` — the literal hint OpenCode and Kilo
   print in the menu — failed the entire send. The documented recovery path was
   itself the trigger.

Production log confirming the original report (`talon.log`, pid 1473455):

```
GrammyError: Call to 'sendMessage' failed! (400: Bad Request: can't parse
entities: Unsupported start tag "name" at byte offset 264)
    at async src/frontend/telegram/commands/settings.ts:93
```

The backend switch itself always succeeded — only the redraw 400'd, which is why
it read as "stuck" / "crashing on switch".

### Added validation

- `npx vitest run src/__tests__/telegram-settings-escaping.test.ts src/__tests__/respawn.test.ts src/__tests__/telegram-model-menu.test.ts` — 35 passed
- `npx tsc --noEmit`, `oxlint`, `prettier --check` on touched files
