### PR TITLE
fix(remote): harden OpenCode and Kilo runtime parity

### DIFF
--- a/src/__tests__/backend-conformance.test.ts
+++ b/src/__tests__/backend-conformance.test.ts
@@ -26,7 +26,7 @@
  *      in.
  *   3. `routeDelivery` returns the same route shape for both backends
  *      given equivalent state.
- *   4. The chat MCP visibility rotation behaves identically for both
+ *   4. Concurrent chat MCP registration behaves identically for both
  *      backends' state containers.
  */
 
@@ -125,7 +125,7 @@ function makeRepresentativeEventSequence(sessionId: string): Array<{
           callID: "call-1",
           tool: "send",
           state: {
-            status: "running",
+            status: "completed",
             input: { type: "text", text: "tool-delivered text" },
           },
         },
@@ -458,10 +458,10 @@ describe("backend conformance — routeDelivery", () => {
   });
 });
 
-// ── Conformance: MCP visibility rotation ───────────────────────────────────
+// ── Conformance: concurrent MCP registration ───────────────────────────────
 
-describe("backend conformance — MCP chat-server rotation", () => {
-  it("rotates chat MCP servers identically for both backend states", async () => {
+describe("backend conformance — MCP chat-server retention", () => {
+  it("retains chat MCP servers identically for both backend states", async () => {
     const kiloState = createRemoteServerState<RemoteAgentClient>({
       label: "Kilo",
       hostname: "127.0.0.1",
@@ -481,14 +481,14 @@ describe("backend conformance — MCP chat-server rotation", () => {
       getRegisteredMcpServerNames(opencodeState),
     );
 
-    // Switch to chat B — both should rotate out chat A
+    // Register chat B while chat A may still be running.
     await ensureChatMcpServer(makeMockClient(), kiloState, "chatB");
     await ensureChatMcpServer(makeMockClient(), opencodeState, "chatB");
 
     const kiloNames = getRegisteredMcpServerNames(kiloState).sort();
     const opencodeNames = getRegisteredMcpServerNames(opencodeState).sort();
     expect(kiloNames).toEqual(opencodeNames);
-    expect(kiloNames).toEqual(["talon-tools-chatB"]);
+    expect(kiloNames).toEqual(["talon-tools-chatA", "talon-tools-chatB"]);
   });
 
   it("preserves heartbeat sentinel for both backends symmetrically", async () => {
@@ -509,7 +509,7 @@ describe("backend conformance — MCP chat-server rotation", () => {
     opencodeState.registeredMcpServers.add("talon-tools-heartbeat");
     opencodeState.registeredMcpServers.add("talon-tools-chatA");
 
-    // Switch to chat B
+    // Register chat B without disrupting the existing chat.
     await ensureChatMcpServer(makeMockClient(), kiloState, "chatB");
     await ensureChatMcpServer(makeMockClient(), opencodeState, "chatB");
 
@@ -519,6 +519,6 @@ describe("backend conformance — MCP chat-server rotation", () => {
     expect(kiloNames).toEqual(opencodeNames);
     expect(kiloNames).toContain("talon-tools-heartbeat");
     expect(kiloNames).toContain("talon-tools-chatB");
-    expect(kiloNames).not.toContain("talon-tools-chatA");
+    expect(kiloNames).toContain("talon-tools-chatA");
   });
 });

--- a/src/__tests__/backend-registry-parity.test.ts
+++ b/src/__tests__/backend-registry-parity.test.ts
@@ -81,6 +81,20 @@ describe("backend registry parity — all built-in backends present", () => {
     expect(getBackend("codex")?.label).toBe("Codex");
     expect(getBackend("openai-agents")?.label).toBe("OpenAI Agents");
   });
+
+  it("gives OpenCode and Kilo live tool-refresh and prompt-control slots", async () => {
+    for (const id of ["opencode", "kilo"] as const) {
+      const instance = await getBackend(id)!.init({} as never, {
+        getBridgePort: () => 19876,
+        frontendName: "telegram",
+      });
+      expect(instance.backend.tools?.refreshTools).toBeTypeOf("function");
+      expect(instance.backend.control?.updateSystemPrompt).toBeTypeOf(
+        "function",
+      );
+      await instance.cleanup?.();
+    }
+  });
 });
 
 describe("backend registry parity — duplicate registration is rejected", () => {

--- a/src/__tests__/backend-registry-parity.test.ts
+++ b/src/__tests__/backend-registry-parity.test.ts
@@ -95,6 +95,41 @@ describe("backend registry parity — all built-in backends present", () => {
       await instance.cleanup?.();
     }
   });
+
+  it("gives OpenCode and Kilo the same session-warm hook as Claude", async () => {
+    // `performSessionReset` calls `backend.sessions.warmSession` right
+    // after a reset. Without the slot the remote-server backends silently
+    // skipped it and the first turn on a fresh session serially paid
+    // session creation plus a full plugin-MCP registration sweep — the
+    // dominant cold-start cost on OpenCode/Kilo.
+    for (const id of ["claude", "opencode", "kilo"] as const) {
+      const instance = await getBackend(id)!.init({} as never, {
+        getBridgePort: () => 19876,
+        frontendName: "telegram",
+      });
+      expect(
+        instance.backend.sessions?.warmSession,
+        `expected ${id} to expose sessions.warmSession`,
+      ).toBeTypeOf("function");
+      await instance.cleanup?.();
+    }
+  });
+
+  it("warms without throwing when the remote server is unreachable", async () => {
+    // Contract: a warm-up is best-effort. `/reset` has already succeeded
+    // by the time it runs, so a server that won't spawn must degrade to a
+    // slow first turn — never reject and surface as a failed reset.
+    for (const id of ["opencode", "kilo"] as const) {
+      const instance = await getBackend(id)!.init({} as never, {
+        getBridgePort: () => 19876,
+        frontendName: "telegram",
+      });
+      await expect(
+        instance.backend.sessions!.warmSession!("-100parity"),
+      ).resolves.toBeUndefined();
+      await instance.cleanup?.();
+    }
+  }, 60_000);
 });
 
 describe("backend registry parity — duplicate registration is rejected", () => {

--- a/src/__tests__/integration/MULTI-BACKEND-HARNESS.md
+++ b/src/__tests__/integration/MULTI-BACKEND-HARNESS.md
@@ -89,9 +89,8 @@ turn.completed` JSONL, exits 0. Reconstructs the MCP server map from the
 - **opencode/kilo**: promptAsync posts to `/session/{id}/prompt_async` (not
   `/message`); `mcp.add` sends `config.command` as a full `[exe, ...args]`
   **array** + `config.environment` (not `env`); disconnect is
-  `POST /mcp/{name}/disconnect`; after a chat switch the current chat's MCP
-  server is the **most-recent** registration (the prior one's gateway context is
-  cleared → "No active chat context" if you pick the stale one); the SSE
+  `POST /mcp/{name}/disconnect`; chat MCP servers remain registered concurrently
+  and production scopes their visibility with prompt `tools` overrides; the SSE
   subscribe is fired-but-not-awaited just before promptAsync (the fake waits on
   the actual connect, event-driven, before emitting).
 - **openai-agents** is tool-preferred (delivers via `end_turn`, not text — plain

--- a/src/__tests__/integration/kilo-real-bootstrap.test.ts
+++ b/src/__tests__/integration/kilo-real-bootstrap.test.ts
@@ -296,9 +296,9 @@ kiloDescribe("Kilo backend — real bootstrap (integration)", () => {
     //    Same shape as TelegramFrontend / DiscordFrontend / TeamsFrontend —
     //    just wired to in-memory hooks instead of an external chat platform.
     const ctx: ContextManager = {
-      acquire: () => {},
-      release: () => {},
-      getMessageCount: () => 0,
+      acquire: (chatId, stringId) => gateway!.setContext(chatId, stringId),
+      release: (chatId) => gateway!.clearContext(chatId),
+      getMessageCount: (chatId) => gateway!.getMessageCount(chatId),
     };
     const frontend: Frontend = {
       name: "telegram",
@@ -423,20 +423,16 @@ kiloDescribe("Kilo backend — real bootstrap (integration)", () => {
 
   // ── Test 2: cross-chat MCP isolation ─────────────────────────────────────
   //
-  // Per-session permission rules block tool *execution* but not *visibility*
-  // — Kilo exposes every registered MCP server's tools to every session.
-  // The fix (`ensureChatMcpServer` in server.ts) holds at most one chat
-  // `talon-tools-<chatId>` registered at a time, disconnecting any other
-  // when a new chat starts.
+  // Kilo exposes every registered MCP server globally, so Talon keeps
+  // chat-namespaced registrations alive for concurrency and isolates their
+  // visibility with per-prompt tool overrides.
   //
-  // This test exercises the disconnect path against a real `kilo serve`:
-  // run a turn for chat A, then a turn for chat B, then assert that only
-  // chat B's MCP server remains registered (chat A's was disconnected
-  // before chat B's was added). Talon's local `registeredMcpServers` Set
+  // This test runs chat A then chat B against a real server and asserts both
+  // remain registered. Talon's local `registeredMcpServers` Set
   // is the source of truth — Kilo's `GET /mcp` returns `{}` regardless of
   // state, so we read the cache directly via `getRegisteredMcpServerNames`.
 
-  it("chat-switch disconnects the previous chat's MCP server", async () => {
+  it("retains both chat MCP servers across chat switches", async () => {
     recording.reset();
     const { execute } = await import("../../core/engine/dispatcher.js");
     const { getRegisteredMcpServerNames } =
@@ -461,9 +457,7 @@ kiloDescribe("Kilo backend — real bootstrap (integration)", () => {
       `expected chat A's MCP to be registered after turn 1; got [${afterA.join(", ")}]`,
     ).toContain("talon-tools-isolation-chat-a");
 
-    // Turn 2 — chat B. Chat A's MCP must be disconnected before chat B's
-    // is added; production logs `Disconnected talon-tools-... (chat switch)`
-    // when this fires.
+    // Turn 2 — chat B must not disrupt chat A's registration.
     await execute({
       chatId: "isolation-chat-b",
       numericChatId: 991_011,
@@ -479,16 +473,8 @@ kiloDescribe("Kilo backend — real bootstrap (integration)", () => {
     expect(chatServers).toContain("talon-tools-isolation-chat-b");
     expect(
       chatServers,
-      `chat A's MCP must be disconnected after switch; cache=[${chatServers.join(", ")}]`,
-    ).not.toContain("talon-tools-isolation-chat-a");
-
-    // Heartbeat sentinel (if present) is exempt from the chat-switch
-    // disconnect, but should be the ONLY non-chat talon-tools-* in the
-    // cache. Anything else means a stale chat MCP wasn't disconnected.
-    const nonHeartbeat = chatServers.filter(
-      (n) => n !== "talon-tools-heartbeat",
-    );
-    expect(nonHeartbeat).toEqual(["talon-tools-isolation-chat-b"]);
+      `chat A's MCP must remain available for concurrent turns; cache=[${chatServers.join(", ")}]`,
+    ).toContain("talon-tools-isolation-chat-a");
   }, 240_000);
 
   // Synthetic output-cap path coverage lives at the unit level:

--- a/src/__tests__/integration/opencode-real-bootstrap.test.ts
+++ b/src/__tests__/integration/opencode-real-bootstrap.test.ts
@@ -224,9 +224,9 @@ opencodeDescribe("OpenCode backend — real bootstrap (integration)", () => {
     await gateway.start(0);
 
     const ctx: ContextManager = {
-      acquire: () => {},
-      release: () => {},
-      getMessageCount: () => 0,
+      acquire: (chatId, stringId) => gateway!.setContext(chatId, stringId),
+      release: (chatId) => gateway!.clearContext(chatId),
+      getMessageCount: (chatId) => gateway!.getMessageCount(chatId),
     };
     const frontend: Frontend = {
       name: "telegram",
@@ -334,22 +334,17 @@ opencodeDescribe("OpenCode backend — real bootstrap (integration)", () => {
 
   // ── Test 2: cross-chat MCP isolation ─────────────────────────────────────
   //
-  // Per-session permission rules block tool *execution* but not *visibility*
-  // — OpenCode exposes every registered MCP server's tools to every session.
-  // The fix (`ensureChatMcpServer` in `remote-server/mcp.ts`) holds at most
-  // one chat `talon-tools-<chatId>` registered at a time, disconnecting any
-  // other when a new chat starts. Same model as the Kilo backend; both
-  // wrap forks of the same upstream HTTP API.
+  // OpenCode exposes every registered MCP server globally, so Talon keeps
+  // chat-namespaced registrations alive for concurrency and isolates their
+  // visibility with per-prompt tool overrides.
   //
-  // This test exercises the disconnect path against a real `opencode`
-  // server: run a turn for chat A, then a turn for chat B, then assert
-  // that only chat B's MCP server remains registered (chat A's was
-  // disconnected before chat B's was added). Talon's local
+  // This test runs chat A then chat B against a real server and asserts both
+  // remain registered. Talon's local
   // `registeredMcpServers` Set is the source of truth — OpenCode's
   // `GET /mcp` returns `{}` regardless of state, so we read the cache
   // directly via `getRegisteredMcpServerNames`.
 
-  it("chat-switch disconnects the previous chat's MCP server", async () => {
+  it("retains both chat MCP servers across chat switches", async () => {
     recording.reset();
     const { execute } = await import("../../core/engine/dispatcher.js");
     const { getRegisteredMcpServerNames } =
@@ -374,9 +369,7 @@ opencodeDescribe("OpenCode backend — real bootstrap (integration)", () => {
       `expected chat A's MCP to be registered after turn 1; got [${afterA.join(", ")}]`,
     ).toContain("talon-tools-opencode-isolation-a");
 
-    // Turn 2 — chat B. Chat A's MCP must be disconnected before chat B's
-    // is added; production logs `Disconnected talon-tools-... (chat switch)`
-    // when this fires.
+    // Turn 2 — chat B must not disrupt chat A's registration.
     await execute({
       chatId: "opencode-isolation-b",
       numericChatId: 992_011,
@@ -392,15 +385,7 @@ opencodeDescribe("OpenCode backend — real bootstrap (integration)", () => {
     expect(chatServers).toContain("talon-tools-opencode-isolation-b");
     expect(
       chatServers,
-      `chat A's MCP must be disconnected after switch; cache=[${chatServers.join(", ")}]`,
-    ).not.toContain("talon-tools-opencode-isolation-a");
-
-    // Heartbeat sentinel (if present) is exempt from the chat-switch
-    // disconnect, but should be the ONLY non-chat talon-tools-* in the
-    // cache. Anything else means a stale chat MCP wasn't disconnected.
-    const nonHeartbeat = chatServers.filter(
-      (n) => n !== "talon-tools-heartbeat",
-    );
-    expect(nonHeartbeat).toEqual(["talon-tools-opencode-isolation-b"]);
+      `chat A's MCP must remain available for concurrent turns; cache=[${chatServers.join(", ")}]`,
+    ).toContain("talon-tools-opencode-isolation-a");
   }, 300_000);
 });

--- a/src/__tests__/integration/stub-remote/fake-remote-server.ts
+++ b/src/__tests__/integration/stub-remote/fake-remote-server.ts
@@ -153,10 +153,9 @@ export async function startFakeRemoteServer(
   };
 
   /**
-   * Pick the talon chat MCP server (named `talon-tools-*`). Use the MOST
-   * RECENT registration — after a chat switch the previous chat's server is
-   * disconnected and its gateway context cleared, so the current chat's server
-   * is the last one added.
+   * Pick the talon chat MCP server (named `talon-tools-*`). The stub executes
+   * turns serially, so the most recent registration matches the prompt's chat;
+   * production additionally scopes the visible catalog per prompt.
    */
   const talonServerName = () => {
     const talon = [...mcpServers.keys()].filter((n) =>

--- a/src/__tests__/kilo-events.test.ts
+++ b/src/__tests__/kilo-events.test.ts
@@ -129,7 +129,7 @@ describe("processStreamEvent — message.part.delta", () => {
 });
 
 describe("processStreamEvent — message.part.updated (tool)", () => {
-  it("fires onToolUse + recordToolUse for a running tool", async () => {
+  it("fires onToolUse + recordToolUse for a completed tool", async () => {
     const onToolUse = vi.fn();
     const ctx = baseContext({ onToolUse });
     await processStreamEvent(
@@ -141,7 +141,7 @@ describe("processStreamEvent — message.part.updated (tool)", () => {
             type: "tool",
             callID: "call_1",
             tool: "get_weather",
-            state: { status: "running", input: { city: "Dublin" } },
+            state: { status: "completed", input: { city: "Dublin" } },
           },
         },
       },
@@ -163,7 +163,7 @@ describe("processStreamEvent — message.part.updated (tool)", () => {
           type: "tool",
           callID: "call_1",
           tool: "x",
-          state: { status: "running", input: {} },
+          state: { status: "completed", input: {} },
         },
       },
     };
@@ -205,7 +205,7 @@ describe("processStreamEvent — message.part.updated (tool)", () => {
             type: "tool",
             callID: "c1",
             tool: "search",
-            state: { status: "running", input: { q: "x" } },
+            state: { status: "completed", input: { q: "x" } },
           },
         },
       },
@@ -227,7 +227,7 @@ describe("processStreamEvent — message.part.updated (tool)", () => {
             type: "tool",
             callID: "c1",
             tool: "end_turn",
-            state: { status: "running", input: { text: "bye" } },
+            state: { status: "completed", input: { text: "bye" } },
           },
         },
       },
@@ -238,6 +238,29 @@ describe("processStreamEvent — message.part.updated (tool)", () => {
       expect(outcome.toolName).toBe("end_turn");
     }
     expect(ctx.state.turnTerminated).toBe(true);
+  });
+
+  it("rejects a nested part event from a concurrent session", async () => {
+    const ctx = baseContext();
+    const outcome = await processStreamEvent(
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            sessionID: "other-session",
+            type: "tool",
+            callID: "foreign-call",
+            tool: "end_turn",
+            state: { status: "completed", input: { text: "wrong chat" } },
+          },
+        },
+      },
+      ctx,
+    );
+
+    expect(outcome).toEqual({ kind: "stop", reason: "out_of_scope" });
+    expect(ctx.state.turnTerminated).toBe(false);
+    expect(ctx.state.toolCalls).toBe(0);
   });
 
   it("does NOT return terminator_fired for react with end_turn:false", async () => {
@@ -264,7 +287,7 @@ describe("processStreamEvent — message.part.updated (tool)", () => {
     expect(ctx.state.turnTerminated).toBe(false);
   });
 
-  it("skips tools that aren't running or completed (pending only)", async () => {
+  it("skips tools that have not completed", async () => {
     const onToolUse = vi.fn();
     const ctx = baseContext({ onToolUse });
     await processStreamEvent(
@@ -647,7 +670,7 @@ describe("processStreamEvent — message.updated info-level scoping", () => {
       },
       ctx as never,
     );
-    expect(outcome).toEqual({ kind: "continue" });
+    expect(outcome).toEqual({ kind: "stop", reason: "out_of_scope" });
     expect(ctx.state.sdkInputTokens).toBe(0);
   });
 

--- a/src/__tests__/kilo-events.test.ts
+++ b/src/__tests__/kilo-events.test.ts
@@ -541,6 +541,37 @@ describe("finalizePartsIntoState — SSE captured tools to skip", () => {
     expect(seen.has("c2")).toBe(true);
   });
 
+  it("does not backfill failed or still-running tools as delivered", () => {
+    const state = createStreamState();
+    const onToolUse = vi.fn();
+    const seen = new Set<string>();
+    const { toolsProcessed } = finalizePartsIntoState({
+      parts: [
+        {
+          type: "tool",
+          callID: "running",
+          tool: "end_turn",
+          state: { status: "running", input: { text: "not sent" } },
+        },
+        {
+          type: "tool",
+          callID: "failed",
+          tool: "send",
+          state: { status: "error", input: { text: "also not sent" } },
+        },
+      ],
+      state,
+      seenToolCallIds: seen,
+      onToolUse,
+    });
+
+    expect(toolsProcessed).toBe(0);
+    expect(state.toolCalls).toBe(0);
+    expect(state.turnTerminated).toBe(false);
+    expect(onToolUse).not.toHaveBeenCalled();
+    expect(seen).toEqual(new Set());
+  });
+
   it("never throws when onToolUse throws", () => {
     const state = createStreamState();
     const onToolUse = vi.fn(() => {

--- a/src/__tests__/kilo-server.test.ts
+++ b/src/__tests__/kilo-server.test.ts
@@ -86,12 +86,12 @@ describe("kilo server helpers", () => {
     });
   });
 
-  it("buildToolOverrides returns undefined when no matching chat tools are present", async () => {
+  it("buildToolOverrides disables a rival while current tools are loading", async () => {
     const oc = makeClient();
     oc.tool.ids.mockResolvedValue({ data: ["talon-tools-other_send_message"] });
     await expect(
       buildToolOverrides(oc as never, "talon-tools-chat_1"),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ "talon-tools-other_send_message": false });
   });
 
   it("ensureChatMcpServer registers the chat server with the hub URL", async () => {
@@ -135,46 +135,35 @@ describe("kilo server helpers", () => {
     expect(oc.mcp.disconnect).toHaveBeenCalledTimes(1);
   });
 
-  it("ensureChatMcpServer disconnects OTHER chat MCP servers when switching chats", async () => {
-    // Per-session permission rules block tool *execution* but not
-    // *visibility* — Kilo still lists every connected MCP server's
-    // tools in the model's catalog. So `talon-tools-chat_a` AND
-    // `talon-tools-chat_b` connected at once means a model in chat A
-    // can see and call `talon-tools-chat_b_send`. Holding only one
-    // chat-namespaced server connected at a time is the only way to
-    // hide cross-chat tools. The heartbeat sentinel server is exempt
-    // (always allowed to coexist).
+  it("ensureChatMcpServer retains other chat MCP servers for concurrent turns", async () => {
     const oc = makeClient();
 
     await ensureChatMcpServer(oc as never, "chat-a");
     await ensureChatMcpServer(oc as never, "heartbeat");
     expect(oc.mcp.add).toHaveBeenCalledTimes(2);
 
-    // Switching to chat-b should disconnect chat-a but leave heartbeat
-    // (heartbeat is the sentinel for background agent outbound calls).
+    // Registering chat-b must not disrupt chat-a if its turn is still live.
     await ensureChatMcpServer(oc as never, "chat-b");
 
-    expect(oc.mcp.disconnect).toHaveBeenCalledTimes(1);
-    expect(oc.mcp.disconnect.mock.calls[0][0]).toEqual({
-      name: "talon-tools-chat-a",
-    });
+    expect(oc.mcp.disconnect).not.toHaveBeenCalled();
     // chat-b registered now.
     expect(oc.mcp.add).toHaveBeenCalledTimes(3);
   });
 
-  it("ensureChatMcpServer leaves heartbeat MCP server connected across chat switches", async () => {
+  it("ensureChatMcpServer leaves heartbeat MCP server connected", async () => {
     const oc = makeClient();
 
     await ensureChatMcpServer(oc as never, "heartbeat");
     await ensureChatMcpServer(oc as never, "chat-a");
     await ensureChatMcpServer(oc as never, "chat-b");
 
-    // heartbeat MUST never get disconnected — it's the sentinel for
-    // outbound tool calls from background agents (heartbeat / dream).
+    // No chat registration disconnects any sibling. Per-prompt tool
+    // overrides provide visibility isolation instead.
     const disconnectNames = (
       oc.mcp.disconnect.mock.calls as Array<[{ name: string }]>
     ).map((c) => c[0].name);
     expect(disconnectNames).not.toContain("talon-tools-heartbeat");
+    expect(disconnectNames).not.toContain("talon-tools-chat-a");
   });
 
   it("ensurePluginMcpServers registers all named servers on first call", async () => {
@@ -259,6 +248,7 @@ describe("kilo server helpers", () => {
       { permission: "tool", pattern: "*", action: "allow" },
       { permission: "edit", pattern: "*", action: "allow" },
       { permission: "bash", pattern: "*", action: "allow" },
+      { permission: "external_directory", pattern: "*", action: "allow" },
     ]);
   });
 

--- a/src/__tests__/kilo-server.test.ts
+++ b/src/__tests__/kilo-server.test.ts
@@ -15,6 +15,16 @@ vi.mock("../core/plugin/index.js", () => ({
   getPluginMcpServers: getPluginMcpServersMock,
 }));
 
+vi.mock("../core/mcp-hub/index.js", () => ({
+  talonHubUrl: (bridgeUrl: string, frontend: string, chatId: string) =>
+    `${bridgeUrl}/mcp/talon/${encodeURIComponent(frontend)}/${encodeURIComponent(chatId)}`,
+  pluginHubUrl: (bridgeUrl: string, name: string, chatId: string) =>
+    `${bridgeUrl}/mcp/plugin/${encodeURIComponent(name)}/${encodeURIComponent(chatId)}`,
+  hubPluginServerNames: () =>
+    Object.keys(getPluginMcpServersMock("", "hub-enum")),
+  listHubPluginToolNames: async (name: string) => [`${name}_tool`],
+}));
+
 vi.mock("../util/log.js", () => ({
   log: vi.fn(),
   logWarn: vi.fn(),
@@ -31,6 +41,8 @@ const {
   resolveProviderID,
   parseStoredKiloModelSelection,
   stopKiloServer,
+  getConfig,
+  updateSystemPrompt,
 } = await import("../backend/kilo/server.js");
 
 type MockKiloClient = {
@@ -175,7 +187,10 @@ describe("kilo server helpers", () => {
 
     const registered = await ensurePluginMcpServers(oc as never, "chat-1");
 
-    expect(registered).toEqual(["alpha", "beta"]);
+    expect(registered).toEqual([
+      "talon-plugin-chat-1-alpha",
+      "talon-plugin-chat-1-beta",
+    ]);
     expect(oc.mcp.add).toHaveBeenCalledTimes(2);
   });
 
@@ -193,8 +208,16 @@ describe("kilo server helpers", () => {
     // so no new adds. This is the path that recovers the ~12s/turn we
     // were burning before the cache existed.
     const reRegistered = await ensurePluginMcpServers(oc as never, "chat-1");
-    expect(reRegistered).toEqual(["alpha", "beta"]);
+    expect(reRegistered).toEqual([
+      "talon-plugin-chat-1-alpha",
+      "talon-plugin-chat-1-beta",
+    ]);
     expect(oc.mcp.add).toHaveBeenCalledTimes(2);
+  });
+
+  it("updates the live system prompt used after plugin reload", () => {
+    updateSystemPrompt("fresh prompt");
+    expect(getConfig().systemPrompt).toBe("fresh prompt");
   });
 
   it("ensureSession reuses a valid existing session and creates a new one when expired", async () => {
@@ -245,6 +268,12 @@ describe("kilo server helpers", () => {
     expect(args.permission).toEqual([
       { permission: "tool", pattern: "talon-tools-chat_a_*", action: "allow" },
       { permission: "tool", pattern: "talon-tools-*", action: "deny" },
+      {
+        permission: "tool",
+        pattern: "talon-plugin-chat_a-*",
+        action: "allow",
+      },
+      { permission: "tool", pattern: "talon-plugin-*", action: "deny" },
       { permission: "tool", pattern: "*", action: "allow" },
       { permission: "edit", pattern: "*", action: "allow" },
       { permission: "bash", pattern: "*", action: "allow" },
@@ -280,6 +309,31 @@ describe("kilo server helpers", () => {
       "openai",
     );
     expect(oc.provider.list).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolveProviderID prefers the connected provider when model ids collide", async () => {
+    const oc = makeClient();
+    oc.provider.list.mockResolvedValue({
+      data: {
+        all: [
+          {
+            id: "openrouter",
+            models: {
+              "nvidia/nemotron:free": { providerID: "openrouter" },
+            },
+          },
+          {
+            id: "kilo",
+            models: { "nvidia/nemotron:free": { providerID: "kilo" } },
+          },
+        ],
+        connected: ["kilo"],
+      },
+    });
+
+    await expect(
+      resolveProviderID(oc as never, "nvidia/nemotron:free"),
+    ).resolves.toBe("kilo");
   });
 
   it("resolveProviderID falls back to guessed provider when catalog has no model match", async () => {

--- a/src/__tests__/opencode-turn-reliability.test.ts
+++ b/src/__tests__/opencode-turn-reliability.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runOpenCodeTurn } from "../backend/opencode/handler/turn.js";
+import { createStreamState } from "../backend/shared/index.js";
+
+async function* turnEvents(): AsyncGenerator<unknown> {
+  yield {
+    payload: {
+      type: "message.part.updated",
+      properties: {
+        sessionID: "sess-1",
+        part: {
+          type: "tool",
+          callID: "call-1",
+          tool: "talon-tools-chat-1_end_turn",
+          state: { status: "completed", input: { text: "done" } },
+        },
+      },
+    },
+  };
+  yield {
+    payload: {
+      type: "session.idle",
+      properties: { sessionID: "sess-1" },
+    },
+  };
+}
+
+describe("OpenCode turn reliability", () => {
+  it("does not abort after end_turn and scopes tools on promptAsync", async () => {
+    const abort = vi.fn(async () => ({ data: true }));
+    const promptAsync = vi.fn(async () => ({ data: true }));
+    const oc = {
+      global: { event: vi.fn(async () => ({ stream: turnEvents() })) },
+      session: {
+        abort,
+        promptAsync,
+        messages: vi.fn(async () => ({ data: [] })),
+      },
+      question: {
+        list: vi.fn(async () => ({ data: [] })),
+        reply: vi.fn(),
+        reject: vi.fn(),
+      },
+      permission: {
+        list: vi.fn(async () => ({ data: [] })),
+        reply: vi.fn(),
+      },
+    };
+    const toolOverrides = {
+      "talon-tools-chat-1_end_turn": true,
+      "talon-tools-chat-2_end_turn": false,
+    };
+
+    await runOpenCodeTurn({
+      oc: oc as never,
+      sessionId: "sess-1",
+      prompt: "hello",
+      systemPrompt: "system",
+      providerID: "provider",
+      modelID: "model",
+      state: createStreamState(),
+      chatId: "chat-1",
+      seenQuestionIds: new Set(),
+      seenPermissionIds: new Set(),
+      seenToolCallIds: new Set(),
+      toolOverrides,
+    });
+
+    expect(promptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ tools: toolOverrides }),
+    );
+    expect(abort).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/opencode-turn-reliability.test.ts
+++ b/src/__tests__/opencode-turn-reliability.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import { runOpenCodeTurn } from "../backend/opencode/handler/turn.js";
 import { createStreamState } from "../backend/shared/index.js";
+import {
+  awaitRemoteTurn,
+  RemoteTurnTimeoutError,
+} from "../backend/remote-server/turn-timeout.js";
+import { subscribeSseStream } from "../backend/remote-server/sse-stream.js";
 
 async function* turnEvents(): AsyncGenerator<unknown> {
   yield {
@@ -71,5 +76,36 @@ describe("OpenCode turn reliability", () => {
       expect.objectContaining({ tools: toolOverrides }),
     );
     expect(abort).not.toHaveBeenCalled();
+  });
+
+  it("aborts and rejects a remote turn that exceeds its deadline", async () => {
+    const abort = vi.fn(async () => ({ data: true }));
+    const never = new Promise<void>(() => {});
+
+    await expect(
+      awaitRemoteTurn(never, {
+        client: { session: { abort } },
+        sessionId: "stuck-session",
+        chatId: "chat-1",
+        label: "OpenCode",
+        timeoutMs: 10,
+      }),
+    ).rejects.toBeInstanceOf(RemoteTurnTimeoutError);
+    expect(abort).toHaveBeenCalledWith({ sessionID: "stuck-session" });
+  });
+
+  it("retries transient SSE subscription failures before giving up", async () => {
+    async function* events() {
+      yield { payload: { type: "session.idle" } };
+    }
+    const event = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("socket reset"))
+      .mockResolvedValueOnce({ stream: events() });
+
+    await expect(
+      subscribeSseStream({ global: { event } }, "chat-1"),
+    ).resolves.toBeDefined();
+    expect(event).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/__tests__/remote-server-mcp.test.ts
+++ b/src/__tests__/remote-server-mcp.test.ts
@@ -363,8 +363,10 @@ describe("remote-server / mcp helpers", () => {
       });
     });
 
-    it("returns undefined and logs a warning when tool.ids throws", async () => {
+    it("keeps synthesized isolation overrides when tool.ids throws", async () => {
       const state = makeState();
+      state.registeredMcpServers.add("talon-tools-chatA");
+      state.registeredMcpServers.add("talon-tools-chatB");
       const { client } = makeMockClient();
       client.tool.ids = vi.fn(async () => {
         throw new Error("upstream timeout");
@@ -375,7 +377,32 @@ describe("remote-server / mcp helpers", () => {
         state,
         "talon-tools-chatA",
       );
-      expect(overrides).toBeUndefined();
+      expect(overrides).toMatchObject({
+        "talon-tools-chatA_end_turn": true,
+        "talon-tools-chatB_end_turn": false,
+      });
+    });
+
+    it("isolates chat-scoped plugin tools as well as Talon tools", async () => {
+      const state = makeState();
+      state.registeredMcpServers.add("talon-tools-chatA");
+      state.registeredMcpServers.add("talon-plugin-chatA-memory");
+      state.registeredMcpServers.add("talon-plugin-chatB-memory");
+      state.registeredMcpTools.set("talon-plugin-chatA-memory", ["search"]);
+      state.registeredMcpTools.set("talon-plugin-chatB-memory", ["search"]);
+      const { client } = makeMockClient([]);
+
+      const overrides = await buildToolOverrides(
+        client,
+        state,
+        "talon-tools-chatA",
+        ["talon-plugin-chatA-memory"],
+      );
+
+      expect(overrides).toMatchObject({
+        "talon-plugin-chatA-memory_search": true,
+        "talon-plugin-chatB-memory_search": false,
+      });
     });
   });
 

--- a/src/__tests__/remote-server-mcp.test.ts
+++ b/src/__tests__/remote-server-mcp.test.ts
@@ -11,11 +11,8 @@
  *
  * Key invariants asserted:
  *
- *   1. Connecting `talon-tools-chatA` after `talon-tools-chatB` is
- *      already registered DISCONNECTS chatB first. (Visibility scoping —
- *      see `mcp.ts` for the rationale.)
- *   2. The `talon-tools-heartbeat` sentinel is exempt from rotation.
- *   3. Plugin MCP servers stay connected across chat switches.
+ *   1. Multiple chat MCP servers stay registered concurrently.
+ *   2. Plugin MCP servers stay connected across chat registrations.
  *   4. Local registration cache short-circuits redundant `mcp.add` calls.
  *   5. `buildToolOverrides` produces the correct enable/disable map for
  *      a multi-chat tool catalog.
@@ -33,6 +30,7 @@ import {
   isTalonToolID,
   getRegisteredMcpServerNames,
   TALON_MCP_SERVER_NAME,
+  stopRemoteServer,
   type RemoteAgentClient,
   type RemoteServerState,
 } from "../backend/remote-server/index.js";
@@ -112,6 +110,17 @@ function makeState(): RemoteServerState<RemoteAgentClient> {
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 describe("remote-server / mcp helpers", () => {
+  it("drops a reused-server client without closing the external server", () => {
+    const state = makeState();
+    const { client } = makeMockClient();
+    state.client = client;
+    state.serverHandle = null;
+
+    stopRemoteServer(state);
+
+    expect(state.client).toBeNull();
+  });
+
   describe("getChatMcpServerName", () => {
     it("derives a stable name from a numeric Telegram chatId", () => {
       expect(getChatMcpServerName("352042062")).toBe("talon-tools-352042062");
@@ -148,7 +157,7 @@ describe("remote-server / mcp helpers", () => {
     });
   });
 
-  describe("ensureChatMcpServer — visibility rotation", () => {
+  describe("ensureChatMcpServer — concurrent registrations", () => {
     let state: RemoteServerState<RemoteAgentClient>;
 
     beforeEach(() => {
@@ -169,27 +178,25 @@ describe("remote-server / mcp helpers", () => {
       expect(getRegisteredMcpServerNames(state)).toContain("talon-tools-chatA");
     });
 
-    it("DISCONNECTS rival chat server before registering current one", async () => {
+    it("retains rival chat servers while registering the current one", async () => {
       const { client, mcpDisconnectCalls, mcpAddCalls } = makeMockClient();
 
       await ensureChatMcpServer(client, state, "chatA");
       expect(getRegisteredMcpServerNames(state)).toContain("talon-tools-chatA");
 
-      // Switch to chatB — chatA must be disconnected first
+      // Register chatB while chatA may still have a turn in flight.
       mcpAddCalls.length = 0;
       mcpDisconnectCalls.length = 0;
       await ensureChatMcpServer(client, state, "chatB");
 
-      expect(mcpDisconnectCalls).toEqual(["talon-tools-chatA"]);
+      expect(mcpDisconnectCalls).toEqual([]);
       expect(mcpAddCalls).toHaveLength(1);
       expect(mcpAddCalls[0].name).toBe("talon-tools-chatB");
-      expect(getRegisteredMcpServerNames(state)).not.toContain(
-        "talon-tools-chatA",
-      );
+      expect(getRegisteredMcpServerNames(state)).toContain("talon-tools-chatA");
       expect(getRegisteredMcpServerNames(state)).toContain("talon-tools-chatB");
     });
 
-    it("never disconnects the heartbeat sentinel server", async () => {
+    it("keeps heartbeat and sibling chat servers connected", async () => {
       const { client, mcpDisconnectCalls } = makeMockClient();
       // Seed the heartbeat sentinel + a rival chat
       state.registeredMcpServers.add("talon-tools-heartbeat");
@@ -197,15 +204,15 @@ describe("remote-server / mcp helpers", () => {
 
       await ensureChatMcpServer(client, state, "chatB");
 
-      // Only chatA gets the boot — heartbeat stays connected
-      expect(mcpDisconnectCalls).toEqual(["talon-tools-chatA"]);
+      expect(mcpDisconnectCalls).toEqual([]);
       expect(getRegisteredMcpServerNames(state)).toContain(
         "talon-tools-heartbeat",
       );
       expect(getRegisteredMcpServerNames(state)).toContain("talon-tools-chatB");
+      expect(getRegisteredMcpServerNames(state)).toContain("talon-tools-chatA");
     });
 
-    it("does not rotate plugin servers across chat switches", async () => {
+    it("does not disturb plugin servers across chat registrations", async () => {
       const { client, mcpDisconnectCalls } = makeMockClient();
       // Seed a plugin server (different prefix, e.g. mempalace, brave-search)
       state.registeredMcpServers.add("mempalace");
@@ -214,8 +221,7 @@ describe("remote-server / mcp helpers", () => {
 
       await ensureChatMcpServer(client, state, "chatB");
 
-      // Only the rival chat server gets disconnected
-      expect(mcpDisconnectCalls).toEqual(["talon-tools-chatA"]);
+      expect(mcpDisconnectCalls).toEqual([]);
       expect(getRegisteredMcpServerNames(state)).toContain("mempalace");
       expect(getRegisteredMcpServerNames(state)).toContain("brave-search");
     });
@@ -305,6 +311,26 @@ describe("remote-server / mcp helpers", () => {
       expect(overrides).not.toHaveProperty("read");
     });
 
+    it("synthesizes MCP tool ids omitted by the upstream ids endpoint", async () => {
+      const state = makeState();
+      state.registeredMcpServers.add("talon-tools-chatA");
+      state.registeredMcpServers.add("talon-tools-chatB");
+      const { client } = makeMockClient(["read", "bash"]);
+
+      const overrides = await buildToolOverrides(
+        client,
+        state,
+        "talon-tools-chatA",
+      );
+
+      expect(overrides).toMatchObject({
+        "talon-tools-chatA_end_turn": true,
+        "talon-tools-chatA_send_message": true,
+        "talon-tools-chatB_end_turn": false,
+        "talon-tools-chatB_send_message": false,
+      });
+    });
+
     it("returns undefined when no chat tools matched", async () => {
       const state = makeState();
       const { client } = makeMockClient(["read", "bash", "brave-search_query"]);
@@ -318,7 +344,7 @@ describe("remote-server / mcp helpers", () => {
       expect(overrides).toBeUndefined();
     });
 
-    it("returns undefined when no chat tool of OURS matched (only rivals exist)", async () => {
+    it("disables rivals while our newly registered tools are still loading", async () => {
       const state = makeState();
       const { client } = makeMockClient([
         "talon-tools-chatB_send",
@@ -331,8 +357,10 @@ describe("remote-server / mcp helpers", () => {
         "talon-tools-chatA",
       );
 
-      // Only OTHER chats' tools are in the catalog — no point overriding
-      expect(overrides).toBeUndefined();
+      expect(overrides).toEqual({
+        "talon-tools-chatB_send": false,
+        "talon-tools-chatB_react": false,
+      });
     });
 
     it("returns undefined and logs a warning when tool.ids throws", async () => {

--- a/src/__tests__/remote-server-session-helpers.test.ts
+++ b/src/__tests__/remote-server-session-helpers.test.ts
@@ -10,6 +10,7 @@
  *   - `listSessionMessages` — dedup + limit semantics.
  *   - `getTurnSummary` / `getSessionSnapshot` — high-level wrappers.
  *   - `rejectPendingQuestions` — auto-respond loop with backend label.
+ *   - `approvePendingPermissions` — headless permission fail-safe.
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -23,6 +24,7 @@ import {
   getTurnSummary,
   getSessionSnapshot,
   rejectPendingQuestions,
+  approvePendingPermissions,
   type RemoteSessionClient,
 } from "../backend/remote-server/session-helpers.js";
 
@@ -31,14 +33,17 @@ function makeMockClient(
     messages?: Array<unknown>;
     sessionGetTime?: { created?: number; updated?: number };
     questions?: Array<unknown>;
+    permissions?: Array<unknown>;
   } = {},
 ): {
   client: RemoteSessionClient;
   questionReplyCalls: Array<{ requestID: string; answers: unknown }>;
   questionRejectCalls: Array<{ requestID: string }>;
+  permissionReplyCalls: Array<{ requestID: string; reply: string }>;
 } {
   const questionReplyCalls: Array<{ requestID: string; answers: unknown }> = [];
   const questionRejectCalls: Array<{ requestID: string }> = [];
+  const permissionReplyCalls: Array<{ requestID: string; reply: string }> = [];
   const client: RemoteSessionClient = {
     mcp: { add: vi.fn(), disconnect: vi.fn() },
     session: {
@@ -63,8 +68,20 @@ function makeMockClient(
         return { ok: true };
       }),
     },
+    permission: {
+      list: vi.fn(async () => ({ data: overrides.permissions ?? [] })),
+      reply: vi.fn(async (args) => {
+        permissionReplyCalls.push(args);
+        return { ok: true };
+      }),
+    },
   };
-  return { client, questionReplyCalls, questionRejectCalls };
+  return {
+    client,
+    questionReplyCalls,
+    questionRejectCalls,
+    permissionReplyCalls,
+  };
 }
 
 // ── extractPartsSummary ────────────────────────────────────────────────────
@@ -487,5 +504,42 @@ describe("session-helpers / rejectPendingQuestions", () => {
     await expect(
       rejectPendingQuestions(client, "sess", "chat-1", new Set(), "Kilo"),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("session-helpers / approvePendingPermissions", () => {
+  it("approves a pending permission once for the current session", async () => {
+    const seen = new Set<string>();
+    const { client, permissionReplyCalls } = makeMockClient({
+      permissions: [
+        {
+          id: "p1",
+          sessionID: "sess",
+          permission: "external_directory",
+          patterns: ["/workspace/media/*"],
+        },
+      ],
+    });
+
+    await approvePendingPermissions(client, "sess", "chat-1", seen, "OpenCode");
+    await approvePendingPermissions(client, "sess", "chat-1", seen, "OpenCode");
+
+    expect(permissionReplyCalls).toEqual([{ requestID: "p1", reply: "once" }]);
+  });
+
+  it("ignores permissions belonging to another session", async () => {
+    const { client, permissionReplyCalls } = makeMockClient({
+      permissions: [{ id: "p2", sessionID: "other", permission: "bash" }],
+    });
+
+    await approvePendingPermissions(
+      client,
+      "sess",
+      "chat-1",
+      new Set(),
+      "OpenCode",
+    );
+
+    expect(permissionReplyCalls).toHaveLength(0);
   });
 });

--- a/src/__tests__/telegram-backend-switch-handoff.test.ts
+++ b/src/__tests__/telegram-backend-switch-handoff.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Backend-switch session handoff.
+ *
+ * Switching a chat's backend from the `/model` menu cleared Talon's own
+ * stores (session row, history, pulse checkpoint) but never touched the
+ * backend capability slots that `performSessionReset` drives. Two things
+ * fell through:
+ *
+ *   - the OUTGOING backend's in-process per-chat state survived. Clearing
+ *     Talon's stores does nothing to a backend that keeps its own map —
+ *     openai-agents holds a `MemorySession` keyed by chat id — so
+ *     switching away and back resurrected the conversation the operator
+ *     had just dropped.
+ *   - the INCOMING backend was never warmed, so the first turn after a
+ *     switch paid the whole cold start. On OpenCode/Kilo that is session
+ *     creation plus a per-plugin MCP registration sweep.
+ *
+ * Same contract `performSessionReset` already implements; this covers the
+ * switch path, for both an explicit pick and a revert to the default.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => "{}"),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+vi.mock("write-file-atomic", () => ({ default: { sync: vi.fn() } }));
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+import type { Backend } from "../core/agent-runtime/capabilities.js";
+import type { UnifiedModelInfo } from "../core/types.js";
+import { stubBackend } from "./helpers/stub-backend.js";
+import {
+  initBackendPool,
+  resetBackendPoolForTest,
+} from "../core/engine/backend-controller/index.js";
+import {
+  registerBackend,
+  clearBackends,
+  type BackendFactory,
+} from "../core/agent-runtime/backend-registry.js";
+import { handleModelCallback } from "../frontend/telegram/callbacks/model.js";
+import type { TalonConfig } from "../util/config.js";
+
+let nextChatId = 7000;
+function freshChat(): string {
+  nextChatId += 1;
+  return `bsw-${nextChatId}`;
+}
+
+const resetChatA = vi.fn();
+const warmSessionA = vi.fn(async () => {});
+const resetChatB = vi.fn();
+const warmSessionB = vi.fn(async () => {});
+
+function makeBackend(
+  label: string,
+  hooks: { resetChat: () => void; warmSession: () => Promise<void> },
+): Backend {
+  const model: UnifiedModelInfo = {
+    id: "active-id",
+    displayName: "Active",
+    provider: label,
+    providerName: label,
+    selectable: true,
+    reasoning: false,
+  };
+  return stubBackend({
+    label,
+    query: vi.fn(),
+    resetChat: hooks.resetChat,
+    warmSession: hooks.warmSession,
+    getModelInfo: vi.fn().mockResolvedValue(model),
+    resolveModel: vi.fn().mockResolvedValue({
+      kind: "exact" as const,
+      storedValue: model.id,
+      model,
+    }),
+    getSettingsPresentation: vi.fn().mockResolvedValue({
+      modelButtons: [],
+      page: 1,
+      totalPages: 1,
+      filter: "all",
+      freeCount: 0,
+      totalCount: 0,
+      modelDetails: [],
+      view: "models",
+    }),
+  });
+}
+
+function makeFactory(id: string, label: string, backend: Backend) {
+  return {
+    id,
+    label,
+    async init() {
+      return { backend };
+    },
+  } satisfies BackendFactory;
+}
+
+const baseConfig = {
+  model: "model-a",
+  workspace: "/tmp/test",
+  backend: "be-a",
+  enabledBackends: ["be-a", "be-b"],
+} as unknown as TalonConfig;
+
+/** Minimal grammy callback-query ctx. */
+function makeCtx(cid: string) {
+  return {
+    chat: { id: cid },
+    callbackQuery: { id: "cbq-1", data: "" },
+    answerCallbackQuery: vi.fn(async () => {}),
+    editMessageText: vi.fn(async () => {}),
+  } as never;
+}
+
+beforeEach(async () => {
+  resetChatA.mockClear();
+  warmSessionA.mockClear();
+  resetChatB.mockClear();
+  warmSessionB.mockClear();
+  resetBackendPoolForTest();
+  clearBackends();
+  registerBackend(
+    makeFactory(
+      "be-a",
+      "Backend A",
+      makeBackend("Backend A", {
+        resetChat: resetChatA,
+        warmSession: warmSessionA,
+      }),
+    ),
+  );
+  registerBackend(
+    makeFactory(
+      "be-b",
+      "Backend B",
+      makeBackend("Backend B", {
+        resetChat: resetChatB,
+        warmSession: warmSessionB,
+      }),
+    ),
+  );
+  await initBackendPool(baseConfig, {
+    getBridgePort: () => 0,
+    frontendName: "telegram",
+  });
+});
+
+afterEach(() => {
+  resetBackendPoolForTest();
+  clearBackends();
+});
+
+describe("backend switch hands the session over", () => {
+  it("resets the outgoing backend and warms the incoming one", async () => {
+    const cid = freshChat();
+    await handleModelCallback(makeCtx(cid), "model:backend:be-b", cid, {
+      config: baseConfig,
+      gateway: {} as never,
+    } as never);
+
+    // Outgoing backend must drop its in-process state for this chat.
+    expect(resetChatA).toHaveBeenCalledWith(cid);
+    // Incoming backend gets warmed so the first turn isn't a cold start.
+    // The warm is fire-and-forget, so let the microtask queue drain.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(warmSessionB).toHaveBeenCalledWith(cid);
+    // The incoming backend is not the one being reset.
+    expect(resetChatB).not.toHaveBeenCalled();
+  });
+
+  it("hands off when reverting to the default backend too", async () => {
+    const cid = freshChat();
+    await handleModelCallback(makeCtx(cid), "model:backend:be-b", cid, {
+      config: baseConfig,
+      gateway: {} as never,
+    } as never);
+    resetChatA.mockClear();
+    resetChatB.mockClear();
+    warmSessionA.mockClear();
+    warmSessionB.mockClear();
+
+    await handleModelCallback(makeCtx(cid), "model:backend-default", cid, {
+      config: baseConfig,
+      gateway: {} as never,
+    } as never);
+
+    // Reverting drops the override — B was live, so B is the one reset.
+    expect(resetChatB).toHaveBeenCalledWith(cid);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(warmSessionA).toHaveBeenCalledWith(cid);
+  });
+
+  it("survives a backend whose warm rejects", async () => {
+    warmSessionB.mockRejectedValueOnce(new Error("server down"));
+    const cid = freshChat();
+
+    // A failed warm must not surface as a failed switch — the switch has
+    // already been committed by the time the warm runs.
+    await expect(
+      handleModelCallback(makeCtx(cid), "model:backend:be-b", cid, {
+        config: baseConfig,
+        gateway: {} as never,
+      } as never),
+    ).resolves.toBeUndefined();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(resetChatA).toHaveBeenCalledWith(cid);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -148,13 +148,14 @@ async function gracefulShutdown(signal: string): Promise<void> {
   await shutdownStep("frontends", () =>
     Promise.allSettled(frontends.map((frontend) => frontend.stop())),
   );
-  if (config.backend === "opencode") {
-    await shutdownStep("opencode server", async () => {
-      const { stopOpenCodeServer } =
-        await import("./backend/opencode/index.js");
-      stopOpenCodeServer();
-    });
-  }
+  // Tear down every instantiated backend, including per-chat overrides.
+  // Checking only config.backend orphaned an OpenCode child whenever the
+  // process default was Claude but one chat had switched to OpenCode.
+  await shutdownStep("backend pool", async () => {
+    const { cleanupBackendPool } =
+      await import("./core/engine/backend-controller/index.js");
+    await cleanupBackendPool();
+  });
   // Destroy plugins (cleanup resources)
   if (config.plugins.length > 0) {
     await shutdownStep("plugins", async () => {

--- a/src/backend/kilo/factory.ts
+++ b/src/backend/kilo/factory.ts
@@ -19,6 +19,7 @@ import {
   type ChatBackend,
   type BackgroundRunner,
   type ModelCatalog,
+  type SessionBackend,
   type SystemControl,
   type ToolRuntime,
   type UsageTelemetry,
@@ -39,6 +40,7 @@ import {
   listModels as kiloListModels,
   refreshPluginMcpServers as kiloRefreshPluginMcpServers,
   updateSystemPrompt as kiloUpdateSystemPrompt,
+  warmSession as kiloWarmSession,
 } from "./index.js";
 
 const kiloFactory: BackendFactory = {
@@ -110,6 +112,15 @@ const kiloFactory: BackendFactory = {
       refreshTools: (chatId) => kiloRefreshPluginMcpServers(chatId),
     };
 
+    // Session state lives on the Kilo server, and `/reset` already clears
+    // Talon's stored id centrally (storage/sessions.ts), so the next turn
+    // creates a fresh one — no `resetChat` needed. `warmSession` front-loads
+    // that creation plus the plugin-MCP sweep, matching what the Claude
+    // backend does after a reset.
+    const sessions: SessionBackend = {
+      warmSession: (chatId) => kiloWarmSession(chatId),
+    };
+
     const control: SystemControl = {
       updateSystemPrompt: (prompt) => kiloUpdateSystemPrompt(prompt),
     };
@@ -121,6 +132,7 @@ const kiloFactory: BackendFactory = {
       chat,
       background,
       models,
+      sessions,
       tools,
       usage,
       control,

--- a/src/backend/kilo/factory.ts
+++ b/src/backend/kilo/factory.ts
@@ -19,6 +19,8 @@ import {
   type ChatBackend,
   type BackgroundRunner,
   type ModelCatalog,
+  type SystemControl,
+  type ToolRuntime,
   type UsageTelemetry,
 } from "../../core/agent-runtime/capabilities.js";
 
@@ -35,6 +37,8 @@ import {
   getProviderModels as kiloGetProviderModels,
   formatModelError as kiloFormatModelError,
   listModels as kiloListModels,
+  refreshPluginMcpServers as kiloRefreshPluginMcpServers,
+  updateSystemPrompt as kiloUpdateSystemPrompt,
 } from "./index.js";
 
 const kiloFactory: BackendFactory = {
@@ -102,6 +106,14 @@ const kiloFactory: BackendFactory = {
       },
     };
 
+    const tools: ToolRuntime = {
+      refreshTools: (chatId) => kiloRefreshPluginMcpServers(chatId),
+    };
+
+    const control: SystemControl = {
+      updateSystemPrompt: (prompt) => kiloUpdateSystemPrompt(prompt),
+    };
+
     const backend = composeBackend({
       id: "kilo",
       label: "Kilo",
@@ -109,7 +121,9 @@ const kiloFactory: BackendFactory = {
       chat,
       background,
       models,
+      tools,
       usage,
+      control,
     });
 
     return {

--- a/src/backend/kilo/handler/message.ts
+++ b/src/backend/kilo/handler/message.ts
@@ -23,6 +23,7 @@ import {
   ensureSession,
   ensureChatMcpServer,
   ensurePluginMcpServers,
+  buildToolOverrides,
   resolveProviderID,
   parseStoredKiloModelSelection,
   getConfig,
@@ -86,12 +87,9 @@ export async function handleMessage(
       (selectedProviderID ? "" : " (provider via catalog lookup)"),
   );
   const sessionId = await ensureSession(oc, chatId);
-  await ensureChatMcpServer(oc, chatId);
+  const chatMcpServerName = await ensureChatMcpServer(oc, chatId);
   await ensurePluginMcpServers(oc, chatId);
-  // Note: we deliberately don't pass `tools` to promptAsync. The session
-  // was created with a `permission` ruleset (ensureSession in server.ts)
-  // that allow-lists this chat's MCP tools and auto-allows built-in
-  // read/bash/edit. The deprecated `tools` map is subsumed by that.
+  const toolOverrides = await buildToolOverrides(oc, chatMcpServerName);
 
   // Build the prompt (time tag + sender + msg_id reference)
   const prompt = formatUserPrompt({
@@ -132,6 +130,7 @@ export async function handleMessage(
   });
   const promptStartedAt = Date.now();
   const seenQuestionIds = new Set<string>();
+  const seenPermissionIds = new Set<string>();
   const seenToolCallIds = new Set<string>();
 
   const setupMs = Date.now() - t0;
@@ -155,7 +154,9 @@ export async function handleMessage(
       state,
       chatId,
       seenQuestionIds,
+      seenPermissionIds,
       seenToolCallIds,
+      toolOverrides,
       onStreamDelta: undefined,
       onTextBlock,
       onToolUse,
@@ -203,6 +204,7 @@ export async function handleMessage(
     // Note: we deliberately do NOT disconnect the chat MCP server here.
     // The server is named per-chat so it's safe to keep across turns;
     // re-spawning the subprocess each turn cost ~800ms per message.
+    // Per-prompt overrides isolate visibility across concurrent chats.
   }
 
   // ── Post-loop accounting ──────────────────────────────────────────────────

--- a/src/backend/kilo/handler/message.ts
+++ b/src/backend/kilo/handler/message.ts
@@ -88,8 +88,12 @@ export async function handleMessage(
   );
   const sessionId = await ensureSession(oc, chatId);
   const chatMcpServerName = await ensureChatMcpServer(oc, chatId);
-  await ensurePluginMcpServers(oc, chatId);
-  const toolOverrides = await buildToolOverrides(oc, chatMcpServerName);
+  const pluginMcpServerNames = await ensurePluginMcpServers(oc, chatId);
+  const toolOverrides = await buildToolOverrides(
+    oc,
+    chatMcpServerName,
+    pluginMcpServerNames,
+  );
 
   // Build the prompt (time tag + sender + msg_id reference)
   const prompt = formatUserPrompt({

--- a/src/backend/kilo/handler/turn.ts
+++ b/src/backend/kilo/handler/turn.ts
@@ -4,13 +4,14 @@
  * `runKiloTurn` subscribes to SSE before issuing the prompt (so no early
  * events are lost), fires `promptAsync`, awaits the SSE close, then reads the
  * authoritative parts list. `subscribeToTurnEvents` translates relevant SSE
- * events into shared stream-state mutations and fires the terminator abort.
+ * events into shared stream-state mutations and observes natural turn idle.
  */
 
 import type { KiloClient } from "@kilocode/sdk/v2";
 import { logWarn } from "../../../util/log.js";
 import { errMsg } from "../server.js";
 import {
+  approvePendingPermissions,
   extractAssistantUsage,
   rejectPendingQuestions,
   type KiloAssistantInfo,
@@ -30,7 +31,9 @@ export interface RunKiloTurnInputs {
   state: ReturnType<typeof createStreamState>;
   chatId: string;
   seenQuestionIds: Set<string>;
+  seenPermissionIds: Set<string>;
   seenToolCallIds: Set<string>;
+  toolOverrides?: Record<string, boolean>;
   onStreamDelta?: (accumulated: string, phase?: "thinking" | "text") => void;
   onTextBlock?: (text: string) => Promise<void>;
   onToolUse?: (toolName: string, input: Record<string, unknown>) => void;
@@ -61,7 +64,9 @@ export async function runKiloTurn(inputs: RunKiloTurnInputs): Promise<void> {
     state,
     chatId,
     seenQuestionIds,
+    seenPermissionIds,
     seenToolCallIds,
+    toolOverrides,
     onStreamDelta,
     onTextBlock,
     onToolUse,
@@ -80,27 +85,18 @@ export async function runKiloTurn(inputs: RunKiloTurnInputs): Promise<void> {
     onStreamDelta,
     onTextBlock,
     onToolUse,
-    onTerminator: async () => {
-      // End_turn fired — abort the in-flight session so Kilo doesn't
-      // burn another round-trip "wrapping up" after the model declared
-      // done. session.idle then fires for our session and the SSE
-      // iterator exits cleanly.
-      try {
-        await oc.session.abort({ sessionID: sessionId });
-      } catch (err) {
-        logWarn("agent", `[${chatId}] session.abort failed: ${errMsg(err)}`);
-      }
-    },
     abortSignal: sseAbort.signal,
   });
 
-  // Question watchdog: Talon manages its own tool permissions, so any
-  // Kilo-side question (tool approval, clarification) is rejected
-  // automatically.
+  // Headless-interaction watchdog: resolve upstream questions and any
+  // permission requests that escaped the session ruleset.
   const questionWatchdog = (async () => {
     while (!sseAbort.signal.aborted) {
       try {
-        await rejectPendingQuestions(oc, sessionId, chatId, seenQuestionIds);
+        await Promise.all([
+          rejectPendingQuestions(oc, sessionId, chatId, seenQuestionIds),
+          approvePendingPermissions(oc, sessionId, chatId, seenPermissionIds),
+        ]);
       } catch (err) {
         logWarn(
           "agent",
@@ -113,14 +109,14 @@ export async function runKiloTurn(inputs: RunKiloTurnInputs): Promise<void> {
 
   try {
     // Fire and forget — promptAsync returns immediately. The await below
-    // is on the SSE close event. No `tools` field: the deprecated
-    // per-prompt tool override map is merged into session-level
-    // `permission` rules set in ensureSession.
+    // is on the SSE close event. Per-prompt overrides hide sibling chats'
+    // MCP tools while session permissions independently deny execution.
     await oc.session.promptAsync({
       sessionID: sessionId,
       parts: [{ type: "text", text: prompt }],
       model: { providerID, modelID },
       system: systemPrompt,
+      ...(toolOverrides ? { tools: toolOverrides } : {}),
     });
 
     // Await turn completion via SSE.
@@ -156,7 +152,7 @@ export async function runKiloTurn(inputs: RunKiloTurnInputs): Promise<void> {
       }
     }
   } catch (err) {
-    // If the model called end_turn we aborted intentionally — swallow.
+    // Explicit user interrupts abort intentionally — swallow that close path.
     if (state.turnTerminated && /abort/i.test(errMsg(err))) {
       return;
     }
@@ -166,7 +162,10 @@ export async function runKiloTurn(inputs: RunKiloTurnInputs): Promise<void> {
     await sseDone.catch(() => {});
     await questionWatchdog.catch(() => {});
     try {
-      await rejectPendingQuestions(oc, sessionId, chatId, seenQuestionIds);
+      await Promise.all([
+        rejectPendingQuestions(oc, sessionId, chatId, seenQuestionIds),
+        approvePendingPermissions(oc, sessionId, chatId, seenPermissionIds),
+      ]);
     } catch {
       /* noop */
     }
@@ -194,7 +193,6 @@ interface SubscribeInputs {
   onStreamDelta?: (accumulated: string, phase?: "thinking" | "text") => void;
   onTextBlock?: (text: string) => Promise<void>;
   onToolUse?: (toolName: string, input: Record<string, unknown>) => void;
-  onTerminator: () => Promise<void>;
   abortSignal: AbortSignal;
 }
 
@@ -214,7 +212,6 @@ async function subscribeToTurnEvents(inputs: SubscribeInputs): Promise<void> {
     onStreamDelta,
     onTextBlock,
     onToolUse,
-    onTerminator,
     abortSignal,
   } = inputs;
 
@@ -260,10 +257,7 @@ async function subscribeToTurnEvents(inputs: SubscribeInputs): Promise<void> {
               data?: Record<string, unknown>;
             }
           | undefined;
-        // MessageAbortedError is OUR own abort signal — fired when a
-        // terminator tool led us to call `oc.session.abort` to
-        // short-circuit the model's wrap-up. It's the EXPECTED close
-        // path, not an upstream failure.
+        // MessageAbortedError is expected for an explicit user interrupt.
         const isOurAbort =
           state.turnTerminated &&
           (errProp?.name === "MessageAbortedError" ||
@@ -301,9 +295,9 @@ async function subscribeToTurnEvents(inputs: SubscribeInputs): Promise<void> {
       if (outcome.kind === "terminator_fired") {
         // tool_calls counter increment happens per-tool inside
         // events.ts processPartUpdate. Don't double-count here.
-        // Fire-and-forget — abort the session so the model's post-end_turn
-        // wrap-up doesn't burn another API call.
-        onTerminator().catch(() => {});
+        // Aborting here can race with a prompt accepted immediately after
+        // this turn settles and cancel that next turn on the reused session.
+        // Delivery is already complete, so wait for natural idle instead.
         continue;
       }
 

--- a/src/backend/kilo/handler/turn.ts
+++ b/src/backend/kilo/handler/turn.ts
@@ -19,6 +19,7 @@ import {
 import { createStreamState, recordTokens, sleep } from "../../shared/index.js";
 import { processStreamEvent, finalizePartsIntoState } from "../events.js";
 import { subscribeSseStream } from "../../remote-server/sse-stream.js";
+import { awaitRemoteTurn } from "../../remote-server/turn-timeout.js";
 import { findLastAssistantMessage as findLastAssistantMessageShared } from "../../remote-server/messages.js";
 
 export interface RunKiloTurnInputs {
@@ -111,16 +112,21 @@ export async function runKiloTurn(inputs: RunKiloTurnInputs): Promise<void> {
     // Fire and forget — promptAsync returns immediately. The await below
     // is on the SSE close event. Per-prompt overrides hide sibling chats'
     // MCP tools while session permissions independently deny execution.
-    await oc.session.promptAsync({
-      sessionID: sessionId,
-      parts: [{ type: "text", text: prompt }],
-      model: { providerID, modelID },
-      system: systemPrompt,
-      ...(toolOverrides ? { tools: toolOverrides } : {}),
-    });
+    await awaitRemoteTurn(
+      (async () => {
+        await oc.session.promptAsync({
+          sessionID: sessionId,
+          parts: [{ type: "text", text: prompt }],
+          model: { providerID, modelID },
+          system: systemPrompt,
+          ...(toolOverrides ? { tools: toolOverrides } : {}),
+        });
 
-    // Await turn completion via SSE.
-    await sseDone;
+        // Await turn completion via SSE.
+        await sseDone;
+      })(),
+      { client: oc, sessionId, chatId, label: "Kilo" },
+    );
 
     // Read authoritative final state from the messages endpoint. The SSE
     // handler already populated state mid-flight; this re-reads to fill
@@ -159,7 +165,10 @@ export async function runKiloTurn(inputs: RunKiloTurnInputs): Promise<void> {
     throw err;
   } finally {
     sseAbort.abort();
-    await sseDone.catch(() => {});
+    // A dead SSE socket may ignore the local abort flag until another event
+    // arrives. Bound cleanup so a timed-out turn cannot wedge its caller in
+    // the finally block it was meant to escape.
+    await Promise.race([sseDone.catch(() => {}), sleep(1_000)]);
     await questionWatchdog.catch(() => {});
     try {
       await Promise.all([
@@ -219,7 +228,7 @@ async function subscribeToTurnEvents(inputs: SubscribeInputs): Promise<void> {
   // subscribe-failed warning. Returns `undefined` for both "subscribe
   // rejected" and "no iterable in the response shape".
   const stream = await subscribeSseStream(oc, chatId);
-  if (!stream) return;
+  if (!stream) throw new Error("Kilo SSE connection unavailable");
 
   try {
     for await (const evt of stream) {

--- a/src/backend/kilo/index.ts
+++ b/src/backend/kilo/index.ts
@@ -41,7 +41,12 @@ export {
 } from "./sessions.js";
 
 // ── Server / lifecycle ─────────────────────────────────────────────────────
-export { initKiloAgent, stopKiloServer } from "./server.js";
+export {
+  initKiloAgent,
+  stopKiloServer,
+  refreshPluginMcpServers,
+  updateSystemPrompt,
+} from "./server.js";
 
 // ── Handler ────────────────────────────────────────────────────────────────
 export { handleMessage } from "./handler/index.js";

--- a/src/backend/kilo/index.ts
+++ b/src/backend/kilo/index.ts
@@ -46,6 +46,7 @@ export {
   stopKiloServer,
   refreshPluginMcpServers,
   updateSystemPrompt,
+  warmSession,
 } from "./server.js";
 
 // ── Handler ────────────────────────────────────────────────────────────────

--- a/src/backend/kilo/server.ts
+++ b/src/backend/kilo/server.ts
@@ -40,6 +40,7 @@ import {
   disconnectChatMcpServer as disconnectChatMcpServerShared,
   refreshPluginMcpServers as refreshPluginMcpServersShared,
   ensureRemoteSession,
+  warmRemoteSession,
   resolveProviderID as resolveProviderIDShared,
   getRegisteredMcpServerNames as getRegisteredMcpServerNamesShared,
   errMsg as sharedErrMsg,
@@ -228,6 +229,20 @@ export function updateSystemPrompt(prompt: string): void {
  */
 export function ensureSession(oc: KiloClient, chatId: string): Promise<string> {
   return ensureRemoteSession(oc, state, chatId);
+}
+
+/**
+ * Front-load a chat's cold start after `/reset`. Mirrors the Claude
+ * backend's `warmSession` so the `sessions` capability slot behaves the
+ * same across backends. Never throws — see `warmRemoteSession`.
+ */
+export function warmSession(chatId: string): Promise<void> {
+  return warmRemoteSession(state, chatId, {
+    ensureServer,
+    ensureSession,
+    ensureChatMcpServer,
+    ensurePluginMcpServers,
+  });
 }
 
 // ── Provider resolution ────────────────────────────────────────────────────

--- a/src/backend/kilo/server.ts
+++ b/src/backend/kilo/server.ts
@@ -23,7 +23,6 @@ import {
 } from "@kilocode/sdk/v2";
 import type { TalonConfig } from "../../util/config.js";
 import type { FrontendName } from "../../core/agent-runtime/backend-registry.js";
-import { logWarn } from "../../util/log.js";
 import { buildDeliveryContract } from "../shared/delivery-contract.js";
 import {
   guessProviderID,
@@ -39,6 +38,7 @@ import {
   ensurePluginMcpServers as ensurePluginMcpServersShared,
   buildToolOverrides as buildToolOverridesShared,
   disconnectChatMcpServer as disconnectChatMcpServerShared,
+  refreshPluginMcpServers as refreshPluginMcpServersShared,
   ensureRemoteSession,
   resolveProviderID as resolveProviderIDShared,
   getRegisteredMcpServerNames as getRegisteredMcpServerNamesShared,
@@ -121,35 +121,6 @@ export function initKiloAgent(
   state.config = cfg;
   if (getGatewayPort) state.gatewayPortFn = getGatewayPort;
   if (frontend) state.frontendName = frontend;
-
-  // Pre-warm plugin MCP servers in the background so the first chat
-  // message doesn't pay the ~12s subprocess-spawn cost. We don't pre-warm
-  // chat-namespaced servers (those depend on chatId, not known yet); the
-  // first turn for any chat still incurs ~800ms for that one server, but
-  // the dominant cost (16+ plugin servers in series) is amortised away.
-  // Errors are swallowed — pre-warm is best-effort, the per-turn ensure
-  // still runs and would log any real failures.
-  prewarmPluginMcpServers().catch((err) => {
-    logWarn(
-      "agent",
-      `Plugin MCP pre-warm failed (non-fatal): ${sharedErrMsg(err)}`,
-    );
-  });
-}
-
-/**
- * Background pre-warm of plugin MCP servers. Connects each
- * plugin-provided MCP server to the Kilo HTTP server eagerly so the
- * first turn doesn't spend 12+ seconds spawning subprocesses in
- * series.
- */
-async function prewarmPluginMcpServers(): Promise<void> {
-  const client = await ensureServer();
-  // Sentinel chat id so plugin MCP servers don't bind their bridge calls
-  // to a real chat (those calls would fail the gateway's active-context
-  // check anyway). Plugin tools that need a real chat context get
-  // re-bound when a chat actually starts.
-  await ensurePluginMcpServers(client, "prewarm");
 }
 
 /**
@@ -226,8 +197,9 @@ export function ensurePluginMcpServers(
 export function buildToolOverrides(
   oc: KiloClient,
   chatServerName: string,
+  pluginServerNames: readonly string[] = [],
 ): Promise<Record<string, boolean> | undefined> {
-  return buildToolOverridesShared(oc, state, chatServerName);
+  return buildToolOverridesShared(oc, state, chatServerName, pluginServerNames);
 }
 
 /** Disconnect a per-chat MCP server (explicit teardown for hot-swap paths). */
@@ -236,6 +208,15 @@ export function disconnectChatMcpServer(
   serverName: string,
 ): Promise<void> {
   return disconnectChatMcpServerShared(oc, state, serverName);
+}
+
+export async function refreshPluginMcpServers(chatId: string) {
+  const oc = await ensureServer();
+  return refreshPluginMcpServersShared(oc, state, chatId);
+}
+
+export function updateSystemPrompt(prompt: string): void {
+  if (state.config) state.config.systemPrompt = prompt;
 }
 
 // ── Session management ─────────────────────────────────────────────────────

--- a/src/backend/kilo/server.ts
+++ b/src/backend/kilo/server.ts
@@ -312,7 +312,7 @@ export function getConfig(): TalonConfig {
 /**
  * Snapshot of the locally-cached MCP server registrations. Test-only:
  * Kilo's `GET /mcp` returns `{}` regardless of state, so integration
- * tests need this to assert chat-switch isolation actually fired.
+ * tests use this to assert concurrent chat registrations are retained.
  */
 export function getRegisteredMcpServerNames(): string[] {
   return getRegisteredMcpServerNamesShared(state);

--- a/src/backend/kilo/sessions.ts
+++ b/src/backend/kilo/sessions.ts
@@ -20,6 +20,7 @@ import {
   getTurnSummary,
   getSessionSnapshot,
   rejectPendingQuestions as rejectPendingQuestionsShared,
+  approvePendingPermissions as approvePendingPermissionsShared,
   type RemoteAssistantInfo,
   type RemoteSessionSnapshot,
   type RemoteSessionClient,
@@ -96,6 +97,22 @@ export function rejectPendingQuestions(
     sessionId,
     chatId,
     seenQuestionIds,
+    "Kilo",
+  );
+}
+
+/** Auto-approve pending Kilo permissions for this headless session. */
+export function approvePendingPermissions(
+  oc: KiloClient,
+  sessionId: string,
+  chatId: string,
+  seenPermissionIds: Set<string>,
+): Promise<void> {
+  return approvePendingPermissionsShared(
+    oc as unknown as RemoteSessionClient,
+    sessionId,
+    chatId,
+    seenPermissionIds,
     "Kilo",
   );
 }

--- a/src/backend/opencode/factory.ts
+++ b/src/backend/opencode/factory.ts
@@ -19,6 +19,7 @@ import {
   type ChatBackend,
   type BackgroundRunner,
   type ModelCatalog,
+  type SessionBackend,
   type SystemControl,
   type ToolRuntime,
   type UsageTelemetry,
@@ -39,6 +40,7 @@ import {
   listModels as ocListModels,
   refreshPluginMcpServers as ocRefreshPluginMcpServers,
   updateSystemPrompt as ocUpdateSystemPrompt,
+  warmSession as ocWarmSession,
 } from "./index.js";
 
 const opencodeFactory: BackendFactory = {
@@ -103,6 +105,15 @@ const opencodeFactory: BackendFactory = {
       refreshTools: (chatId) => ocRefreshPluginMcpServers(chatId),
     };
 
+    // Session state lives on the OpenCode server, and `/reset` already
+    // clears Talon's stored id centrally (storage/sessions.ts), so the
+    // next turn creates a fresh one — no `resetChat` needed. `warmSession`
+    // front-loads that creation plus the plugin-MCP sweep, matching what
+    // the Claude backend does after a reset.
+    const sessions: SessionBackend = {
+      warmSession: (chatId) => ocWarmSession(chatId),
+    };
+
     const control: SystemControl = {
       updateSystemPrompt: (prompt) => ocUpdateSystemPrompt(prompt),
     };
@@ -114,6 +125,7 @@ const opencodeFactory: BackendFactory = {
       chat,
       background,
       models,
+      sessions,
       tools,
       usage,
       control,

--- a/src/backend/opencode/factory.ts
+++ b/src/backend/opencode/factory.ts
@@ -19,6 +19,8 @@ import {
   type ChatBackend,
   type BackgroundRunner,
   type ModelCatalog,
+  type SystemControl,
+  type ToolRuntime,
   type UsageTelemetry,
 } from "../../core/agent-runtime/capabilities.js";
 
@@ -35,6 +37,8 @@ import {
   getProviderModels as ocGetProviderModels,
   formatModelError as ocFormatModelError,
   listModels as ocListModels,
+  refreshPluginMcpServers as ocRefreshPluginMcpServers,
+  updateSystemPrompt as ocUpdateSystemPrompt,
 } from "./index.js";
 
 const opencodeFactory: BackendFactory = {
@@ -95,6 +99,14 @@ const opencodeFactory: BackendFactory = {
       },
     };
 
+    const tools: ToolRuntime = {
+      refreshTools: (chatId) => ocRefreshPluginMcpServers(chatId),
+    };
+
+    const control: SystemControl = {
+      updateSystemPrompt: (prompt) => ocUpdateSystemPrompt(prompt),
+    };
+
     const backend = composeBackend({
       id: "opencode",
       label: "OpenCode",
@@ -102,7 +114,9 @@ const opencodeFactory: BackendFactory = {
       chat,
       background,
       models,
+      tools,
       usage,
+      control,
     });
 
     return {

--- a/src/backend/opencode/handler/message.ts
+++ b/src/backend/opencode/handler/message.ts
@@ -24,6 +24,7 @@ import {
   ensureSession,
   ensureChatMcpServer,
   ensurePluginMcpServers,
+  buildToolOverrides,
   resolveProviderID,
   parseStoredOpenCodeModelSelection,
   getConfig,
@@ -87,8 +88,9 @@ export async function handleMessage(
       (selectedProviderID ? "" : " (provider via catalog lookup)"),
   );
   const sessionId = await ensureSession(oc, chatId);
-  await ensureChatMcpServer(oc, chatId);
+  const chatMcpServerName = await ensureChatMcpServer(oc, chatId);
   await ensurePluginMcpServers(oc, chatId);
+  const toolOverrides = await buildToolOverrides(oc, chatMcpServerName);
 
   // Build the prompt (time tag + sender + msg_id reference)
   const prompt = formatUserPrompt({
@@ -129,6 +131,7 @@ export async function handleMessage(
   });
   const promptStartedAt = Date.now();
   const seenQuestionIds = new Set<string>();
+  const seenPermissionIds = new Set<string>();
   const seenToolCallIds = new Set<string>();
 
   const setupMs = Date.now() - t0;
@@ -152,7 +155,9 @@ export async function handleMessage(
       state,
       chatId,
       seenQuestionIds,
+      seenPermissionIds,
       seenToolCallIds,
+      toolOverrides,
       onStreamDelta: undefined,
       onTextBlock,
       onToolUse,
@@ -202,9 +207,8 @@ export async function handleMessage(
     }
     // Note: we deliberately do NOT disconnect the chat MCP server here.
     // The server is named per-chat so it's safe to keep across turns;
-    // re-spawning the subprocess each turn cost ~800ms per message. The
-    // chat-switch disconnect dance (remote-server/mcp.ts) handles
-    // visibility scoping when the active chat changes.
+    // re-spawning the subprocess each turn cost ~800ms per message.
+    // Per-prompt overrides isolate visibility across concurrent chats.
   }
 
   // ── Post-loop accounting ──────────────────────────────────────────────────

--- a/src/backend/opencode/handler/message.ts
+++ b/src/backend/opencode/handler/message.ts
@@ -89,8 +89,12 @@ export async function handleMessage(
   );
   const sessionId = await ensureSession(oc, chatId);
   const chatMcpServerName = await ensureChatMcpServer(oc, chatId);
-  await ensurePluginMcpServers(oc, chatId);
-  const toolOverrides = await buildToolOverrides(oc, chatMcpServerName);
+  const pluginMcpServerNames = await ensurePluginMcpServers(oc, chatId);
+  const toolOverrides = await buildToolOverrides(
+    oc,
+    chatMcpServerName,
+    pluginMcpServerNames,
+  );
 
   // Build the prompt (time tag + sender + msg_id reference)
   const prompt = formatUserPrompt({

--- a/src/backend/opencode/handler/turn.ts
+++ b/src/backend/opencode/handler/turn.ts
@@ -26,6 +26,7 @@ import {
   finalizePartsIntoState,
 } from "../../remote-server/events.js";
 import { subscribeSseStream } from "../../remote-server/sse-stream.js";
+import { awaitRemoteTurn } from "../../remote-server/turn-timeout.js";
 import { findLastAssistantMessage as findLastAssistantMessageShared } from "../../remote-server/messages.js";
 
 export interface RunOpenCodeTurnInputs {
@@ -111,16 +112,21 @@ export async function runOpenCodeTurn(
   try {
     // Fire and forget — promptAsync returns immediately. The await below
     // is on the SSE close event.
-    await oc.session.promptAsync({
-      sessionID: sessionId,
-      parts: [{ type: "text", text: prompt }],
-      model: { providerID, modelID },
-      system: systemPrompt,
-      ...(toolOverrides ? { tools: toolOverrides } : {}),
-    });
+    await awaitRemoteTurn(
+      (async () => {
+        await oc.session.promptAsync({
+          sessionID: sessionId,
+          parts: [{ type: "text", text: prompt }],
+          model: { providerID, modelID },
+          system: systemPrompt,
+          ...(toolOverrides ? { tools: toolOverrides } : {}),
+        });
 
-    // Await turn completion via SSE.
-    await sseDone;
+        // Await turn completion via SSE.
+        await sseDone;
+      })(),
+      { client: oc, sessionId, chatId, label: "OpenCode" },
+    );
 
     // Read authoritative final state from the messages endpoint.
     const messagesResp = await oc.session.messages({ sessionID: sessionId });
@@ -158,7 +164,10 @@ export async function runOpenCodeTurn(
     throw err;
   } finally {
     sseAbort.abort();
-    await sseDone.catch(() => {});
+    // A dead SSE socket may ignore the local abort flag until another event
+    // arrives. Bound cleanup so a timed-out turn cannot wedge its caller in
+    // the finally block it was meant to escape.
+    await Promise.race([sseDone.catch(() => {}), sleep(1_000)]);
     await questionWatchdog.catch(() => {});
     try {
       await Promise.all([
@@ -217,7 +226,7 @@ async function subscribeToTurnEvents(inputs: SubscribeInputs): Promise<void> {
   // `subscribeSseStream` handles the narrowing with a runtime guard + the
   // subscribe-failed warning.
   const stream = await subscribeSseStream(oc, chatId);
-  if (!stream) return;
+  if (!stream) throw new Error("OpenCode SSE connection unavailable");
 
   try {
     for await (const evt of stream) {

--- a/src/backend/opencode/handler/turn.ts
+++ b/src/backend/opencode/handler/turn.ts
@@ -4,7 +4,7 @@
  * `runOpenCodeTurn` subscribes to SSE before issuing the prompt (so no early
  * events are lost), fires `promptAsync`, awaits the SSE close, then reads the
  * authoritative parts list. `subscribeToTurnEvents` translates relevant SSE
- * events into shared stream-state mutations and fires the terminator abort.
+ * events into shared stream-state mutations and observes natural turn idle.
  *
  * The streaming + event-processing logic is shared with the Kilo backend via
  * `backend/remote-server/events.ts`.
@@ -14,6 +14,7 @@ import type { OpencodeClient } from "@opencode-ai/sdk/v2";
 import { logWarn } from "../../../util/log.js";
 import { errMsg } from "../server.js";
 import {
+  approvePendingPermissions,
   extractPartsSummary,
   extractAssistantUsage,
   rejectPendingQuestions,
@@ -37,7 +38,9 @@ export interface RunOpenCodeTurnInputs {
   state: ReturnType<typeof createStreamState>;
   chatId: string;
   seenQuestionIds: Set<string>;
+  seenPermissionIds: Set<string>;
   seenToolCallIds: Set<string>;
+  toolOverrides?: Record<string, boolean>;
   onStreamDelta?: (accumulated: string, phase?: "thinking" | "text") => void;
   onTextBlock?: (text: string) => Promise<void>;
   onToolUse?: (toolName: string, input: Record<string, unknown>) => void;
@@ -62,7 +65,9 @@ export async function runOpenCodeTurn(
     state,
     chatId,
     seenQuestionIds,
+    seenPermissionIds,
     seenToolCallIds,
+    toolOverrides,
     onStreamDelta,
     onTextBlock,
     onToolUse,
@@ -81,26 +86,18 @@ export async function runOpenCodeTurn(
     onStreamDelta,
     onTextBlock,
     onToolUse,
-    onTerminator: async () => {
-      // End_turn fired — abort the in-flight session so OpenCode doesn't
-      // burn another round-trip "wrapping up" after the model declared
-      // done. session.idle then fires for our session and the SSE
-      // iterator exits cleanly.
-      try {
-        await oc.session.abort({ sessionID: sessionId });
-      } catch (err) {
-        logWarn("agent", `[${chatId}] session.abort failed: ${errMsg(err)}`);
-      }
-    },
     abortSignal: sseAbort.signal,
   });
 
-  // Question watchdog: Talon manages its own tool permissions, so any
-  // upstream-side question (tool approval, clarification) is auto-handled.
+  // Headless-interaction watchdog: resolve upstream questions and any
+  // permission requests that escaped the session ruleset.
   const questionWatchdog = (async () => {
     while (!sseAbort.signal.aborted) {
       try {
-        await rejectPendingQuestions(oc, sessionId, chatId, seenQuestionIds);
+        await Promise.all([
+          rejectPendingQuestions(oc, sessionId, chatId, seenQuestionIds),
+          approvePendingPermissions(oc, sessionId, chatId, seenPermissionIds),
+        ]);
       } catch (err) {
         logWarn(
           "agent",
@@ -119,6 +116,7 @@ export async function runOpenCodeTurn(
       parts: [{ type: "text", text: prompt }],
       model: { providerID, modelID },
       system: systemPrompt,
+      ...(toolOverrides ? { tools: toolOverrides } : {}),
     });
 
     // Await turn completion via SSE.
@@ -153,7 +151,7 @@ export async function runOpenCodeTurn(
       }
     }
   } catch (err) {
-    // If the model called end_turn we aborted intentionally — swallow.
+    // Explicit user interrupts abort intentionally — swallow that close path.
     if (state.turnTerminated && /abort/i.test(errMsg(err))) {
       return;
     }
@@ -163,7 +161,10 @@ export async function runOpenCodeTurn(
     await sseDone.catch(() => {});
     await questionWatchdog.catch(() => {});
     try {
-      await rejectPendingQuestions(oc, sessionId, chatId, seenQuestionIds);
+      await Promise.all([
+        rejectPendingQuestions(oc, sessionId, chatId, seenQuestionIds),
+        approvePendingPermissions(oc, sessionId, chatId, seenPermissionIds),
+      ]);
     } catch {
       /* noop */
     }
@@ -191,7 +192,6 @@ interface SubscribeInputs {
   onStreamDelta?: (accumulated: string, phase?: "thinking" | "text") => void;
   onTextBlock?: (text: string) => Promise<void>;
   onToolUse?: (toolName: string, input: Record<string, unknown>) => void;
-  onTerminator: () => Promise<void>;
   abortSignal: AbortSignal;
 }
 
@@ -211,7 +211,6 @@ async function subscribeToTurnEvents(inputs: SubscribeInputs): Promise<void> {
     onStreamDelta,
     onTextBlock,
     onToolUse,
-    onTerminator,
     abortSignal,
   } = inputs;
 
@@ -254,8 +253,7 @@ async function subscribeToTurnEvents(inputs: SubscribeInputs): Promise<void> {
               data?: Record<string, unknown>;
             }
           | undefined;
-        // MessageAbortedError is our own abort signal when a terminator
-        // tool fired; expected close path, not an upstream failure.
+        // MessageAbortedError is expected for an explicit user interrupt.
         const isOurAbort =
           state.turnTerminated &&
           (errProp?.name === "MessageAbortedError" ||
@@ -288,7 +286,9 @@ async function subscribeToTurnEvents(inputs: SubscribeInputs): Promise<void> {
       });
 
       if (outcome.kind === "terminator_fired") {
-        onTerminator().catch(() => {});
+        // Aborting here can race with a prompt accepted immediately after
+        // this turn settles and cancel that next turn on the reused session.
+        // Delivery is already complete, so wait for natural idle instead.
         continue;
       }
 

--- a/src/backend/opencode/index.ts
+++ b/src/backend/opencode/index.ts
@@ -23,7 +23,12 @@ export {
   getOpenCodeSessionSnapshot,
 } from "./sessions.js";
 
-export { initOpenCodeAgent, stopOpenCodeServer } from "./server.js";
+export {
+  initOpenCodeAgent,
+  stopOpenCodeServer,
+  refreshPluginMcpServers,
+  updateSystemPrompt,
+} from "./server.js";
 
 export { handleMessage } from "./handler/index.js";
 

--- a/src/backend/opencode/index.ts
+++ b/src/backend/opencode/index.ts
@@ -28,6 +28,7 @@ export {
   stopOpenCodeServer,
   refreshPluginMcpServers,
   updateSystemPrompt,
+  warmSession,
 } from "./server.js";
 
 export { handleMessage } from "./handler/index.js";

--- a/src/backend/opencode/server.ts
+++ b/src/backend/opencode/server.ts
@@ -40,6 +40,7 @@ import {
   disconnectChatMcpServer as disconnectChatMcpServerShared,
   refreshPluginMcpServers as refreshPluginMcpServersShared,
   ensureRemoteSession,
+  warmRemoteSession,
   resolveProviderID as resolveProviderIDShared,
   getRegisteredMcpServerNames as getRegisteredMcpServerNamesShared,
   errMsg as sharedErrMsg,
@@ -169,6 +170,20 @@ export function ensureSession(
   chatId: string,
 ): Promise<string> {
   return ensureRemoteSession(oc, state, chatId);
+}
+
+/**
+ * Front-load a chat's cold start after `/reset`. Mirrors the Claude
+ * backend's `warmSession` so the `sessions` capability slot behaves the
+ * same across backends. Never throws — see `warmRemoteSession`.
+ */
+export function warmSession(chatId: string): Promise<void> {
+  return warmRemoteSession(state, chatId, {
+    ensureServer,
+    ensureSession,
+    ensureChatMcpServer,
+    ensurePluginMcpServers,
+  });
 }
 
 // ── Provider resolution ────────────────────────────────────────────────────

--- a/src/backend/opencode/server.ts
+++ b/src/backend/opencode/server.ts
@@ -23,7 +23,6 @@ import {
 } from "@opencode-ai/sdk/v2";
 import type { TalonConfig } from "../../util/config.js";
 import type { FrontendName } from "../../core/agent-runtime/backend-registry.js";
-import { logWarn } from "../../util/log.js";
 import { buildDeliveryContract } from "../shared/delivery-contract.js";
 import {
   guessProviderID,
@@ -39,6 +38,7 @@ import {
   ensurePluginMcpServers as ensurePluginMcpServersShared,
   buildToolOverrides as buildToolOverridesShared,
   disconnectChatMcpServer as disconnectChatMcpServerShared,
+  refreshPluginMcpServers as refreshPluginMcpServersShared,
   ensureRemoteSession,
   resolveProviderID as resolveProviderIDShared,
   getRegisteredMcpServerNames as getRegisteredMcpServerNamesShared,
@@ -91,20 +91,6 @@ export function initOpenCodeAgent(
   state.config = cfg;
   if (getGatewayPort) state.gatewayPortFn = getGatewayPort;
   if (frontend) state.frontendName = frontend;
-
-  // Pre-warm plugin MCP servers in the background. Same rationale as
-  // the Kilo backend's init pre-warm.
-  prewarmPluginMcpServers().catch((err) => {
-    logWarn(
-      "agent",
-      `Plugin MCP pre-warm failed (non-fatal): ${sharedErrMsg(err)}`,
-    );
-  });
-}
-
-async function prewarmPluginMcpServers(): Promise<void> {
-  const client = await ensureServer();
-  await ensurePluginMcpServers(client, "prewarm");
 }
 
 /**
@@ -155,8 +141,9 @@ export function ensurePluginMcpServers(
 export function buildToolOverrides(
   oc: OpencodeClient,
   chatServerName: string,
+  pluginServerNames: readonly string[] = [],
 ): Promise<Record<string, boolean> | undefined> {
-  return buildToolOverridesShared(oc, state, chatServerName);
+  return buildToolOverridesShared(oc, state, chatServerName, pluginServerNames);
 }
 
 export function disconnectChatMcpServer(
@@ -164,6 +151,15 @@ export function disconnectChatMcpServer(
   serverName: string,
 ): Promise<void> {
   return disconnectChatMcpServerShared(oc, state, serverName);
+}
+
+export async function refreshPluginMcpServers(chatId: string) {
+  const oc = await ensureServer();
+  return refreshPluginMcpServersShared(oc, state, chatId);
+}
+
+export function updateSystemPrompt(prompt: string): void {
+  if (state.config) state.config.systemPrompt = prompt;
 }
 
 // ── Session management ─────────────────────────────────────────────────────

--- a/src/backend/opencode/sessions.ts
+++ b/src/backend/opencode/sessions.ts
@@ -18,6 +18,7 @@ import {
   getTurnSummary,
   getSessionSnapshot,
   rejectPendingQuestions as rejectPendingQuestionsShared,
+  approvePendingPermissions as approvePendingPermissionsShared,
   type RemoteAssistantInfo,
   type RemoteSessionSnapshot,
   type RemoteSessionClient,
@@ -94,6 +95,22 @@ export function rejectPendingQuestions(
     sessionId,
     chatId,
     seenQuestionIds,
+    "OpenCode",
+  );
+}
+
+/** Auto-approve pending OpenCode permissions for this headless session. */
+export function approvePendingPermissions(
+  oc: OpencodeClient,
+  sessionId: string,
+  chatId: string,
+  seenPermissionIds: Set<string>,
+): Promise<void> {
+  return approvePendingPermissionsShared(
+    oc as unknown as RemoteSessionClient,
+    sessionId,
+    chatId,
+    seenPermissionIds,
     "OpenCode",
   );
 }

--- a/src/backend/remote-server/client.ts
+++ b/src/backend/remote-server/client.ts
@@ -35,7 +35,7 @@ export type RemoteMcpServerConfig =
 
 /** Permission-rule shape both SDKs share. */
 export interface RemotePermissionRule {
-  permission: "tool" | "edit" | "bash";
+  permission: "tool" | "edit" | "bash" | "external_directory";
   pattern: string;
   action: "allow" | "deny" | "ask";
 }

--- a/src/backend/remote-server/events.ts
+++ b/src/backend/remote-server/events.ts
@@ -449,7 +449,7 @@ export function finalizePartsIntoState(inputs: FinalizePartsInputs): {
     const callID = typeof part.callID === "string" ? part.callID : "";
     const toolName = typeof part.tool === "string" ? part.tool : "tool";
     if (callID && seenToolCallIds.has(callID)) continue;
-    if (stateObj?.input) {
+    if (stateObj?.status === "completed" && stateObj.input) {
       if (callID) seenToolCallIds.add(callID);
       recordToolUse(state, toolName, stateObj.input);
       toolsProcessed++;

--- a/src/backend/remote-server/events.ts
+++ b/src/backend/remote-server/events.ts
@@ -108,9 +108,21 @@ export async function processStreamEvent(
 ): Promise<ProcessEventOutcome> {
   if (!event || typeof event !== "object") return { kind: "continue" };
   const props = event.properties ?? {};
-  // Scope to our session only
+  // Scope to our session only. OpenCode/Kilo use three wire shapes:
+  // session events put sessionID on properties, part events put it inside
+  // properties.part, and message events put it inside properties.info.
+  // Missing the nested part shape lets a concurrent heartbeat/dream tool
+  // event terminate the active chat turn.
+  const part = props.part as Record<string, unknown> | undefined;
+  const info = props.info as Record<string, unknown> | undefined;
   const evtSessionID =
-    typeof props.sessionID === "string" ? props.sessionID : undefined;
+    typeof props.sessionID === "string"
+      ? props.sessionID
+      : typeof part?.sessionID === "string"
+        ? part.sessionID
+        : typeof info?.sessionID === "string"
+          ? info.sessionID
+          : undefined;
   if (evtSessionID && evtSessionID !== ctx.sessionId) {
     return { kind: "stop", reason: "out_of_scope" };
   }
@@ -246,11 +258,12 @@ async function processPartUpdate(
   const stateObj = part.state as
     { status?: string; input?: Record<string, unknown> } | undefined;
 
-  // Fire onToolUse ONCE when the tool transitions to running or completed
-  // with input available. Subsequent state changes don't re-fire.
+  // Record a tool only after the upstream reports successful completion.
+  // Treating `running` as delivery made failed MCP calls flip end_turn and
+  // suppress fallback text even though nothing reached the user.
   if (
     !stateObj ||
-    (stateObj.status !== "running" && stateObj.status !== "completed") ||
+    stateObj.status !== "completed" ||
     !callID ||
     ctx.seenToolCallIds.has(callID)
   ) {

--- a/src/backend/remote-server/index.ts
+++ b/src/backend/remote-server/index.ts
@@ -64,7 +64,12 @@ export {
   getRegisteredMcpServerNames,
 } from "./mcp.js";
 
-export { buildPermissionRuleset, ensureRemoteSession } from "./sessions.js";
+export {
+  buildPermissionRuleset,
+  ensureRemoteSession,
+  warmRemoteSession,
+  type RemoteWarmDeps,
+} from "./sessions.js";
 
 export { type ProviderResolverHooks, resolveProviderID } from "./providers.js";
 

--- a/src/backend/remote-server/index.ts
+++ b/src/backend/remote-server/index.ts
@@ -51,15 +51,25 @@ export {
 
 export {
   TALON_MCP_SERVER_NAME,
+  TALON_PLUGIN_MCP_SERVER_NAME,
   getChatMcpServerName,
+  getPluginMcpServerName,
+  safeMcpNamePart,
   isTalonToolID,
   ensureChatMcpServer,
   ensurePluginMcpServers,
   buildToolOverrides,
   disconnectChatMcpServer,
+  refreshPluginMcpServers,
   getRegisteredMcpServerNames,
 } from "./mcp.js";
 
 export { buildPermissionRuleset, ensureRemoteSession } from "./sessions.js";
 
 export { type ProviderResolverHooks, resolveProviderID } from "./providers.js";
+
+export {
+  RemoteTurnTimeoutError,
+  remoteTurnTimeoutMs,
+  awaitRemoteTurn,
+} from "./turn-timeout.js";

--- a/src/backend/remote-server/lifecycle.ts
+++ b/src/backend/remote-server/lifecycle.ts
@@ -193,7 +193,9 @@ export function stopRemoteServer<TClient extends RemoteAgentClient>(
   if (state.serverHandle) {
     state.serverHandle.close();
     state.serverHandle = null;
-    state.client = null;
     log("agent", `${state.label} server stopped`);
   }
+  // Always discard this process's client, including when the server was
+  // reused and is intentionally left running for its external owner.
+  state.client = null;
 }

--- a/src/backend/remote-server/lifecycle.ts
+++ b/src/backend/remote-server/lifecycle.ts
@@ -182,6 +182,8 @@ export function stopRemoteServer<TClient extends RemoteAgentClient>(
   state.clientPromise = null;
   state.modelProviderCache.clear();
   state.registeredMcpServers.clear();
+  state.registeredMcpTools.clear();
+  state.pluginMcpServersByChat.clear();
   try {
     extraCleanup?.();
   } catch (err) {

--- a/src/backend/remote-server/mcp.ts
+++ b/src/backend/remote-server/mcp.ts
@@ -13,10 +13,8 @@
  *   - {@link ensureChatMcpServer} — register the current chat's
  *     `talon-tools-<chatId>` MCP server. Returns the registered name so
  *     callers can scope tool overrides to this chat alone.
- *   - {@link ensurePluginMcpServers} — bulk-register all plugin-provided
- *     MCP servers (`mempalace-tools`, `brave-search`, `github-tools`, …).
- *     These are shared globally (not chat-scoped) and only registered
- *     once per Talon process.
+ *   - {@link ensurePluginMcpServers} — register chat-namespaced plugin MCP
+ *     servers (`mempalace-tools`, `brave-search`, `github-tools`, …).
  *   - {@link buildToolOverrides} — produce a `tools` map that whitelists
  *     this chat's Talon tools and blacklists every other chat's. Used
  *     as the `tools` field on the prompt payload to constrain the model's
@@ -27,9 +25,8 @@
  * Performance: registrations are cached locally in
  * `state.registeredMcpServers`. Both OpenCode's and Kilo's `GET /mcp` is
  * known to return `{}` regardless of actual state, so we can't rely on
- * the server to tell us what's already registered. The local cache
- * skips ~16 redundant POSTs per turn (≈12s of wasted setup) for the
- * plugin servers, which spawn subprocesses on each `add`.
+ * the server to tell us what's already registered. A chat's initial plugin
+ * registrations run concurrently through the hub; later turns skip them.
  */
 
 import { log, logWarn } from "../../util/log.js";
@@ -37,6 +34,7 @@ import {
   talonHubUrl,
   pluginHubUrl,
   hubPluginServerNames,
+  listHubPluginToolNames,
 } from "../../core/mcp-hub/index.js";
 import type { RemoteAgentClient } from "./client.js";
 import type { RemoteServerState } from "./state.js";
@@ -53,6 +51,8 @@ import {
 
 /** Stable name prefix for Talon's per-chat MCP servers. */
 export const TALON_MCP_SERVER_NAME = "talon-tools";
+/** Stable prefix for chat-scoped plugin MCP registrations. */
+export const TALON_PLUGIN_MCP_SERVER_NAME = "talon-plugin";
 
 /**
  * MCP add() calls slower than this get a `[slow]` annotation in the log
@@ -79,8 +79,21 @@ const TALON_TOOL_NAMES = [...ALL_TOOLS, ...nativeTools].map(
  * sanitisation step is defense-in-depth for any future frontend.
  */
 export function getChatMcpServerName(chatId: string): string {
-  const safeChatId = chatId.replace(/[^a-zA-Z0-9_-]+/g, "_") || "chat";
+  const safeChatId = safeMcpNamePart(chatId, "chat");
   return `${TALON_MCP_SERVER_NAME}-${safeChatId}`;
+}
+
+/** Sanitize a component embedded in an upstream MCP registration name. */
+export function safeMcpNamePart(value: string, fallback: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]+/g, "_") || fallback;
+}
+
+/** Per-chat registration name for a plugin-provided MCP server. */
+export function getPluginMcpServerName(
+  pluginName: string,
+  chatId: string,
+): string {
+  return `${TALON_PLUGIN_MCP_SERVER_NAME}-${safeMcpNamePart(chatId, "chat")}-${safeMcpNamePart(pluginName, "plugin")}`;
 }
 
 /** Whether a tool id belongs to one of Talon's MCP servers. */
@@ -165,6 +178,7 @@ export async function ensureChatMcpServer<TClient extends RemoteAgentClient>(
       },
     });
     state.registeredMcpServers.add(serverName);
+    state.registeredMcpTools.set(serverName, TALON_TOOL_NAMES);
     const ms = Date.now() - startedAt;
     log(
       "agent",
@@ -184,11 +198,11 @@ export async function ensureChatMcpServer<TClient extends RemoteAgentClient>(
 /**
  * Register all plugin-provided MCP servers with the upstream agent server.
  *
- * Plugins (mempalace, brave-search, github, …) expose MCP servers via
- * `getPluginMcpServers`. Each is registered under its plugin-provided
- * name so the model can see them in the tool catalog. Already-connected
- * servers are skipped via the local cache (their `name → process` mapping
- * survives the entire Talon process; only `stopRemoteServer` clears it).
+ * Plugins are chat-scoped because most receive `TALON_CHAT_ID` at process
+ * start. Each registration therefore gets a chat-qualified name and URL.
+ * Registering a global `mempalace-tools` name during prewarm used to bind all
+ * later chats to the sentinel `prewarm` context (and concurrent adds raced to
+ * replace that URL). Namespacing removes both the routing bug and the race.
  *
  * Returns the list of server names that ended up registered (either
  * freshly added or already connected).
@@ -200,41 +214,63 @@ export async function ensurePluginMcpServers<TClient extends RemoteAgentClient>(
 ): Promise<string[]> {
   const bridgeUrl = `http://127.0.0.1:${state.gatewayPortFn()}`;
   const names = hubPluginServerNames();
-  const registered: string[] = [];
+  const byPlugin =
+    state.pluginMcpServersByChat.get(chatId) ?? new Map<string, string>();
+  state.pluginMcpServersByChat.set(chatId, byPlugin);
 
-  for (const name of names) {
-    if (state.registeredMcpServers.has(name)) {
-      registered.push(name);
-      continue;
-    }
-    try {
-      const startedAt = Date.now();
-      await client.mcp.add({
-        name,
-        config: {
-          type: "remote",
-          // Hub-managed child, shared across sessions and idle-reaped —
-          // the agent server holds an HTTP connection, not a subprocess.
-          url: pluginHubUrl(bridgeUrl, name, chatId),
-        },
-      });
-      registered.push(name);
-      state.registeredMcpServers.add(name);
-      const ms = Date.now() - startedAt;
-      log(
-        "agent",
-        `Registered plugin MCP server: ${name} (${ms}ms)` +
-          (ms > SLOW_MCP_REGISTRATION_MS ? " [slow]" : ""),
-      );
-    } catch (err) {
-      logWarn(
-        "agent",
-        `Plugin MCP registration failed for ${name}: ${errMsg(err)}`,
-      );
-    }
-  }
+  // Drop registrations for plugins removed since this chat last ran.
+  const desired = new Set(names);
+  await Promise.all(
+    [...byPlugin].map(async ([pluginName, serverName]) => {
+      if (desired.has(pluginName)) return;
+      await disconnectChatMcpServer(client, state, serverName);
+      byPlugin.delete(pluginName);
+    }),
+  );
 
-  return registered;
+  const results = await Promise.all(
+    names.map(async (name): Promise<string | null> => {
+      const serverName = getPluginMcpServerName(name, chatId);
+      if (state.registeredMcpServers.has(serverName)) {
+        byPlugin.set(name, serverName);
+        return serverName;
+      }
+      try {
+        // Enumerate before adding. The upstream tool-id endpoint omits MCP
+        // tools, so this list is required to disable sibling chats' plugin
+        // tools in the prompt override map.
+        const toolNames = await listHubPluginToolNames(name, chatId, bridgeUrl);
+        const startedAt = Date.now();
+        await client.mcp.add({
+          name: serverName,
+          config: {
+            type: "remote",
+            // Hub-managed child, shared across sessions and idle-reaped —
+            // the agent server holds an HTTP connection, not a subprocess.
+            url: pluginHubUrl(bridgeUrl, name, chatId),
+          },
+        });
+        state.registeredMcpServers.add(serverName);
+        state.registeredMcpTools.set(serverName, toolNames);
+        byPlugin.set(name, serverName);
+        const ms = Date.now() - startedAt;
+        log(
+          "agent",
+          `Registered plugin MCP server: ${serverName} (${ms}ms)` +
+            (ms > SLOW_MCP_REGISTRATION_MS ? " [slow]" : ""),
+        );
+        return serverName;
+      } catch (err) {
+        logWarn(
+          "agent",
+          `Plugin MCP registration failed for ${serverName}: ${errMsg(err)}`,
+        );
+        return null;
+      }
+    }),
+  );
+
+  return results.filter((name): name is string => Boolean(name));
 }
 
 /**
@@ -256,39 +292,54 @@ export async function buildToolOverrides<TClient extends RemoteAgentClient>(
   client: TClient,
   state: RemoteServerState<TClient>,
   chatServerName: string,
+  pluginServerNames: readonly string[] = [],
 ): Promise<Record<string, boolean> | undefined> {
+  const overrides: Record<string, boolean> = {};
+  const enabledServers = new Set([chatServerName, ...pluginServerNames]);
+  let matchedManagedTool = false;
+
+  // Build from Talon's own registration ledger first. This is the reliable
+  // source for dynamic MCP tools; the upstream ids endpoint omits them and can
+  // itself fail during a server wobble. A failed discovery call must never
+  // discard the isolation map we can synthesize locally.
+  for (const serverName of state.registeredMcpServers) {
+    const toolNames =
+      state.registeredMcpTools.get(serverName) ??
+      (serverName.startsWith(`${TALON_MCP_SERVER_NAME}-`)
+        ? TALON_TOOL_NAMES
+        : []);
+    const enabled = enabledServers.has(serverName);
+    for (const toolName of toolNames) {
+      overrides[`${serverName}_${toolName}`] = enabled;
+    }
+    if (toolNames.length > 0) matchedManagedTool = true;
+  }
+
   try {
     const toolIdsResp = await client.tool.ids();
     const toolIds = Array.isArray(toolIdsResp.data) ? toolIdsResp.data : [];
-    const overrides: Record<string, boolean> = {};
-    const chatToolPrefix = `${chatServerName}_`;
-    let matchedTalonTool = false;
-
-    for (const serverName of state.registeredMcpServers) {
-      if (!serverName.startsWith(`${TALON_MCP_SERVER_NAME}-`)) continue;
-      const enabled = serverName === chatServerName;
-      for (const toolName of TALON_TOOL_NAMES) {
-        overrides[`${serverName}_${toolName}`] = enabled;
-      }
-      matchedTalonTool = true;
-    }
 
     for (const toolId of toolIds) {
-      if (typeof toolId !== "string" || !isTalonToolID(toolId)) continue;
-
-      const enabled = toolId.startsWith(chatToolPrefix);
-      overrides[toolId] = enabled;
-      matchedTalonTool = true;
+      if (typeof toolId !== "string") continue;
+      const owner = [...state.registeredMcpServers].find((serverName) =>
+        toolId.startsWith(`${serverName}_`),
+      );
+      if (owner) {
+        overrides[toolId] = enabledServers.has(owner);
+      } else if (isTalonToolID(toolId)) {
+        overrides[toolId] = toolId.startsWith(`${chatServerName}_`);
+      } else {
+        continue;
+      }
+      matchedManagedTool = true;
     }
-
-    return matchedTalonTool ? overrides : undefined;
   } catch (err) {
     logWarn(
       "agent",
       `Failed to build ${state.label} tool overrides for ${chatServerName}: ${errMsg(err)}`,
     );
-    return undefined;
   }
+  return matchedManagedTool ? overrides : undefined;
 }
 
 /**
@@ -312,10 +363,59 @@ export async function disconnectChatMcpServer<
 ): Promise<void> {
   try {
     await client.mcp.disconnect({ name: serverName });
-    state.registeredMcpServers.delete(serverName);
   } catch (err) {
     logWarn("agent", `Failed to disconnect ${serverName}: ${errMsg(err)}`);
+  } finally {
+    state.registeredMcpServers.delete(serverName);
+    state.registeredMcpTools.delete(serverName);
+    for (const byPlugin of state.pluginMcpServersByChat.values()) {
+      for (const [pluginName, registeredName] of byPlugin) {
+        if (registeredName === serverName) byPlugin.delete(pluginName);
+      }
+    }
   }
+}
+
+/**
+ * Reconnect one chat's plugin registrations after a hot reload so the remote
+ * server refreshes cached tool schemas. Hub children are already retired by
+ * the plugin registry; this refresh handles added/removed/renamed tools.
+ */
+export async function refreshPluginMcpServers<
+  TClient extends RemoteAgentClient,
+>(
+  client: TClient,
+  state: RemoteServerState<TClient>,
+  chatId: string,
+): Promise<{
+  added: string[];
+  removed: string[];
+  errors: Record<string, string>;
+}> {
+  const previous = new Set(
+    state.pluginMcpServersByChat.get(chatId)?.keys() ?? [],
+  );
+  const existingNames = [
+    ...(state.pluginMcpServersByChat.get(chatId)?.values() ?? []),
+  ];
+  await Promise.all(
+    existingNames.map((name) => disconnectChatMcpServer(client, state, name)),
+  );
+  state.pluginMcpServersByChat.delete(chatId);
+
+  const registered = await ensurePluginMcpServers(client, state, chatId);
+  const current = new Set(
+    state.pluginMcpServersByChat.get(chatId)?.keys() ?? [],
+  );
+  const desiredCount = hubPluginServerNames().length;
+  return {
+    added: [...current].filter((name) => !previous.has(name)),
+    removed: [...previous].filter((name) => !current.has(name)),
+    errors:
+      registered.length === desiredCount && current.size === desiredCount
+        ? {}
+        : { registration: "one or more plugin MCP servers failed to register" },
+  };
 }
 
 /**

--- a/src/backend/remote-server/mcp.ts
+++ b/src/backend/remote-server/mcp.ts
@@ -4,17 +4,15 @@
  * Both OpenCode and Kilo expose the same MCP HTTP API surface
  * (`POST /mcp` to add, `DELETE /mcp/:name` to disconnect) and share the
  * same visibility model upstream: every registered MCP server's tools
- * are visible to every session by default. Per-session permission rules
- * only block *execution*, not *visibility* — which is why Talon has to
- * disconnect rival chat-namespaced MCP servers before connecting the
- * current one, instead of relying on permission rules alone.
+ * are visible to every session by default. Talon keeps namespaced servers
+ * registered concurrently, then scopes visibility per prompt with a tool
+ * override map and execution with per-session permission rules.
  *
  * Functions exported here:
  *
  *   - {@link ensureChatMcpServer} — register the current chat's
- *     `talon-tools-<chatId>` MCP server, disconnecting any other chat's
- *     server in the process. Returns the registered name so callers can
- *     scope tool overrides to this chat alone.
+ *     `talon-tools-<chatId>` MCP server. Returns the registered name so
+ *     callers can scope tool overrides to this chat alone.
  *   - {@link ensurePluginMcpServers} — bulk-register all plugin-provided
  *     MCP servers (`mempalace-tools`, `brave-search`, `github-tools`, …).
  *     These are shared globally (not chat-scoped) and only registered
@@ -45,6 +43,7 @@ import type { RemoteServerState } from "./state.js";
 import { errMsg } from "./state.js";
 import type { TalonConfig } from "../../util/config.js";
 import type { FrontendName } from "../../core/agent-runtime/backend-registry.js";
+import { ALL_TOOLS, nativeTools } from "../../core/tools/index.js";
 import {
   frontendForChatId,
   nonTerminalFrontends,
@@ -62,6 +61,15 @@ export const TALON_MCP_SERVER_NAME = "talon-tools";
  * <500ms; the outliers are the ones worth investigating.
  */
 const SLOW_MCP_REGISTRATION_MS = 1000;
+
+/**
+ * OpenCode's `/experimental/tool/ids` endpoint omits dynamically registered
+ * MCP tools despite its API description. Synthesize Talon's known MCP ids so
+ * prompt-level overrides can still isolate concurrently registered chats.
+ */
+const TALON_TOOL_NAMES = [...ALL_TOOLS, ...nativeTools].map(
+  (tool) => tool.name,
+);
 
 // ── Internal helpers ────────────────────────────────────────────────────────
 
@@ -110,15 +118,10 @@ function resolveChatToolFrontend(
  * Ensure the per-chat Talon MCP server is registered with the upstream
  * agent server.
  *
- * Each chat gets its own namespaced MCP server (`talon-tools-<chatId>`)
- * so concurrent chats can't see each other's tool environment. Before
- * connecting the current chat's server we DISCONNECT every other chat's
- * server (except the heartbeat sentinel) — this is the only way to hide
- * cross-chat tools from the model's visible catalog. The model's
- * permission rules deny EXECUTION of cross-chat tools but don't hide
- * them from visibility, so without the disconnect step the model in
- * chat A would see `talon-tools-<chatB>_send` in its tool catalog and
- * try to call it.
+ * Each chat gets its own namespaced MCP server (`talon-tools-<chatId>`).
+ * Servers stay registered across concurrent turns; callers pass the result
+ * of `buildToolOverrides` with each prompt so chat A cannot see chat B's
+ * tools. Session permission rules independently deny cross-chat execution.
  *
  * Best-effort: a registration failure logs a warning but doesn't throw —
  * the conversation can still proceed without Talon-tool access.
@@ -129,30 +132,6 @@ export async function ensureChatMcpServer<TClient extends RemoteAgentClient>(
   chatId: string,
 ): Promise<string> {
   const serverName = getChatMcpServerName(chatId);
-
-  // Rotate out other chat servers BEFORE registering this one. The
-  // heartbeat sentinel server is exempt (it has no real chat to leak
-  // into and stays connected for cron / trigger paths).
-  // Snapshot: rotation removes entries from the live set mid-iteration.
-  for (const other of Array.from(state.registeredMcpServers)) {
-    if (
-      !other.startsWith(`${TALON_MCP_SERVER_NAME}-`) ||
-      other === serverName ||
-      other === `${TALON_MCP_SERVER_NAME}-heartbeat`
-    ) {
-      continue;
-    }
-    try {
-      await client.mcp.disconnect({ name: other });
-      state.registeredMcpServers.delete(other);
-      log("agent", `Disconnected ${other} MCP server (chat switch)`);
-    } catch (err) {
-      logWarn(
-        "agent",
-        `Failed to disconnect ${other} during chat switch: ${errMsg(err)}`,
-      );
-    }
-  }
 
   // Local cache short-circuit. The upstream's GET /mcp returns {} regardless
   // of state, so we trust our own record of what we registered earlier in
@@ -267,9 +246,11 @@ export async function ensurePluginMcpServers<TClient extends RemoteAgentClient>(
  * access at the visibility layer (not just the execution layer that
  * permission rules cover).
  *
- * Returns `undefined` when no chat-scoped tools matched (e.g. MCP
- * registration failed silently above) — caller should skip passing
- * the `tools` field in that case.
+ * When the current chat's tools have not appeared in `tool.ids()` yet, still
+ * returns a map that disables any sibling chat tools already visible. MCP
+ * registration completes asynchronously upstream; returning `undefined` in
+ * that window exposed a concurrent heartbeat/dream toolset to the chat.
+ * Returns `undefined` only when the catalog contains no Talon tools at all.
  */
 export async function buildToolOverrides<TClient extends RemoteAgentClient>(
   client: TClient,
@@ -281,17 +262,26 @@ export async function buildToolOverrides<TClient extends RemoteAgentClient>(
     const toolIds = Array.isArray(toolIdsResp.data) ? toolIdsResp.data : [];
     const overrides: Record<string, boolean> = {};
     const chatToolPrefix = `${chatServerName}_`;
-    let matchedChatTool = false;
+    let matchedTalonTool = false;
+
+    for (const serverName of state.registeredMcpServers) {
+      if (!serverName.startsWith(`${TALON_MCP_SERVER_NAME}-`)) continue;
+      const enabled = serverName === chatServerName;
+      for (const toolName of TALON_TOOL_NAMES) {
+        overrides[`${serverName}_${toolName}`] = enabled;
+      }
+      matchedTalonTool = true;
+    }
 
     for (const toolId of toolIds) {
       if (typeof toolId !== "string" || !isTalonToolID(toolId)) continue;
 
       const enabled = toolId.startsWith(chatToolPrefix);
       overrides[toolId] = enabled;
-      matchedChatTool ||= enabled;
+      matchedTalonTool = true;
     }
 
-    return matchedChatTool ? overrides : undefined;
+    return matchedTalonTool ? overrides : undefined;
   } catch (err) {
     logWarn(
       "agent",
@@ -302,20 +292,16 @@ export async function buildToolOverrides<TClient extends RemoteAgentClient>(
 }
 
 /**
- * Disconnect a per-chat MCP server. Called in handler `finally` blocks
- * to release the chat-namespaced MCP subprocess once the turn ends.
+ * Disconnect a per-chat MCP server. One-shot paths use this to release
+ * their ephemeral context registration once the run ends.
  *
  * Errors are swallowed (the server may already be gone if MCP itself
  * crashed). The local cache entry is removed unconditionally so a
  * future `ensureChatMcpServer` re-registers — otherwise the cache
  * short-circuit would skip a server the upstream no longer has.
  *
- * Note: Kilo's handler deliberately does NOT call this in its
- * per-turn `finally` (the disconnect-others-then-add dance in
- * `ensureChatMcpServer` handles the rotation, and re-registering the
- * same chat's server every turn costs ~800ms of subprocess spawn).
- * OpenCode's handler still calls it for now; the next refactor pass
- * will align both backends on the keep-across-turns policy.
+ * Chat handlers deliberately keep registrations cached across turns;
+ * per-prompt tool overrides provide cross-chat visibility isolation.
  */
 export async function disconnectChatMcpServer<
   TClient extends RemoteAgentClient,
@@ -335,7 +321,7 @@ export async function disconnectChatMcpServer<
 /**
  * Snapshot of the locally-cached MCP server registrations. Test-only:
  * `registeredMcpServers` is module-private state that integration tests
- * need to inspect to assert chat-switch isolation actually fired (the
+ * need to inspect to assert concurrent registrations are retained (the
  * upstream's GET /mcp returns {} regardless of state, so we can't query
  * the server itself).
  */

--- a/src/backend/remote-server/one-shot.ts
+++ b/src/backend/remote-server/one-shot.ts
@@ -35,10 +35,14 @@
 import type { OneShotAgentParams, OneShotUsage } from "../../core/types.js";
 import { logWarn } from "../../util/log.js";
 import {
+  approvePendingPermissions,
   extractAssistantUsage,
+  rejectPendingQuestions,
+  type RemoteSessionClient,
   type RemoteAssistantInfo,
 } from "./session-helpers.js";
-import { appendBackendSuffix } from "../shared/index.js";
+import { appendBackendSuffix, sleep } from "../shared/index.js";
+import { buildPermissionRuleset } from "./sessions.js";
 
 // ── Client surface ──────────────────────────────────────────────────────────
 
@@ -49,9 +53,8 @@ import { appendBackendSuffix } from "../shared/index.js";
  * parameter checking bivariant so both concrete SDK clients satisfy
  * it structurally.
  */
-export interface RemoteOneShotClient {
-  session: {
-    create(args: { title: string }): Promise<{ data?: unknown }>;
+export interface RemoteOneShotClient extends RemoteSessionClient {
+  session: RemoteSessionClient["session"] & {
     prompt(args: {
       sessionID: string;
       parts: Array<{ type: "text"; text: string }>;
@@ -84,6 +87,7 @@ export type RemoteOneShotBindings<TClient extends RemoteOneShotClient> = {
   buildToolOverrides(
     client: TClient,
     chatServerName: string,
+    pluginServerNames?: readonly string[],
   ): Promise<Record<string, boolean> | undefined>;
   disconnectChatMcpServer(client: TClient, serverName: string): Promise<void>;
   errMsg(e: unknown): string;
@@ -117,14 +121,19 @@ export async function runRemoteOneShotAgent<
     oc,
     contextLabel,
   );
-  await bindings.ensurePluginMcpServers(oc, contextLabel);
+  const pluginMcpServerNames = await bindings.ensurePluginMcpServers(
+    oc,
+    contextLabel,
+  );
   const toolOverrides = await bindings.buildToolOverrides(
     oc,
     chatMcpServerName,
+    pluginMcpServerNames,
   );
 
   const sessionResp = await oc.session.create({
     title: `One-shot ${contextLabel} ${new Date().toISOString()}`,
+    permission: buildPermissionRuleset(contextLabel),
   });
   const sessionData = sessionResp.data as Record<string, unknown> | undefined;
   const sessionID =
@@ -145,6 +154,37 @@ export async function runRemoteOneShotAgent<
       );
   };
   abortController.signal.addEventListener("abort", onAbort, { once: true });
+  const watchdogAbort = new AbortController();
+  const seenQuestionIds = new Set<string>();
+  const seenPermissionIds = new Set<string>();
+  const interactionWatchdog = (async () => {
+    while (!watchdogAbort.signal.aborted) {
+      try {
+        await Promise.all([
+          rejectPendingQuestions(
+            oc,
+            sessionID,
+            contextLabel,
+            seenQuestionIds,
+            label,
+          ),
+          approvePendingPermissions(
+            oc,
+            sessionID,
+            contextLabel,
+            seenPermissionIds,
+            label,
+          ),
+        ]);
+      } catch (err) {
+        logWarn(
+          "agent",
+          `${label} one-shot interaction watchdog failed: ${errMsg(err)}`,
+        );
+      }
+      await sleep(350, watchdogAbort.signal);
+    }
+  })();
 
   try {
     if (abortController.signal.aborted) {
@@ -189,7 +229,14 @@ export async function runRemoteOneShotAgent<
     }
   } finally {
     abortController.signal.removeEventListener("abort", onAbort);
-    await bindings.disconnectChatMcpServer(oc, chatMcpServerName);
+    watchdogAbort.abort();
+    await interactionWatchdog.catch(() => {});
+    await Promise.all([
+      bindings.disconnectChatMcpServer(oc, chatMcpServerName),
+      ...pluginMcpServerNames.map((name) =>
+        bindings.disconnectChatMcpServer(oc, name),
+      ),
+    ]);
     try {
       await oc.session.delete({ sessionID });
     } catch (err) {

--- a/src/backend/remote-server/providers.ts
+++ b/src/backend/remote-server/providers.ts
@@ -72,6 +72,17 @@ export async function resolveProviderID<TClient extends RemoteAgentClient>(
   const providerResp = await client.provider.list();
   const providerBuckets =
     (providerResp.data as Record<string, unknown> | undefined) ?? {};
+  // Current OpenCode/Kilo shape: `all` contains the provider objects while
+  // `connected` is an array of provider ids. Older releases exposed provider
+  // objects in named buckets such as `connected` / `configured`. Support both
+  // shapes, but always prefer a provider the server says is authenticated.
+  const connectedProviderIDs = new Set(
+    Array.isArray(providerBuckets.connected)
+      ? providerBuckets.connected.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [],
+  );
   const guessedProviderID = hooks.guessProviderID(modelID);
   const matches: Array<{ providerID: string; bucketName: string }> = [];
 
@@ -98,6 +109,7 @@ export async function resolveProviderID<TClient extends RemoteAgentClient>(
 
   if (matches.length > 0) {
     const score = (m: (typeof matches)[0]): number =>
+      (connectedProviderIDs.has(m.providerID) ? 0 : 100) +
       (m.providerID === guessedProviderID ? 0 : 2) +
       (m.providerID === "opencode" ? 0 : 1) +
       hooks.getBucketPriority(m.bucketName) * 0.1;

--- a/src/backend/remote-server/session-helpers.ts
+++ b/src/backend/remote-server/session-helpers.ts
@@ -25,6 +25,9 @@
  *     `/status` enrichment).
  *   - {@link rejectPendingQuestions} — auto-respond to upstream questions
  *     (tool-approval → "always", clarifications → reject).
+ *   - {@link approvePendingPermissions} — approve upstream permission asks
+ *     that escaped the session ruleset, preventing headless turns from
+ *     waiting forever for a TUI response.
  */
 
 import { logWarn } from "../../util/log.js";
@@ -138,6 +141,13 @@ export interface RemoteSessionClient extends RemoteAgentClient {
       answers: Array<Array<string>>;
     }): Promise<unknown>;
     reject(args: { requestID: string }): Promise<unknown>;
+  };
+  permission: {
+    list(): Promise<{ data?: unknown }>;
+    reply(args: {
+      requestID: string;
+      reply: "once" | "always" | "reject";
+    }): Promise<unknown>;
   };
 }
 
@@ -536,6 +546,65 @@ export async function rejectPendingQuestions(
       logWarn(
         "agent",
         `[${chatId}] Failed to handle ${backendLabel} question ${requestId}: ${errMsg(err)}`,
+      );
+    }
+  }
+}
+
+/**
+ * Approve pending upstream permission requests for this session.
+ *
+ * Remote agent servers normally resolve these from the permission ruleset
+ * installed at session creation. New permission categories can still appear
+ * upstream, though, and a headless Talon process has no TUI to answer them.
+ * Polling the pending list is therefore a fail-safe: approve each request
+ * once, scoped strictly to the current session, and deduplicate until the
+ * server removes it from the list.
+ */
+export async function approvePendingPermissions(
+  oc: RemoteSessionClient,
+  sessionId: string,
+  chatId: string,
+  seenPermissionIds: Set<string>,
+  backendLabel: string,
+): Promise<void> {
+  const permissionsResp = await oc.permission.list();
+  const pendingPermissions = Array.isArray(permissionsResp.data)
+    ? permissionsResp.data
+    : [];
+
+  for (const request of pendingPermissions) {
+    if (!request || typeof request !== "object") continue;
+
+    const data = request as {
+      id?: string;
+      sessionID?: string;
+      permission?: string;
+      patterns?: string[];
+    };
+    const requestId = data.id;
+    if (!requestId || data.sessionID !== sessionId) continue;
+    if (seenPermissionIds.has(requestId)) continue;
+
+    seenPermissionIds.add(requestId);
+    try {
+      await oc.permission.reply({ requestID: requestId, reply: "once" });
+      const detail = [
+        data.permission,
+        ...(Array.isArray(data.patterns) ? data.patterns : []),
+      ]
+        .filter(Boolean)
+        .join(" ");
+      logWarn(
+        "agent",
+        `[${chatId}] Auto-approved ${backendLabel} permission ${requestId}${
+          detail ? `: ${detail}` : ""
+        }`,
+      );
+    } catch (err) {
+      logWarn(
+        "agent",
+        `[${chatId}] Failed to approve ${backendLabel} permission ${requestId}: ${errMsg(err)}`,
       );
     }
   }

--- a/src/backend/remote-server/sessions.ts
+++ b/src/backend/remote-server/sessions.ts
@@ -118,3 +118,51 @@ export async function ensureRemoteSession<TClient extends RemoteAgentClient>(
 
   return newId;
 }
+
+/**
+ * The per-turn setup a warm-up front-loads. Both remote-server backends
+ * expose these under identical signatures; the shape lets the helper stay
+ * backend-agnostic without importing either SDK.
+ */
+export interface RemoteWarmDeps<TClient extends RemoteAgentClient> {
+  ensureServer(): Promise<TClient>;
+  ensureSession(client: TClient, chatId: string): Promise<string>;
+  ensureChatMcpServer(client: TClient, chatId: string): Promise<string>;
+  ensurePluginMcpServers(client: TClient, chatId: string): Promise<string[]>;
+}
+
+/**
+ * Pre-pay a chat's cold start: spawn the server if it isn't up, create (or
+ * resume) the session, and register the chat + plugin MCP servers.
+ *
+ * This is the remote-server analogue of the Claude backend's `warmSession`,
+ * and closes the last `sessions` capability gap between the two families.
+ * `performSessionReset` and the native frontend call it right after a reset,
+ * so the first turn on a fresh session doesn't serially pay session creation
+ * plus a full plugin-MCP registration sweep — the dominant cold-start cost
+ * here, since each plugin server is a separate connect.
+ *
+ * Best-effort by contract: `/reset` has already succeeded by the time this
+ * runs, and the same work is idempotent and repeated at the head of every
+ * turn. A failure must degrade to a slow first turn, never surface as a
+ * failed reset — so everything is caught and logged, not rethrown.
+ */
+export async function warmRemoteSession<TClient extends RemoteAgentClient>(
+  state: RemoteServerState<TClient>,
+  chatId: string,
+  deps: RemoteWarmDeps<TClient>,
+): Promise<void> {
+  try {
+    const client = await deps.ensureServer();
+    await deps.ensureSession(client, chatId);
+    await deps.ensureChatMcpServer(client, chatId);
+    await deps.ensurePluginMcpServers(client, chatId);
+    log("agent", `[${chatId}] Warmed ${state.label} session`);
+  } catch (err) {
+    logWarn(
+      "agent",
+      `[${chatId}] ${state.label} warm-up skipped (first turn pays cold start): ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/backend/remote-server/sessions.ts
+++ b/src/backend/remote-server/sessions.ts
@@ -33,14 +33,13 @@ import { TALON_MCP_SERVER_NAME, getChatMcpServerName } from "./mcp.js";
  *      "No active chat context". Or in the cross-chat case where chat B
  *      IS active, the model in chat A could leak content into chat B.
  *      Deny pattern blocks both. (Visibility is also blocked at the
- *      MCP-registration layer via `ensureChatMcpServer`; this rule is
- *      defense in depth.)
+ *      prompt layer by `buildToolOverrides`; this rule is defense in depth.)
  *
- *   2. Auto-allow built-in tools (`tool *`, `edit *`, `bash *`) so they
+ *   2. Auto-allow built-in tools (`tool *`, `edit *`, `bash *`) and
+ *      workspace paths outside the server process's launch directory so they
  *      don't sit in `permission.asked` waiting for a reply that never
- *      arrives — Talon's question watchdog only handles `question.*`
- *      events, not `permission.*`. Without the allow rule the model's
- *      first `read` call hangs the entire turn.
+ *      arrives. The permission watchdog is a fallback for new categories;
+ *      this rule resolves the known path case without a polling round trip.
  *
  * Rules are evaluated in order; first match wins. (See upstream's
  * `PermissionRule` type — `permission` is the rule category, `pattern`
@@ -58,6 +57,7 @@ export function buildPermissionRuleset(chatId: string): RemotePermissionRule[] {
     { permission: "tool", pattern: "*", action: "allow" },
     { permission: "edit", pattern: "*", action: "allow" },
     { permission: "bash", pattern: "*", action: "allow" },
+    { permission: "external_directory", pattern: "*", action: "allow" },
   ];
 }
 

--- a/src/backend/remote-server/sessions.ts
+++ b/src/backend/remote-server/sessions.ts
@@ -17,7 +17,12 @@ import {
 import { log, logWarn } from "../../util/log.js";
 import type { RemoteAgentClient, RemotePermissionRule } from "./client.js";
 import type { RemoteServerState } from "./state.js";
-import { TALON_MCP_SERVER_NAME, getChatMcpServerName } from "./mcp.js";
+import {
+  TALON_MCP_SERVER_NAME,
+  TALON_PLUGIN_MCP_SERVER_NAME,
+  getChatMcpServerName,
+  safeMcpNamePart,
+} from "./mcp.js";
 
 /**
  * Build the per-session permission ruleset Talon installs on every fresh
@@ -47,11 +52,18 @@ import { TALON_MCP_SERVER_NAME, getChatMcpServerName } from "./mcp.js";
  */
 export function buildPermissionRuleset(chatId: string): RemotePermissionRule[] {
   const ourServerName = getChatMcpServerName(chatId);
+  const ourPluginPrefix = `${TALON_PLUGIN_MCP_SERVER_NAME}-${safeMcpNamePart(chatId, "chat")}-`;
   return [
     { permission: "tool", pattern: `${ourServerName}_*`, action: "allow" },
     {
       permission: "tool",
       pattern: `${TALON_MCP_SERVER_NAME}-*`,
+      action: "deny",
+    },
+    { permission: "tool", pattern: `${ourPluginPrefix}*`, action: "allow" },
+    {
+      permission: "tool",
+      pattern: `${TALON_PLUGIN_MCP_SERVER_NAME}-*`,
       action: "deny",
     },
     { permission: "tool", pattern: "*", action: "allow" },

--- a/src/backend/remote-server/sse-stream.ts
+++ b/src/backend/remote-server/sse-stream.ts
@@ -44,17 +44,24 @@ export async function subscribeSseStream(
   client: SseSubscribableClient,
   chatId: string,
 ): Promise<AsyncIterable<unknown> | undefined> {
-  let result: unknown;
-  try {
-    result = await client.global.event();
-  } catch (err) {
-    logWarn(
-      "agent",
-      `[${chatId}] SSE subscribe failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return undefined;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const stream = narrowSseResult(await client.global.event());
+      if (stream) return stream;
+      lastError = new Error("response did not contain an async event stream");
+    } catch (err) {
+      lastError = err;
+    }
+    if (attempt < 3) {
+      await new Promise((resolve) => setTimeout(resolve, 150 * attempt));
+    }
   }
-  return narrowSseResult(result);
+  logWarn(
+    "agent",
+    `[${chatId}] SSE subscribe failed after 3 attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+  );
+  return undefined;
 }
 
 /**

--- a/src/backend/remote-server/state.ts
+++ b/src/backend/remote-server/state.ts
@@ -52,6 +52,10 @@ export interface RemoteServerState<TClient extends RemoteAgentClient> {
    * actual state, so we cache locally instead of trusting the server.
    */
   readonly registeredMcpServers: Set<string>;
+  /** Exact tool names exposed by each registered MCP server. */
+  readonly registeredMcpTools: Map<string, readonly string[]>;
+  /** Plugin-name → registered server-name mapping for each chat context. */
+  readonly pluginMcpServersByChat: Map<string, Map<string, string>>;
 }
 
 /** Inputs for {@link createRemoteServerState}. */
@@ -84,6 +88,8 @@ export function createRemoteServerState<TClient extends RemoteAgentClient>(
     serverHandle: null,
     modelProviderCache: new Map(),
     registeredMcpServers: new Set(),
+    registeredMcpTools: new Map(),
+    pluginMcpServersByChat: new Map(),
   };
 }
 

--- a/src/backend/remote-server/turn-timeout.ts
+++ b/src/backend/remote-server/turn-timeout.ts
@@ -1,0 +1,71 @@
+/** Bounded turn execution for OpenCode/Kilo's long-lived HTTP servers. */
+
+import { logWarn } from "../../util/log.js";
+
+const DEFAULT_REMOTE_TURN_TIMEOUT_MS = 10 * 60_000;
+
+export function remoteTurnTimeoutMs(): number {
+  const configured = Number(process.env.TALON_REMOTE_TURN_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_REMOTE_TURN_TIMEOUT_MS;
+}
+
+export class RemoteTurnTimeoutError extends Error {
+  constructor(label: string, timeoutMs: number) {
+    super(`${label} turn timed out after ${Math.round(timeoutMs / 1000)}s`);
+    // Core error classification treats TimeoutError as a retryable transport
+    // failure, so the normal fallback-model path remains available.
+    this.name = "TimeoutError";
+  }
+}
+
+export interface RemoteTurnAbortClient {
+  session: {
+    abort(args: { sessionID: string }): Promise<unknown>;
+  };
+}
+
+/**
+ * Race a prompt+SSE turn against a hard deadline. On expiry, abort upstream
+ * generation before rejecting so the provider stops spending tokens and the
+ * session can be safely reset by the shared retry path.
+ */
+export async function awaitRemoteTurn<T>(
+  turn: Promise<T>,
+  inputs: {
+    client: RemoteTurnAbortClient;
+    sessionId: string;
+    chatId: string;
+    label: string;
+    timeoutMs?: number;
+  },
+): Promise<T> {
+  const timeoutMs = inputs.timeoutMs ?? remoteTurnTimeoutMs();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      turn,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          logWarn(
+            "agent",
+            `[${inputs.chatId}] ${inputs.label} turn exceeded ${Math.round(timeoutMs / 1000)}s; aborting`,
+          );
+          inputs.client.session
+            .abort({ sessionID: inputs.sessionId })
+            .catch((err) =>
+              logWarn(
+                "agent",
+                `[${inputs.chatId}] ${inputs.label} timeout abort failed: ${err instanceof Error ? err.message : String(err)}`,
+              ),
+            );
+          reject(new RemoteTurnTimeoutError(inputs.label, timeoutMs));
+        }, timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/src/core/mcp-hub/index.ts
+++ b/src/core/mcp-hub/index.ts
@@ -104,6 +104,28 @@ export function hubPluginServerNames(only?: string[]): string[] {
   return Object.keys(getPluginMcpServers("", "hub-enum", only));
 }
 
+/**
+ * Enumerate one plugin server's tools through the same hub-managed child that
+ * serves MCP requests. Remote agent servers do not include dynamically-added
+ * MCP tools in their `/experimental/tool/ids` response, so OpenCode/Kilo need
+ * this authoritative list to build per-chat visibility overrides.
+ */
+export async function listHubPluginToolNames(
+  serverName: string,
+  chatId: string,
+  bridgeUrl: string,
+): Promise<string[]> {
+  const key =
+    serverName === "brave-search"
+      ? "brave-search"
+      : `${serverName}\u0000${chatId}`;
+  const child = await acquireChild(key, () =>
+    pluginSpec(serverName, chatId, bridgeUrl),
+  );
+  child.touch();
+  return (await child.listTools()).map((tool) => tool.name);
+}
+
 // ── Server construction per session ─────────────────────────────────────────
 
 type HubTarget =

--- a/src/frontend/telegram/callbacks/model.ts
+++ b/src/frontend/telegram/callbacks/model.ts
@@ -44,6 +44,47 @@ import {
   editOrIgnoreSame,
   type CallbackDeps,
 } from "./shared.js";
+import { logWarn } from "../../../util/log.js";
+
+/**
+ * Run the backend-side half of a chat's session handoff.
+ *
+ * A backend switch already clears Talon's own stores (session row,
+ * history, pulse checkpoint), but those are only half the state.
+ * `performSessionReset` also drives the backend capability slots, and
+ * the switch path skipped them entirely:
+ *
+ *   - the OUTGOING backend keeps in-process per-chat state that no
+ *     amount of clearing Talon's stores touches. openai-agents holds a
+ *     `MemorySession` map keyed by chat id, so switching away and back
+ *     resurrected the old conversation the operator meant to drop.
+ *   - the INCOMING backend was never warmed, so the first turn after a
+ *     switch paid the full cold start — on OpenCode/Kilo that is session
+ *     creation plus a per-plugin MCP registration sweep.
+ *
+ * The warm is deliberately fire-and-forget: it can take seconds, and the
+ * callback still has a toast to answer and a menu to redraw. Telegram
+ * expires an unanswered callback query, so blocking here would trade a
+ * cold first turn for a visibly stuck button.
+ */
+function handOffBackendSession(
+  chatId: string,
+  previousBackend: ReturnType<typeof resolveBackendForChat>,
+  gateway: CallbackDeps["gateway"],
+): void {
+  previousBackend?.sessions?.resetChat?.(chatId);
+  const nextBackend = resolveBackendForChat(chatId, gateway);
+  // Same instance on a no-op switch — warming it again is harmless
+  // (every step is idempotent) but pointless, so skip it.
+  if (!nextBackend || nextBackend === previousBackend) return;
+  void Promise.resolve(nextBackend.sessions?.warmSession?.(chatId)).catch(
+    (err) =>
+      logWarn(
+        "bot",
+        `[${chatId}] warm after backend switch failed: ${err instanceof Error ? err.message : String(err)}`,
+      ),
+  );
+}
 
 export async function handleModelCallback(
   ctx: Context,
@@ -171,6 +212,10 @@ export async function handleModelCallback(
       });
       return;
     }
+    // Resolve the outgoing backend BEFORE rebinding — afterwards this
+    // chat already points at the new one and the old in-process state
+    // would be unreachable.
+    const previousBackend = resolveBackendForChat(cid, gateway);
     const result = await rebindChat(cid, action.backendId, config);
     if (!result.ok) {
       await answerCallbackQuerySafe(ctx, {
@@ -188,6 +233,7 @@ export async function handleModelCallback(
     resetSession(cid);
     clearHistory(cid);
     resetPulseCheckpoint(cid);
+    handOffBackendSession(cid, previousBackend, gateway);
     const label =
       available.find((b) => b.id === action.backendId)?.label ??
       action.backendId;
@@ -210,11 +256,13 @@ export async function handleModelCallback(
     // global chat-role backend. Per-backend model picks are
     // preserved (modelByBackend stays intact) so reverting and
     // switching back later still restores prior choices.
+    const previousBackend = resolveBackendForChat(cid, gateway);
     await releaseChat(cid);
     setChatBackend(cid, undefined);
     resetSession(cid);
     clearHistory(cid);
     resetPulseCheckpoint(cid);
+    handOffBackendSession(cid, previousBackend, gateway);
     // Resolve the now-default backend's model for the toast.
     const defaultBackend = resolveBackendForChat(cid, gateway);
     const defaultBackendId = getBackendIdForChat(cid);


### PR DESCRIPTION
## Summary

- prevent headless OpenCode/Kilo turns from waiting forever on permissions, questions, dead SSE sockets, or providers that never finish
- keep chat and plugin MCP registrations chat-scoped, concurrent, reloadable, and isolated from sibling chats
- prefer the provider Kilo actually reports as connected when duplicate model IDs exist
- bring OpenCode/Kilo runtime capability slots in line with Claude/Codex: plugin tool refresh, live system-prompt updates, one-shot permission handling, and complete backend-pool cleanup
- count delivery tools only after upstream reports successful completion and avoid stale aborts canceling the following turn

## Root causes found in production logs

- turn `1d18e10f` waited over 12 hours on an unanswered `external_directory` permission
- the stale abort from that turn canceled the next turn `38e0ad48` with `MessageAbortedError`
- plugin MCP prewarm registered global names using the sentinel `prewarm` chat; real-chat registrations then raced under those same names, leaving tools bound to the wrong chat
- concurrent turns could disconnect another chat's Talon MCP registration
- current Kilo `/provider` advertises Nemotron under both `openrouter` and `kilo`, but only reports `kilo` connected; the old resolver chose `openrouter` and Kilo rejected the model
- failed/running `send` and `end_turn` parts could be backfilled as successful delivery
- backend shutdown only cleaned the configured default, leaving remote server processes behind

## Reliability changes

- per-chat Talon and plugin MCP names, exact tool enumeration through the hub, prompt overrides plus permission deny rules for sibling chats
- concurrent registration, hot-reload reconnection, and live system-prompt update support
- permission/question watchdogs for chat and one-shot runs
- three-attempt SSE subscription, explicit failure when no stream exists, and a configurable 10-minute hard turn deadline that aborts upstream before entering the normal retry/fallback path
- connected-provider preference for current OpenCode/Kilo provider catalog shapes
- completed-only delivery accounting and session-scoped nested SSE events

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes; two pre-existing generated-native warnings)
- `pnpm format:check`
- focused reliability suites: 6 files / 107 tests passed
- isolated live discovery: 2 files / 18 tests passed
- real free-model bootstrap: OpenCode + Kilo, 2 files / 4 tests passed, including cross-chat registration retention
- live Kilo one-shot hit `external_directory`; the new watchdog approved it and the run completed
- full suite: 251 files / 4,332 tests passed; its sole failure was the packaging smoke test rejecting a pnpm-injected npm config warning on stderr, and that test passes 2/2 when Vitest is invoked directly

## Follow-up: the last capability-slot gap

OpenCode and Kilo exposed no `sessions` slot at all, so `performSessionReset`
and the native frontend's reset both silently skipped `warmSession` on them.
`/reset` still worked — the stored session id is cleared centrally in
`storage/sessions.ts` — but the next turn then serially paid session creation
plus a full plugin-MCP registration sweep, the dominant cold-start cost here
since every plugin server is a separate connect.

`warmRemoteSession` front-loads that work (spawn server, create/resume session,
register chat + plugin MCP servers) and is shared, since both backends expose
identical signatures. Best-effort by contract: the reset has already succeeded
by the time it runs and every step repeats idempotently at the head of each
turn, so a failure degrades to a slow first turn rather than a failed reset.

### Slot parity after this change

| | claude | codex | opencode | kilo |
|---|---|---|---|---|
| `interruptChatTurn` | ✓ | ✓ | ✓ | ✓ |
| `warmSession` | ✓ | – | ✓ | ✓ |
| `refreshTools` | ✓ | – | ✓ | ✓ |
| `updateSystemPrompt` | ✓ | – | ✓ | ✓ |
| `getSessionSnapshot` | – | – | ✓ | ✓ |
| `evictOrphanSubprocesses` | ✓ | – | n/a | n/a |

`evictOrphanSubprocesses` stays unimplemented on purpose: these backends drive
one long-lived shared server rather than a subprocess per run, so there is
nothing to evict (already documented in `remote-server/one-shot.ts`).

### Added validation

- `backend-registry-parity` — 9 passed, including a live warm against real
  OpenCode and Kilo servers and a "warm never rejects when the server is
  unreachable" contract test
- backend suites (registry, conformance, contract, controller, pool,
  remote-server session helpers + MCP) — 116 passed
- `npm run test:opencode:backend` — 7 passed; `npm run test:kilo:backend` — 11 passed
- `npx tsc --noEmit`, `oxlint`, `prettier`

## Follow-up 2: backend-switch session handoff

Switching a chat's backend cleared Talon's own stores (session row, history,
pulse checkpoint) but never drove the backend capability slots that
`performSessionReset` drives, so half the state survived the switch:

- The **outgoing** backend kept its in-process per-chat state. openai-agents
  keys a `MemorySession` by chat id, so switching away and back resurrected
  the conversation the operator had just dropped. It now gets `resetChat`,
  resolved *before* the rebind while it is still reachable.
- The **incoming** backend was never warmed, so the first turn after a switch
  paid the full cold start — on OpenCode/Kilo, session creation plus a
  per-plugin MCP registration sweep. It now gets `warmSession`.

The warm is deliberately fire-and-forget: it can take seconds, the callback
still has a toast to answer and a menu to redraw, and Telegram expires an
unanswered callback query — blocking would trade a cold first turn for a
visibly stuck button. A rejected warm is logged, never surfaced.

Covers both switch paths (pick a backend, revert to default). All three new
tests fail without the fix.