### PR TITLE
feat(status): show plan rate limits and session cost

### DIFF
--- a/src/__tests__/plan-usage.test.ts
+++ b/src/__tests__/plan-usage.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { parsePlanUsage } from "../backend/claude-sdk/plan-usage.js";
+import { buildPlanDisplay } from "../frontend/shared/status-context.js";
+import { setTimezone } from "../util/time.js";
+
+/** Shape of one row as the usage endpoint reports it. */
+function limit(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    kind: "weekly_all",
+    group: "weekly",
+    percent: 12,
+    severity: "normal",
+    resets_at: "2026-08-06T12:00:00.149270+00:00",
+    scope: null,
+    is_active: true,
+    ...over,
+  };
+}
+
+describe("parsePlanUsage", () => {
+  it("labels the documented window kinds", () => {
+    const usage = parsePlanUsage(
+      {
+        limits: [
+          limit({ kind: "session", percent: 4 }),
+          limit({ kind: "weekly_all", percent: 12 }),
+          limit({
+            kind: "weekly_scoped",
+            percent: 0,
+            resets_at: null,
+            scope: {
+              model: { id: null, display_name: "Fable" },
+              surface: null,
+            },
+          }),
+        ],
+      },
+      "max",
+    );
+
+    expect(usage?.plan).toBe("max");
+    expect(usage?.windows.map((w) => w.label)).toEqual(["5h", "7d", "Fable"]);
+  });
+
+  it("keeps a scoped window that is reported at zero", () => {
+    const usage = parsePlanUsage({
+      limits: [
+        limit({
+          kind: "weekly_scoped",
+          percent: 0,
+          resets_at: null,
+          scope: { model: { display_name: "Fable" } },
+        }),
+      ],
+    });
+    expect(usage?.windows).toEqual([{ label: "Fable", percent: 0 }]);
+  });
+
+  it("skips undocumented kinds and unnamed scopes", () => {
+    const usage = parsePlanUsage({
+      limits: [
+        limit(),
+        limit({ kind: "monthly_experiment", percent: 90 }),
+        limit({ kind: "weekly_scoped", scope: null }),
+      ],
+    });
+    expect(usage?.windows.map((w) => w.label)).toEqual(["7d"]);
+  });
+
+  it("clamps and rounds the percentage", () => {
+    const usage = parsePlanUsage({
+      limits: [
+        limit({ kind: "session", percent: 4.6 }),
+        limit({ kind: "weekly_all", percent: 140 }),
+        limit({
+          kind: "weekly_scoped",
+          percent: undefined,
+          scope: { model: { display_name: "Fable" } },
+        }),
+      ],
+    });
+    expect(usage?.windows.map((w) => w.percent)).toEqual([5, 100, 0]);
+  });
+
+  it("returns undefined when nothing renderable came back", () => {
+    expect(parsePlanUsage({})).toBeUndefined();
+    expect(parsePlanUsage(null)).toBeUndefined();
+    expect(parsePlanUsage({ limits: [] })).toBeUndefined();
+    expect(
+      parsePlanUsage({ limits: [limit({ kind: "codename_window" })] }),
+    ).toBeUndefined();
+  });
+});
+
+describe("buildPlanDisplay", () => {
+  beforeAll(() => setTimezone("UTC"));
+  afterAll(() => setTimezone(undefined));
+
+  it("renders a bar per window", () => {
+    const display = buildPlanDisplay(
+      {
+        plan: "max",
+        fetchedAt: Date.now(),
+        windows: [
+          { label: "5h", percent: 0 },
+          { label: "7d", percent: 50 },
+        ],
+      },
+      10,
+    );
+
+    expect(display?.windows[0]?.bar).toBe("░".repeat(10));
+    expect(display?.windows[1]?.bar).toBe("█".repeat(5) + "░".repeat(5));
+    expect(display?.ageLabel).toBeUndefined();
+  });
+
+  it("rounds a reset reported a second short of the boundary", () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const display = buildPlanDisplay({
+      fetchedAt: Date.now(),
+      windows: [
+        { label: "5h", percent: 3, resetsAt: `${today}T20:59:59.509831+00:00` },
+      ],
+    });
+    expect(display?.windows[0]?.resetLabel).toBe("21:00");
+  });
+
+  it("ages figures that are no longer fresh", () => {
+    const display = buildPlanDisplay({
+      fetchedAt: Date.now() - 12 * 60_000,
+      windows: [{ label: "7d", percent: 12 }],
+    });
+    expect(display?.ageLabel).toBe("12m ago");
+  });
+
+  it("hides the section when there is nothing to show", () => {
+    expect(buildPlanDisplay(undefined)).toBeNull();
+    expect(buildPlanDisplay({ fetchedAt: Date.now(), windows: [] })).toBeNull();
+  });
+});

--- a/src/backend/claude-sdk/factory.ts
+++ b/src/backend/claude-sdk/factory.ts
@@ -22,7 +22,9 @@ import {
   type SessionBackend,
   type SystemControl,
   type ToolRuntime,
+  type UsageTelemetry,
 } from "../../core/agent-runtime/capabilities.js";
+import { getPlanUsage } from "./plan-usage.js";
 
 import {
   initAgent as initClaudeAgent,
@@ -117,6 +119,12 @@ const claudeSdkFactory: BackendFactory = {
       updateSystemPrompt: (prompt) => claudeUpdateSystemPrompt(prompt),
     };
 
+    // No per-session snapshot to offer (each turn is a fresh subprocess),
+    // but the subscription's rate-limit windows are readable.
+    const usage: UsageTelemetry = {
+      getPlanUsage: () => getPlanUsage(),
+    };
+
     const backend = composeBackend({
       id: "claude",
       label: "Anthropic",
@@ -126,6 +134,7 @@ const claudeSdkFactory: BackendFactory = {
       models,
       sessions,
       tools,
+      usage,
       control,
     });
 

--- a/src/backend/claude-sdk/handler.ts
+++ b/src/backend/claude-sdk/handler.ts
@@ -36,6 +36,7 @@ import { applyRetryDecisionStream } from "../shared/handle-retry.js";
 import { getConfig } from "./state.js";
 import { buildSdkOptions, getActiveFrontends } from "./options.js";
 import { waitForMcpServersReady } from "./mcp-ready.js";
+import { invalidatePlanUsage } from "./plan-usage.js";
 import { frontendsForChat } from "../shared/frontends.js";
 import {
   createStreamState,
@@ -43,6 +44,7 @@ import {
   isStreamEvent,
   isAssistant,
   isResult,
+  isRateLimitEvent,
   isUserMessage,
   extractToolResults,
   processStreamDelta,
@@ -384,6 +386,14 @@ export async function* runChatTurn(
         continue;
       }
 
+      // The turn just moved the plan's usage — drop the cached windows so
+      // the next /status reads them again instead of showing pre-turn
+      // figures.
+      if (isRateLimitEvent(message)) {
+        invalidatePlanUsage();
+        continue;
+      }
+
       if (isResult(message)) {
         processResultMessage(message, state, options.model ?? activeModel);
         armPostResultWatchdog();
@@ -515,6 +525,7 @@ export async function* runChatTurn(
     contextTokens: state.contextTokens,
     contextWindow: state.contextWindow,
     numApiCalls: state.numApiCalls,
+    costUsd: state.costUsd,
   });
 
   // Set a descriptive session name from the first message.

--- a/src/backend/claude-sdk/plan-usage.ts
+++ b/src/backend/claude-sdk/plan-usage.ts
@@ -1,0 +1,170 @@
+/**
+ * Claude.ai subscription rate-limit windows for /status.
+ *
+ * The 5-hour, weekly, and per-model utilisation percentages come from the
+ * same OAuth endpoint Claude Code's own usage panel reads. The Agent SDK
+ * also exposes them through a control request, but that path additionally
+ * builds a local-session behaviour report and costs seconds per call; the
+ * endpoint alone answers in well under a second.
+ *
+ * Everything degrades to `undefined`: no credentials, an API-key session
+ * (plan limits don't apply), or any transport failure. /status hides the
+ * section rather than rendering zeroes.
+ */
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logWarn } from "../../util/log.js";
+import type {
+  PlanUsage,
+  PlanWindow,
+} from "../../core/agent-runtime/capabilities.js";
+
+const USAGE_ENDPOINT = "https://api.anthropic.com/api/oauth/usage";
+const REQUEST_TIMEOUT_MS = 5_000;
+const CACHE_TTL_MS = 60_000;
+
+let cache: { value: PlanUsage; fetchedAt: number } | undefined;
+let inFlight: Promise<PlanUsage | undefined> | undefined;
+
+function credentialsPath(): string {
+  const configDir = process.env.CLAUDE_CONFIG_DIR?.trim();
+  return join(
+    configDir && configDir.length > 0 ? configDir : join(homedir(), ".claude"),
+    ".credentials.json",
+  );
+}
+
+interface OAuthCredentials {
+  accessToken?: string;
+  subscriptionType?: string;
+}
+
+async function readCredentials(): Promise<OAuthCredentials | undefined> {
+  try {
+    const parsed = JSON.parse(await readFile(credentialsPath(), "utf8")) as {
+      claudeAiOauth?: OAuthCredentials;
+    };
+    const oauth = parsed.claudeAiOauth;
+    return oauth?.accessToken ? oauth : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+interface RawLimit {
+  kind?: string;
+  percent?: number;
+  resets_at?: string | null;
+  scope?: { model?: { display_name?: string | null } | null } | null;
+}
+
+/**
+ * Short display label for one window, or undefined to skip the row.
+ *
+ * Only the three documented kinds are rendered. The response also carries
+ * internal codenamed windows; skipping unknown kinds keeps those out of the
+ * user-facing panel.
+ */
+function windowLabel(limit: RawLimit): string | undefined {
+  if (limit.kind === "session") return "5h";
+  if (limit.kind === "weekly_all") return "7d";
+  if (limit.kind === "weekly_scoped") {
+    const model = limit.scope?.model?.display_name?.trim();
+    return model && model.length > 0 ? model : undefined;
+  }
+  return undefined;
+}
+
+export function parsePlanUsage(
+  body: unknown,
+  subscriptionType?: string,
+): PlanUsage | undefined {
+  const limits = (body as { limits?: unknown } | null)?.limits;
+  if (!Array.isArray(limits)) return undefined;
+
+  const windows: PlanWindow[] = [];
+  for (const limit of limits as RawLimit[]) {
+    const label = windowLabel(limit);
+    if (!label) continue;
+    const raw = limit.percent;
+    const percent =
+      typeof raw === "number" && Number.isFinite(raw)
+        ? Math.max(0, Math.min(100, Math.round(raw)))
+        : 0;
+    windows.push({
+      label,
+      percent,
+      ...(typeof limit.resets_at === "string"
+        ? { resetsAt: limit.resets_at }
+        : {}),
+    });
+  }
+
+  if (windows.length === 0) return undefined;
+  return {
+    ...(subscriptionType ? { plan: subscriptionType } : {}),
+    windows,
+    fetchedAt: Date.now(),
+  };
+}
+
+async function load(): Promise<PlanUsage | undefined> {
+  const creds = await readCredentials();
+  if (!creds?.accessToken) return undefined;
+
+  try {
+    const res = await fetch(USAGE_ENDPOINT, {
+      headers: {
+        Authorization: `Bearer ${creds.accessToken}`,
+        "anthropic-beta": "oauth-2025-04-20",
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      logWarn("agent", `plan usage: endpoint returned ${res.status}`);
+      return undefined;
+    }
+    return parsePlanUsage(await res.json(), creds.subscriptionType);
+  } catch (err) {
+    logWarn(
+      "agent",
+      `plan usage: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Plan windows for /status, cached for a minute so a burst of commands
+ * makes one request. A failed refresh falls back to the last known values
+ * — `fetchedAt` lets the caller age them.
+ */
+export async function getPlanUsage(): Promise<PlanUsage | undefined> {
+  // An API-key session bills against the key, not the subscription, so the
+  // stored OAuth credentials would describe limits that don't apply here.
+  if (process.env.ANTHROPIC_API_KEY) return undefined;
+
+  if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) return cache.value;
+
+  inFlight ??= load().finally(() => {
+    inFlight = undefined;
+  });
+  const loaded = await inFlight;
+  if (loaded) cache = { value: loaded, fetchedAt: loaded.fetchedAt };
+  return loaded ?? cache?.value;
+}
+
+/**
+ * Expire the cache after the SDK reports a rate-limit change, so the next
+ * /status re-reads instead of showing figures from before the turn.
+ */
+export function invalidatePlanUsage(): void {
+  if (cache) cache.fetchedAt = 0;
+}
+
+export function resetPlanUsageForTest(): void {
+  cache = undefined;
+  inFlight = undefined;
+}

--- a/src/backend/claude-sdk/stream.ts
+++ b/src/backend/claude-sdk/stream.ts
@@ -39,6 +39,8 @@ export type StreamState = {
   sdkOutputTokens: number;
   sdkCacheRead: number;
   sdkCacheWrite: number;
+  /** Cost of this turn in USD, as reported by the result message. */
+  costUsd: number;
   /**
    * Per-turn cache behaviour derived from the result message's per-request
    * `usage.iterations`. Undefined when the provider reported none — the
@@ -113,6 +115,7 @@ export function createStreamState(): StreamState {
     sdkOutputTokens: 0,
     sdkCacheRead: 0,
     sdkCacheWrite: 0,
+    costUsd: 0,
     cacheStats: undefined,
     lastStreamUpdate: 0,
     lastTrailingText: "",
@@ -146,6 +149,11 @@ export function isUserMessage(msg: SDKMessage): msg is SDKUserMessage {
 
 export function isResult(msg: SDKMessage): msg is SDKResultMessage {
   return msg.type === "result";
+}
+
+/** Emitted when the subscription's rate-limit state changes mid-turn. */
+export function isRateLimitEvent(msg: SDKMessage): boolean {
+  return msg.type === "rate_limit_event";
 }
 
 // ── Message processors ──────────────────────────────────────────────────────
@@ -336,6 +344,11 @@ export function processResultMessage(
   sdkModel: string,
 ): void {
   state.numApiCalls = msg.num_turns ?? 0;
+
+  // Per-turn, not cumulative across a resumed session — safe to add up.
+  if (typeof msg.total_cost_usd === "number" && msg.total_cost_usd > 0) {
+    state.costUsd = msg.total_cost_usd;
+  }
 
   // Context fill from last API iteration
   const usage = msg.usage;

--- a/src/core/agent-runtime/capabilities.ts
+++ b/src/core/agent-runtime/capabilities.ts
@@ -199,10 +199,11 @@ export interface ToolRuntime {
 }
 
 /**
- * `/status` enrichment. Backends that track per-session usage
- * (Codex, OpenAI Agents) implement this. Backends without a
- * per-session model (Claude SDK on a fresh subprocess per turn)
- * return `undefined`.
+ * `/status` enrichment. Both members are optional — a backend
+ * implements whichever it can answer. Backends that track per-session
+ * usage (Codex, OpenAI Agents) supply `getSessionSnapshot`; a backend
+ * with no per-session model (Claude SDK on a fresh subprocess per
+ * turn) omits it and may still report plan limits.
  *
  * The snapshot's `contextModelId` carries the resolved-this-turn
  * model id when the SDK can surface it. Frontend `/status` reads
@@ -211,7 +212,7 @@ export interface ToolRuntime {
  * ChatGPT-OAuth).
  */
 export interface UsageTelemetry {
-  getSessionSnapshot(sessionId: string): Promise<
+  getSessionSnapshot?(sessionId: string): Promise<
     | {
         inputTokens?: number;
         outputTokens?: number;
@@ -221,6 +222,31 @@ export interface UsageTelemetry {
       }
     | undefined
   >;
+  /**
+   * Subscription rate-limit windows. Account-level rather than
+   * per-chat: `/status` renders whichever backend can answer, even
+   * when another one is serving the chat. Absent on backends with no
+   * plan concept; resolves `undefined` when the data can't be read.
+   */
+  getPlanUsage?(): Promise<PlanUsage | undefined>;
+}
+
+/** One subscription rate-limit window, as `/status` renders it. */
+export interface PlanWindow {
+  /** Short label — `5h`, `7d`, or the scoped model's display name. */
+  label: string;
+  /** Window utilisation, 0-100. */
+  percent: number;
+  /** ISO timestamp of the next reset, when the plan reports one. */
+  resetsAt?: string;
+}
+
+export interface PlanUsage {
+  /** Subscription tier (`max`, `pro`, …) when known. */
+  plan?: string;
+  windows: PlanWindow[];
+  /** Epoch ms of the read, so renderers can flag figures as aged. */
+  fetchedAt: number;
 }
 
 /**

--- a/src/core/agent-runtime/contract-tests.ts
+++ b/src/core/agent-runtime/contract-tests.ts
@@ -272,16 +272,16 @@ export async function assertModelCatalogDefaultShape(
 }
 
 /**
- * Backends that expose `UsageTelemetry` must answer
- * `getSessionSnapshot` with either a `UsageSnapshot` object whose
- * counters are non-negative numbers, or `undefined`. Negative
- * counters or `NaN`s are contract violations.
+ * Backends that implement `getSessionSnapshot` must answer it with
+ * either a `UsageSnapshot` object whose counters are non-negative
+ * numbers, or `undefined`. Negative counters or `NaN`s are contract
+ * violations. Backends that only report plan limits are skipped.
  */
 export async function assertUsageTelemetryShape(
   backend: Backend,
   sessionId = "contract-test-session",
 ): Promise<void> {
-  if (!backend.usage) return;
+  if (!backend.usage?.getSessionSnapshot) return;
   const snapshot = await backend.usage.getSessionSnapshot(sessionId);
   if (snapshot === undefined) return;
   const fields: (keyof typeof snapshot)[] = [

--- a/src/core/engine/gateway-actions/models.ts
+++ b/src/core/engine/gateway-actions/models.ts
@@ -98,6 +98,39 @@ export const modelHandlers: SharedActionHandlers = {
     }
   },
 
+  // Account-level, so it falls back to the pooled Claude backend when
+  // another provider is serving this chat.
+  plan_usage: async (_body, chatId) => {
+    const current = getPooledBackend(getBackendIdForChat(String(chatId)));
+    const source = current?.usage?.getPlanUsage
+      ? current
+      : getPooledBackend("claude");
+    if (!source?.usage?.getPlanUsage)
+      return {
+        ok: false,
+        error: "No configured backend reports subscription rate limits.",
+      };
+
+    const usage = await source.usage.getPlanUsage();
+    if (!usage)
+      return {
+        ok: false,
+        error:
+          "Plan usage is unavailable — no subscription credentials, or this session authenticates with an API key.",
+      };
+
+    const lines = usage.windows.map(
+      (w) =>
+        `- ${w.label}: ${w.percent}% used${w.resetsAt ? `, resets ${w.resetsAt}` : ""}`,
+    );
+    return {
+      ok: true,
+      plan: usage.plan ?? null,
+      windows: usage.windows,
+      text: `Plan usage${usage.plan ? ` (${usage.plan})` : ""}:\n${lines.join("\n")}`,
+    };
+  },
+
   list_backends: (body, chatId) => {
     const currentId = getBackendIdForChat(String(chatId));
     const backends = getAvailableBackends().map((b) => ({

--- a/src/core/tools/models.ts
+++ b/src/core/tools/models.ts
@@ -29,6 +29,15 @@ export const modelTools: ToolDefinition[] = [
   },
 
   {
+    name: "plan_usage",
+    description:
+      "Read your own subscription usage: how much of the 5-hour, weekly, and per-model rate-limit windows is spent, and when each resets. Use it before starting long or expensive work, or when deciding whether to defer something. Only answers on a subscription-backed Anthropic backend; other providers report no plan limits.",
+    schema: {},
+    execute: (_params, bridge) => bridge("plan_usage", {}),
+    tag: "models",
+  },
+
+  {
     name: "list_backends",
     description:
       "List the available backends (providers) and which one this chat is currently using. Useful for understanding the model/provider landscape. Note: a per-job `model` override must stay on this chat's current backend, so use list_models (no argument) to pick a model for a trigger or cron job.",

--- a/src/frontend/discord/commands/session.ts
+++ b/src/frontend/discord/commands/session.ts
@@ -13,6 +13,7 @@ import {
   formatDuration,
   formatTokenCount,
   formatBytes,
+  formatUsd,
 } from "../helpers.js";
 import {
   getBackendIdForChat,
@@ -78,8 +79,18 @@ export async function handleStatus(
           `  Read ${formatTokenCount(s.cache.read)}${s.cache.showsWrite ? `  Write ${formatTokenCount(s.cache.write)}` : ""}`,
         ]
       : []),
-    `  Input ${formatTokenCount(s.inputTokens)}  Output ${formatTokenCount(s.outputTokens)}`,
+    `  Input ${formatTokenCount(s.inputTokens)}  Output ${formatTokenCount(s.outputTokens)}${s.costUsd > 0 ? `  Cost ${formatUsd(s.costUsd)}` : ""}`,
     "",
+    ...(s.plan
+      ? [
+          `**Plan**${s.plan.plan ? `  ${s.plan.plan}` : ""}${s.plan.ageLabel ? ` *(${s.plan.ageLabel})*` : ""}`,
+          ...s.plan.windows.map(
+            (w) =>
+              `  \`${w.label.padEnd(6)}${w.bar} ${String(w.percent).padStart(3)}%\`${w.resetLabel ? ` reset ${w.resetLabel}` : ""}`,
+          ),
+          "",
+        ]
+      : []),
     `**Pulse**  ${s.pulseOn ? "on" : "off"}`,
     `**Workspace**  ${formatBytes(s.diskBytes)}`,
     `**Session**   ${s.sessionName ? `"${s.sessionName}" ` : ""}${s.sessionId ? "`" + s.sessionId.slice(0, 8) + "...`" : "_(new)_"} · ${s.sessionAge} old`,

--- a/src/frontend/discord/helpers.ts
+++ b/src/frontend/discord/helpers.ts
@@ -20,6 +20,7 @@ export {
   formatDuration,
   formatTokenCount,
   formatBytes,
+  formatUsd,
   formatModelLabel,
 } from "../shared/format.js";
 

--- a/src/frontend/shared/session-status.ts
+++ b/src/frontend/shared/session-status.ts
@@ -23,11 +23,14 @@ import { isPulseEnabled } from "../../core/background/pulse.js";
 import { getWorkspaceDiskUsage } from "../../util/workspace.js";
 import { appendDailyLog } from "../../storage/daily-log.js";
 import { resolveActiveModelForChat } from "../../core/models/active-model.js";
+import { getPooledBackend } from "../../core/engine/backend-controller/index.js";
 import {
   buildCacheDisplay,
   buildContextDisplay,
+  buildPlanDisplay,
   type CacheDisplay,
   type ContextDisplay,
+  type PlanDisplay,
 } from "./status-context.js";
 import { formatDuration } from "./format.js";
 
@@ -70,8 +73,10 @@ export interface SessionStatusData {
   pulseOn: boolean;
   context: ContextDisplay;
   cache: CacheDisplay | null;
+  plan: PlanDisplay | null;
   inputTokens: number;
   outputTokens: number;
+  costUsd: number;
   turns: number;
   turnsModelLabel: string | undefined;
   lastResponseMs: number;
@@ -157,6 +162,16 @@ export async function collectSessionStatus(
     contextWindow: ctxMax,
   });
 
+  // Plan limits belong to the account, not the chat: fall back to the pooled
+  // Claude backend so the section still shows while another provider serves
+  // this chat.
+  const planSource = backend?.usage?.getPlanUsage
+    ? backend
+    : getPooledBackend("claude");
+  const plan = buildPlanDisplay(
+    await planSource?.usage?.getPlanUsage?.().catch(() => undefined),
+  );
+
   const avgResponseMs =
     info.turns > 0 && u.totalResponseMs
       ? Math.round(u.totalResponseMs / info.turns)
@@ -170,8 +185,10 @@ export async function collectSessionStatus(
     pulseOn: isPulseEnabled(chatId),
     context,
     cache,
+    plan,
     inputTokens,
     outputTokens,
+    costUsd: u.estimatedCostUsd,
     turns: info.turns,
     turnsModelLabel,
     lastResponseMs: u.lastResponseMs || 0,

--- a/src/frontend/shared/status-context.ts
+++ b/src/frontend/shared/status-context.ts
@@ -1,4 +1,6 @@
 import type { CacheMetricsSupport } from "../../core/types.js";
+import type { PlanUsage } from "../../core/agent-runtime/capabilities.js";
+import { formatSmartTimestamp, formatRelativeAge } from "../../util/time.js";
 
 // ── /context breakdown ────────────────────────────────────────────────────────
 
@@ -282,5 +284,65 @@ export function buildCacheDisplay(input: {
     read,
     write,
     showsWrite: mode === "readwrite",
+  };
+}
+
+// ── Plan limits ─────────────────────────────────────────────────────────────
+
+/** Figures older than this are labelled with their age in /status. */
+const PLAN_STALE_AFTER_MS = 5 * 60_000;
+
+export interface PlanWindowDisplay {
+  label: string;
+  percent: number;
+  bar: string;
+  /** Local-time reset, absent for windows the plan reports no reset for. */
+  resetLabel: string | undefined;
+}
+
+export interface PlanDisplay {
+  plan: string | undefined;
+  windows: PlanWindowDisplay[];
+  /** Set only once the figures have aged, e.g. "12m ago". */
+  ageLabel: string | undefined;
+}
+
+function planResetLabel(iso: string | undefined): string | undefined {
+  if (!iso) return undefined;
+  const ts = Date.parse(iso);
+  if (!Number.isFinite(ts)) return undefined;
+  // Windows are reported a second short of the boundary (20:59:59); round to
+  // the minute so the panel reads 21:00, as the plan's own dashboards do.
+  return formatSmartTimestamp(Math.round(ts / 60_000) * 60_000);
+}
+
+/**
+ * Lay out the subscription's rate-limit windows for /status. Returns null
+ * when the backend has nothing to report, so the section disappears rather
+ * than rendering empty bars.
+ */
+export function buildPlanDisplay(
+  usage: PlanUsage | undefined,
+  barLen = 20,
+): PlanDisplay | null {
+  if (!usage || usage.windows.length === 0) return null;
+
+  const age = Date.now() - usage.fetchedAt;
+  return {
+    plan: usage.plan,
+    ageLabel:
+      age > PLAN_STALE_AFTER_MS
+        ? formatRelativeAge(usage.fetchedAt)
+        : undefined,
+    windows: usage.windows.map((w) => {
+      const percent = Math.max(0, Math.min(100, Math.round(w.percent)));
+      const filled = Math.round((percent / 100) * barLen);
+      return {
+        label: w.label,
+        percent,
+        bar: "█".repeat(filled) + "░".repeat(barLen - filled),
+        resetLabel: planResetLabel(w.resetsAt),
+      };
+    }),
   };
 }

--- a/src/frontend/telegram/commands/session.ts
+++ b/src/frontend/telegram/commands/session.ts
@@ -12,6 +12,7 @@ import {
   formatDuration,
   formatTokenCount,
   formatBytes,
+  formatUsd,
 } from "../helpers/index.js";
 import { resolveBackendForChat } from "../model-menu.js";
 import { getBackendIdForChat } from "../../../core/engine/backend-controller/index.js";
@@ -65,8 +66,18 @@ export function registerSessionCommands(
             `  Read ${formatTokenCount(s.cache.read)}${s.cache.showsWrite ? `  Write ${formatTokenCount(s.cache.write)}` : ""}`,
           ]
         : []),
-      `  Input ${formatTokenCount(s.inputTokens)}  Output ${formatTokenCount(s.outputTokens)}`,
+      `  Input ${formatTokenCount(s.inputTokens)}  Output ${formatTokenCount(s.outputTokens)}${s.costUsd > 0 ? `  Cost ${formatUsd(s.costUsd)}` : ""}`,
       "",
+      ...(s.plan
+        ? [
+            `<b>Plan</b>${s.plan.plan ? `  ${escapeHtml(s.plan.plan)}` : ""}${s.plan.ageLabel ? ` <i>(${s.plan.ageLabel})</i>` : ""}`,
+            ...s.plan.windows.map(
+              (w) =>
+                `  <code>${escapeHtml(w.label.padEnd(6))}${w.bar} ${String(w.percent).padStart(3)}%</code>${w.resetLabel ? ` reset ${w.resetLabel}` : ""}`,
+            ),
+            "",
+          ]
+        : []),
       `<b>Pulse</b>  ${s.pulseOn ? "on" : "off"}`,
       `<b>Workspace</b>  ${formatBytes(s.diskBytes)}`,
       `<b>Session</b>   ${s.sessionName ? `"${escapeHtml(s.sessionName)}" ` : ""}${s.sessionId ? "<code>" + escapeHtml(s.sessionId.slice(0, 8)) + "...</code>" : "<i>(new)</i>"} · ${s.sessionAge} old`,

--- a/src/frontend/telegram/helpers/format.ts
+++ b/src/frontend/telegram/helpers/format.ts
@@ -13,6 +13,7 @@ export {
   formatDuration,
   formatTokenCount,
   formatBytes,
+  formatUsd,
   formatModelLabel,
 } from "../../shared/format.js";
 

--- a/src/frontend/terminal/commands.ts
+++ b/src/frontend/terminal/commands.ts
@@ -18,6 +18,7 @@ import {
 import {
   buildCacheDisplay,
   buildContextDisplay,
+  buildPlanDisplay,
   buildContextBreakdown,
   estimateContextTokens,
   apportionCells,
@@ -43,6 +44,7 @@ import {
   setSessionName,
 } from "../../storage/sessions.js";
 import { getLoadedPlugins } from "../../core/plugin/index.js";
+import { getPooledBackend } from "../../core/engine/backend-controller/index.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -429,6 +431,24 @@ export function registerBuiltinCommands(): void {
         ctx.renderer.writeln(
           `  ${pc.dim(`estimated session cost ${formatUsd(u.estimatedCostUsd)}`)}`,
         );
+      }
+
+      const planSource = be?.usage?.getPlanUsage
+        ? be
+        : getPooledBackend("claude");
+      const plan = buildPlanDisplay(
+        await planSource?.usage?.getPlanUsage?.().catch(() => undefined),
+      );
+      if (plan) {
+        ctx.renderer.writeln();
+        ctx.renderer.writeln(
+          `  ${pc.bold("Plan")}${plan.plan ? `  ${plan.plan}` : ""}${plan.ageLabel ? pc.dim(`  (${plan.ageLabel})`) : ""}`,
+        );
+        for (const w of plan.windows) {
+          ctx.renderer.writeln(
+            `  ${w.label.padEnd(6)}${pc.dim(w.bar)} ${String(w.percent).padStart(3)}%${w.resetLabel ? pc.dim(`  reset ${w.resetLabel}`) : ""}`,
+          );
+        }
       }
       if (backendModelLine) {
         ctx.renderer.writeln();


### PR DESCRIPTION
`/status` had no view of the subscription's rate-limit windows, and the session cost it could have shown was never populated: `recordUsage` has always accepted `costUsd`, but no backend passed one, so `estimatedCostUsd` stayed at zero and the terminal's cost line (gated on `> 0`) never rendered.

### Plan limits

The Claude backend reports the plan's 5-hour, weekly, and per-model windows through a new optional `UsageTelemetry.getPlanUsage`.

It reads the OAuth usage endpoint directly rather than going through the SDK's usage control request. Measured on a Raspberry Pi 5, same account, same values returned:

| path | latency |
|---|---|
| `GET /api/oauth/usage` | 277 / 407 / 676 ms (min / median / max over 5 calls) |
| SDK `usage_EXPERIMENTAL…` | 40.7s cold, then 6.9s and 7.9s in the same process |

The control request stays slow because it also builds a local-session behaviour report on every call, which `/status` does not need.

Windows come from the response's `limits[]` array rather than the flat keys. That array is self-describing — a model-scoped row carries its own display name (currently Fable) — and it keeps undocumented internal windows out of the panel: the flat form of the same response carries `seven_day_cowork`, `tangelo`, `iguana_necktie`, `nimbus_quill` and friends, all null today, which a key-iterating renderer would eventually surface to users.

Plan limits belong to the account rather than the chat, so `/status` falls back to the pooled `claude` backend when another provider is serving the chat. A `rate_limit_event` mid-turn expires the cache, so the next `/status` re-reads instead of showing pre-turn figures. An API-key session reports nothing, since the stored subscription credentials would describe limits that don't apply to it.

The same data is exposed to the model as a `plan_usage` tool, so the bot can check its own headroom before starting long work.

```
Plan  max
  5h    █░░░░░░░░░░░░░░░░░░░   4%  reset 23:00
  7d    ██▌░░░░░░░░░░░░░░░░░  12%  reset Aug 6 14:00
  Fable ░░░░░░░░░░░░░░░░░░░░   0%
```

### Session cost

Cost now comes from the result message's `total_cost_usd`, which is per-turn rather than cumulative across a resumed session (verified against a two-turn resumed session). Telegram and Discord render it next to the token counts; the terminal's existing line starts working.

### Notes

- `UsageTelemetry.getSessionSnapshot` became optional so a backend can report plan limits without a per-session snapshot. Every existing call site already guarded it; `assertUsageTelemetryShape` now skips backends that don't implement it.
- Other backends are untouched — an absent slot simply hides the section.
- Rendered in Telegram, Discord and the terminal; 9 unit tests cover window parsing (including the Fable row at zero, clamping, and skipping unknown kinds) and the display builder.
