### PR TITLE
feat(background): warn the admin chat before plan limits run out

### DIFF
--- a/src/__tests__/integration/talon-bootstrap.ts
+++ b/src/__tests__/integration/talon-bootstrap.ts
@@ -176,6 +176,8 @@ export async function ensureBooted(args: EnsureBootedArgs = {}): Promise<void> {
     concurrency: 1,
     pulse: false,
     pulseIntervalMs: 300_000,
+    planAlerts: false,
+    planAlertThreshold: 80,
     // Dreams read ~/.talon dream state and fire-and-forget a one-shot
     // agent mid-turn — nondeterministic in tests. Explicitly disabled.
     dream: false,

--- a/src/__tests__/plan-alerts.test.ts
+++ b/src/__tests__/plan-alerts.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  initPlanAlerts,
+  checkPlanAlerts,
+  resetPlanAlertsForTest,
+} from "../core/background/plan-alerts.js";
+import type { PlanUsage } from "../core/agent-runtime/capabilities.js";
+
+const getPooledBackend = vi.hoisted(() => vi.fn());
+vi.mock("../core/engine/backend-controller/index.js", () => ({
+  getPooledBackend,
+}));
+
+let sent: string[] = [];
+
+function planUsage(windows: PlanUsage["windows"]): {
+  usage: { getPlanUsage: () => Promise<PlanUsage> };
+} {
+  return {
+    usage: {
+      getPlanUsage: async () => ({
+        plan: "max",
+        fetchedAt: Date.now(),
+        windows,
+      }),
+    },
+  };
+}
+
+function arm(threshold = 80): void {
+  initPlanAlerts({
+    sendMessage: async (_chatId, text) => {
+      sent.push(text);
+    },
+    enabled: true,
+    threshold,
+    chatId: "123",
+  });
+}
+
+describe("plan alerts", () => {
+  beforeEach(() => {
+    sent = [];
+    getPooledBackend.mockReset();
+  });
+  afterEach(() => resetPlanAlertsForTest());
+
+  it("warns once a window crosses the threshold", async () => {
+    getPooledBackend.mockReturnValue(
+      planUsage([{ label: "7d", percent: 82, resetsAt: undefined }]),
+    );
+    arm();
+    await checkPlanAlerts();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain("7d");
+    expect(sent[0]).toContain("82%");
+  });
+
+  it("stays quiet below the threshold", async () => {
+    getPooledBackend.mockReturnValue(planUsage([{ label: "7d", percent: 79 }]));
+    arm();
+    await checkPlanAlerts();
+    expect(sent).toEqual([]);
+  });
+
+  it("does not repeat within the same reset cycle", async () => {
+    getPooledBackend.mockReturnValue(
+      planUsage([
+        { label: "7d", percent: 82, resetsAt: "2026-08-06T12:00:00Z" },
+      ]),
+    );
+    arm();
+    await checkPlanAlerts();
+    await checkPlanAlerts();
+    await checkPlanAlerts();
+    expect(sent).toHaveLength(1);
+  });
+
+  it("warns again in the next reset cycle", async () => {
+    getPooledBackend.mockReturnValue(
+      planUsage([
+        { label: "7d", percent: 82, resetsAt: "2026-08-06T12:00:00Z" },
+      ]),
+    );
+    arm();
+    await checkPlanAlerts();
+
+    getPooledBackend.mockReturnValue(
+      planUsage([
+        { label: "7d", percent: 91, resetsAt: "2026-08-13T12:00:00Z" },
+      ]),
+    );
+    await checkPlanAlerts();
+    expect(sent).toHaveLength(2);
+  });
+
+  it("re-arms after a window drops back under the threshold", async () => {
+    getPooledBackend.mockReturnValue(
+      planUsage([{ label: "Fable", percent: 84 }]),
+    );
+    arm();
+    await checkPlanAlerts();
+
+    getPooledBackend.mockReturnValue(
+      planUsage([{ label: "Fable", percent: 5 }]),
+    );
+    await checkPlanAlerts();
+
+    getPooledBackend.mockReturnValue(
+      planUsage([{ label: "Fable", percent: 88 }]),
+    );
+    await checkPlanAlerts();
+    expect(sent).toHaveLength(2);
+  });
+
+  it("tracks each window separately", async () => {
+    getPooledBackend.mockReturnValue(
+      planUsage([
+        { label: "5h", percent: 95 },
+        { label: "7d", percent: 81 },
+        { label: "Fable", percent: 0 },
+      ]),
+    );
+    arm();
+    await checkPlanAlerts();
+    expect(sent).toHaveLength(2);
+  });
+
+  it("sends nothing while disabled", async () => {
+    getPooledBackend.mockReturnValue(planUsage([{ label: "7d", percent: 99 }]));
+    initPlanAlerts({
+      sendMessage: async (_chatId, text) => {
+        sent.push(text);
+      },
+      enabled: false,
+      threshold: 80,
+      chatId: "123",
+    });
+    await checkPlanAlerts();
+    expect(sent).toEqual([]);
+  });
+
+  it("does nothing when no backend reports plan limits", async () => {
+    getPooledBackend.mockReturnValue(undefined);
+    arm();
+    await expect(checkPlanAlerts()).resolves.toBeUndefined();
+    expect(sent).toEqual([]);
+  });
+
+  it("keeps a window marked as warned when delivery fails", async () => {
+    getPooledBackend.mockReturnValue(planUsage([{ label: "7d", percent: 82 }]));
+    let attempts = 0;
+    initPlanAlerts({
+      sendMessage: async () => {
+        attempts += 1;
+        throw new Error("frontend down");
+      },
+      enabled: true,
+      threshold: 80,
+      chatId: "123",
+    });
+    await checkPlanAlerts();
+    await checkPlanAlerts();
+    expect(attempts).toBe(1);
+  });
+});

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -45,6 +45,8 @@ describe("plugin system", () => {
       concurrency: 1,
       pulse: true,
       pulseIntervalMs: 300000,
+      planAlerts: false,
+      planAlertThreshold: 80,
       dream: true,
       heartbeat: false,
       heartbeatIntervalMinutes: 60,

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import { startUploadCleanup, stopUploadCleanup } from "./util/workspace.js";
 import { flushDatabase } from "./storage/db.js";
 import { getActiveCount } from "./core/engine/dispatcher.js";
 import { startPulseTimer, stopPulseTimer } from "./core/background/pulse.js";
+import { stopPlanAlerts } from "./core/background/plan-alerts.js";
 import {
   startHeartbeatTimer,
   stopHeartbeatTimer,
@@ -179,6 +180,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
     await awaitHeartbeat();
   });
   await shutdownStep("cron timer", stopCronTimer);
+  await shutdownStep("plan alerts", stopPlanAlerts);
   await shutdownStep("trigger prune timer", () => {
     if (triggerPruneTimer) clearInterval(triggerPruneTimer);
     triggerPruneTimer = null;

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -26,6 +26,7 @@ import { bus } from "./core/bus/index.js";
 import { appendToJournal } from "./storage/journal.js";
 import { initPulse, resetPulseTimer } from "./core/background/pulse.js";
 import { initCron } from "./core/background/cron.js";
+import { initPlanAlerts } from "./core/background/plan-alerts.js";
 import {
   initTriggers,
   resumeAfterRestart as resumeTriggersAfterRestart,
@@ -419,6 +420,19 @@ export async function initBackendAndDispatcher(
   resumeTriggersAfterRestart().catch((err) =>
     log("triggers", `resumeAfterRestart failed: ${err}`),
   );
+
+  initPlanAlerts({
+    sendMessage: async (chatId: number, text: string, stringId?: string) =>
+      resolveFrontendByNumericId(chatId, stringId, frontends).sendMessage(
+        chatId,
+        text,
+      ),
+    enabled: config.planAlerts,
+    threshold: config.planAlertThreshold,
+    chatId:
+      config.planAlertChatId ??
+      (config.adminUserId ? String(config.adminUserId) : undefined),
+  });
 
   // Soul — initialize the identity kernel singleton from config so the prompt
   // injection / dream hooks see the right enabled state. Off by default; a

--- a/src/core/background/plan-alerts.ts
+++ b/src/core/background/plan-alerts.ts
@@ -1,0 +1,115 @@
+/**
+ * Plan rate-limit warnings.
+ *
+ * Off unless `planAlerts` is enabled. Polls the subscription's windows on a
+ * timer and messages the admin chat the first time one crosses the
+ * threshold, so a long background run doesn't walk into the ceiling
+ * unannounced.
+ *
+ * One message per window per reset cycle: the reset timestamp identifies the
+ * cycle, and a window that drops back under the threshold re-arms (which is
+ * also what covers windows the plan reports no reset for).
+ */
+
+import { getPooledBackend } from "../engine/backend-controller/index.js";
+import { log, logWarn } from "../../util/log.js";
+import { formatSmartTimestamp } from "../../util/time.js";
+
+const CHECK_INTERVAL_MS = 5 * 60_000;
+
+export interface PlanAlertDeps {
+  sendMessage: (
+    chatId: number,
+    text: string,
+    stringId?: string,
+  ) => Promise<void>;
+  enabled: boolean;
+  threshold: number;
+  /** Chat the warnings go to. Callers resolve the admin default. */
+  chatId: string | undefined;
+}
+
+let deps: PlanAlertDeps | undefined;
+let timer: ReturnType<typeof setInterval> | null = null;
+
+/** Window label → the reset cycle it was last warned about. */
+const warned = new Map<string, string>();
+
+export function initPlanAlerts(d: PlanAlertDeps): void {
+  deps = d;
+  stopPlanAlerts();
+  warned.clear();
+  if (!d.enabled) return;
+  if (!d.chatId) {
+    logWarn(
+      "bot",
+      "planAlerts is on but no chat to warn — set planAlertChatId or adminUserId",
+    );
+    return;
+  }
+  timer = setInterval(() => {
+    void checkPlanAlerts();
+  }, CHECK_INTERVAL_MS);
+  timer.unref?.();
+  log("bot", `Plan alerts: on (threshold ${d.threshold}%)`);
+}
+
+export function stopPlanAlerts(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+function warningText(
+  label: string,
+  percent: number,
+  resetsAt: string | undefined,
+): string {
+  const ts = resetsAt ? Date.parse(resetsAt) : NaN;
+  const reset = Number.isFinite(ts)
+    ? `, resets ${formatSmartTimestamp(Math.round(ts / 60_000) * 60_000)}`
+    : "";
+  return `⚠️ Plan limit — ${label} at ${percent}% used${reset}.`;
+}
+
+/** One pass. Exported so the timer isn't the only way to drive it. */
+export async function checkPlanAlerts(): Promise<void> {
+  const d = deps;
+  if (!d?.enabled || !d.chatId) return;
+
+  const usage = await getPooledBackend("claude")
+    ?.usage?.getPlanUsage?.()
+    .catch(() => undefined);
+  if (!usage) return;
+
+  for (const window of usage.windows) {
+    // An unwarned window that is back under the threshold re-arms.
+    if (window.percent < d.threshold) {
+      warned.delete(window.label);
+      continue;
+    }
+    const cycle = window.resetsAt ?? "";
+    if (warned.get(window.label) === cycle) continue;
+    warned.set(window.label, cycle);
+
+    const text = warningText(window.label, window.percent, window.resetsAt);
+    try {
+      await d.sendMessage(Number(d.chatId), text, d.chatId);
+      log("bot", `Plan alert sent: ${window.label} at ${window.percent}%`);
+    } catch (err) {
+      // Keep it marked as warned — a frontend that can't deliver now won't
+      // deliver on the next tick either, and retrying would spam on recovery.
+      logWarn(
+        "bot",
+        `Plan alert delivery failed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+}
+
+export function resetPlanAlertsForTest(): void {
+  stopPlanAlerts();
+  deps = undefined;
+  warned.clear();
+}

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -340,6 +340,16 @@ const configSchema = z.object({
   allowedUsers: z.array(z.number().int()).optional(), // Whitelist of user IDs allowed to DM the bot
   pulse: z.boolean().default(true),
   pulseIntervalMs: z.number().int().min(60000).default(300000),
+  /**
+   * Warn the admin chat when a subscription rate-limit window crosses
+   * `planAlertThreshold`. Off by default. Needs a backend that reports plan
+   * limits (Claude on a subscription); one message per window per reset
+   * cycle.
+   */
+  planAlerts: z.boolean().default(false),
+  planAlertThreshold: z.number().int().min(1).max(100).default(80),
+  /** Chat that receives plan warnings. Defaults to `adminUserId`. */
+  planAlertChatId: z.string().optional(),
   /** Background memory-consolidation (dream) runs. Mirrors `pulse`/`heartbeat`. */
   dream: z.boolean().default(true),
   /**


### PR DESCRIPTION
Stacked on #709 — that PR is the first commit here; the change to review is [`101701c`](https://github.com/PawiX25/talon-upstream/commit/101701c2edc75c69aa832d7dbd01921676ad9b68). Rebase once #709 lands.

A background run that walks into a rate limit just goes quiet: the turn fails with the API's usage-limit text, and nothing said how close the account was beforehand.

An opt-in watcher polls the plan windows every five minutes and messages the admin chat the first time one crosses the threshold:

```
⚠️ Plan limit — 7d at 82% used, resets Aug 6 14:00.
```

### Opting in

```json
{ "planAlerts": true, "planAlertThreshold": 80, "planAlertChatId": "..." }
```

Off unless `planAlerts` is set, and it needs a backend that reports plan limits, so nothing changes for anyone who leaves it alone. `planAlertChatId` falls back to `adminUserId`; enabled with no resolvable chat logs a warning at startup rather than failing.

### Not spamming

- One message per window per reset cycle — the reset timestamp identifies the cycle, so a fresh window warns again while a hot one stays quiet.
- A window that drops back under the threshold re-arms, which is what covers windows the plan reports no reset for (a model-scoped window can sit at `resets_at: null`).
- Failed delivery does **not** re-arm: a frontend that can't deliver now won't deliver a tick later, and retrying would land as a burst once it recovers.

### Cost

None. No model call is involved — the check compares cached figures and the message text is fixed. The underlying read is cached for a minute and takes ~400ms when it does go out, against a five-minute tick.

10 unit tests cover the threshold, the cycle and re-arm behaviour, per-window tracking, the disabled path, a backend that reports nothing, and the delivery-failure case.
