### PR TITLE
fix(discord): feed reactions on the bot's messages to the soul

### DIFF
--- a/src/frontend/discord/index.ts
+++ b/src/frontend/discord/index.ts
@@ -73,8 +73,17 @@ export function createDiscordFrontend(
       GatewayIntentBits.MessageContent,
       GatewayIntentBits.DirectMessages,
       GatewayIntentBits.GuildMessageReactions,
+      GatewayIntentBits.DirectMessageReactions,
     ],
-    partials: [Partials.Channel, Partials.Message, Partials.User],
+    // Partials.Reaction is what makes reactions on messages that predate the
+    // current cache arrive at all — without it the soul's reaction tap only
+    // ever sees freshly-cached messages.
+    partials: [
+      Partials.Channel,
+      Partials.Message,
+      Partials.User,
+      Partials.Reaction,
+    ],
     allowedMentions: { parse: [] }, // never ping anyone unless we explicitly opt in
   });
 

--- a/src/frontend/discord/middleware.ts
+++ b/src/frontend/discord/middleware.ts
@@ -21,6 +21,7 @@ import { pushMessage } from "../../storage/history.js";
 import { registerChat } from "../../core/background/pulse.js";
 import { deriveNumericChatId } from "../../util/chat-id.js";
 import { handleMessage, getSenderName } from "./handlers/index.js";
+import { recordReactionToBot } from "../../core/soul/taps.js";
 
 export function registerMiddleware(client: Client, config: TalonConfig): void {
   client.on("messageCreate", (msg: Message) => {
@@ -84,5 +85,28 @@ export function registerMiddleware(client: Client, config: TalonConfig): void {
     handleMessage(client, msg, config).catch(() => {
       /* logged inside */
     });
+  });
+
+  // ── Reaction tap — feed reactions on Talon's own messages to the soul ────
+  // The gateway records outgoing message ids as `Number(snowflake)`, so the
+  // lookup here must use the same conversion to match. Inert unless the soul
+  // is enabled.
+  client.on("messageReactionAdd", async (reaction, user) => {
+    if (user.id === client.user?.id) return;
+    try {
+      // A partial arrives when the message predates the cache; the chat id
+      // can't be built without the channel/guild it belongs to.
+      if (reaction.partial) await reaction.fetch();
+    } catch {
+      return;
+    }
+    const msg = reaction.message;
+    const emoji = reaction.emoji.name;
+    if (!emoji) return;
+    const chatId =
+      msg.channel.type === ChannelType.DM
+        ? `discord_dm_${msg.author?.id ?? user.id}`
+        : `discord_guild_${msg.guildId}_${msg.channelId}`;
+    recordReactionToBot(chatId, Number(msg.id), [emoji]);
   });
 }


### PR DESCRIPTION
The soul learns from reactions — but only on Telegram.

`src/frontend/discord/index.ts` already requested `GuildMessageReactions`, and nothing ever listened for the event. So on a deployment running both frontends, reactions on Telegram trained the identity kernel and reactions on Discord did nothing.

Three pieces were missing:

- the `messageReactionAdd` listener
- the `DirectMessageReactions` intent, so DMs count as well
- `Partials.Reaction` — without it a reaction on any message that predates the current cache never arrives at all, which would have made the listener look like it worked while quietly missing most events

Bot messages are matched with the same `Number(snowflake)` conversion `gateway.ts` records them under, so the ids line up. The tap is inert while the soul is disabled, exactly like the Telegram one, so this is dormant unless `TALON_SOUL_ENABLED` is set.

Two files, 34 lines. Not verified against a live soul-enabled deployment — the tap is unreachable without that flag — but it mirrors `frontend/telegram/middleware.ts` line for line.
