### PR TITLE
feat(doctor): check every exposed backend, and group the idle ones

### DIFF
--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -46,24 +46,63 @@ describe("collectDoctorReport", () => {
     expect(report.issues).toBeGreaterThanOrEqual(1);
   });
 
-  it("reports a configured bundled backend with zero backend issues", async () => {
+  it("reports a configured bundled backend without raising unrelated issues", async () => {
     const report = await collectDoctorReport({
       hasConfigFile: true,
       config: { frontend: "terminal", backend: "kilo" },
     });
     const labels = report.checks.map((c) => c.label);
     expect(labels).toContain("Frontend: terminal");
-    expect(labels).toContain("Kilo SDK bundled");
+    // The SDK is only a client for a CLI of the same name, so the check
+    // reports on that binary — which is present or not per machine.
+    expect(
+      labels.some(
+        (l) => l === "Kilo CLI installed" || l === "Kilo CLI not found",
+      ),
+    ).toBe(true);
     expect(report.native).toHaveLength(6);
-    // Node version and workspace presence vary by machine — assert
-    // that nothing *else* (frontend, backend, native) raises an issue.
+    // Node version, workspace presence, and the backend CLI vary by
+    // machine — assert that nothing *else* raises an issue.
     const envCheck = (label: string) =>
-      label.startsWith("Node.js ") || label.startsWith("Workspace");
+      label.startsWith("Node.js ") ||
+      label.startsWith("Workspace") ||
+      label.startsWith("Kilo CLI");
     const nonEnvIssues = report.checks.filter(
       (c) => (c.status === "fail" || c.issue) && !envCheck(c.label),
     );
     expect(nonEnvIssues).toEqual([]);
     expect(report.native.every((m) => m.ok)).toBe(true);
+  });
+
+  it("reports the idle backends too, without counting them as issues", async () => {
+    const report = await collectDoctorReport({
+      hasConfigFile: true,
+      config: { frontend: "terminal", backend: "claude" },
+    });
+    const labels = report.checks.map((c) => c.label);
+    // A backend nobody is using is one click away from being used, so it
+    // gets a line — but a missing CLI there is a heads-up, not a fault.
+    const idle = report.checks.filter((c) => c.inactive);
+    expect(idle.length).toBeGreaterThan(0);
+    expect(idle.every((c) => c.status !== "fail")).toBe(true);
+    expect(idle.every((c) => !c.issue)).toBe(true);
+    expect(
+      labels.some(
+        (l) => l.startsWith("OpenCode CLI") || l.startsWith("Kilo CLI"),
+      ),
+    ).toBe(true);
+  });
+
+  it("only audits configured models for the active backend", async () => {
+    const report = await collectDoctorReport({
+      hasConfigFile: true,
+      config: { frontend: "terminal", backend: "kilo", model: "some-model" },
+    });
+    // The Claude model audit spawns a probe; it must not run for a backend
+    // that is merely listed.
+    expect(report.checks.some((c) => c.label.startsWith("Model ("))).toBe(
+      false,
+    );
   });
 
   it("flags an unconfigured telegram frontend by name", async () => {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -25,9 +25,19 @@ export async function runDoctor(): Promise<void> {
     config: hasConfigFile ? loadConfig() : undefined,
     hasConfigFile,
   });
-  for (const check of report.checks) {
+  const print = (check: (typeof report.checks)[number]): void => {
     const detail = check.detail ? ` ${pc.dim(`(${check.detail})`)}` : "";
     console.log(`  ${DOCTOR_ICONS[check.status]} ${check.label}${detail}`);
+  };
+  for (const check of report.checks.filter((c) => !c.inactive)) print(check);
+
+  // Configured-but-idle backends describe what a switch would run into,
+  // not the state of the running deployment.
+  const idle = report.checks.filter((c) => c.inactive);
+  if (idle.length > 0) {
+    console.log(`\n  ${pc.bold("Other backends")}\n`);
+    for (const check of idle) print(check);
+    console.log();
   }
   // Native plane, one line per embedded module with provenance.
   for (const mod of report.native) {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -29,6 +29,12 @@ export interface DoctorCheck {
    * starts but a backend won't work.
    */
   issue?: boolean;
+  /**
+   * A backend that is configured but not serving chats. Renderers group
+   * these away from the environment so a handful of idle providers can't
+   * bury the checks that describe the running deployment.
+   */
+  inactive?: boolean;
 }
 
 /** One embedded native module: provenance plus a live self-test result. */
@@ -59,6 +65,8 @@ export interface DoctorReport {
 export interface DoctorConfigSlice {
   frontend: string | string[];
   backend?: string;
+  /** Backends config exposes. Empty / absent means every registered one. */
+  enabledBackends?: string[];
   model?: string;
   heartbeatModel?: string;
   heartbeatBackend?: string;
@@ -284,12 +292,55 @@ async function checkClaudeConfiguredModels(
   return checks;
 }
 
-/** Binary / auth checks for the active backend only. */
+/** Every backend id doctor knows how to inspect. */
+const KNOWN_BACKENDS = [
+  "claude",
+  "codex",
+  "kilo",
+  "opencode",
+  "openai-agents",
+] as const;
+
+/**
+ * Binary / auth checks across every backend the config exposes.
+ *
+ * Only the active one counts toward the issue total; the rest are reported
+ * so a switch doesn't have to be the thing that discovers a backend can't
+ * run. That distinction matters now that a chat can be rebound at runtime —
+ * a report of all-green while two backends are one click from failing is
+ * worse than no report.
+ */
 async function checkBackend(
   config: DoctorConfigSlice | undefined,
 ): Promise<DoctorCheck[]> {
+  const active = config?.backend ?? "claude";
+  const exposed = config?.enabledBackends?.length
+    ? config.enabledBackends
+    : [...KNOWN_BACKENDS];
+
+  const checks = await checkOneBackend(active, config, true);
+  for (const id of exposed) {
+    if (id === active || !KNOWN_BACKENDS.includes(id as never)) continue;
+    // An idle backend's missing binary is a heads-up, not a fault of this
+    // deployment: downgrade it and keep it out of the issue count.
+    for (const check of await checkOneBackend(id, config, false)) {
+      checks.push({
+        ...check,
+        status: check.status === "fail" ? "warn" : check.status,
+        issue: false,
+        inactive: true,
+      });
+    }
+  }
+  return checks;
+}
+
+async function checkOneBackend(
+  backend: string,
+  config: DoctorConfigSlice | undefined,
+  isActive: boolean,
+): Promise<DoctorCheck[]> {
   const checks: DoctorCheck[] = [];
-  const backend = config?.backend ?? "claude";
 
   if (backend === "claude") {
     if (config?.claudeBinary) {
@@ -313,7 +364,9 @@ async function checkBackend(
           : { label: "Claude Code not found", status: "fail" },
       );
     }
-    checks.push(...(await checkClaudeConfiguredModels(config)));
+    // Model resolution spawns a probe — worth it for the backend actually
+    // serving chats, wasteful for one nobody is using.
+    if (isActive) checks.push(...(await checkClaudeConfiguredModels(config)));
   } else if (backend === "codex") {
     if (!binaryOnPath("codex")) {
       checks.push({
@@ -349,11 +402,21 @@ async function checkBackend(
       });
     }
   } else if (backend === "kilo" || backend === "opencode") {
-    // Bundled as npm deps — no external binary to check.
-    checks.push({
-      label: `${backend === "kilo" ? "Kilo" : "OpenCode"} SDK bundled`,
-      status: "ok",
-    });
+    // The SDK ships as an npm dep but only talks to a server it spawns from
+    // the CLI of the same name (`cross-spawn` → PATH lookup). A present
+    // package with an absent binary fails at the first turn with a bare
+    // ENOENT, so check what actually gets executed.
+    const label = backend === "kilo" ? "Kilo" : "OpenCode";
+    checks.push(
+      binaryOnPath(backend)
+        ? { label: `${label} CLI installed`, status: "ok" }
+        : {
+            label: `${label} CLI not found`,
+            status: "fail",
+            detail: `the ${label} SDK spawns \`${backend}\` — install it or this backend cannot start`,
+            issue: true,
+          },
+    );
   } else if (backend === "openai-agents") {
     checks.push({ label: "OpenAI Agents SDK bundled", status: "ok" });
     const hasEnvKey = Boolean(process.env.OPENAI_API_KEY);

--- a/src/frontend/telegram/helpers/diagnostics.ts
+++ b/src/frontend/telegram/helpers/diagnostics.ts
@@ -211,11 +211,20 @@ const DOCTOR_ICONS: Record<string, string> = {
 export function renderDoctorMessage(report: DoctorReport): string {
   const lines = ["<b>🩺 Talon Doctor</b>", "", "<b>Environment</b>"];
 
-  for (const check of report.checks) {
+  const render = (check: DoctorReport["checks"][number]): string => {
     const detail = check.detail ? ` (${escapeHtml(check.detail)})` : "";
-    lines.push(
-      `${DOCTOR_ICONS[check.status]} ${escapeHtml(check.label)}${detail}`,
-    );
+    return `${DOCTOR_ICONS[check.status]} ${escapeHtml(check.label)}${detail}`;
+  };
+
+  for (const check of report.checks.filter((c) => !c.inactive)) {
+    lines.push(render(check));
+  }
+
+  // Configured-but-idle backends get their own block: they describe what a
+  // switch would run into, not the state of the running deployment.
+  const idle = report.checks.filter((c) => c.inactive);
+  if (idle.length > 0) {
+    lines.push("", "<b>Other backends</b>", ...idle.map(render));
   }
 
   lines.push("", "<b>Native modules</b>");


### PR DESCRIPTION
`/doctor` inspected `config.backend` and nothing else. That was fine when a chat was stuck with whatever the config named — it isn't now that a chat can be rebound at runtime, because every exposed backend is one click away from serving.

### The failure it was hiding

The OpenCode and Kilo SDKs ship as npm dependencies, but they are only clients: each spawns a CLI of the same name off `PATH`. So a deployment can have the package and not the binary. The old check reported that as:

```
✅ Kilo SDK bundled
```

and the truth surfaced later, mid-switch, as a bare `spawn kilo ENOENT`. On my deployment `/doctor` printed "All checks passed" while two of the five backends could not start at all.

### What it does now

Every backend the config exposes gets a line. The active one counts toward the issue total as before; idle ones are downgraded (`fail` becomes `warn`), kept out of the count, and grouped under their own heading — a provider nobody uses shouldn't make a healthy deployment look broken:

```
Environment
✅ Claude Code installed
✅ Model (model): opus[1m] → Opus 5 (1M context)

Other backends
⚠️ Codex CLI not found (npm i -g @openai/codex)
✅ Kilo CLI installed
✅ OpenCode CLI installed
⚠️ OpenAI Agents auth missing (set OPENAI_API_KEY or openaiApiKey in talon.json)

✅ All checks passed.
```

The Claude model audit still runs for the active backend only — it spawns a probe, which is worth paying for the backend serving chats and wasteful for one that is merely listed.

### Scope

`core/doctor.ts` is shared, so `talon doctor` and Telegram's `/doctor` both pick this up; the renderers only learned to split on the new `inactive` flag. Discord has no `/doctor` yet — that follows in a separate PR that adds the missing commands.

Four files. Two new tests cover that idle backends are reported without raising issues, and that the model audit doesn't fire for a backend that is merely listed. Verified against the running report above.
