### PR TITLE
feat(discord): add the four commands only Telegram had

### DIFF
--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -46,24 +46,63 @@ describe("collectDoctorReport", () => {
     expect(report.issues).toBeGreaterThanOrEqual(1);
   });
 
-  it("reports a configured bundled backend with zero backend issues", async () => {
+  it("reports a configured bundled backend without raising unrelated issues", async () => {
     const report = await collectDoctorReport({
       hasConfigFile: true,
       config: { frontend: "terminal", backend: "kilo" },
     });
     const labels = report.checks.map((c) => c.label);
     expect(labels).toContain("Frontend: terminal");
-    expect(labels).toContain("Kilo SDK bundled");
+    // The SDK is only a client for a CLI of the same name, so the check
+    // reports on that binary — which is present or not per machine.
+    expect(
+      labels.some(
+        (l) => l === "Kilo CLI installed" || l === "Kilo CLI not found",
+      ),
+    ).toBe(true);
     expect(report.native).toHaveLength(6);
-    // Node version and workspace presence vary by machine — assert
-    // that nothing *else* (frontend, backend, native) raises an issue.
+    // Node version, workspace presence, and the backend CLI vary by
+    // machine — assert that nothing *else* raises an issue.
     const envCheck = (label: string) =>
-      label.startsWith("Node.js ") || label.startsWith("Workspace");
+      label.startsWith("Node.js ") ||
+      label.startsWith("Workspace") ||
+      label.startsWith("Kilo CLI");
     const nonEnvIssues = report.checks.filter(
       (c) => (c.status === "fail" || c.issue) && !envCheck(c.label),
     );
     expect(nonEnvIssues).toEqual([]);
     expect(report.native.every((m) => m.ok)).toBe(true);
+  });
+
+  it("reports the idle backends too, without counting them as issues", async () => {
+    const report = await collectDoctorReport({
+      hasConfigFile: true,
+      config: { frontend: "terminal", backend: "claude" },
+    });
+    const labels = report.checks.map((c) => c.label);
+    // A backend nobody is using is one click away from being used, so it
+    // gets a line — but a missing CLI there is a heads-up, not a fault.
+    const idle = report.checks.filter((c) => c.inactive);
+    expect(idle.length).toBeGreaterThan(0);
+    expect(idle.every((c) => c.status !== "fail")).toBe(true);
+    expect(idle.every((c) => !c.issue)).toBe(true);
+    expect(
+      labels.some(
+        (l) => l.startsWith("OpenCode CLI") || l.startsWith("Kilo CLI"),
+      ),
+    ).toBe(true);
+  });
+
+  it("only audits configured models for the active backend", async () => {
+    const report = await collectDoctorReport({
+      hasConfigFile: true,
+      config: { frontend: "terminal", backend: "kilo", model: "some-model" },
+    });
+    // The Claude model audit spawns a probe; it must not run for a backend
+    // that is merely listed.
+    expect(report.checks.some((c) => c.label.startsWith("Model ("))).toBe(
+      false,
+    );
   });
 
   it("flags an unconfigured telegram frontend by name", async () => {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -25,9 +25,19 @@ export async function runDoctor(): Promise<void> {
     config: hasConfigFile ? loadConfig() : undefined,
     hasConfigFile,
   });
-  for (const check of report.checks) {
+  const print = (check: (typeof report.checks)[number]): void => {
     const detail = check.detail ? ` ${pc.dim(`(${check.detail})`)}` : "";
     console.log(`  ${DOCTOR_ICONS[check.status]} ${check.label}${detail}`);
+  };
+  for (const check of report.checks.filter((c) => !c.inactive)) print(check);
+
+  // Configured-but-idle backends describe what a switch would run into,
+  // not the state of the running deployment.
+  const idle = report.checks.filter((c) => c.inactive);
+  if (idle.length > 0) {
+    console.log(`\n  ${pc.bold("Other backends")}\n`);
+    for (const check of idle) print(check);
+    console.log();
   }
   // Native plane, one line per embedded module with provenance.
   for (const mod of report.native) {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -29,6 +29,12 @@ export interface DoctorCheck {
    * starts but a backend won't work.
    */
   issue?: boolean;
+  /**
+   * A backend that is configured but not serving chats. Renderers group
+   * these away from the environment so a handful of idle providers can't
+   * bury the checks that describe the running deployment.
+   */
+  inactive?: boolean;
 }
 
 /** One embedded native module: provenance plus a live self-test result. */
@@ -59,6 +65,8 @@ export interface DoctorReport {
 export interface DoctorConfigSlice {
   frontend: string | string[];
   backend?: string;
+  /** Backends config exposes. Empty / absent means every registered one. */
+  enabledBackends?: string[];
   model?: string;
   heartbeatModel?: string;
   heartbeatBackend?: string;
@@ -284,12 +292,55 @@ async function checkClaudeConfiguredModels(
   return checks;
 }
 
-/** Binary / auth checks for the active backend only. */
+/** Every backend id doctor knows how to inspect. */
+const KNOWN_BACKENDS = [
+  "claude",
+  "codex",
+  "kilo",
+  "opencode",
+  "openai-agents",
+] as const;
+
+/**
+ * Binary / auth checks across every backend the config exposes.
+ *
+ * Only the active one counts toward the issue total; the rest are reported
+ * so a switch doesn't have to be the thing that discovers a backend can't
+ * run. That distinction matters now that a chat can be rebound at runtime —
+ * a report of all-green while two backends are one click from failing is
+ * worse than no report.
+ */
 async function checkBackend(
   config: DoctorConfigSlice | undefined,
 ): Promise<DoctorCheck[]> {
+  const active = config?.backend ?? "claude";
+  const exposed = config?.enabledBackends?.length
+    ? config.enabledBackends
+    : [...KNOWN_BACKENDS];
+
+  const checks = await checkOneBackend(active, config, true);
+  for (const id of exposed) {
+    if (id === active || !KNOWN_BACKENDS.includes(id as never)) continue;
+    // An idle backend's missing binary is a heads-up, not a fault of this
+    // deployment: downgrade it and keep it out of the issue count.
+    for (const check of await checkOneBackend(id, config, false)) {
+      checks.push({
+        ...check,
+        status: check.status === "fail" ? "warn" : check.status,
+        issue: false,
+        inactive: true,
+      });
+    }
+  }
+  return checks;
+}
+
+async function checkOneBackend(
+  backend: string,
+  config: DoctorConfigSlice | undefined,
+  isActive: boolean,
+): Promise<DoctorCheck[]> {
   const checks: DoctorCheck[] = [];
-  const backend = config?.backend ?? "claude";
 
   if (backend === "claude") {
     if (config?.claudeBinary) {
@@ -313,7 +364,9 @@ async function checkBackend(
           : { label: "Claude Code not found", status: "fail" },
       );
     }
-    checks.push(...(await checkClaudeConfiguredModels(config)));
+    // Model resolution spawns a probe — worth it for the backend actually
+    // serving chats, wasteful for one nobody is using.
+    if (isActive) checks.push(...(await checkClaudeConfiguredModels(config)));
   } else if (backend === "codex") {
     if (!binaryOnPath("codex")) {
       checks.push({
@@ -349,11 +402,21 @@ async function checkBackend(
       });
     }
   } else if (backend === "kilo" || backend === "opencode") {
-    // Bundled as npm deps — no external binary to check.
-    checks.push({
-      label: `${backend === "kilo" ? "Kilo" : "OpenCode"} SDK bundled`,
-      status: "ok",
-    });
+    // The SDK ships as an npm dep but only talks to a server it spawns from
+    // the CLI of the same name (`cross-spawn` → PATH lookup). A present
+    // package with an absent binary fails at the first turn with a bare
+    // ENOENT, so check what actually gets executed.
+    const label = backend === "kilo" ? "Kilo" : "OpenCode";
+    checks.push(
+      binaryOnPath(backend)
+        ? { label: `${label} CLI installed`, status: "ok" }
+        : {
+            label: `${label} CLI not found`,
+            status: "fail",
+            detail: `the ${label} SDK spawns \`${backend}\` — install it or this backend cannot start`,
+            issue: true,
+          },
+    );
   } else if (backend === "openai-agents") {
     checks.push({ label: "OpenAI Agents SDK bundled", status: "ok" });
     const hasEnvKey = Boolean(process.env.OPENAI_API_KEY);

--- a/src/frontend/discord/callbacks/components.ts
+++ b/src/frontend/discord/callbacks/components.ts
@@ -68,6 +68,7 @@ import {
   DISCORD_MAX_TEXT,
 } from "../formatting.js";
 import { chatIdFromInteraction, type ComponentInteraction } from "./shared.js";
+import { metricsViewRow, renderMetricsView } from "../commands/admin.js";
 
 export async function handleComponentInteraction(
   interaction: ComponentInteraction,
@@ -348,6 +349,21 @@ export async function handleComponentInteraction(
       } catch {
         /* ignore */
       }
+    }
+    return;
+  }
+
+  // ── /metrics today ↔ all-time toggle ────────────────────────────────────
+  if (customId === "metrics:today" || customId === "metrics:all") {
+    const view = customId === "metrics:all" ? "all" : "today";
+    const messages = renderMetricsView(view);
+    try {
+      await interaction.update({
+        content: messages[0]!,
+        components: [metricsViewRow(view).toJSON()],
+      });
+    } catch {
+      /* ignore */
     }
     return;
   }

--- a/src/frontend/discord/commands/admin.ts
+++ b/src/frontend/discord/commands/admin.ts
@@ -3,16 +3,37 @@
  * All gate on `isAdmin`.
  */
 
-import { type ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import {
+  type ChatInputCommandInteraction,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  MessageFlags,
+} from "discord.js";
 import type { TalonConfig } from "../../../util/config.js";
 import type { Gateway } from "../../../core/engine/gateway.js";
 import { respawnSelf } from "../../../util/respawn.js";
 import { forceDream } from "../../../core/background/dream.js";
-import { formatDuration, renderMetricsMessages } from "../helpers.js";
+import {
+  formatDuration,
+  renderMetricsMessages,
+  renderDoctorMessages,
+} from "../helpers.js";
+import { collectDoctorReport } from "../../../core/doctor.js";
+import { getSoul } from "../../../core/soul/service.js";
 import { getMetrics, getTodayMetrics } from "../../../storage/metrics.js";
 import { handleAdminSubcommand } from "../admin.js";
 import { isAdmin } from "../handlers/index.js";
-import { suppressMentions, DISCORD_MAX_TEXT } from "../formatting.js";
+import {
+  suppressMentions,
+  DISCORD_MAX_TEXT,
+  safeSlice,
+  escapeForCodeBlock,
+} from "../formatting.js";
+import {
+  getRepoRoot,
+  runSelfUpdate,
+} from "../../../core/update/self-update.js";
 import { reply } from "./shared.js";
 
 export async function handleRestart(
@@ -34,18 +55,112 @@ export async function handleMetrics(
     return;
   }
   // Ephemeral — admin counters (token usage, latencies, errors) shouldn't leak
-  // into a public channel where non-admins can read them.
-  const messages = [
-    ...renderMetricsMessages(getMetrics()),
-    ...renderMetricsMessages(
-      getTodayMetrics(),
-      undefined,
-      "📊 Metrics — today (UTC)",
-    ),
-  ];
-  for (const m of messages) {
-    await reply(i, m, true);
+  // into a public channel where non-admins can read them. Both views are one
+  // button apart rather than two bursts of messages.
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  const messages = renderMetricsMessages(
+    getTodayMetrics(),
+    undefined,
+    "📊 Metrics — today (UTC)",
+  );
+  await i.editReply({
+    content: messages[0]!,
+    components: [metricsViewRow("today").toJSON()],
+  });
+  for (const extra of messages.slice(1)) {
+    await i.followUp({ content: extra, flags: MessageFlags.Ephemeral });
   }
+}
+
+/** Today / all-time toggle under the metrics panel. */
+export function metricsViewRow(
+  view: MetricsView,
+): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId("metrics:today")
+      .setLabel("Today")
+      .setStyle(view === "today" ? ButtonStyle.Primary : ButtonStyle.Secondary)
+      .setDisabled(view === "today"),
+    new ButtonBuilder()
+      .setCustomId("metrics:all")
+      .setLabel("All time")
+      .setStyle(view === "all" ? ButtonStyle.Primary : ButtonStyle.Secondary)
+      .setDisabled(view === "all"),
+  );
+}
+
+export type MetricsView = "today" | "all";
+
+/** Panel body for one view — shared by the command and the toggle. */
+export function renderMetricsView(view: MetricsView): string[] {
+  return view === "today"
+    ? renderMetricsMessages(
+        getTodayMetrics(),
+        undefined,
+        "📊 Metrics — today (UTC)",
+      )
+    : renderMetricsMessages(getMetrics(), undefined, "📊 Metrics — all time");
+}
+
+export async function handleDoctor(
+  i: ChatInputCommandInteraction,
+  config: TalonConfig,
+): Promise<void> {
+  if (!isAdmin(i.user.id)) {
+    await reply(i, "Not authorized.", true);
+    return;
+  }
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  await i.editReply("🩺 Running checks...");
+  try {
+    // Same checks as `talon doctor` — config exists by definition when the
+    // bot is processing this command.
+    const report = await collectDoctorReport({ config, hasConfigFile: true });
+    const messages = renderDoctorMessages(report);
+    await i.editReply(messages[0]!);
+    for (const extra of messages.slice(1))
+      await i.followUp({
+        content: extra,
+        flags: MessageFlags.Ephemeral,
+      });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await i.editReply(`🩺 Doctor failed: ${msg}`);
+  }
+}
+
+/**
+ * /soul — read-only introspection of the compiled identity. `action:dream`
+ * runs the organic maintenance pass and is admin-only. Inert while the soul
+ * is disabled, so it is safe to ship dormant.
+ */
+export async function handleSoul(
+  i: ChatInputCommandInteraction,
+): Promise<void> {
+  const soul = getSoul();
+  if (!soul.enabled) {
+    await reply(
+      i,
+      "Soul is disabled (set TALON_SOUL_ENABLED to enable).",
+      true,
+    );
+    return;
+  }
+  if (i.options.getString("action") === "dream") {
+    if (!isAdmin(i.user.id)) {
+      await reply(i, "Not authorized.", true);
+      return;
+    }
+    await i.deferReply({ flags: MessageFlags.Ephemeral });
+    await i.editReply("🧠 Soul dreaming...");
+    soul
+      .dream()
+      .then(() => i.editReply("🧠 Soul dream complete."))
+      .catch(() => undefined);
+    return;
+  }
+  await reply(i, suppressMentions(soul.introspect()), true);
 }
 
 export async function handleDream(
@@ -68,6 +183,65 @@ export async function handleDream(
     .catch(async (err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err);
       await i.editReply(`🌙 Dream failed: ${msg}`);
+    });
+}
+
+/**
+ * /update — pull, reinstall, run setup, restart. Only reachable on developer
+ * builds running from a git checkout; the command is not registered at all
+ * otherwise (see buildCommandDefinitions).
+ */
+export async function handleUpdate(
+  i: ChatInputCommandInteraction,
+  config: TalonConfig,
+): Promise<void> {
+  if (!isAdmin(i.user.id)) {
+    await reply(i, "Not authorized.", true);
+    return;
+  }
+  const repoRoot = config.devBuild ? getRepoRoot() : null;
+  if (!repoRoot) {
+    await reply(i, "Update is only available on developer builds.", true);
+    return;
+  }
+  const remote = config.update?.remote ?? "origin";
+  const branch = config.update?.branch ?? "main";
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  await i.editReply(`⏳ Updating from \`${remote}/${branch}\`…`);
+  const edit = (text: string) => i.editReply(safeSlice(text, DISCORD_MAX_TEXT));
+
+  // Fire-and-forget so the gateway keeps processing other interactions.
+  runSelfUpdate({
+    remote,
+    branch,
+    setup: config.update?.setup,
+    repoRoot,
+  })
+    .then(async (res) => {
+      if (!res.ok) {
+        const tail = res.steps[res.steps.length - 1]?.output ?? "";
+        await edit(
+          `⚠️ Update failed: ${res.error ?? "unknown error"}` +
+            (tail
+              ? `\n\`\`\`\n${escapeForCodeBlock(tail.slice(-1200))}\n\`\`\``
+              : ""),
+        );
+        return;
+      }
+      if (!res.changed) {
+        await edit(
+          `✅ Already up to date at \`${res.before ?? "?"}\` — no restart needed.`,
+        );
+        return;
+      }
+      await edit(
+        `✅ Updated \`${res.before ?? "?"}\` → \`${res.after ?? "?"}\`. ♻️ Restarting…`,
+      );
+      respawnSelf("discord /update");
+    })
+    .catch(async (err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      await edit(`⚠️ Update crashed: ${msg}`);
     });
 }
 

--- a/src/frontend/discord/commands/definitions.ts
+++ b/src/frontend/discord/commands/definitions.ts
@@ -15,8 +15,9 @@
 import { type Client, REST, Routes, SlashCommandBuilder } from "discord.js";
 import type { TalonConfig } from "../../../util/config.js";
 import { log, logError, logWarn } from "../../../util/log.js";
+import { getRepoRoot } from "../../../core/update/self-update.js";
 
-export function buildCommandDefinitions(): unknown[] {
+export function buildCommandDefinitions(devBuild = false): unknown[] {
   return [
     new SlashCommandBuilder()
       .setName("start")
@@ -98,6 +99,36 @@ export function buildCommandDefinitions(): unknown[] {
       .setDescription("List loaded plugins")
       .toJSON(),
     new SlashCommandBuilder()
+      .setName("doctor")
+      .setDescription("Environment and native-module health (admin)")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("mesh")
+      .setDescription("Ping and list mesh devices")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("soul")
+      .setDescription("Inspect the compiled identity")
+      .addStringOption((o) =>
+        o
+          .setName("action")
+          .setDescription("Leave empty to introspect")
+          .setRequired(false)
+          .addChoices({ name: "dream", value: "dream" }),
+      )
+      .toJSON(),
+    // /update only exists on developer builds running from a git checkout —
+    // a packaged binary has no source tree to pull into, so the command is
+    // never registered there (same gate as the Telegram handler).
+    ...(devBuild && getRepoRoot()
+      ? [
+          new SlashCommandBuilder()
+            .setName("update")
+            .setDescription("Pull latest, reinstall, restart (admin)")
+            .toJSON(),
+        ]
+      : []),
+    new SlashCommandBuilder()
       .setName("admin")
       .setDescription("Admin operations (admin only)")
       .addStringOption((o) =>
@@ -128,7 +159,7 @@ export async function registerCommandsForGuilds(
 ): Promise<void> {
   const dc = config.discord!;
   const rest = new REST({ version: "10" }).setToken(dc.botToken);
-  const definitions = buildCommandDefinitions();
+  const definitions = buildCommandDefinitions(config.devBuild);
 
   // Step 1: clear or set global commands depending on DM setting.
   try {

--- a/src/frontend/discord/commands/info.ts
+++ b/src/frontend/discord/commands/info.ts
@@ -7,8 +7,10 @@ import {
   type Client,
   MessageFlags,
 } from "discord.js";
-import { formatDuration } from "../helpers.js";
+import { formatDuration, renderMeshReport } from "../helpers.js";
 import { getLoadedPlugins } from "../../../core/plugin/index.js";
+import { getMeshService } from "../../../core/mesh/index.js";
+import type { MeshPingResult } from "../../../core/mesh/service.js";
 import { reply } from "./shared.js";
 
 export async function handleStart(
@@ -65,6 +67,21 @@ export async function handleHelp(
     ].join("\n"),
     true,
   );
+}
+
+export async function handleMesh(
+  i: ChatInputCommandInteraction,
+): Promise<void> {
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  await i.editReply("Pinging mesh devices…");
+  let results: MeshPingResult[];
+  try {
+    results = await getMeshService().pingAll();
+  } catch {
+    await i.editReply("Could not reach the mesh service.");
+    return;
+  }
+  await i.editReply(renderMeshReport(results));
 }
 
 export async function handlePing(

--- a/src/frontend/discord/commands/router.ts
+++ b/src/frontend/discord/commands/router.ts
@@ -22,7 +22,13 @@ import {
   handleModalSubmit,
 } from "../callbacks/index.js";
 import { chatIdFromInteraction, reply, client } from "./shared.js";
-import { handleStart, handleHelp, handlePing, handlePlugins } from "./info.js";
+import {
+  handleStart,
+  handleHelp,
+  handlePing,
+  handlePlugins,
+  handleMesh,
+} from "./info.js";
 import { handleReset, handleStatus } from "./session.js";
 import {
   handleModel,
@@ -35,6 +41,9 @@ import {
   handleMetrics,
   handleDream,
   handleAdmin,
+  handleDoctor,
+  handleSoul,
+  handleUpdate,
 } from "./admin.js";
 
 export function registerInteractionRouter(
@@ -141,6 +150,14 @@ async function routeSlashCommand(
       return handleDream(interaction);
     case "plugins":
       return handlePlugins(interaction);
+    case "doctor":
+      return handleDoctor(interaction, config);
+    case "mesh":
+      return handleMesh(interaction);
+    case "soul":
+      return handleSoul(interaction);
+    case "update":
+      return handleUpdate(interaction, config);
     case "admin":
       return handleAdmin(interaction, config, gateway);
     default:

--- a/src/frontend/discord/helpers.ts
+++ b/src/frontend/discord/helpers.ts
@@ -8,10 +8,17 @@
  */
 
 import { REASONING_LEVEL_DESCRIPTIONS } from "../../core/models/reasoning-levels.js";
-import { DISCORD_MAX_TEXT, DISCORD_SAFE_RESERVE } from "./formatting.js";
+import {
+  DISCORD_MAX_TEXT,
+  DISCORD_SAFE_RESERVE,
+  splitMessage,
+} from "./formatting.js";
+import type { DoctorReport } from "../../core/doctor.js";
+import type { MeshPingResult } from "../../core/mesh/service.js";
 import {
   DEFAULT_PULSE_INTERVAL_MS,
   formatDuration,
+  formatBytes,
   formatModelLabel,
 } from "../shared/format.js";
 
@@ -155,6 +162,121 @@ export function renderMetricsMessages(
   }
   if (current !== header || chunks.length === 0) chunks.push(current);
   return chunks;
+}
+
+const DOCTOR_ICONS: Record<string, string> = {
+  ok: "✅",
+  warn: "⚠️",
+  fail: "❌",
+  info: "▫️",
+};
+
+/**
+ * Render a DoctorReport as Discord markdown, split to fit the message cap.
+ * Same data as `talon doctor` and Telegram's /doctor.
+ */
+export function renderDoctorMessages(
+  report: DoctorReport,
+  maxLen = DEFAULT_METRICS_MESSAGE_MAX,
+): string[] {
+  const lines = ["**🩺 Talon Doctor**", "", "**Environment**"];
+
+  const render = (check: DoctorReport["checks"][number]): string =>
+    `${DOCTOR_ICONS[check.status]} ${check.label}${check.detail ? ` (${check.detail})` : ""}`;
+
+  for (const check of report.checks.filter((c) => !c.inactive)) {
+    lines.push(render(check));
+  }
+
+  // Configured-but-idle backends get their own block: they describe what a
+  // switch would run into, not the state of the running deployment.
+  const idle = report.checks.filter((c) => c.inactive);
+  if (idle.length > 0) {
+    lines.push("", "**Other backends**", ...idle.map(render));
+  }
+
+  lines.push("", "**Native modules**");
+  for (const mod of report.native) {
+    const size =
+      mod.sizeBytes !== undefined ? ` · ${formatBytes(mod.sizeBytes)}` : "";
+    const note = mod.note ? ` (${mod.note})` : "";
+    lines.push(
+      `${mod.ok ? DOCTOR_ICONS.ok : DOCTOR_ICONS.fail} \`${mod.name}\` — ${mod.language} → ${mod.target}${size}${note}`,
+    );
+  }
+
+  lines.push(
+    "",
+    "**Process**",
+    `Uptime ${formatDuration(process.uptime() * 1000)} · PID ${process.pid} · Node ${process.versions.node}`,
+    "",
+    report.issues === 0
+      ? `${DOCTOR_ICONS.ok} All checks passed.`
+      : `${DOCTOR_ICONS.warn} ${report.issues} issue(s) found.`,
+  );
+
+  return splitMessage(lines.join("\n"), maxLen);
+}
+
+function meshDeviceLine(r: MeshPingResult, now: number): string {
+  const d = r.device;
+  const bits: string[] = [d.platform];
+  if (r.reachable && typeof r.latencyMs === "number") {
+    bits.push(`${r.latencyMs} ms`);
+  } else if (d.online && r.error) {
+    bits.push(r.error);
+  } else if (!d.online) {
+    bits.push(`last seen ${formatDuration(now - d.lastSeen)} ago`);
+  }
+  if (typeof d.battery === "number") {
+    bits.push(`${d.battery}%${d.charging ? " charging" : ""}`);
+  }
+  return `  **${d.name}** — ${bits.join(" · ")}`;
+}
+
+/**
+ * Render the /mesh fleet report as Discord markdown. Devices group under a
+ * state heading; empty groups are omitted.
+ */
+export function renderMeshReport(
+  results: MeshPingResult[],
+  now = Date.now(),
+): string {
+  if (results.length === 0) {
+    return "**Mesh**\n\n_No devices have registered yet._";
+  }
+
+  const responding = results
+    .filter((r) => r.reachable)
+    .sort((a, b) => (a.latencyMs ?? Infinity) - (b.latencyMs ?? Infinity));
+  const unreachable = results
+    .filter((r) => !r.reachable && r.device.online)
+    .sort((a, b) => a.device.name.localeCompare(b.device.name));
+  const offline = results
+    .filter((r) => !r.reachable && !r.device.online)
+    .sort((a, b) => b.device.lastSeen - a.device.lastSeen);
+
+  const summary = [
+    `${results.length} device${results.length === 1 ? "" : "s"}`,
+    `${responding.length} responding`,
+    ...(unreachable.length > 0 ? [`${unreachable.length} unreachable`] : []),
+    ...(offline.length > 0 ? [`${offline.length} offline`] : []),
+  ].join(" · ");
+
+  const lines = ["**Mesh**", summary];
+  const section = (title: string, entries: MeshPingResult[]): void => {
+    if (entries.length === 0) return;
+    lines.push(
+      "",
+      `**${title}**`,
+      ...entries.map((r) => meshDeviceLine(r, now)),
+    );
+  };
+  section("Responding", responding);
+  section("Unreachable", unreachable);
+  section("Offline", offline);
+
+  return lines.join("\n");
 }
 
 /** Settings panel: build the markdown body. */

--- a/src/frontend/telegram/helpers/diagnostics.ts
+++ b/src/frontend/telegram/helpers/diagnostics.ts
@@ -211,11 +211,20 @@ const DOCTOR_ICONS: Record<string, string> = {
 export function renderDoctorMessage(report: DoctorReport): string {
   const lines = ["<b>🩺 Talon Doctor</b>", "", "<b>Environment</b>"];
 
-  for (const check of report.checks) {
+  const render = (check: DoctorReport["checks"][number]): string => {
     const detail = check.detail ? ` (${escapeHtml(check.detail)})` : "";
-    lines.push(
-      `${DOCTOR_ICONS[check.status]} ${escapeHtml(check.label)}${detail}`,
-    );
+    return `${DOCTOR_ICONS[check.status]} ${escapeHtml(check.label)}${detail}`;
+  };
+
+  for (const check of report.checks.filter((c) => !c.inactive)) {
+    lines.push(render(check));
+  }
+
+  // Configured-but-idle backends get their own block: they describe what a
+  // switch would run into, not the state of the running deployment.
+  const idle = report.checks.filter((c) => c.inactive);
+  if (idle.length > 0) {
+    lines.push("", "<b>Other backends</b>", ...idle.map(render));
   }
 
   lines.push("", "<b>Native modules</b>");


### PR DESCRIPTION
Stacked on #715 — that PR is the first commit here; the change to review is the second. Rebase once #715 lands.

Discord was missing four commands Telegram has: `/doctor`, `/mesh`, `/soul` and `/update`. `/doctor` most painfully — it left the frontend with no way to ask whether the deployment is healthy at all.

### Renderers, not a converter

The report builders already take plain data (`DoctorReport`, `MeshPingResult[]`), so this adds Discord-flavoured renderers next to the existing `renderMetricsMessages` rather than pushing Telegram's HTML through a converter. Long reports split across messages the same way metrics already do.

### /update

Registered only on developer builds running from a git checkout, the same gate as the Telegram handler — a packaged image never shows a command it cannot run. In a container, `buildCommandDefinitions` simply omits it, which is why the running deployment registers 17 commands rather than 18.

### /metrics

Stops sending all-time and today as two bursts of messages and renders one view with a `Today` / `All time` toggle, matching the Telegram keyboard.

### Verified

Running on a Raspberry Pi deployment: all four commands respond, `/doctor` prints the full report including the "Other backends" section from #715, and the metrics toggle switches in place. `tsc`, `prettier` and `oxlint` clean; the suite passes except two failures that also fail on a clean checkout of `main` on that machine (timezone-dependent).
