### PR TITLE
feat(models): paginate the picker, and let Discord switch backends

### DIFF
--- a/src/__tests__/discord-model-picker.test.ts
+++ b/src/__tests__/discord-model-picker.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildModelPickerView,
+  buildBackendPickerView,
+  decodeModelNav,
+  MODEL_NAV_PREFIX,
+  MODEL_PAGE_SIZE,
+} from "../frontend/discord/model-picker.js";
+import type { ModelPickerResult } from "../core/types.js";
+
+function pres(over: Partial<ModelPickerResult> = {}): ModelPickerResult {
+  return {
+    modelButtons: [
+      { text: "✓ Opus 5", callback_data: "model:opus" },
+      { text: "Sonnet 5", callback_data: "model:sonnet" },
+    ],
+    modelDetails: [],
+    view: "models",
+    page: 1,
+    totalPages: 1,
+    filter: "all",
+    freeCount: 0,
+    totalCount: 2,
+    ...over,
+  };
+}
+
+/** Buttons of the first row that carries any, flattened to label + state. */
+function buttons(
+  components: ReturnType<typeof buildModelPickerView>["components"],
+): { label: string; id: string; disabled: boolean }[] {
+  const out: { label: string; id: string; disabled: boolean }[] = [];
+  for (const row of components) {
+    for (const c of row.components as unknown as Record<string, unknown>[]) {
+      if (c.type === 2) {
+        out.push({
+          label: String(c.label ?? ""),
+          id: String(c.custom_id ?? ""),
+          disabled: Boolean(c.disabled),
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function selectOptions(
+  components: ReturnType<typeof buildModelPickerView>["components"],
+): { label: string; value: string }[] {
+  for (const row of components) {
+    for (const c of row.components as unknown as Record<string, unknown>[]) {
+      if (c.type === 3) {
+        return (c.options as { label: string; value: string }[]) ?? [];
+      }
+    }
+  }
+  return [];
+}
+
+describe("decodeModelNav", () => {
+  it("ignores custom_ids from other namespaces", () => {
+    expect(decodeModelNav("settings:model")).toBeNull();
+    expect(decodeModelNav("model:select")).toBeNull();
+  });
+
+  it("decodes a page target with its filter", () => {
+    expect(decodeModelNav(`${MODEL_NAV_PREFIX}:page:3:free`)).toEqual({
+      page: 3,
+      filter: "free",
+    });
+  });
+
+  it("carries the provider through paging", () => {
+    expect(decodeModelNav(`${MODEL_NAV_PREFIX}:page:2:all:openai`)).toEqual({
+      page: 2,
+      filter: "all",
+      provider: "openai",
+    });
+  });
+
+  it("resets to page 1 when the filter flips", () => {
+    expect(decodeModelNav(`${MODEL_NAV_PREFIX}:filter:free`)).toEqual({
+      page: 1,
+      filter: "free",
+    });
+  });
+
+  it("falls back to page 1 on a malformed page number", () => {
+    expect(decodeModelNav(`${MODEL_NAV_PREFIX}:page:zero:all`)?.page).toBe(1);
+    expect(decodeModelNav(`${MODEL_NAV_PREFIX}:page:-4:all`)?.page).toBe(1);
+  });
+
+  it("decodes the provider list and a provider drill", () => {
+    expect(decodeModelNav(`${MODEL_NAV_PREFIX}:providers`)).toEqual({
+      page: 1,
+      filter: "all",
+    });
+    expect(decodeModelNav(`${MODEL_NAV_PREFIX}:provider:anthropic`)).toEqual({
+      page: 1,
+      filter: "all",
+      provider: "anthropic",
+    });
+  });
+
+  it("rejects an unknown action", () => {
+    expect(decodeModelNav(`${MODEL_NAV_PREFIX}:teleport`)).toBeNull();
+  });
+});
+
+describe("buildModelPickerView", () => {
+  it("omits the arrows on a single-page catalog", () => {
+    const view = buildModelPickerView(pres(), "Opus 5", "claude");
+    const labels = buttons(view.components).map((b) => b.label);
+    expect(labels).not.toContain("◀");
+    expect(labels).not.toContain("▶");
+    // The backend button is always offered.
+    expect(labels.some((l) => l.includes("Backend"))).toBe(true);
+  });
+
+  it("disables the arrow at each edge", () => {
+    const first = buttons(
+      buildModelPickerView(pres({ page: 1, totalPages: 7 }), "Opus 5", "claude")
+        .components,
+    );
+    expect(first.find((b) => b.label === "◀")?.disabled).toBe(true);
+    expect(first.find((b) => b.label === "▶")?.disabled).toBe(false);
+
+    const last = buttons(
+      buildModelPickerView(pres({ page: 7, totalPages: 7 }), "Opus 5", "claude")
+        .components,
+    );
+    expect(last.find((b) => b.label === "◀")?.disabled).toBe(false);
+    expect(last.find((b) => b.label === "▶")?.disabled).toBe(true);
+  });
+
+  it("shows the page counter as an inert button", () => {
+    const b = buttons(
+      buildModelPickerView(pres({ page: 3, totalPages: 7 }), "Opus 5", "claude")
+        .components,
+    );
+    const counter = b.find((x) => x.label === "3/7");
+    expect(counter?.disabled).toBe(true);
+  });
+
+  it("points each arrow at the neighbouring page, keeping the filter", () => {
+    const b = buttons(
+      buildModelPickerView(
+        pres({ page: 4, totalPages: 9, filter: "free" }),
+        "Opus 5",
+        "claude",
+      ).components,
+    );
+    expect(b.find((x) => x.label === "◀")?.id).toBe(
+      `${MODEL_NAV_PREFIX}:page:3:free`,
+    );
+    expect(b.find((x) => x.label === "▶")?.id).toBe(
+      `${MODEL_NAV_PREFIX}:page:5:free`,
+    );
+  });
+
+  it("offers the free filter only when free models exist, and toggles back", () => {
+    const none = buttons(
+      buildModelPickerView(pres({ freeCount: 0 }), "Opus 5", "claude")
+        .components,
+    );
+    expect(none.some((b) => b.label.includes("Free"))).toBe(false);
+
+    // Everything free means the filter would keep everything — no button.
+    const allFree = buttons(
+      buildModelPickerView(
+        pres({ freeCount: 7, totalCount: 7 }),
+        "Opus 5",
+        "claude",
+      ).components,
+    );
+    expect(allFree.some((b) => b.label.includes("Free"))).toBe(false);
+
+    const some = buttons(
+      buildModelPickerView(
+        pres({ freeCount: 12, totalCount: 300 }),
+        "Opus 5",
+        "claude",
+      ).components,
+    );
+    expect(some.find((b) => b.label.startsWith("Free only"))?.id).toBe(
+      `${MODEL_NAV_PREFIX}:filter:free`,
+    );
+
+    const on = buttons(
+      buildModelPickerView(
+        pres({ freeCount: 12, totalCount: 300, filter: "free" }),
+        "Opus 5",
+        "claude",
+      ).components,
+    );
+    expect(on.find((b) => b.label === "All models")?.id).toBe(
+      `${MODEL_NAV_PREFIX}:filter:all`,
+    );
+  });
+
+  it("offers a way back only while drilled into a provider", () => {
+    const flat = buttons(
+      buildModelPickerView(pres(), "Opus 5", "claude").components,
+    );
+    expect(flat.some((b) => b.label === "← Providers")).toBe(false);
+
+    const drilled = buttons(
+      buildModelPickerView(pres({ provider: "openai" }), "Opus 5", "claude")
+        .components,
+    );
+    expect(drilled.find((b) => b.label === "← Providers")?.id).toBe(
+      `${MODEL_NAV_PREFIX}:providers`,
+    );
+  });
+
+  it("never exceeds Discord's option cap", () => {
+    const many = Array.from({ length: 40 }, (_, i) => ({
+      text: `Model ${i}`,
+      callback_data: `model:m${i}`,
+    }));
+    const view = buildModelPickerView(
+      pres({ modelButtons: many, totalPages: 2 }),
+      "Opus 5",
+      "claude",
+    );
+    expect(selectOptions(view.components)).toHaveLength(MODEL_PAGE_SIZE);
+  });
+
+  it("strips the selected-marker from labels and keeps the raw value", () => {
+    const opts = selectOptions(
+      buildModelPickerView(pres(), "Opus 5", "claude").components,
+    );
+    expect(opts[0]).toMatchObject({ label: "Opus 5", value: "opus" });
+  });
+
+  it("marks provider chips so the handler can tell them from models", () => {
+    const view = buildModelPickerView(
+      pres({
+        view: "groups",
+        modelButtons: [
+          { text: "OpenRouter (278)", callback_data: "model:nav:provider:or" },
+          { text: "Zen (7)", callback_data: "model:nav:provider:zen" },
+        ],
+      }),
+      "Opus 5",
+      "kilo",
+    );
+    // Both views share one select; without the prefix the handler would try
+    // to resolve a provider id as a model and report it unavailable.
+    expect(selectOptions(view.components).map((o) => o.value)).toEqual([
+      "provider:or",
+      "provider:zen",
+    ]);
+  });
+
+  it("names the current backend on its button", () => {
+    const b = buttons(
+      buildModelPickerView(pres(), "Opus 5", "opencode").components,
+    );
+    expect(b.some((x) => x.label === "⚙ Backend: opencode")).toBe(true);
+  });
+});
+
+describe("buildBackendPickerView", () => {
+  it("marks the current backend and offers a way back", () => {
+    const view = buildBackendPickerView(
+      [
+        { id: "claude", label: "Anthropic" },
+        { id: "opencode", label: "OpenCode" },
+      ],
+      "claude",
+    );
+    const opts = selectOptions(view.components);
+    expect(opts.map((o) => o.value)).toEqual(["claude", "opencode"]);
+    expect(opts[0]).toMatchObject({ label: "Anthropic" });
+    expect(buttons(view.components).some((b) => b.label === "← Models")).toBe(
+      true,
+    );
+    expect(view.content).toContain("claude");
+  });
+});

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -46,24 +46,63 @@ describe("collectDoctorReport", () => {
     expect(report.issues).toBeGreaterThanOrEqual(1);
   });
 
-  it("reports a configured bundled backend with zero backend issues", async () => {
+  it("reports a configured bundled backend without raising unrelated issues", async () => {
     const report = await collectDoctorReport({
       hasConfigFile: true,
       config: { frontend: "terminal", backend: "kilo" },
     });
     const labels = report.checks.map((c) => c.label);
     expect(labels).toContain("Frontend: terminal");
-    expect(labels).toContain("Kilo SDK bundled");
+    // The SDK is only a client for a CLI of the same name, so the check
+    // reports on that binary — which is present or not per machine.
+    expect(
+      labels.some(
+        (l) => l === "Kilo CLI installed" || l === "Kilo CLI not found",
+      ),
+    ).toBe(true);
     expect(report.native).toHaveLength(6);
-    // Node version and workspace presence vary by machine — assert
-    // that nothing *else* (frontend, backend, native) raises an issue.
+    // Node version, workspace presence, and the backend CLI vary by
+    // machine — assert that nothing *else* raises an issue.
     const envCheck = (label: string) =>
-      label.startsWith("Node.js ") || label.startsWith("Workspace");
+      label.startsWith("Node.js ") ||
+      label.startsWith("Workspace") ||
+      label.startsWith("Kilo CLI");
     const nonEnvIssues = report.checks.filter(
       (c) => (c.status === "fail" || c.issue) && !envCheck(c.label),
     );
     expect(nonEnvIssues).toEqual([]);
     expect(report.native.every((m) => m.ok)).toBe(true);
+  });
+
+  it("reports the idle backends too, without counting them as issues", async () => {
+    const report = await collectDoctorReport({
+      hasConfigFile: true,
+      config: { frontend: "terminal", backend: "claude" },
+    });
+    const labels = report.checks.map((c) => c.label);
+    // A backend nobody is using is one click away from being used, so it
+    // gets a line — but a missing CLI there is a heads-up, not a fault.
+    const idle = report.checks.filter((c) => c.inactive);
+    expect(idle.length).toBeGreaterThan(0);
+    expect(idle.every((c) => c.status !== "fail")).toBe(true);
+    expect(idle.every((c) => !c.issue)).toBe(true);
+    expect(
+      labels.some(
+        (l) => l.startsWith("OpenCode CLI") || l.startsWith("Kilo CLI"),
+      ),
+    ).toBe(true);
+  });
+
+  it("only audits configured models for the active backend", async () => {
+    const report = await collectDoctorReport({
+      hasConfigFile: true,
+      config: { frontend: "terminal", backend: "kilo", model: "some-model" },
+    });
+    // The Claude model audit spawns a probe; it must not run for a backend
+    // that is merely listed.
+    expect(report.checks.some((c) => c.label.startsWith("Model ("))).toBe(
+      false,
+    );
   });
 
   it("flags an unconfigured telegram frontend by name", async () => {

--- a/src/__tests__/kilo-model-provider.test.ts
+++ b/src/__tests__/kilo-model-provider.test.ts
@@ -383,10 +383,9 @@ describe("kilo/model-provider — formatModelError", () => {
 
 describe("kilo/model-provider — getSettingsPresentation", () => {
   it("delegates to getOpenCodeSettingsPresentation and passes the callback prefix", async () => {
-    const presentation = await getSettingsPresentation(
-      "big-pickle",
-      "settings:model:",
-    );
+    const presentation = await getSettingsPresentation("big-pickle", {
+      callbackPrefix: "settings:model:",
+    });
     expect(presentation.modelButtons).toEqual([
       { text: "big-pickle", callback_data: "settings:model:big-pickle" },
     ]);

--- a/src/__tests__/remote-model-pagination.test.ts
+++ b/src/__tests__/remote-model-pagination.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+
+import { createRemoteModelPresentation } from "../backend/remote-server/model-catalog/presentation.js";
+import type {
+  RemoteModelCatalog,
+  RemoteModelCatalogEntry,
+} from "../backend/remote-server/model-catalog/types.js";
+
+function model(
+  id: string,
+  over: Partial<RemoteModelCatalogEntry> = {},
+): RemoteModelCatalogEntry {
+  return {
+    id,
+    name: id.toUpperCase(),
+    providerID: "openrouter",
+    providerName: "OpenRouter",
+    providerSource: "api",
+    connected: true,
+    selectable: true,
+    loginRequired: false,
+    envRequired: false,
+    authMethods: [],
+    free: false,
+    status: "active",
+    contextWindow: 200_000,
+    outputWindow: 64_000,
+    reasoning: false,
+    attachment: false,
+    toolcall: true,
+    costInput: 1,
+    costOutput: 2,
+    costCacheRead: 0,
+    costCacheWrite: 0,
+    ...over,
+  } as RemoteModelCatalogEntry;
+}
+
+function provider(id: string, name: string, modelCount: number) {
+  return {
+    id,
+    name,
+    source: "api",
+    connected: true,
+    modelCount,
+    authMethods: [],
+    envKeys: [],
+    loginRequired: false,
+    envRequired: false,
+  } as RemoteModelCatalog["providers"][number];
+}
+
+/** `count` models, every third one free, split across two providers. */
+function catalogOf(count: number): RemoteModelCatalog {
+  const models = Array.from({ length: count }, (_, i) =>
+    model(`m${i}`, {
+      free: i % 3 === 0,
+      providerID: i % 2 === 0 ? "openrouter" : "zen",
+      providerName: i % 2 === 0 ? "OpenRouter" : "OpenCode Zen",
+    }),
+  );
+  const providers = [
+    provider("openrouter", "OpenRouter", Math.ceil(count / 2)),
+    provider("zen", "OpenCode Zen", Math.floor(count / 2)),
+  ];
+  return {
+    generatedAt: 0,
+    providers,
+    models,
+    connectedProviders: providers,
+    loginProviders: [],
+    connectedModels: models,
+    connectedFreeModels: models.filter((m) => m.free),
+  };
+}
+
+function presentationFor(count: number, groupThreshold = 60) {
+  return createRemoteModelPresentation({
+    label: "OpenCode",
+    getCatalog: async () => catalogOf(count),
+    maxCallbackIdLength: 100,
+    allowCallbackSeparators: true,
+    quickPickLimit: 4,
+    groupThreshold,
+  });
+}
+
+describe("remote model picker pagination", () => {
+  it("splits a large catalog into pages of the requested size", async () => {
+    const p = presentationFor(343, 10_000);
+    const first = await p.getSettingsPresentation("m0", { pageSize: 25 });
+    expect(first.view).toBe("models");
+    expect(first.page).toBe(1);
+    expect(first.totalPages).toBe(Math.ceil(343 / 25));
+    expect(first.totalCount).toBe(343);
+    // 25 models plus the trailing Reset button.
+    expect(first.modelButtons).toHaveLength(26);
+  });
+
+  it("serves different models on different pages", async () => {
+    const p = presentationFor(343, 10_000);
+    const a = await p.getSettingsPresentation("m0", { pageSize: 25, page: 1 });
+    const b = await p.getSettingsPresentation("m0", { pageSize: 25, page: 2 });
+    const ids = (r: { modelButtons: { callback_data: string }[] }) =>
+      r.modelButtons.map((x) => x.callback_data);
+    expect(ids(a)).not.toEqual(ids(b));
+    expect(b.page).toBe(2);
+  });
+
+  it("clamps a page past the end rather than serving an empty list", async () => {
+    const p = presentationFor(343, 10_000);
+    const far = await p.getSettingsPresentation("m0", {
+      pageSize: 25,
+      page: 999,
+    });
+    expect(far.page).toBe(far.totalPages);
+    expect(far.modelButtons.length).toBeGreaterThan(1);
+  });
+
+  it("falls back to the backend's quick-pick count when no size is given", async () => {
+    const p = presentationFor(343, 10_000);
+    const r = await p.getSettingsPresentation("m0");
+    // quickPickLimit 4 + Reset.
+    expect(r.modelButtons).toHaveLength(5);
+    expect(r.totalPages).toBe(Math.ceil(343 / 4));
+  });
+
+  it("narrows to free models and still reports the unfiltered free count", async () => {
+    const p = presentationFor(90, 10_000);
+    const all = await p.getSettingsPresentation("m0", { pageSize: 1000 });
+    const free = await p.getSettingsPresentation("m0", {
+      pageSize: 1000,
+      filter: "free",
+    });
+    expect(all.filter).toBe("all");
+    expect(free.filter).toBe("free");
+    expect(free.freeCount).toBe(all.freeCount);
+    expect(free.modelButtons.length).toBeLessThan(all.modelButtons.length);
+  });
+
+  it("opens as provider chips once the flat list gets unreadable", async () => {
+    const p = presentationFor(343, 60);
+    const groups = await p.getSettingsPresentation("m0", { pageSize: 25 });
+    expect(groups.view).toBe("groups");
+    expect(groups.totalPages).toBe(1);
+    expect(groups.modelButtons.map((b) => b.callback_data)).toEqual([
+      "settings:models:provider:openrouter",
+      "settings:models:provider:zen",
+    ]);
+  });
+
+  it("lists one provider's models once drilled in", async () => {
+    const p = presentationFor(343, 60);
+    const drilled = await p.getSettingsPresentation("m0", {
+      pageSize: 25,
+      provider: "zen",
+    });
+    expect(drilled.view).toBe("models");
+    expect(drilled.provider).toBe("zen");
+    expect(drilled.totalCount).toBe(343);
+    // Only Zen models on the page — every id is odd-numbered by construction.
+    const shown = drilled.modelButtons
+      .map((b) => b.callback_data)
+      .filter((v) => v !== "settings:model:reset");
+    expect(shown.length).toBeGreaterThan(0);
+  });
+
+  it("stays a flat list when only one provider is connected", async () => {
+    const single = createRemoteModelPresentation({
+      label: "OpenCode",
+      getCatalog: async () => {
+        const c = catalogOf(200);
+        return { ...c, connectedProviders: [c.connectedProviders[0]!] };
+      },
+      maxCallbackIdLength: 100,
+      allowCallbackSeparators: true,
+      quickPickLimit: 4,
+      groupThreshold: 10,
+    });
+    const r = await single.getSettingsPresentation("m0", { pageSize: 25 });
+    expect(r.view).toBe("models");
+  });
+
+  it("honours the callback prefixes the frontend asked for", async () => {
+    const p = presentationFor(343, 60);
+    const groups = await p.getSettingsPresentation("m0", {
+      navCallbackPrefix: "model:nav",
+    });
+    expect(groups.modelButtons[0]?.callback_data).toBe(
+      "model:nav:provider:openrouter",
+    );
+    const models = await p.getSettingsPresentation("m0", {
+      callbackPrefix: "model:",
+      provider: "zen",
+      pageSize: 5,
+    });
+    expect(models.modelButtons[0]?.callback_data.startsWith("model:")).toBe(
+      true,
+    );
+  });
+});

--- a/src/backend/kilo/factory.ts
+++ b/src/backend/kilo/factory.ts
@@ -69,25 +69,8 @@ const kiloFactory: BackendFactory = {
       // through to `config.backendDefaults.kilo`.
       getDefaultModelId: () => undefined,
       getRawModelInfo: (id) => kiloGetModelInfo(id),
-      getSettingsPresentation: async (m, options) => {
-        // Kilo's internal helper returns the bare picker shape;
-        // wrap into the canonical `ModelPickerResult`. Kilo doesn't
-        // expose pagination or a free-tier filter so the result is
-        // always page 1 of 1 with filter "all".
-        const inner = await kiloGetSettingsPresentation(
-          m,
-          options?.callbackPrefix,
-        );
-        return {
-          ...inner,
-          view: "models" as const,
-          page: 1,
-          totalPages: 1,
-          filter: "all" as const,
-          freeCount: 0,
-          totalCount: inner.modelButtons.length,
-        };
-      },
+      getSettingsPresentation: (m, options) =>
+        kiloGetSettingsPresentation(m, options),
       getProviders: () => kiloGetProviders(),
       getProviderModels: (p, pg, ps) => kiloGetProviderModels(p, pg, ps),
       formatModelError: (q, r) => kiloFormatModelError(q, r),

--- a/src/backend/opencode/factory.ts
+++ b/src/backend/opencode/factory.ts
@@ -66,21 +66,8 @@ const opencodeFactory: BackendFactory = {
       // Catalog-driven backend with no canonical default.
       getDefaultModelId: () => undefined,
       getRawModelInfo: (id) => ocGetModelInfo(id),
-      getSettingsPresentation: async (m, options) => {
-        const inner = await ocGetSettingsPresentation(
-          m,
-          options?.callbackPrefix,
-        );
-        return {
-          ...inner,
-          view: "models" as const,
-          page: 1,
-          totalPages: 1,
-          filter: "all" as const,
-          freeCount: 0,
-          totalCount: inner.modelButtons.length,
-        };
-      },
+      getSettingsPresentation: (m, options) =>
+        ocGetSettingsPresentation(m, options),
       getProviders: () => ocGetProviders(),
       getProviderModels: (p, pg, ps) => ocGetProviderModels(p, pg, ps),
       formatModelError: (q, r) => ocFormatModelError(q, r),

--- a/src/backend/remote-server/model-catalog/presentation.ts
+++ b/src/backend/remote-server/model-catalog/presentation.ts
@@ -35,8 +35,40 @@ export interface RemotePresentationOptions {
    * true where the transport accepts arbitrary characters (Discord).
    */
   allowCallbackSeparators: boolean;
-  /** How many quick-pick buttons to offer (Telegram 4, Discord 24). */
+  /**
+   * Default page size when the frontend doesn't ask for one — also the
+   * legacy quick-pick count (Telegram 4, Discord 24).
+   */
   quickPickLimit: number;
+  /**
+   * Flat model lists longer than this collapse into provider chips, so a
+   * catalog of several hundred models opens as a handful of providers
+   * rather than dozens of indistinguishable pages. Defaults to 60.
+   */
+  groupThreshold?: number;
+}
+
+/** Paging / filtering knobs, mirroring `ModelPickerOptions`. */
+export interface RemotePickerOptions {
+  callbackPrefix?: string;
+  navCallbackPrefix?: string;
+  page?: number;
+  pageSize?: number;
+  filter?: "all" | "free";
+  provider?: string;
+}
+
+/** What the frontend needs to render one page of the picker. */
+export interface RemotePickerResult {
+  modelButtons: Array<ModelButton>;
+  modelDetails: Array<string>;
+  view: "groups" | "models";
+  page: number;
+  totalPages: number;
+  filter: "all" | "free";
+  freeCount: number;
+  totalCount: number;
+  provider?: string;
 }
 
 function getAvailabilityLabel(model: RemoteModelCatalogEntry) {
@@ -69,8 +101,8 @@ export interface RemoteModelPresentation {
   ): Array<RemoteModelCatalogEntry>;
   getSettingsPresentation(
     activeModel: string,
-    callbackPrefix?: string,
-  ): Promise<{ modelButtons: Array<ModelButton>; modelDetails: Array<string> }>;
+    options?: RemotePickerOptions,
+  ): Promise<RemotePickerResult>;
   renderModelSummary(
     activeModel: string,
     defaultModel: string,
@@ -92,6 +124,7 @@ export function createRemoteModelPresentation(
     maxCallbackIdLength,
     allowCallbackSeparators,
     quickPickLimit,
+    groupThreshold = 60,
   } = options;
 
   function isCallbackSafeModelID(modelID: string): boolean {
@@ -140,30 +173,64 @@ export function createRemoteModelPresentation(
 
   async function getSettingsPresentation(
     activeModel: string,
-    callbackPrefix = "settings:model:",
-  ): Promise<{
-    modelButtons: Array<ModelButton>;
-    modelDetails: Array<string>;
-  }> {
+    options: RemotePickerOptions = {},
+  ): Promise<RemotePickerResult> {
+    const callbackPrefix = options.callbackPrefix ?? "settings:model:";
+    const navPrefix = options.navCallbackPrefix ?? "settings:models";
     const catalog = await getCatalog();
     const current = getRemoteModelInfo(catalog, activeModel);
-    const picks = getQuickPickModels(catalog, activeModel);
 
-    const modelButtons: Array<ModelButton> = picks.map((m) => {
-      const btnLabel =
-        m.id.length <= 20 ? m.id : m.name.length <= 20 ? m.name : m.id;
-      const txt = m.free ? `${btnLabel} ★` : btnLabel;
-      const sel =
-        current && m.id === current.id && m.providerID === current.providerID;
-      return {
-        text: sel ? `✓ ${txt}` : txt,
-        callback_data: `${callbackPrefix}${m.id}`,
-      };
-    });
-    modelButtons.push({
-      text: "Reset",
-      callback_data: `${callbackPrefix}reset`,
-    });
+    const filter = options.filter === "free" ? "free" : "all";
+    const selectable = catalog.connectedModels.filter((m) =>
+      isCallbackSafeModelID(m.id),
+    );
+    const freeCount = selectable.filter((m) => m.free).length;
+    const scoped = selectable.filter(
+      (m) =>
+        (filter === "all" || m.free) &&
+        (!options.provider || m.providerID === options.provider),
+    );
+
+    // A remote catalog can run to hundreds of models, and only the first
+    // page's worth ever fit on screen — so offer the provider list as the
+    // way in when nothing narrower was asked for and the flat list would be
+    // unreadable anyway.
+    const providers = catalog.connectedProviders;
+    const asGroups =
+      !options.provider &&
+      providers.length > 1 &&
+      scoped.length > groupThreshold;
+
+    const pageSize = Math.max(1, options.pageSize ?? quickPickLimit);
+    const source = asGroups ? providers : scoped;
+    const totalPages = Math.max(1, Math.ceil(source.length / pageSize));
+    const page = Math.min(Math.max(1, options.page ?? 1), totalPages);
+    const slice = source.slice((page - 1) * pageSize, page * pageSize);
+
+    const modelButtons: Array<ModelButton> = asGroups
+      ? (slice as typeof providers).map((p) => ({
+          text: `${p.name} (${p.modelCount})`,
+          callback_data: `${navPrefix}:provider:${p.id}`,
+        }))
+      : (slice as typeof scoped).map((m) => {
+          const btnLabel =
+            m.id.length <= 20 ? m.id : m.name.length <= 20 ? m.name : m.id;
+          const txt = m.free ? `${btnLabel} ★` : btnLabel;
+          const sel =
+            current &&
+            m.id === current.id &&
+            m.providerID === current.providerID;
+          return {
+            text: sel ? `✓ ${txt}` : txt,
+            callback_data: `${callbackPrefix}${m.id}`,
+          };
+        });
+    if (!asGroups) {
+      modelButtons.push({
+        text: "Reset",
+        callback_data: `${callbackPrefix}reset`,
+      });
+    }
 
     const details: Array<string> = [];
     if (current) {
@@ -189,7 +256,17 @@ export function createRemoteModelPresentation(
       );
     }
     details.push("Hint: use /model <name> to switch.");
-    return { modelButtons, modelDetails: details };
+    return {
+      modelButtons,
+      modelDetails: details,
+      view: asGroups ? "groups" : "models",
+      page,
+      totalPages,
+      filter,
+      freeCount,
+      totalCount: selectable.length,
+      ...(options.provider ? { provider: options.provider } : {}),
+    };
   }
 
   async function renderModelSummary(

--- a/src/backend/remote-server/model-catalog/provider.ts
+++ b/src/backend/remote-server/model-catalog/provider.ts
@@ -19,6 +19,10 @@ import type {
   RemoteModelCatalogEntry,
   RemoteModelResolution,
 } from "./types.js";
+import type {
+  RemotePickerOptions,
+  RemotePickerResult,
+} from "./presentation.js";
 
 export interface RemoteModelProviderDeps {
   /** Human label — "OpenCode" / "Kilo" — used in error strings. */
@@ -36,8 +40,8 @@ export interface RemoteModelProviderDeps {
   formatUnavailableModel(model: RemoteModelCatalogEntry): string;
   getSettingsPresentation(
     activeModel: string,
-    callbackPrefix?: string,
-  ): Promise<{ modelButtons: ModelButton[]; modelDetails: string[] }>;
+    options?: RemotePickerOptions,
+  ): Promise<RemotePickerResult>;
 }
 
 export interface RemoteModelProvider {
@@ -45,8 +49,8 @@ export interface RemoteModelProvider {
   getModelInfo(id: string): Promise<UnifiedModelInfo | undefined>;
   getSettingsPresentation(
     activeModel: string,
-    callbackPrefix?: string,
-  ): Promise<{ modelButtons: ModelButton[]; modelDetails: string[] }>;
+    options?: RemotePickerOptions,
+  ): Promise<RemotePickerResult>;
   getProviders(): Promise<UnifiedProviderInfo[]>;
   getProviderModels(
     providerId: string,
@@ -118,8 +122,8 @@ export function createRemoteModelProvider(
       return entry ? toUnifiedModelInfo(entry) : undefined;
     },
 
-    getSettingsPresentation(activeModel, callbackPrefix = "settings:model:") {
-      return deps.getSettingsPresentation(activeModel, callbackPrefix);
+    getSettingsPresentation(activeModel, options) {
+      return deps.getSettingsPresentation(activeModel, options);
     },
 
     async getProviders() {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -25,9 +25,19 @@ export async function runDoctor(): Promise<void> {
     config: hasConfigFile ? loadConfig() : undefined,
     hasConfigFile,
   });
-  for (const check of report.checks) {
+  const print = (check: (typeof report.checks)[number]): void => {
     const detail = check.detail ? ` ${pc.dim(`(${check.detail})`)}` : "";
     console.log(`  ${DOCTOR_ICONS[check.status]} ${check.label}${detail}`);
+  };
+  for (const check of report.checks.filter((c) => !c.inactive)) print(check);
+
+  // Configured-but-idle backends describe what a switch would run into,
+  // not the state of the running deployment.
+  const idle = report.checks.filter((c) => c.inactive);
+  if (idle.length > 0) {
+    console.log(`\n  ${pc.bold("Other backends")}\n`);
+    for (const check of idle) print(check);
+    console.log();
   }
   // Native plane, one line per embedded module with provenance.
   for (const mod of report.native) {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -29,6 +29,12 @@ export interface DoctorCheck {
    * starts but a backend won't work.
    */
   issue?: boolean;
+  /**
+   * A backend that is configured but not serving chats. Renderers group
+   * these away from the environment so a handful of idle providers can't
+   * bury the checks that describe the running deployment.
+   */
+  inactive?: boolean;
 }
 
 /** One embedded native module: provenance plus a live self-test result. */
@@ -59,6 +65,8 @@ export interface DoctorReport {
 export interface DoctorConfigSlice {
   frontend: string | string[];
   backend?: string;
+  /** Backends config exposes. Empty / absent means every registered one. */
+  enabledBackends?: string[];
   model?: string;
   heartbeatModel?: string;
   heartbeatBackend?: string;
@@ -284,12 +292,55 @@ async function checkClaudeConfiguredModels(
   return checks;
 }
 
-/** Binary / auth checks for the active backend only. */
+/** Every backend id doctor knows how to inspect. */
+const KNOWN_BACKENDS = [
+  "claude",
+  "codex",
+  "kilo",
+  "opencode",
+  "openai-agents",
+] as const;
+
+/**
+ * Binary / auth checks across every backend the config exposes.
+ *
+ * Only the active one counts toward the issue total; the rest are reported
+ * so a switch doesn't have to be the thing that discovers a backend can't
+ * run. That distinction matters now that a chat can be rebound at runtime —
+ * a report of all-green while two backends are one click from failing is
+ * worse than no report.
+ */
 async function checkBackend(
   config: DoctorConfigSlice | undefined,
 ): Promise<DoctorCheck[]> {
+  const active = config?.backend ?? "claude";
+  const exposed = config?.enabledBackends?.length
+    ? config.enabledBackends
+    : [...KNOWN_BACKENDS];
+
+  const checks = await checkOneBackend(active, config, true);
+  for (const id of exposed) {
+    if (id === active || !KNOWN_BACKENDS.includes(id as never)) continue;
+    // An idle backend's missing binary is a heads-up, not a fault of this
+    // deployment: downgrade it and keep it out of the issue count.
+    for (const check of await checkOneBackend(id, config, false)) {
+      checks.push({
+        ...check,
+        status: check.status === "fail" ? "warn" : check.status,
+        issue: false,
+        inactive: true,
+      });
+    }
+  }
+  return checks;
+}
+
+async function checkOneBackend(
+  backend: string,
+  config: DoctorConfigSlice | undefined,
+  isActive: boolean,
+): Promise<DoctorCheck[]> {
   const checks: DoctorCheck[] = [];
-  const backend = config?.backend ?? "claude";
 
   if (backend === "claude") {
     if (config?.claudeBinary) {
@@ -313,7 +364,9 @@ async function checkBackend(
           : { label: "Claude Code not found", status: "fail" },
       );
     }
-    checks.push(...(await checkClaudeConfiguredModels(config)));
+    // Model resolution spawns a probe — worth it for the backend actually
+    // serving chats, wasteful for one nobody is using.
+    if (isActive) checks.push(...(await checkClaudeConfiguredModels(config)));
   } else if (backend === "codex") {
     if (!binaryOnPath("codex")) {
       checks.push({
@@ -349,11 +402,21 @@ async function checkBackend(
       });
     }
   } else if (backend === "kilo" || backend === "opencode") {
-    // Bundled as npm deps — no external binary to check.
-    checks.push({
-      label: `${backend === "kilo" ? "Kilo" : "OpenCode"} SDK bundled`,
-      status: "ok",
-    });
+    // The SDK ships as an npm dep but only talks to a server it spawns from
+    // the CLI of the same name (`cross-spawn` → PATH lookup). A present
+    // package with an absent binary fails at the first turn with a bare
+    // ENOENT, so check what actually gets executed.
+    const label = backend === "kilo" ? "Kilo" : "OpenCode";
+    checks.push(
+      binaryOnPath(backend)
+        ? { label: `${label} CLI installed`, status: "ok" }
+        : {
+            label: `${label} CLI not found`,
+            status: "fail",
+            detail: `the ${label} SDK spawns \`${backend}\` — install it or this backend cannot start`,
+            issue: true,
+          },
+    );
   } else if (backend === "openai-agents") {
     checks.push({ label: "OpenAI Agents SDK bundled", status: "ok" });
     const hasEnvKey = Boolean(process.env.OPENAI_API_KEY);

--- a/src/frontend/discord/callbacks/components.ts
+++ b/src/frontend/discord/callbacks/components.ts
@@ -68,6 +68,7 @@ import {
   DISCORD_MAX_TEXT,
 } from "../formatting.js";
 import { chatIdFromInteraction, type ComponentInteraction } from "./shared.js";
+import { metricsViewRow, renderMetricsView } from "../commands/admin.js";
 
 export async function handleComponentInteraction(
   interaction: ComponentInteraction,
@@ -348,6 +349,21 @@ export async function handleComponentInteraction(
       } catch {
         /* ignore */
       }
+    }
+    return;
+  }
+
+  // ── /metrics today ↔ all-time toggle ────────────────────────────────────
+  if (customId === "metrics:today" || customId === "metrics:all") {
+    const view = customId === "metrics:all" ? "all" : "today";
+    const messages = renderMetricsView(view);
+    try {
+      await interaction.update({
+        content: messages[0]!,
+        components: [metricsViewRow(view).toJSON()],
+      });
+    } catch {
+      /* ignore */
     }
     return;
   }

--- a/src/frontend/discord/callbacks/components.ts
+++ b/src/frontend/discord/callbacks/components.ts
@@ -30,6 +30,14 @@ import {
 import type { TalonConfig } from "../../../util/config.js";
 import type { Gateway } from "../../../core/engine/gateway.js";
 import {
+  buildModelPickerView,
+  buildBackendPickerView,
+  decodeModelNav,
+  MODEL_NAV_PREFIX,
+  MODEL_PAGE_SIZE,
+} from "../model-picker.js";
+import { metricsViewRow, renderMetricsView } from "../commands/admin.js";
+import {
   getChatSettings,
   setChatModelForBackend,
   setChatBackend,
@@ -52,7 +60,12 @@ import { execute } from "../../../core/engine/dispatcher.js";
 import {
   getBackendIdForChat,
   resolveChatBackend,
+  listAvailableBackends,
+  rebindChat,
 } from "../../../core/engine/backend-controller/index.js";
+import { resetSession } from "../../../storage/sessions.js";
+import { clearHistory } from "../../../storage/history.js";
+import { resetPulseCheckpoint } from "../../../core/background/pulse.js";
 import { resolveActiveModelForChat } from "../../../core/models/active-model.js";
 import {
   displayReasoningEffort,
@@ -68,7 +81,6 @@ import {
   DISCORD_MAX_TEXT,
 } from "../formatting.js";
 import { chatIdFromInteraction, type ComponentInteraction } from "./shared.js";
-import { metricsViewRow, renderMetricsView } from "../commands/admin.js";
 
 export async function handleComponentInteraction(
   interaction: ComponentInteraction,
@@ -287,6 +299,38 @@ export async function handleComponentInteraction(
     const be = resolveChatBackend(chatId, gateway?.backend);
     const beId = getBackendIdForChat(chatId);
 
+    // In the provider view the select carries chips, not models — picking
+    // one drills into that provider rather than choosing anything.
+    if (value?.startsWith("provider:") && be?.models?.getSettingsPresentation) {
+      const providerId = value.slice("provider:".length);
+      const { model: activeNow } = await resolveActiveModelForChat(
+        chatId,
+        be,
+        beId,
+        config,
+      );
+      const pres = await be.models.getSettingsPresentation(activeNow ?? "", {
+        callbackPrefix: "model:",
+        navCallbackPrefix: MODEL_NAV_PREFIX,
+        pageSize: MODEL_PAGE_SIZE,
+        provider: providerId,
+      });
+      const view = buildModelPickerView(
+        pres,
+        activeNow ?? "_No model selected_",
+        beId,
+      );
+      try {
+        await interaction.update({
+          content: view.content,
+          components: view.components,
+        });
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+
     if (value === "reset") {
       // Clear THIS backend's slot only — other backends stay intact.
       setChatModelForBackend(chatId, beId, undefined);
@@ -320,35 +364,219 @@ export async function handleComponentInteraction(
       const current = resolvedCurrent ?? "";
       const pres = await be.models?.getSettingsPresentation(current, {
         callbackPrefix: "model:",
+        navCallbackPrefix: MODEL_NAV_PREFIX,
+        pageSize: MODEL_PAGE_SIZE,
       });
       const modelInfo = resolvedCurrent
         ? await be.models?.getRawModelInfo?.(resolvedCurrent)
         : undefined;
       const displayName =
         modelInfo?.displayName ?? resolvedCurrent ?? "_No model selected_";
-      const menu = new StringSelectMenuBuilder()
-        .setCustomId("model:select")
-        .setPlaceholder("Pick a model")
-        .addOptions(
-          pres.modelButtons.slice(0, 25).map((b) => ({
-            label: safeSlice(b.text.replace(/^✓ /, ""), 100),
-            value: safeSlice(b.callback_data.replace(/^model:/, ""), 100),
-            default: b.text.startsWith("✓"),
-          })),
-        );
-      const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
-        menu,
-      );
+      const view = buildModelPickerView(pres, displayName, beId);
       try {
         await interaction.update({
-          content: [`**Model:** \`${displayName}\``, ...pres.modelDetails].join(
-            "\n",
-          ),
-          components: [row],
+          content: view.content,
+          components: view.components,
         });
       } catch {
         /* ignore */
       }
+    }
+    return;
+  }
+
+  // ── /model pager — page arrows, free-tier toggle, provider drill ────────
+  // Pure navigation: re-render the same panel at the requested page without
+  // touching the chat's selected model.
+  if (customId.startsWith(`${MODEL_NAV_PREFIX}:`)) {
+    // Backend submenu — the one nav action that isn't a re-page.
+    if (customId === `${MODEL_NAV_PREFIX}:backends`) {
+      const view = buildBackendPickerView(
+        listAvailableBackends(config),
+        getBackendIdForChat(chatId),
+      );
+      try {
+        await interaction.update({
+          content: view.content,
+          components: view.components,
+        });
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+
+    const target = decodeModelNav(customId);
+    if (!target) {
+      try {
+        await interaction.deferUpdate();
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+    const be = resolveChatBackend(chatId, gateway?.backend);
+    const beId = getBackendIdForChat(chatId);
+    const { model: current } = await resolveActiveModelForChat(
+      chatId,
+      be,
+      beId,
+      config,
+    );
+    if (!be?.models?.getSettingsPresentation) {
+      try {
+        await interaction.deferUpdate();
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+    const pres = await be.models.getSettingsPresentation(current ?? "", {
+      callbackPrefix: "model:",
+      navCallbackPrefix: MODEL_NAV_PREFIX,
+      pageSize: MODEL_PAGE_SIZE,
+      page: target.page,
+      filter: target.filter,
+      ...(target.provider ? { provider: target.provider } : {}),
+    });
+    const modelInfo = current
+      ? await be.models?.getRawModelInfo?.(current)
+      : undefined;
+    const view = buildModelPickerView(
+      pres,
+      modelInfo?.displayName ?? current ?? "_No model selected_",
+      beId,
+    );
+    try {
+      await interaction.update({
+        content: view.content,
+        components: view.components,
+      });
+    } catch {
+      /* ignore */
+    }
+    return;
+  }
+
+  // ── /model backend switch ───────────────────────────────────────────────
+  // Rebinding drops this chat's session (it isn't portable across backends)
+  // but keeps each backend's remembered model pick, so switching back
+  // restores what was selected there before.
+  if (customId === "model:backend-select" && interaction.isStringSelectMenu()) {
+    const backendId = interaction.values[0] ?? "";
+    const available = listAvailableBackends(config);
+    if (!available.some((b) => b.id === backendId)) {
+      await interaction.reply({
+        content: "Backend not available.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    // Booting a cold backend takes seconds — Kilo and OpenCode spawn a server
+    // and sweep MCP registrations — and Discord drops an interaction that
+    // isn't acknowledged within three. Ack first, edit the panel after.
+    try {
+      await interaction.deferUpdate();
+    } catch {
+      /* already acknowledged */
+    }
+    const fail = async (text: string): Promise<void> => {
+      try {
+        await interaction.followUp({
+          content: text,
+          flags: MessageFlags.Ephemeral,
+        });
+      } catch {
+        /* ignore */
+      }
+    };
+
+    // Resolve the outgoing backend before rebinding — afterwards the chat
+    // already points at the new one and the old instance is unreachable.
+    const previousId = getBackendIdForChat(chatId);
+    const previous = resolveChatBackend(chatId, gateway?.backend);
+    const alreadyThere = previousId === backendId;
+    const result = alreadyThere
+      ? { ok: true as const }
+      : await rebindChat(chatId, backendId, config);
+    if (!result.ok) {
+      await fail(result.error?.slice(0, 200) ?? "Rebind failed.");
+      return;
+    }
+    setChatBackend(chatId, backendId);
+
+    // The pool accepts a backend whose SDK is installed, but the SDK may only
+    // be a client for a CLI that isn't (OpenCode and Kilo spawn `opencode` /
+    // `kilo`). That surfaces here, on the first real call. Reading the
+    // catalog is the cheapest way to find out, and it is needed for the panel
+    // anyway — so treat a throw as "this backend can't serve" and put the
+    // chat back where it was rather than stranding it somewhere unusable.
+    let next = resolveChatBackend(chatId, gateway?.backend);
+    let newModel: string | undefined;
+    let pres;
+    try {
+      newModel =
+        (await resolveActiveModelForChat(chatId, next, backendId, config))
+          .model ?? undefined;
+      if (next?.models?.getSettingsPresentation) {
+        pres = await next.models.getSettingsPresentation(newModel ?? "", {
+          callbackPrefix: "model:",
+          navCallbackPrefix: MODEL_NAV_PREFIX,
+          pageSize: MODEL_PAGE_SIZE,
+        });
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      logError("discord", `Backend switch to ${backendId} failed`, err);
+      if (!alreadyThere) {
+        await rebindChat(chatId, previousId, config).catch(() => undefined);
+        setChatBackend(chatId, previousId);
+      }
+      await fail(
+        `⚠️ \`${backendId}\` could not start — staying on \`${previousId}\`.\n` +
+          `\`\`\`\n${safeSlice(reason, 300)}\n\`\`\``,
+      );
+      return;
+    }
+
+    // Only now is the switch known to hold. Session state doesn't port across
+    // backends, so it goes — but each backend's remembered model pick stays.
+    // A re-pick of the backend already in use clears nothing: the retry after
+    // a timed-out interaction must not cost the session a second time.
+    if (!alreadyThere) {
+      resetSession(chatId);
+      clearHistory(chatId);
+      resetPulseCheckpoint(chatId);
+      previous?.sessions?.resetChat?.(chatId);
+    }
+
+    next = resolveChatBackend(chatId, gateway?.backend);
+    // Warming is fire-and-forget: it can take seconds on OpenCode/Kilo and
+    // the interaction still has a panel to redraw.
+    if (next && next !== previous) {
+      void Promise.resolve(next.sessions?.warmSession?.(chatId)).catch(
+        () => undefined,
+      );
+    }
+
+    try {
+      await interaction.editReply(
+        pres
+          ? {
+              ...buildModelPickerView(
+                pres,
+                newModel ?? "_No model selected_",
+                backendId,
+              ),
+            }
+          : {
+              content: `**Backend:** \`${backendId}\` · model \`${newModel ?? "none"}\``,
+              components: [],
+            },
+      );
+    } catch {
+      /* ignore */
     }
     return;
   }

--- a/src/frontend/discord/commands/admin.ts
+++ b/src/frontend/discord/commands/admin.ts
@@ -3,16 +3,37 @@
  * All gate on `isAdmin`.
  */
 
-import { type ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import {
+  type ChatInputCommandInteraction,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  MessageFlags,
+} from "discord.js";
 import type { TalonConfig } from "../../../util/config.js";
 import type { Gateway } from "../../../core/engine/gateway.js";
 import { respawnSelf } from "../../../util/respawn.js";
 import { forceDream } from "../../../core/background/dream.js";
-import { formatDuration, renderMetricsMessages } from "../helpers.js";
+import {
+  formatDuration,
+  renderMetricsMessages,
+  renderDoctorMessages,
+} from "../helpers.js";
+import { collectDoctorReport } from "../../../core/doctor.js";
+import { getSoul } from "../../../core/soul/service.js";
 import { getMetrics, getTodayMetrics } from "../../../storage/metrics.js";
 import { handleAdminSubcommand } from "../admin.js";
 import { isAdmin } from "../handlers/index.js";
-import { suppressMentions, DISCORD_MAX_TEXT } from "../formatting.js";
+import {
+  suppressMentions,
+  DISCORD_MAX_TEXT,
+  safeSlice,
+  escapeForCodeBlock,
+} from "../formatting.js";
+import {
+  getRepoRoot,
+  runSelfUpdate,
+} from "../../../core/update/self-update.js";
 import { reply } from "./shared.js";
 
 export async function handleRestart(
@@ -34,18 +55,112 @@ export async function handleMetrics(
     return;
   }
   // Ephemeral — admin counters (token usage, latencies, errors) shouldn't leak
-  // into a public channel where non-admins can read them.
-  const messages = [
-    ...renderMetricsMessages(getMetrics()),
-    ...renderMetricsMessages(
-      getTodayMetrics(),
-      undefined,
-      "📊 Metrics — today (UTC)",
-    ),
-  ];
-  for (const m of messages) {
-    await reply(i, m, true);
+  // into a public channel where non-admins can read them. Both views are one
+  // button apart rather than two bursts of messages.
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  const messages = renderMetricsMessages(
+    getTodayMetrics(),
+    undefined,
+    "📊 Metrics — today (UTC)",
+  );
+  await i.editReply({
+    content: messages[0]!,
+    components: [metricsViewRow("today").toJSON()],
+  });
+  for (const extra of messages.slice(1)) {
+    await i.followUp({ content: extra, flags: MessageFlags.Ephemeral });
   }
+}
+
+/** Today / all-time toggle under the metrics panel. */
+export function metricsViewRow(
+  view: MetricsView,
+): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId("metrics:today")
+      .setLabel("Today")
+      .setStyle(view === "today" ? ButtonStyle.Primary : ButtonStyle.Secondary)
+      .setDisabled(view === "today"),
+    new ButtonBuilder()
+      .setCustomId("metrics:all")
+      .setLabel("All time")
+      .setStyle(view === "all" ? ButtonStyle.Primary : ButtonStyle.Secondary)
+      .setDisabled(view === "all"),
+  );
+}
+
+export type MetricsView = "today" | "all";
+
+/** Panel body for one view — shared by the command and the toggle. */
+export function renderMetricsView(view: MetricsView): string[] {
+  return view === "today"
+    ? renderMetricsMessages(
+        getTodayMetrics(),
+        undefined,
+        "📊 Metrics — today (UTC)",
+      )
+    : renderMetricsMessages(getMetrics(), undefined, "📊 Metrics — all time");
+}
+
+export async function handleDoctor(
+  i: ChatInputCommandInteraction,
+  config: TalonConfig,
+): Promise<void> {
+  if (!isAdmin(i.user.id)) {
+    await reply(i, "Not authorized.", true);
+    return;
+  }
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  await i.editReply("🩺 Running checks...");
+  try {
+    // Same checks as `talon doctor` — config exists by definition when the
+    // bot is processing this command.
+    const report = await collectDoctorReport({ config, hasConfigFile: true });
+    const messages = renderDoctorMessages(report);
+    await i.editReply(messages[0]!);
+    for (const extra of messages.slice(1))
+      await i.followUp({
+        content: extra,
+        flags: MessageFlags.Ephemeral,
+      });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await i.editReply(`🩺 Doctor failed: ${msg}`);
+  }
+}
+
+/**
+ * /soul — read-only introspection of the compiled identity. `action:dream`
+ * runs the organic maintenance pass and is admin-only. Inert while the soul
+ * is disabled, so it is safe to ship dormant.
+ */
+export async function handleSoul(
+  i: ChatInputCommandInteraction,
+): Promise<void> {
+  const soul = getSoul();
+  if (!soul.enabled) {
+    await reply(
+      i,
+      "Soul is disabled (set TALON_SOUL_ENABLED to enable).",
+      true,
+    );
+    return;
+  }
+  if (i.options.getString("action") === "dream") {
+    if (!isAdmin(i.user.id)) {
+      await reply(i, "Not authorized.", true);
+      return;
+    }
+    await i.deferReply({ flags: MessageFlags.Ephemeral });
+    await i.editReply("🧠 Soul dreaming...");
+    soul
+      .dream()
+      .then(() => i.editReply("🧠 Soul dream complete."))
+      .catch(() => undefined);
+    return;
+  }
+  await reply(i, suppressMentions(soul.introspect()), true);
 }
 
 export async function handleDream(
@@ -68,6 +183,65 @@ export async function handleDream(
     .catch(async (err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err);
       await i.editReply(`🌙 Dream failed: ${msg}`);
+    });
+}
+
+/**
+ * /update — pull, reinstall, run setup, restart. Only reachable on developer
+ * builds running from a git checkout; the command is not registered at all
+ * otherwise (see buildCommandDefinitions).
+ */
+export async function handleUpdate(
+  i: ChatInputCommandInteraction,
+  config: TalonConfig,
+): Promise<void> {
+  if (!isAdmin(i.user.id)) {
+    await reply(i, "Not authorized.", true);
+    return;
+  }
+  const repoRoot = config.devBuild ? getRepoRoot() : null;
+  if (!repoRoot) {
+    await reply(i, "Update is only available on developer builds.", true);
+    return;
+  }
+  const remote = config.update?.remote ?? "origin";
+  const branch = config.update?.branch ?? "main";
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  await i.editReply(`⏳ Updating from \`${remote}/${branch}\`…`);
+  const edit = (text: string) => i.editReply(safeSlice(text, DISCORD_MAX_TEXT));
+
+  // Fire-and-forget so the gateway keeps processing other interactions.
+  runSelfUpdate({
+    remote,
+    branch,
+    setup: config.update?.setup,
+    repoRoot,
+  })
+    .then(async (res) => {
+      if (!res.ok) {
+        const tail = res.steps[res.steps.length - 1]?.output ?? "";
+        await edit(
+          `⚠️ Update failed: ${res.error ?? "unknown error"}` +
+            (tail
+              ? `\n\`\`\`\n${escapeForCodeBlock(tail.slice(-1200))}\n\`\`\``
+              : ""),
+        );
+        return;
+      }
+      if (!res.changed) {
+        await edit(
+          `✅ Already up to date at \`${res.before ?? "?"}\` — no restart needed.`,
+        );
+        return;
+      }
+      await edit(
+        `✅ Updated \`${res.before ?? "?"}\` → \`${res.after ?? "?"}\`. ♻️ Restarting…`,
+      );
+      respawnSelf("discord /update");
+    })
+    .catch(async (err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      await edit(`⚠️ Update crashed: ${msg}`);
     });
 }
 

--- a/src/frontend/discord/commands/definitions.ts
+++ b/src/frontend/discord/commands/definitions.ts
@@ -15,8 +15,9 @@
 import { type Client, REST, Routes, SlashCommandBuilder } from "discord.js";
 import type { TalonConfig } from "../../../util/config.js";
 import { log, logError, logWarn } from "../../../util/log.js";
+import { getRepoRoot } from "../../../core/update/self-update.js";
 
-export function buildCommandDefinitions(): unknown[] {
+export function buildCommandDefinitions(devBuild = false): unknown[] {
   return [
     new SlashCommandBuilder()
       .setName("start")
@@ -98,6 +99,36 @@ export function buildCommandDefinitions(): unknown[] {
       .setDescription("List loaded plugins")
       .toJSON(),
     new SlashCommandBuilder()
+      .setName("doctor")
+      .setDescription("Environment and native-module health (admin)")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("mesh")
+      .setDescription("Ping and list mesh devices")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("soul")
+      .setDescription("Inspect the compiled identity")
+      .addStringOption((o) =>
+        o
+          .setName("action")
+          .setDescription("Leave empty to introspect")
+          .setRequired(false)
+          .addChoices({ name: "dream", value: "dream" }),
+      )
+      .toJSON(),
+    // /update only exists on developer builds running from a git checkout —
+    // a packaged binary has no source tree to pull into, so the command is
+    // never registered there (same gate as the Telegram handler).
+    ...(devBuild && getRepoRoot()
+      ? [
+          new SlashCommandBuilder()
+            .setName("update")
+            .setDescription("Pull latest, reinstall, restart (admin)")
+            .toJSON(),
+        ]
+      : []),
+    new SlashCommandBuilder()
       .setName("admin")
       .setDescription("Admin operations (admin only)")
       .addStringOption((o) =>
@@ -128,7 +159,7 @@ export async function registerCommandsForGuilds(
 ): Promise<void> {
   const dc = config.discord!;
   const rest = new REST({ version: "10" }).setToken(dc.botToken);
-  const definitions = buildCommandDefinitions();
+  const definitions = buildCommandDefinitions(config.devBuild);
 
   // Step 1: clear or set global commands depending on DM setting.
   try {

--- a/src/frontend/discord/commands/info.ts
+++ b/src/frontend/discord/commands/info.ts
@@ -7,8 +7,10 @@ import {
   type Client,
   MessageFlags,
 } from "discord.js";
-import { formatDuration } from "../helpers.js";
+import { formatDuration, renderMeshReport } from "../helpers.js";
 import { getLoadedPlugins } from "../../../core/plugin/index.js";
+import { getMeshService } from "../../../core/mesh/index.js";
+import type { MeshPingResult } from "../../../core/mesh/service.js";
 import { reply } from "./shared.js";
 
 export async function handleStart(
@@ -65,6 +67,21 @@ export async function handleHelp(
     ].join("\n"),
     true,
   );
+}
+
+export async function handleMesh(
+  i: ChatInputCommandInteraction,
+): Promise<void> {
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  await i.editReply("Pinging mesh devices…");
+  let results: MeshPingResult[];
+  try {
+    results = await getMeshService().pingAll();
+  } catch {
+    await i.editReply("Could not reach the mesh service.");
+    return;
+  }
+  await i.editReply(renderMeshReport(results));
 }
 
 export async function handlePing(

--- a/src/frontend/discord/commands/router.ts
+++ b/src/frontend/discord/commands/router.ts
@@ -22,7 +22,13 @@ import {
   handleModalSubmit,
 } from "../callbacks/index.js";
 import { chatIdFromInteraction, reply, client } from "./shared.js";
-import { handleStart, handleHelp, handlePing, handlePlugins } from "./info.js";
+import {
+  handleStart,
+  handleHelp,
+  handlePing,
+  handlePlugins,
+  handleMesh,
+} from "./info.js";
 import { handleReset, handleStatus } from "./session.js";
 import {
   handleModel,
@@ -35,6 +41,9 @@ import {
   handleMetrics,
   handleDream,
   handleAdmin,
+  handleDoctor,
+  handleSoul,
+  handleUpdate,
 } from "./admin.js";
 
 export function registerInteractionRouter(
@@ -141,6 +150,14 @@ async function routeSlashCommand(
       return handleDream(interaction);
     case "plugins":
       return handlePlugins(interaction);
+    case "doctor":
+      return handleDoctor(interaction, config);
+    case "mesh":
+      return handleMesh(interaction);
+    case "soul":
+      return handleSoul(interaction);
+    case "update":
+      return handleUpdate(interaction, config);
     case "admin":
       return handleAdmin(interaction, config, gateway);
     default:

--- a/src/frontend/discord/commands/settings.ts
+++ b/src/frontend/discord/commands/settings.ts
@@ -46,6 +46,11 @@ import {
 import { resolveActiveModelForChat } from "../../../core/models/active-model.js";
 import { safeSlice } from "../formatting.js";
 import { reply } from "./shared.js";
+import {
+  buildModelPickerView,
+  MODEL_NAV_PREFIX,
+  MODEL_PAGE_SIZE,
+} from "../model-picker.js";
 
 export async function handleModel(
   i: ChatInputCommandInteraction,
@@ -94,6 +99,8 @@ export async function handleModel(
     if (be?.models?.getSettingsPresentation) {
       const pres = await be.models?.getSettingsPresentation(activeModel, {
         callbackPrefix: "model:",
+        navCallbackPrefix: MODEL_NAV_PREFIX,
+        pageSize: MODEL_PAGE_SIZE,
       });
       const modelInfo = activeModel
         ? await be.models?.getRawModelInfo?.(activeModel)
@@ -102,25 +109,10 @@ export async function handleModel(
         modelInfo?.displayName ??
         (activeModel ? formatModelLabel(activeModel) : "_No model selected_");
 
-      // Build select menu from the top 25 models. Discord caps select-menu
-      // options at 25; if the backend exposes more, use `/model name:<value>`
-      // (autocomplete-backed) to pick anything outside this list.
-      const options = pres.modelButtons.slice(0, 25).map((b) => ({
-        label: safeSlice(b.text.replace(/^✓ /, ""), 100),
-        value: safeSlice(b.callback_data.replace(/^model:/, ""), 100),
-        default: b.text.startsWith("✓"),
-      }));
-      const menu = new StringSelectMenuBuilder()
-        .setCustomId("model:select")
-        .setPlaceholder("Pick a model")
-        .addOptions(options);
-      const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
-        menu,
-      );
-      const lines = [`**Model:** \`${displayName}\``, ...pres.modelDetails];
+      const view = buildModelPickerView(pres, displayName, beId);
       await i.editReply({
-        content: lines.join("\n"),
-        components: [row],
+        content: view.content,
+        components: view.components,
         allowedMentions: { parse: [] },
       });
     } else {

--- a/src/frontend/discord/helpers.ts
+++ b/src/frontend/discord/helpers.ts
@@ -8,10 +8,17 @@
  */
 
 import { REASONING_LEVEL_DESCRIPTIONS } from "../../core/models/reasoning-levels.js";
-import { DISCORD_MAX_TEXT, DISCORD_SAFE_RESERVE } from "./formatting.js";
+import {
+  DISCORD_MAX_TEXT,
+  DISCORD_SAFE_RESERVE,
+  splitMessage,
+} from "./formatting.js";
+import type { DoctorReport } from "../../core/doctor.js";
+import type { MeshPingResult } from "../../core/mesh/service.js";
 import {
   DEFAULT_PULSE_INTERVAL_MS,
   formatDuration,
+  formatBytes,
   formatModelLabel,
 } from "../shared/format.js";
 
@@ -155,6 +162,121 @@ export function renderMetricsMessages(
   }
   if (current !== header || chunks.length === 0) chunks.push(current);
   return chunks;
+}
+
+const DOCTOR_ICONS: Record<string, string> = {
+  ok: "✅",
+  warn: "⚠️",
+  fail: "❌",
+  info: "▫️",
+};
+
+/**
+ * Render a DoctorReport as Discord markdown, split to fit the message cap.
+ * Same data as `talon doctor` and Telegram's /doctor.
+ */
+export function renderDoctorMessages(
+  report: DoctorReport,
+  maxLen = DEFAULT_METRICS_MESSAGE_MAX,
+): string[] {
+  const lines = ["**🩺 Talon Doctor**", "", "**Environment**"];
+
+  const render = (check: DoctorReport["checks"][number]): string =>
+    `${DOCTOR_ICONS[check.status]} ${check.label}${check.detail ? ` (${check.detail})` : ""}`;
+
+  for (const check of report.checks.filter((c) => !c.inactive)) {
+    lines.push(render(check));
+  }
+
+  // Configured-but-idle backends get their own block: they describe what a
+  // switch would run into, not the state of the running deployment.
+  const idle = report.checks.filter((c) => c.inactive);
+  if (idle.length > 0) {
+    lines.push("", "**Other backends**", ...idle.map(render));
+  }
+
+  lines.push("", "**Native modules**");
+  for (const mod of report.native) {
+    const size =
+      mod.sizeBytes !== undefined ? ` · ${formatBytes(mod.sizeBytes)}` : "";
+    const note = mod.note ? ` (${mod.note})` : "";
+    lines.push(
+      `${mod.ok ? DOCTOR_ICONS.ok : DOCTOR_ICONS.fail} \`${mod.name}\` — ${mod.language} → ${mod.target}${size}${note}`,
+    );
+  }
+
+  lines.push(
+    "",
+    "**Process**",
+    `Uptime ${formatDuration(process.uptime() * 1000)} · PID ${process.pid} · Node ${process.versions.node}`,
+    "",
+    report.issues === 0
+      ? `${DOCTOR_ICONS.ok} All checks passed.`
+      : `${DOCTOR_ICONS.warn} ${report.issues} issue(s) found.`,
+  );
+
+  return splitMessage(lines.join("\n"), maxLen);
+}
+
+function meshDeviceLine(r: MeshPingResult, now: number): string {
+  const d = r.device;
+  const bits: string[] = [d.platform];
+  if (r.reachable && typeof r.latencyMs === "number") {
+    bits.push(`${r.latencyMs} ms`);
+  } else if (d.online && r.error) {
+    bits.push(r.error);
+  } else if (!d.online) {
+    bits.push(`last seen ${formatDuration(now - d.lastSeen)} ago`);
+  }
+  if (typeof d.battery === "number") {
+    bits.push(`${d.battery}%${d.charging ? " charging" : ""}`);
+  }
+  return `  **${d.name}** — ${bits.join(" · ")}`;
+}
+
+/**
+ * Render the /mesh fleet report as Discord markdown. Devices group under a
+ * state heading; empty groups are omitted.
+ */
+export function renderMeshReport(
+  results: MeshPingResult[],
+  now = Date.now(),
+): string {
+  if (results.length === 0) {
+    return "**Mesh**\n\n_No devices have registered yet._";
+  }
+
+  const responding = results
+    .filter((r) => r.reachable)
+    .sort((a, b) => (a.latencyMs ?? Infinity) - (b.latencyMs ?? Infinity));
+  const unreachable = results
+    .filter((r) => !r.reachable && r.device.online)
+    .sort((a, b) => a.device.name.localeCompare(b.device.name));
+  const offline = results
+    .filter((r) => !r.reachable && !r.device.online)
+    .sort((a, b) => b.device.lastSeen - a.device.lastSeen);
+
+  const summary = [
+    `${results.length} device${results.length === 1 ? "" : "s"}`,
+    `${responding.length} responding`,
+    ...(unreachable.length > 0 ? [`${unreachable.length} unreachable`] : []),
+    ...(offline.length > 0 ? [`${offline.length} offline`] : []),
+  ].join(" · ");
+
+  const lines = ["**Mesh**", summary];
+  const section = (title: string, entries: MeshPingResult[]): void => {
+    if (entries.length === 0) return;
+    lines.push(
+      "",
+      `**${title}**`,
+      ...entries.map((r) => meshDeviceLine(r, now)),
+    );
+  };
+  section("Responding", responding);
+  section("Unreachable", unreachable);
+  section("Offline", offline);
+
+  return lines.join("\n");
 }
 
 /** Settings panel: build the markdown body. */

--- a/src/frontend/discord/model-picker.ts
+++ b/src/frontend/discord/model-picker.ts
@@ -1,0 +1,234 @@
+/**
+ * Model picker rendering — select menu plus pager controls.
+ *
+ * The backend already paginates and filters the catalog
+ * (`getSettingsPresentation` returns page / totalPages / filter / provider);
+ * this only lays that out as Discord components. A select menu caps at 25
+ * options, so without the pager everything past the first 25 models was
+ * unreachable from the UI.
+ *
+ * Navigation state rides in the custom_id — `model:nav:page:3:free` — which
+ * is what keeps the handler stateless across re-renders.
+ */
+
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  StringSelectMenuBuilder,
+  type APIActionRowComponent,
+  type APIComponentInMessageActionRow,
+} from "discord.js";
+import type { ModelPickerResult } from "../../core/types.js";
+import { safeSlice } from "./formatting.js";
+
+export const MODEL_NAV_PREFIX = "model:nav";
+/** Discord's hard cap on select-menu options — also the page size we request. */
+export const MODEL_PAGE_SIZE = 25;
+
+/** Where a nav button points. Decoded from a `model:nav:…` custom_id. */
+export type ModelNavTarget = {
+  page: number;
+  filter: "all" | "free";
+  provider?: string;
+};
+
+export function decodeModelNav(customId: string): ModelNavTarget | null {
+  if (!customId.startsWith(`${MODEL_NAV_PREFIX}:`)) return null;
+  const parts = customId.slice(MODEL_NAV_PREFIX.length + 1).split(":");
+  const [kind] = parts;
+
+  if (kind === "providers") return { page: 1, filter: "all" };
+  if (kind === "provider") {
+    return { page: 1, filter: "all", provider: parts[1] };
+  }
+  if (kind === "page") {
+    const page = Number(parts[1]);
+    const filter = parts[2] === "free" ? "free" : "all";
+    return {
+      page: Number.isFinite(page) && page > 0 ? page : 1,
+      filter,
+      ...(parts[3] ? { provider: parts[3] } : {}),
+    };
+  }
+  if (kind === "filter") {
+    const filter = parts[1] === "free" ? "free" : "all";
+    return { page: 1, filter, ...(parts[2] ? { provider: parts[2] } : {}) };
+  }
+  return null;
+}
+
+function navId(suffix: string, provider?: string): string {
+  const base = `${MODEL_NAV_PREFIX}:${suffix}`;
+  return provider ? `${base}:${provider}` : base;
+}
+
+/**
+ * Buttons under the select: page arrows, a page counter, the free-tier
+ * toggle, and a way back to the provider list. Five buttons is exactly one
+ * Action Row, so this never spills into a second row.
+ */
+function controlRow(
+  pres: ModelPickerResult,
+): ActionRowBuilder<ButtonBuilder> | null {
+  const buttons: ButtonBuilder[] = [];
+  const { page, totalPages, filter, freeCount, provider } = pres;
+
+  if (totalPages > 1) {
+    buttons.push(
+      new ButtonBuilder()
+        .setCustomId(navId(`page:${page - 1}:${filter}`, provider))
+        .setLabel("◀")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(page <= 1),
+      // A disabled button is the only way to render a static counter
+      // inline with the arrows.
+      new ButtonBuilder()
+        .setCustomId(navId("noop"))
+        .setLabel(`${page}/${totalPages}`)
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(true),
+      new ButtonBuilder()
+        .setCustomId(navId(`page:${page + 1}:${filter}`, provider))
+        .setLabel("▶")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(page >= totalPages),
+    );
+  }
+
+  // A filter that would keep everything is just a button that does nothing —
+  // offer it only when part of the catalog costs money.
+  if (freeCount > 0 && freeCount < pres.totalCount) {
+    buttons.push(
+      new ButtonBuilder()
+        .setCustomId(
+          navId(`filter:${filter === "free" ? "all" : "free"}`, provider),
+        )
+        .setLabel(filter === "free" ? `All models` : `Free only (${freeCount})`)
+        .setStyle(ButtonStyle.Secondary),
+    );
+  }
+
+  if (provider) {
+    buttons.push(
+      new ButtonBuilder()
+        .setCustomId(navId("providers"))
+        .setLabel("← Providers")
+        .setStyle(ButtonStyle.Secondary),
+    );
+  }
+
+  if (buttons.length === 0) return null;
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(buttons);
+}
+
+export interface ModelPickerView {
+  content: string;
+  components: APIActionRowComponent<APIComponentInMessageActionRow>[];
+}
+
+/** Select of the backends config exposes, plus a way back to the models. */
+export function buildBackendPickerView(
+  backends: { id: string; label: string }[],
+  currentId: string,
+): ModelPickerView {
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId("model:backend-select")
+    .setPlaceholder("Pick a backend")
+    .addOptions(
+      backends.map((b) => ({
+        label: safeSlice(b.label || b.id, 100),
+        value: safeSlice(b.id, 100),
+        description: b.id === currentId ? "current" : undefined,
+        default: b.id === currentId,
+      })),
+    );
+
+  const back = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(navId("page:1:all"))
+      .setLabel("← Models")
+      .setStyle(ButtonStyle.Secondary),
+  );
+
+  return {
+    content: [
+      `**Backend:** \`${currentId}\``,
+      "",
+      "_Switching clears this chat's session — each backend keeps its own model pick._",
+    ].join("\n"),
+    components: [
+      new ActionRowBuilder<StringSelectMenuBuilder>()
+        .addComponents(menu)
+        .toJSON(),
+      back.toJSON(),
+    ],
+  };
+}
+
+/**
+ * Lay out one page of the picker. In the `groups` view the select lists
+ * providers to drill into; in `models` it lists selectable models.
+ */
+export function buildModelPickerView(
+  pres: ModelPickerResult,
+  displayName: string,
+  backendId: string,
+): ModelPickerView {
+  const isGroups = pres.view === "groups";
+  const options = pres.modelButtons.slice(0, MODEL_PAGE_SIZE).map((b) => ({
+    // Discord's own guidance is ~38 characters before a label starts
+    // truncating visually, well under the 100-character hard cap.
+    label: safeSlice(b.text.replace(/^✓ /, ""), 100),
+    value: safeSlice(
+      isGroups
+        ? b.callback_data.replace(/^.*:provider:/, "provider:")
+        : b.callback_data.replace(/^model:/, ""),
+      100,
+    ),
+    default: !isGroups && b.text.startsWith("✓"),
+  }));
+
+  const components: APIActionRowComponent<APIComponentInMessageActionRow>[] =
+    [];
+
+  if (options.length > 0) {
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId("model:select")
+      .setPlaceholder(isGroups ? "Pick a provider" : "Pick a model")
+      .addOptions(options);
+    components.push(
+      new ActionRowBuilder<StringSelectMenuBuilder>()
+        .addComponents(menu)
+        .toJSON(),
+    );
+  }
+
+  const controls = controlRow(pres);
+  if (controls) components.push(controls.toJSON());
+
+  // Own row: the control row is already at Discord's five-button ceiling
+  // whenever the catalog pages.
+  components.push(
+    new ActionRowBuilder<ButtonBuilder>()
+      .addComponents(
+        new ButtonBuilder()
+          .setCustomId(navId("backends"))
+          .setLabel(`⚙ Backend: ${backendId}`)
+          .setStyle(ButtonStyle.Secondary),
+      )
+      .toJSON(),
+  );
+
+  const scope = pres.provider ? ` · ${pres.provider}` : "";
+  const counts =
+    pres.totalPages > 1
+      ? ` · ${pres.totalCount} model${pres.totalCount === 1 ? "" : "s"}`
+      : "";
+  const lines = [
+    `**Model:** \`${displayName}\`${scope}${counts}`,
+    ...pres.modelDetails,
+  ];
+
+  return { content: lines.join("\n"), components };
+}

--- a/src/frontend/telegram/helpers/diagnostics.ts
+++ b/src/frontend/telegram/helpers/diagnostics.ts
@@ -211,11 +211,20 @@ const DOCTOR_ICONS: Record<string, string> = {
 export function renderDoctorMessage(report: DoctorReport): string {
   const lines = ["<b>🩺 Talon Doctor</b>", "", "<b>Environment</b>"];
 
-  for (const check of report.checks) {
+  const render = (check: DoctorReport["checks"][number]): string => {
     const detail = check.detail ? ` (${escapeHtml(check.detail)})` : "";
-    lines.push(
-      `${DOCTOR_ICONS[check.status]} ${escapeHtml(check.label)}${detail}`,
-    );
+    return `${DOCTOR_ICONS[check.status]} ${escapeHtml(check.label)}${detail}`;
+  };
+
+  for (const check of report.checks.filter((c) => !c.inactive)) {
+    lines.push(render(check));
+  }
+
+  // Configured-but-idle backends get their own block: they describe what a
+  // switch would run into, not the state of the running deployment.
+  const idle = report.checks.filter((c) => c.inactive);
+  if (idle.length > 0) {
+    lines.push("", "<b>Other backends</b>", ...idle.map(render));
   }
 
   lines.push("", "<b>Native modules</b>");


### PR DESCRIPTION
Stacked on #716 (which stacks on #715) — the change to review is the last commit. Rebase once those land.

`getSettingsPresentation` for OpenCode and Kilo took only a callback prefix and returned a fixed quick-pick list: four buttons for OpenCode, twenty-four for Kilo. Both factories then stamped the result with

```ts
page: 1, totalPages: 1, filter: "all", freeCount: 0
```

so every frontend was told there was exactly one page regardless of catalog size. On my deployment Kilo lists **278 usable models** and 274 of them were unreachable from the UI — the only way in was typing an id into `/model name:`.

### The catalog side

The presentation now accepts the options both frontends were already sending (`page`, `pageSize`, `filter`, `provider`) and reports what it actually served. `quickPickLimit` becomes the default page size, so a caller that asks for nothing sees exactly what it saw before, only with honest page counts alongside. Catalogs past `groupThreshold` (60) open as provider chips instead of a flat list — thirteen pages of near-identical ids is not a picker.

This is shared code, so Telegram's model menu benefits too; it had no way to page these backends either.

### The Discord side

A select plus a control row: page arrows with an inert counter between them, a free-tier filter that appears only when part of the catalog costs money, and provider drill-in. Navigation state rides in the `custom_id`, so the handler stays stateless across re-renders.

Discord also gains a backend switcher, which Telegram has had inside `/model` and Discord had nowhere. Two details that cost me a broken chat before I got them right:

- **It reads the new backend's catalog before committing.** The pool accepts a backend whose SDK is installed, but those SDKs are only clients for a CLI that may not be — so the failure surfaces on the first real call as `spawn opencode ENOENT`. A throw now means "this backend can't serve": rebind back, report the real reason, leave the session alone. Before that, a failed switch left the chat pinned to a backend whose picker threw on every render, with no way out through the UI.
- **The interaction is acknowledged before the backend boots.** A cold Kilo takes ~40s here (server spawn, session creation, MCP sweep) against Discord's three-second window. Re-picking the backend already in use is treated as success rather than an error, so the retry after a timeout doesn't clear the session a second time.

### Tests

26 new: page arithmetic, edge-disabled arrows, clamping a page past the end, the free filter appearing only when it filters something, provider chips being distinguishable from models in the shared select, the 25-option cap, and `custom_id` decoding. `tsc`, `prettier` and `oxlint` clean; the suite passes except two failures that also fail on a clean checkout of `main` on that machine.

Verified on a live deployment for command flow and the backend switcher; the multi-page view was verified against a synthetic 343-model catalog, since reaching it live needs a provider catalog that large.
