### PR TITLE
feat: add /usage — plan limits across every backend

### DIFF
--- a/src/__tests__/codex-plan-usage.test.ts
+++ b/src/__tests__/codex-plan-usage.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { parseCodexUsage } from "../backend/codex/plan-usage.js";
+
+/** The shape the ChatGPT backend returns for a plan install. */
+function body(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    plan_type: "plus",
+    rate_limit: {
+      primary_window: {
+        used_percent: 26,
+        limit_window_seconds: 604800,
+        reset_at: 1786225824,
+      },
+      secondary_window: null,
+    },
+    ...over,
+  };
+}
+
+describe("parseCodexUsage", () => {
+  it("labels a window by its length and converts the reset to ISO", () => {
+    const usage = parseCodexUsage(body());
+    expect(usage?.plan).toBe("plus");
+    expect(usage?.windows).toEqual([
+      {
+        label: "7d",
+        percent: 26,
+        resetsAt: new Date(1786225824 * 1000).toISOString(),
+      },
+    ]);
+  });
+
+  it("keeps both windows when the plan still has a shorter one", () => {
+    const usage = parseCodexUsage(
+      body({
+        rate_limit: {
+          primary_window: {
+            used_percent: 26,
+            limit_window_seconds: 604800,
+            reset_at: 1786225824,
+          },
+          secondary_window: {
+            used_percent: 4,
+            limit_window_seconds: 18000,
+            reset_at: 1786000000,
+          },
+        },
+      }),
+    );
+    expect(usage?.windows.map((w) => w.label)).toEqual(["7d", "5h"]);
+  });
+
+  it("drops a window the plan no longer has", () => {
+    // The 5-hour window was retired; a null secondary is normal, not a gap.
+    const usage = parseCodexUsage(body());
+    expect(usage?.windows).toHaveLength(1);
+  });
+
+  it("clamps and rounds the percentage", () => {
+    const usage = parseCodexUsage(
+      body({
+        rate_limit: {
+          primary_window: {
+            used_percent: 99.6,
+            limit_window_seconds: 604800,
+          },
+        },
+      }),
+    );
+    expect(usage?.windows[0]?.percent).toBe(100);
+    expect(usage?.windows[0]?.resetsAt).toBeUndefined();
+  });
+
+  it("returns undefined when there is no plan to report", () => {
+    expect(parseCodexUsage(null)).toBeUndefined();
+    expect(parseCodexUsage({})).toBeUndefined();
+    expect(parseCodexUsage({ rate_limit: {} })).toBeUndefined();
+    expect(
+      parseCodexUsage({ rate_limit: { primary_window: {} } }),
+    ).toBeUndefined();
+  });
+});

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -46,24 +46,63 @@ describe("collectDoctorReport", () => {
     expect(report.issues).toBeGreaterThanOrEqual(1);
   });
 
-  it("reports a configured bundled backend with zero backend issues", async () => {
+  it("reports a configured bundled backend without raising unrelated issues", async () => {
     const report = await collectDoctorReport({
       hasConfigFile: true,
       config: { frontend: "terminal", backend: "kilo" },
     });
     const labels = report.checks.map((c) => c.label);
     expect(labels).toContain("Frontend: terminal");
-    expect(labels).toContain("Kilo SDK bundled");
+    // The SDK is only a client for a CLI of the same name, so the check
+    // reports on that binary — which is present or not per machine.
+    expect(
+      labels.some(
+        (l) => l === "Kilo CLI installed" || l === "Kilo CLI not found",
+      ),
+    ).toBe(true);
     expect(report.native).toHaveLength(6);
-    // Node version and workspace presence vary by machine — assert
-    // that nothing *else* (frontend, backend, native) raises an issue.
+    // Node version, workspace presence, and the backend CLI vary by
+    // machine — assert that nothing *else* raises an issue.
     const envCheck = (label: string) =>
-      label.startsWith("Node.js ") || label.startsWith("Workspace");
+      label.startsWith("Node.js ") ||
+      label.startsWith("Workspace") ||
+      label.startsWith("Kilo CLI");
     const nonEnvIssues = report.checks.filter(
       (c) => (c.status === "fail" || c.issue) && !envCheck(c.label),
     );
     expect(nonEnvIssues).toEqual([]);
     expect(report.native.every((m) => m.ok)).toBe(true);
+  });
+
+  it("reports the idle backends too, without counting them as issues", async () => {
+    const report = await collectDoctorReport({
+      hasConfigFile: true,
+      config: { frontend: "terminal", backend: "claude" },
+    });
+    const labels = report.checks.map((c) => c.label);
+    // A backend nobody is using is one click away from being used, so it
+    // gets a line — but a missing CLI there is a heads-up, not a fault.
+    const idle = report.checks.filter((c) => c.inactive);
+    expect(idle.length).toBeGreaterThan(0);
+    expect(idle.every((c) => c.status !== "fail")).toBe(true);
+    expect(idle.every((c) => !c.issue)).toBe(true);
+    expect(
+      labels.some(
+        (l) => l.startsWith("OpenCode CLI") || l.startsWith("Kilo CLI"),
+      ),
+    ).toBe(true);
+  });
+
+  it("only audits configured models for the active backend", async () => {
+    const report = await collectDoctorReport({
+      hasConfigFile: true,
+      config: { frontend: "terminal", backend: "kilo", model: "some-model" },
+    });
+    // The Claude model audit spawns a probe; it must not run for a backend
+    // that is merely listed.
+    expect(report.checks.some((c) => c.label.startsWith("Model ("))).toBe(
+      false,
+    );
   });
 
   it("flags an unconfigured telegram frontend by name", async () => {

--- a/src/__tests__/plan-usage-report.test.ts
+++ b/src/__tests__/plan-usage-report.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TalonConfig } from "../util/config.js";
+
+const listAvailableBackends = vi.hoisted(() => vi.fn());
+const getPooledBackend = vi.hoisted(() => vi.fn());
+vi.mock("../core/engine/backend-controller/index.js", () => ({
+  listAvailableBackends,
+  getPooledBackend,
+}));
+
+const { collectPlanUsage } =
+  await import("../frontend/shared/plan-usage-report.js");
+
+const config = {} as TalonConfig;
+
+function reporting(percent: number) {
+  return {
+    usage: {
+      getPlanUsage: async () => ({
+        plan: "max",
+        fetchedAt: Date.now(),
+        windows: [{ label: "7d", percent }],
+      }),
+    },
+  };
+}
+
+describe("collectPlanUsage", () => {
+  beforeEach(() => {
+    listAvailableBackends.mockReset();
+    getPooledBackend.mockReset();
+  });
+
+  it("reports a backend that has plan limits", async () => {
+    listAvailableBackends.mockReturnValue([
+      { id: "claude", label: "Anthropic" },
+    ]);
+    getPooledBackend.mockReturnValue(reporting(12));
+
+    const [entry] = await collectPlanUsage(config);
+    expect(entry?.label).toBe("Anthropic");
+    expect(entry?.plan?.windows[0]).toMatchObject({ label: "7d", percent: 12 });
+    expect(entry?.note).toBeUndefined();
+  });
+
+  it("explains a backend with no plan concept rather than omitting it", async () => {
+    listAvailableBackends.mockReturnValue([{ id: "kilo", label: "Kilo" }]);
+    getPooledBackend.mockReturnValue({ usage: undefined });
+
+    const [entry] = await collectPlanUsage(config);
+    expect(entry?.plan).toBeNull();
+    expect(entry?.note).toContain("no plan limits");
+  });
+
+  it("says so when a backend isn't running", async () => {
+    listAvailableBackends.mockReturnValue([{ id: "codex", label: "Codex" }]);
+    getPooledBackend.mockReturnValue(null);
+
+    const [entry] = await collectPlanUsage(config);
+    expect(entry?.plan).toBeNull();
+    expect(entry?.note).toBe("not running");
+  });
+
+  it("treats a backend that answers nothing as unavailable, not broken", async () => {
+    listAvailableBackends.mockReturnValue([{ id: "codex", label: "Codex" }]);
+    getPooledBackend.mockReturnValue({
+      usage: { getPlanUsage: async () => undefined },
+    });
+
+    const [entry] = await collectPlanUsage(config);
+    expect(entry?.note).toBe("no usage information available");
+  });
+
+  it("survives a backend that throws", async () => {
+    listAvailableBackends.mockReturnValue([{ id: "codex", label: "Codex" }]);
+    getPooledBackend.mockReturnValue({
+      usage: {
+        getPlanUsage: async () => {
+          throw new Error("network down");
+        },
+      },
+    });
+
+    const [entry] = await collectPlanUsage(config);
+    expect(entry?.note).toBe("no usage information available");
+  });
+
+  it("keeps config order and reports every exposed backend", async () => {
+    listAvailableBackends.mockReturnValue([
+      { id: "claude", label: "Anthropic" },
+      { id: "codex", label: "Codex" },
+      { id: "kilo", label: "Kilo" },
+    ]);
+    getPooledBackend.mockImplementation((id: string) =>
+      id === "claude" ? reporting(31) : id === "codex" ? reporting(26) : null,
+    );
+
+    const entries = await collectPlanUsage(config);
+    expect(entries.map((e) => e.id)).toEqual(["claude", "codex", "kilo"]);
+    expect(entries[0]?.plan?.windows[0]?.percent).toBe(31);
+    expect(entries[1]?.plan?.windows[0]?.percent).toBe(26);
+    expect(entries[2]?.note).toBe("not running");
+  });
+});

--- a/src/backend/codex/factory.ts
+++ b/src/backend/codex/factory.ts
@@ -16,7 +16,9 @@ import {
   type ChatBackend,
   type BackgroundRunner,
   type ModelCatalog,
+  type UsageTelemetry,
 } from "../../core/agent-runtime/capabilities.js";
+import { getPlanUsage as getCodexPlanUsage } from "./plan-usage.js";
 
 import { initCodexAgent, getCodexAuthInfo } from "./init.js";
 import { handleMessage as codexHandleMessage } from "./handler/index.js";
@@ -77,6 +79,12 @@ const codexFactory: BackendFactory = {
     // the per-chat thread lifecycle directly via `setSessionId` on
     // `storage/sessions.ts`. No `sessions` slot needed; `/reset`
     // clears the stored thread id through the storage path.
+    // No per-session snapshot to offer, but a ChatGPT-plan install can
+    // report its rate-limit windows.
+    const usage: UsageTelemetry = {
+      getPlanUsage: () => getCodexPlanUsage(),
+    };
+
     const backend = composeBackend({
       id: "codex",
       label: "Codex",
@@ -84,6 +92,7 @@ const codexFactory: BackendFactory = {
       chat,
       background,
       models,
+      usage,
     });
 
     return {

--- a/src/backend/codex/plan-usage.ts
+++ b/src/backend/codex/plan-usage.ts
@@ -1,0 +1,160 @@
+/**
+ * ChatGPT subscription rate-limit windows for the Codex backend.
+ *
+ * The Codex CLI reads these from an endpoint on the ChatGPT backend and
+ * caches the result in its session transcripts; `/status` renders that cache
+ * rather than re-fetching. Talon queries the endpoint directly so `/usage`
+ * reports the current state instead of whatever the last turn happened to
+ * see, using the OAuth token `codex login` already stored.
+ *
+ * Degrades to `undefined` for API-key installs (no plan to report), a
+ * missing or expired token, or any transport failure.
+ */
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logWarn } from "../../util/log.js";
+import type {
+  PlanUsage,
+  PlanWindow,
+} from "../../core/agent-runtime/capabilities.js";
+
+const USAGE_ENDPOINT = "https://chatgpt.com/backend-api/wham/usage";
+const REQUEST_TIMEOUT_MS = 5_000;
+const CACHE_TTL_MS = 60_000;
+
+let cache: { value: PlanUsage; fetchedAt: number } | undefined;
+let inFlight: Promise<PlanUsage | undefined> | undefined;
+
+function authPath(): string {
+  const home = process.env.CODEX_HOME?.trim();
+  return home && home.length > 0
+    ? join(home, "auth.json")
+    : join(homedir(), ".codex", "auth.json");
+}
+
+interface CodexAuth {
+  accessToken: string;
+  accountId?: string;
+}
+
+async function readAuth(): Promise<CodexAuth | undefined> {
+  try {
+    const parsed = JSON.parse(await readFile(authPath(), "utf8")) as {
+      auth_mode?: string;
+      tokens?: { access_token?: string; account_id?: string };
+    };
+    const token = parsed.tokens?.access_token;
+    if (!token) return undefined;
+    return {
+      accessToken: token,
+      ...(parsed.tokens?.account_id
+        ? { accountId: parsed.tokens.account_id }
+        : {}),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+interface RawWindow {
+  used_percent?: number;
+  limit_window_seconds?: number;
+  reset_at?: number;
+}
+
+/**
+ * Window label from its length. The plan exposes a weekly window and,
+ * historically, a shorter one; naming them by duration keeps the label
+ * right whichever windows the account actually has.
+ */
+function windowLabel(seconds: number | undefined): string {
+  if (!seconds || !Number.isFinite(seconds)) return "limit";
+  const hours = Math.round(seconds / 3600);
+  if (hours % 24 === 0 && hours >= 24) return `${hours / 24}d`;
+  return `${hours}h`;
+}
+
+function toWindow(raw: RawWindow | null | undefined): PlanWindow | undefined {
+  if (!raw || typeof raw.used_percent !== "number") return undefined;
+  return {
+    label: windowLabel(raw.limit_window_seconds),
+    percent: Math.max(0, Math.min(100, Math.round(raw.used_percent))),
+    // `reset_at` is unix seconds; the shared shape speaks ISO.
+    ...(typeof raw.reset_at === "number" && raw.reset_at > 0
+      ? { resetsAt: new Date(raw.reset_at * 1000).toISOString() }
+      : {}),
+  };
+}
+
+export function parseCodexUsage(body: unknown): PlanUsage | undefined {
+  const data = body as {
+    plan_type?: string;
+    rate_limit?: {
+      primary_window?: RawWindow | null;
+      secondary_window?: RawWindow | null;
+    };
+  } | null;
+  const limit = data?.rate_limit;
+  if (!limit) return undefined;
+
+  const windows = [
+    toWindow(limit.primary_window),
+    toWindow(limit.secondary_window),
+  ].filter((w): w is PlanWindow => Boolean(w));
+  if (windows.length === 0) return undefined;
+
+  return {
+    ...(data?.plan_type ? { plan: data.plan_type } : {}),
+    windows,
+    fetchedAt: Date.now(),
+  };
+}
+
+async function load(): Promise<PlanUsage | undefined> {
+  const auth = await readAuth();
+  if (!auth) return undefined;
+
+  try {
+    const res = await fetch(USAGE_ENDPOINT, {
+      headers: {
+        Authorization: `Bearer ${auth.accessToken}`,
+        ...(auth.accountId ? { "chatgpt-account-id": auth.accountId } : {}),
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      logWarn("agent", `codex usage: endpoint returned ${res.status}`);
+      return undefined;
+    }
+    return parseCodexUsage(await res.json());
+  } catch (err) {
+    logWarn(
+      "agent",
+      `codex usage: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Plan windows for `/usage`, cached for a minute. A failed refresh keeps
+ * serving the last known values — `fetchedAt` lets the caller age them.
+ */
+export async function getPlanUsage(): Promise<PlanUsage | undefined> {
+  if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) return cache.value;
+
+  inFlight ??= load().finally(() => {
+    inFlight = undefined;
+  });
+  const loaded = await inFlight;
+  if (loaded) cache = { value: loaded, fetchedAt: loaded.fetchedAt };
+  return loaded ?? cache?.value;
+}
+
+export function resetCodexPlanUsageForTest(): void {
+  cache = undefined;
+  inFlight = undefined;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -25,9 +25,19 @@ export async function runDoctor(): Promise<void> {
     config: hasConfigFile ? loadConfig() : undefined,
     hasConfigFile,
   });
-  for (const check of report.checks) {
+  const print = (check: (typeof report.checks)[number]): void => {
     const detail = check.detail ? ` ${pc.dim(`(${check.detail})`)}` : "";
     console.log(`  ${DOCTOR_ICONS[check.status]} ${check.label}${detail}`);
+  };
+  for (const check of report.checks.filter((c) => !c.inactive)) print(check);
+
+  // Configured-but-idle backends describe what a switch would run into,
+  // not the state of the running deployment.
+  const idle = report.checks.filter((c) => c.inactive);
+  if (idle.length > 0) {
+    console.log(`\n  ${pc.bold("Other backends")}\n`);
+    for (const check of idle) print(check);
+    console.log();
   }
   // Native plane, one line per embedded module with provenance.
   for (const mod of report.native) {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -29,6 +29,12 @@ export interface DoctorCheck {
    * starts but a backend won't work.
    */
   issue?: boolean;
+  /**
+   * A backend that is configured but not serving chats. Renderers group
+   * these away from the environment so a handful of idle providers can't
+   * bury the checks that describe the running deployment.
+   */
+  inactive?: boolean;
 }
 
 /** One embedded native module: provenance plus a live self-test result. */
@@ -59,6 +65,8 @@ export interface DoctorReport {
 export interface DoctorConfigSlice {
   frontend: string | string[];
   backend?: string;
+  /** Backends config exposes. Empty / absent means every registered one. */
+  enabledBackends?: string[];
   model?: string;
   heartbeatModel?: string;
   heartbeatBackend?: string;
@@ -284,12 +292,55 @@ async function checkClaudeConfiguredModels(
   return checks;
 }
 
-/** Binary / auth checks for the active backend only. */
+/** Every backend id doctor knows how to inspect. */
+const KNOWN_BACKENDS = [
+  "claude",
+  "codex",
+  "kilo",
+  "opencode",
+  "openai-agents",
+] as const;
+
+/**
+ * Binary / auth checks across every backend the config exposes.
+ *
+ * Only the active one counts toward the issue total; the rest are reported
+ * so a switch doesn't have to be the thing that discovers a backend can't
+ * run. That distinction matters now that a chat can be rebound at runtime —
+ * a report of all-green while two backends are one click from failing is
+ * worse than no report.
+ */
 async function checkBackend(
   config: DoctorConfigSlice | undefined,
 ): Promise<DoctorCheck[]> {
+  const active = config?.backend ?? "claude";
+  const exposed = config?.enabledBackends?.length
+    ? config.enabledBackends
+    : [...KNOWN_BACKENDS];
+
+  const checks = await checkOneBackend(active, config, true);
+  for (const id of exposed) {
+    if (id === active || !KNOWN_BACKENDS.includes(id as never)) continue;
+    // An idle backend's missing binary is a heads-up, not a fault of this
+    // deployment: downgrade it and keep it out of the issue count.
+    for (const check of await checkOneBackend(id, config, false)) {
+      checks.push({
+        ...check,
+        status: check.status === "fail" ? "warn" : check.status,
+        issue: false,
+        inactive: true,
+      });
+    }
+  }
+  return checks;
+}
+
+async function checkOneBackend(
+  backend: string,
+  config: DoctorConfigSlice | undefined,
+  isActive: boolean,
+): Promise<DoctorCheck[]> {
   const checks: DoctorCheck[] = [];
-  const backend = config?.backend ?? "claude";
 
   if (backend === "claude") {
     if (config?.claudeBinary) {
@@ -313,7 +364,9 @@ async function checkBackend(
           : { label: "Claude Code not found", status: "fail" },
       );
     }
-    checks.push(...(await checkClaudeConfiguredModels(config)));
+    // Model resolution spawns a probe — worth it for the backend actually
+    // serving chats, wasteful for one nobody is using.
+    if (isActive) checks.push(...(await checkClaudeConfiguredModels(config)));
   } else if (backend === "codex") {
     if (!binaryOnPath("codex")) {
       checks.push({
@@ -349,11 +402,21 @@ async function checkBackend(
       });
     }
   } else if (backend === "kilo" || backend === "opencode") {
-    // Bundled as npm deps — no external binary to check.
-    checks.push({
-      label: `${backend === "kilo" ? "Kilo" : "OpenCode"} SDK bundled`,
-      status: "ok",
-    });
+    // The SDK ships as an npm dep but only talks to a server it spawns from
+    // the CLI of the same name (`cross-spawn` → PATH lookup). A present
+    // package with an absent binary fails at the first turn with a bare
+    // ENOENT, so check what actually gets executed.
+    const label = backend === "kilo" ? "Kilo" : "OpenCode";
+    checks.push(
+      binaryOnPath(backend)
+        ? { label: `${label} CLI installed`, status: "ok" }
+        : {
+            label: `${label} CLI not found`,
+            status: "fail",
+            detail: `the ${label} SDK spawns \`${backend}\` — install it or this backend cannot start`,
+            issue: true,
+          },
+    );
   } else if (backend === "openai-agents") {
     checks.push({ label: "OpenAI Agents SDK bundled", status: "ok" });
     const hasEnvKey = Boolean(process.env.OPENAI_API_KEY);

--- a/src/frontend/discord/callbacks/components.ts
+++ b/src/frontend/discord/callbacks/components.ts
@@ -68,6 +68,7 @@ import {
   DISCORD_MAX_TEXT,
 } from "../formatting.js";
 import { chatIdFromInteraction, type ComponentInteraction } from "./shared.js";
+import { metricsViewRow, renderMetricsView } from "../commands/admin.js";
 
 export async function handleComponentInteraction(
   interaction: ComponentInteraction,
@@ -348,6 +349,21 @@ export async function handleComponentInteraction(
       } catch {
         /* ignore */
       }
+    }
+    return;
+  }
+
+  // ── /metrics today ↔ all-time toggle ────────────────────────────────────
+  if (customId === "metrics:today" || customId === "metrics:all") {
+    const view = customId === "metrics:all" ? "all" : "today";
+    const messages = renderMetricsView(view);
+    try {
+      await interaction.update({
+        content: messages[0]!,
+        components: [metricsViewRow(view).toJSON()],
+      });
+    } catch {
+      /* ignore */
     }
     return;
   }

--- a/src/frontend/discord/commands/admin.ts
+++ b/src/frontend/discord/commands/admin.ts
@@ -3,16 +3,37 @@
  * All gate on `isAdmin`.
  */
 
-import { type ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import {
+  type ChatInputCommandInteraction,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  MessageFlags,
+} from "discord.js";
 import type { TalonConfig } from "../../../util/config.js";
 import type { Gateway } from "../../../core/engine/gateway.js";
 import { respawnSelf } from "../../../util/respawn.js";
 import { forceDream } from "../../../core/background/dream.js";
-import { formatDuration, renderMetricsMessages } from "../helpers.js";
+import {
+  formatDuration,
+  renderMetricsMessages,
+  renderDoctorMessages,
+} from "../helpers.js";
+import { collectDoctorReport } from "../../../core/doctor.js";
+import { getSoul } from "../../../core/soul/service.js";
 import { getMetrics, getTodayMetrics } from "../../../storage/metrics.js";
 import { handleAdminSubcommand } from "../admin.js";
 import { isAdmin } from "../handlers/index.js";
-import { suppressMentions, DISCORD_MAX_TEXT } from "../formatting.js";
+import {
+  suppressMentions,
+  DISCORD_MAX_TEXT,
+  safeSlice,
+  escapeForCodeBlock,
+} from "../formatting.js";
+import {
+  getRepoRoot,
+  runSelfUpdate,
+} from "../../../core/update/self-update.js";
 import { reply } from "./shared.js";
 
 export async function handleRestart(
@@ -34,18 +55,112 @@ export async function handleMetrics(
     return;
   }
   // Ephemeral — admin counters (token usage, latencies, errors) shouldn't leak
-  // into a public channel where non-admins can read them.
-  const messages = [
-    ...renderMetricsMessages(getMetrics()),
-    ...renderMetricsMessages(
-      getTodayMetrics(),
-      undefined,
-      "📊 Metrics — today (UTC)",
-    ),
-  ];
-  for (const m of messages) {
-    await reply(i, m, true);
+  // into a public channel where non-admins can read them. Both views are one
+  // button apart rather than two bursts of messages.
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  const messages = renderMetricsMessages(
+    getTodayMetrics(),
+    undefined,
+    "📊 Metrics — today (UTC)",
+  );
+  await i.editReply({
+    content: messages[0]!,
+    components: [metricsViewRow("today").toJSON()],
+  });
+  for (const extra of messages.slice(1)) {
+    await i.followUp({ content: extra, flags: MessageFlags.Ephemeral });
   }
+}
+
+/** Today / all-time toggle under the metrics panel. */
+export function metricsViewRow(
+  view: MetricsView,
+): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId("metrics:today")
+      .setLabel("Today")
+      .setStyle(view === "today" ? ButtonStyle.Primary : ButtonStyle.Secondary)
+      .setDisabled(view === "today"),
+    new ButtonBuilder()
+      .setCustomId("metrics:all")
+      .setLabel("All time")
+      .setStyle(view === "all" ? ButtonStyle.Primary : ButtonStyle.Secondary)
+      .setDisabled(view === "all"),
+  );
+}
+
+export type MetricsView = "today" | "all";
+
+/** Panel body for one view — shared by the command and the toggle. */
+export function renderMetricsView(view: MetricsView): string[] {
+  return view === "today"
+    ? renderMetricsMessages(
+        getTodayMetrics(),
+        undefined,
+        "📊 Metrics — today (UTC)",
+      )
+    : renderMetricsMessages(getMetrics(), undefined, "📊 Metrics — all time");
+}
+
+export async function handleDoctor(
+  i: ChatInputCommandInteraction,
+  config: TalonConfig,
+): Promise<void> {
+  if (!isAdmin(i.user.id)) {
+    await reply(i, "Not authorized.", true);
+    return;
+  }
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  await i.editReply("🩺 Running checks...");
+  try {
+    // Same checks as `talon doctor` — config exists by definition when the
+    // bot is processing this command.
+    const report = await collectDoctorReport({ config, hasConfigFile: true });
+    const messages = renderDoctorMessages(report);
+    await i.editReply(messages[0]!);
+    for (const extra of messages.slice(1))
+      await i.followUp({
+        content: extra,
+        flags: MessageFlags.Ephemeral,
+      });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await i.editReply(`🩺 Doctor failed: ${msg}`);
+  }
+}
+
+/**
+ * /soul — read-only introspection of the compiled identity. `action:dream`
+ * runs the organic maintenance pass and is admin-only. Inert while the soul
+ * is disabled, so it is safe to ship dormant.
+ */
+export async function handleSoul(
+  i: ChatInputCommandInteraction,
+): Promise<void> {
+  const soul = getSoul();
+  if (!soul.enabled) {
+    await reply(
+      i,
+      "Soul is disabled (set TALON_SOUL_ENABLED to enable).",
+      true,
+    );
+    return;
+  }
+  if (i.options.getString("action") === "dream") {
+    if (!isAdmin(i.user.id)) {
+      await reply(i, "Not authorized.", true);
+      return;
+    }
+    await i.deferReply({ flags: MessageFlags.Ephemeral });
+    await i.editReply("🧠 Soul dreaming...");
+    soul
+      .dream()
+      .then(() => i.editReply("🧠 Soul dream complete."))
+      .catch(() => undefined);
+    return;
+  }
+  await reply(i, suppressMentions(soul.introspect()), true);
 }
 
 export async function handleDream(
@@ -68,6 +183,65 @@ export async function handleDream(
     .catch(async (err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err);
       await i.editReply(`🌙 Dream failed: ${msg}`);
+    });
+}
+
+/**
+ * /update — pull, reinstall, run setup, restart. Only reachable on developer
+ * builds running from a git checkout; the command is not registered at all
+ * otherwise (see buildCommandDefinitions).
+ */
+export async function handleUpdate(
+  i: ChatInputCommandInteraction,
+  config: TalonConfig,
+): Promise<void> {
+  if (!isAdmin(i.user.id)) {
+    await reply(i, "Not authorized.", true);
+    return;
+  }
+  const repoRoot = config.devBuild ? getRepoRoot() : null;
+  if (!repoRoot) {
+    await reply(i, "Update is only available on developer builds.", true);
+    return;
+  }
+  const remote = config.update?.remote ?? "origin";
+  const branch = config.update?.branch ?? "main";
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  await i.editReply(`⏳ Updating from \`${remote}/${branch}\`…`);
+  const edit = (text: string) => i.editReply(safeSlice(text, DISCORD_MAX_TEXT));
+
+  // Fire-and-forget so the gateway keeps processing other interactions.
+  runSelfUpdate({
+    remote,
+    branch,
+    setup: config.update?.setup,
+    repoRoot,
+  })
+    .then(async (res) => {
+      if (!res.ok) {
+        const tail = res.steps[res.steps.length - 1]?.output ?? "";
+        await edit(
+          `⚠️ Update failed: ${res.error ?? "unknown error"}` +
+            (tail
+              ? `\n\`\`\`\n${escapeForCodeBlock(tail.slice(-1200))}\n\`\`\``
+              : ""),
+        );
+        return;
+      }
+      if (!res.changed) {
+        await edit(
+          `✅ Already up to date at \`${res.before ?? "?"}\` — no restart needed.`,
+        );
+        return;
+      }
+      await edit(
+        `✅ Updated \`${res.before ?? "?"}\` → \`${res.after ?? "?"}\`. ♻️ Restarting…`,
+      );
+      respawnSelf("discord /update");
+    })
+    .catch(async (err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      await edit(`⚠️ Update crashed: ${msg}`);
     });
 }
 

--- a/src/frontend/discord/commands/definitions.ts
+++ b/src/frontend/discord/commands/definitions.ts
@@ -99,6 +99,10 @@ export function buildCommandDefinitions(devBuild = false): unknown[] {
       .setDescription("List loaded plugins")
       .toJSON(),
     new SlashCommandBuilder()
+      .setName("usage")
+      .setDescription("Plan limits across every backend")
+      .toJSON(),
+    new SlashCommandBuilder()
       .setName("doctor")
       .setDescription("Environment and native-module health (admin)")
       .toJSON(),

--- a/src/frontend/discord/commands/definitions.ts
+++ b/src/frontend/discord/commands/definitions.ts
@@ -15,8 +15,9 @@
 import { type Client, REST, Routes, SlashCommandBuilder } from "discord.js";
 import type { TalonConfig } from "../../../util/config.js";
 import { log, logError, logWarn } from "../../../util/log.js";
+import { getRepoRoot } from "../../../core/update/self-update.js";
 
-export function buildCommandDefinitions(): unknown[] {
+export function buildCommandDefinitions(devBuild = false): unknown[] {
   return [
     new SlashCommandBuilder()
       .setName("start")
@@ -98,6 +99,36 @@ export function buildCommandDefinitions(): unknown[] {
       .setDescription("List loaded plugins")
       .toJSON(),
     new SlashCommandBuilder()
+      .setName("doctor")
+      .setDescription("Environment and native-module health (admin)")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("mesh")
+      .setDescription("Ping and list mesh devices")
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName("soul")
+      .setDescription("Inspect the compiled identity")
+      .addStringOption((o) =>
+        o
+          .setName("action")
+          .setDescription("Leave empty to introspect")
+          .setRequired(false)
+          .addChoices({ name: "dream", value: "dream" }),
+      )
+      .toJSON(),
+    // /update only exists on developer builds running from a git checkout —
+    // a packaged binary has no source tree to pull into, so the command is
+    // never registered there (same gate as the Telegram handler).
+    ...(devBuild && getRepoRoot()
+      ? [
+          new SlashCommandBuilder()
+            .setName("update")
+            .setDescription("Pull latest, reinstall, restart (admin)")
+            .toJSON(),
+        ]
+      : []),
+    new SlashCommandBuilder()
       .setName("admin")
       .setDescription("Admin operations (admin only)")
       .addStringOption((o) =>
@@ -128,7 +159,7 @@ export async function registerCommandsForGuilds(
 ): Promise<void> {
   const dc = config.discord!;
   const rest = new REST({ version: "10" }).setToken(dc.botToken);
-  const definitions = buildCommandDefinitions();
+  const definitions = buildCommandDefinitions(config.devBuild);
 
   // Step 1: clear or set global commands depending on DM setting.
   try {

--- a/src/frontend/discord/commands/info.ts
+++ b/src/frontend/discord/commands/info.ts
@@ -7,8 +7,10 @@ import {
   type Client,
   MessageFlags,
 } from "discord.js";
-import { formatDuration } from "../helpers.js";
+import { formatDuration, renderMeshReport } from "../helpers.js";
 import { getLoadedPlugins } from "../../../core/plugin/index.js";
+import { getMeshService } from "../../../core/mesh/index.js";
+import type { MeshPingResult } from "../../../core/mesh/service.js";
 import { reply } from "./shared.js";
 
 export async function handleStart(
@@ -65,6 +67,21 @@ export async function handleHelp(
     ].join("\n"),
     true,
   );
+}
+
+export async function handleMesh(
+  i: ChatInputCommandInteraction,
+): Promise<void> {
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  await i.editReply("Pinging mesh devices…");
+  let results: MeshPingResult[];
+  try {
+    results = await getMeshService().pingAll();
+  } catch {
+    await i.editReply("Could not reach the mesh service.");
+    return;
+  }
+  await i.editReply(renderMeshReport(results));
 }
 
 export async function handlePing(

--- a/src/frontend/discord/commands/info.ts
+++ b/src/frontend/discord/commands/info.ts
@@ -7,7 +7,13 @@ import {
   type Client,
   MessageFlags,
 } from "discord.js";
-import { formatDuration, renderMeshReport } from "../helpers.js";
+import {
+  formatDuration,
+  renderMeshReport,
+  renderUsageMessage,
+} from "../helpers.js";
+import type { TalonConfig } from "../../../util/config.js";
+import { collectPlanUsage } from "../../shared/plan-usage-report.js";
 import { getLoadedPlugins } from "../../../core/plugin/index.js";
 import { getMeshService } from "../../../core/mesh/index.js";
 import type { MeshPingResult } from "../../../core/mesh/service.js";
@@ -67,6 +73,20 @@ export async function handleHelp(
     ].join("\n"),
     true,
   );
+}
+
+/**
+ * /usage — plan limits across every exposed backend, not just this chat's.
+ * Not admin-gated: it says how close the shared account is to a wall, which
+ * is exactly what a user hitting one needs to know.
+ */
+export async function handleUsage(
+  i: ChatInputCommandInteraction,
+  config: TalonConfig,
+): Promise<void> {
+  await i.deferReply({ flags: MessageFlags.Ephemeral });
+  const entries = await collectPlanUsage(config);
+  await i.editReply(renderUsageMessage(entries));
 }
 
 export async function handleMesh(

--- a/src/frontend/discord/commands/router.ts
+++ b/src/frontend/discord/commands/router.ts
@@ -28,6 +28,7 @@ import {
   handlePing,
   handlePlugins,
   handleMesh,
+  handleUsage,
 } from "./info.js";
 import { handleReset, handleStatus } from "./session.js";
 import {
@@ -150,6 +151,8 @@ async function routeSlashCommand(
       return handleDream(interaction);
     case "plugins":
       return handlePlugins(interaction);
+    case "usage":
+      return handleUsage(interaction, config);
     case "doctor":
       return handleDoctor(interaction, config);
     case "mesh":

--- a/src/frontend/discord/commands/router.ts
+++ b/src/frontend/discord/commands/router.ts
@@ -22,7 +22,13 @@ import {
   handleModalSubmit,
 } from "../callbacks/index.js";
 import { chatIdFromInteraction, reply, client } from "./shared.js";
-import { handleStart, handleHelp, handlePing, handlePlugins } from "./info.js";
+import {
+  handleStart,
+  handleHelp,
+  handlePing,
+  handlePlugins,
+  handleMesh,
+} from "./info.js";
 import { handleReset, handleStatus } from "./session.js";
 import {
   handleModel,
@@ -35,6 +41,9 @@ import {
   handleMetrics,
   handleDream,
   handleAdmin,
+  handleDoctor,
+  handleSoul,
+  handleUpdate,
 } from "./admin.js";
 
 export function registerInteractionRouter(
@@ -141,6 +150,14 @@ async function routeSlashCommand(
       return handleDream(interaction);
     case "plugins":
       return handlePlugins(interaction);
+    case "doctor":
+      return handleDoctor(interaction, config);
+    case "mesh":
+      return handleMesh(interaction);
+    case "soul":
+      return handleSoul(interaction);
+    case "update":
+      return handleUpdate(interaction, config);
     case "admin":
       return handleAdmin(interaction, config, gateway);
     default:

--- a/src/frontend/discord/helpers.ts
+++ b/src/frontend/discord/helpers.ts
@@ -15,6 +15,7 @@ import {
 } from "./formatting.js";
 import type { DoctorReport } from "../../core/doctor.js";
 import type { MeshPingResult } from "../../core/mesh/service.js";
+import type { BackendUsageEntry } from "../shared/plan-usage-report.js";
 import {
   DEFAULT_PULSE_INTERVAL_MS,
   formatDuration,
@@ -275,6 +276,30 @@ export function renderMeshReport(
   section("Responding", responding);
   section("Unreachable", unreachable);
   section("Offline", offline);
+
+  return lines.join("\n");
+}
+
+/** Render the `/usage` report — one block per exposed backend. */
+export function renderUsageMessage(entries: BackendUsageEntry[]): string {
+  const lines = ["**📊 Plan usage**"];
+
+  for (const entry of entries) {
+    const name = entry.label || entry.id;
+    if (!entry.plan) {
+      lines.push("", `**${name}** — _${entry.note ?? ""}_`);
+      continue;
+    }
+    const age = entry.plan.ageLabel ? ` *(${entry.plan.ageLabel})*` : "";
+    const plan = entry.plan.plan ? ` · ${entry.plan.plan}` : "";
+    lines.push("", `**${name}**${plan}${age}`);
+    for (const w of entry.plan.windows) {
+      const reset = w.resetLabel ? ` reset ${w.resetLabel}` : "";
+      lines.push(
+        `  \`${w.label.padEnd(6)}${w.bar} ${String(w.percent).padStart(3)}%\`${reset}`,
+      );
+    }
+  }
 
   return lines.join("\n");
 }

--- a/src/frontend/discord/helpers.ts
+++ b/src/frontend/discord/helpers.ts
@@ -8,10 +8,17 @@
  */
 
 import { REASONING_LEVEL_DESCRIPTIONS } from "../../core/models/reasoning-levels.js";
-import { DISCORD_MAX_TEXT, DISCORD_SAFE_RESERVE } from "./formatting.js";
+import {
+  DISCORD_MAX_TEXT,
+  DISCORD_SAFE_RESERVE,
+  splitMessage,
+} from "./formatting.js";
+import type { DoctorReport } from "../../core/doctor.js";
+import type { MeshPingResult } from "../../core/mesh/service.js";
 import {
   DEFAULT_PULSE_INTERVAL_MS,
   formatDuration,
+  formatBytes,
   formatModelLabel,
 } from "../shared/format.js";
 
@@ -155,6 +162,121 @@ export function renderMetricsMessages(
   }
   if (current !== header || chunks.length === 0) chunks.push(current);
   return chunks;
+}
+
+const DOCTOR_ICONS: Record<string, string> = {
+  ok: "✅",
+  warn: "⚠️",
+  fail: "❌",
+  info: "▫️",
+};
+
+/**
+ * Render a DoctorReport as Discord markdown, split to fit the message cap.
+ * Same data as `talon doctor` and Telegram's /doctor.
+ */
+export function renderDoctorMessages(
+  report: DoctorReport,
+  maxLen = DEFAULT_METRICS_MESSAGE_MAX,
+): string[] {
+  const lines = ["**🩺 Talon Doctor**", "", "**Environment**"];
+
+  const render = (check: DoctorReport["checks"][number]): string =>
+    `${DOCTOR_ICONS[check.status]} ${check.label}${check.detail ? ` (${check.detail})` : ""}`;
+
+  for (const check of report.checks.filter((c) => !c.inactive)) {
+    lines.push(render(check));
+  }
+
+  // Configured-but-idle backends get their own block: they describe what a
+  // switch would run into, not the state of the running deployment.
+  const idle = report.checks.filter((c) => c.inactive);
+  if (idle.length > 0) {
+    lines.push("", "**Other backends**", ...idle.map(render));
+  }
+
+  lines.push("", "**Native modules**");
+  for (const mod of report.native) {
+    const size =
+      mod.sizeBytes !== undefined ? ` · ${formatBytes(mod.sizeBytes)}` : "";
+    const note = mod.note ? ` (${mod.note})` : "";
+    lines.push(
+      `${mod.ok ? DOCTOR_ICONS.ok : DOCTOR_ICONS.fail} \`${mod.name}\` — ${mod.language} → ${mod.target}${size}${note}`,
+    );
+  }
+
+  lines.push(
+    "",
+    "**Process**",
+    `Uptime ${formatDuration(process.uptime() * 1000)} · PID ${process.pid} · Node ${process.versions.node}`,
+    "",
+    report.issues === 0
+      ? `${DOCTOR_ICONS.ok} All checks passed.`
+      : `${DOCTOR_ICONS.warn} ${report.issues} issue(s) found.`,
+  );
+
+  return splitMessage(lines.join("\n"), maxLen);
+}
+
+function meshDeviceLine(r: MeshPingResult, now: number): string {
+  const d = r.device;
+  const bits: string[] = [d.platform];
+  if (r.reachable && typeof r.latencyMs === "number") {
+    bits.push(`${r.latencyMs} ms`);
+  } else if (d.online && r.error) {
+    bits.push(r.error);
+  } else if (!d.online) {
+    bits.push(`last seen ${formatDuration(now - d.lastSeen)} ago`);
+  }
+  if (typeof d.battery === "number") {
+    bits.push(`${d.battery}%${d.charging ? " charging" : ""}`);
+  }
+  return `  **${d.name}** — ${bits.join(" · ")}`;
+}
+
+/**
+ * Render the /mesh fleet report as Discord markdown. Devices group under a
+ * state heading; empty groups are omitted.
+ */
+export function renderMeshReport(
+  results: MeshPingResult[],
+  now = Date.now(),
+): string {
+  if (results.length === 0) {
+    return "**Mesh**\n\n_No devices have registered yet._";
+  }
+
+  const responding = results
+    .filter((r) => r.reachable)
+    .sort((a, b) => (a.latencyMs ?? Infinity) - (b.latencyMs ?? Infinity));
+  const unreachable = results
+    .filter((r) => !r.reachable && r.device.online)
+    .sort((a, b) => a.device.name.localeCompare(b.device.name));
+  const offline = results
+    .filter((r) => !r.reachable && !r.device.online)
+    .sort((a, b) => b.device.lastSeen - a.device.lastSeen);
+
+  const summary = [
+    `${results.length} device${results.length === 1 ? "" : "s"}`,
+    `${responding.length} responding`,
+    ...(unreachable.length > 0 ? [`${unreachable.length} unreachable`] : []),
+    ...(offline.length > 0 ? [`${offline.length} offline`] : []),
+  ].join(" · ");
+
+  const lines = ["**Mesh**", summary];
+  const section = (title: string, entries: MeshPingResult[]): void => {
+    if (entries.length === 0) return;
+    lines.push(
+      "",
+      `**${title}**`,
+      ...entries.map((r) => meshDeviceLine(r, now)),
+    );
+  };
+  section("Responding", responding);
+  section("Unreachable", unreachable);
+  section("Offline", offline);
+
+  return lines.join("\n");
 }
 
 /** Settings panel: build the markdown body. */

--- a/src/frontend/shared/plan-usage-report.ts
+++ b/src/frontend/shared/plan-usage-report.ts
@@ -1,0 +1,72 @@
+/**
+ * `/usage` data gathering — plan limits across every backend the config
+ * exposes, not just the one serving this chat.
+ *
+ * Most backends have no plan to report: a gateway (Kilo, OpenCode) bills
+ * through whichever provider it fronts, and an API-key install pays per
+ * token with no window to be near the end of. Those are listed with a
+ * reason rather than omitted, so the answer to "am I close to a limit?" is
+ * never silence.
+ */
+
+import type { TalonConfig } from "../../util/config.js";
+import type { PlanUsage } from "../../core/agent-runtime/capabilities.js";
+import {
+  listAvailableBackends,
+  getPooledBackend,
+} from "../../core/engine/backend-controller/index.js";
+import { buildPlanDisplay, type PlanDisplay } from "./status-context.js";
+
+export interface BackendUsageEntry {
+  id: string;
+  label: string;
+  /** Rendered windows, or null when this backend reported nothing. */
+  plan: PlanDisplay | null;
+  /** Why there is nothing to show. Absent when `plan` is set. */
+  note?: string;
+}
+
+/**
+ * One entry per exposed backend, in config order.
+ *
+ * Only backends already running are queried — booting one to read a
+ * number would spawn a subprocess or a server per idle provider, which is
+ * far more than a status command should cost.
+ */
+export async function collectPlanUsage(
+  config: TalonConfig,
+): Promise<BackendUsageEntry[]> {
+  const entries: BackendUsageEntry[] = [];
+
+  for (const { id, label } of listAvailableBackends(config)) {
+    const backend = getPooledBackend(id);
+    if (!backend) {
+      entries.push({ id, label, plan: null, note: "not running" });
+      continue;
+    }
+    if (!backend.usage?.getPlanUsage) {
+      entries.push({
+        id,
+        label,
+        plan: null,
+        note: "no plan limits on this backend",
+      });
+      continue;
+    }
+
+    let usage: PlanUsage | undefined;
+    try {
+      usage = await backend.usage.getPlanUsage();
+    } catch {
+      usage = undefined;
+    }
+    const plan = buildPlanDisplay(usage);
+    entries.push(
+      plan
+        ? { id, label, plan }
+        : { id, label, plan: null, note: "no usage information available" },
+    );
+  }
+
+  return entries;
+}

--- a/src/frontend/telegram/commands/admin.ts
+++ b/src/frontend/telegram/commands/admin.ts
@@ -21,7 +21,9 @@ import {
   renderDoctorMessage,
   renderMetricsKeyboard,
   renderMetricsPanel,
+  renderUsageMessage,
 } from "../helpers/index.js";
+import { collectPlanUsage } from "../../shared/plan-usage-report.js";
 import { collectDoctorReport } from "../../../core/doctor.js";
 import { handleAdminCommand } from "../admin.js";
 import { getTodayMetrics } from "../../../storage/metrics.js";
@@ -51,6 +53,14 @@ export function registerAdminCommands(
       parse_mode: "HTML",
       reply_markup: { inline_keyboard: renderMetricsKeyboard("today") },
     });
+  });
+
+  // /usage — plan limits across every exposed backend, not just this
+  // chat's. Not admin-gated: it says how close the shared account is to a
+  // wall, which is exactly what a user hitting one needs to know.
+  bot.command("usage", async (ctx) => {
+    const entries = await collectPlanUsage(config);
+    await ctx.reply(renderUsageMessage(entries), { parse_mode: "HTML" });
   });
 
   bot.command("doctor", async (ctx) => {

--- a/src/frontend/telegram/commands/definitions.ts
+++ b/src/frontend/telegram/commands/definitions.ts
@@ -28,6 +28,7 @@ export const TELEGRAM_COMMANDS: ReadonlyArray<{
   { command: "pulse", description: "Conversation engagement settings" },
   { command: "reset", description: "Clear session and start fresh" },
   { command: "restart", description: "Restart the bot (admin)" },
+  { command: "usage", description: "Plan limits across every backend" },
   { command: "metrics", description: "Aggregate performance metrics" },
   {
     command: "doctor",

--- a/src/frontend/telegram/helpers/diagnostics.ts
+++ b/src/frontend/telegram/helpers/diagnostics.ts
@@ -5,6 +5,7 @@
 import { escapeHtml } from "../formatting.js";
 import type { DoctorReport } from "../../../core/doctor.js";
 import type { MeshPingResult } from "../../../core/mesh/service.js";
+import type { BackendUsageEntry } from "../../shared/plan-usage-report.js";
 import type { SettingsButton } from "./menu.js";
 import { formatDuration, formatBytes } from "./format.js";
 
@@ -208,6 +209,30 @@ const DOCTOR_ICONS: Record<string, string> = {
  * when this renders, the bot is by definition running, so the CLI's
  * "is the bot up" probe becomes an uptime line instead.
  */
+/** Render the `/usage` report — one block per exposed backend. */
+export function renderUsageMessage(entries: BackendUsageEntry[]): string {
+  const lines = ["<b>📊 Plan usage</b>"];
+
+  for (const entry of entries) {
+    const name = escapeHtml(entry.label || entry.id);
+    if (!entry.plan) {
+      lines.push("", `<b>${name}</b> — <i>${escapeHtml(entry.note ?? "")}</i>`);
+      continue;
+    }
+    const age = entry.plan.ageLabel ? ` <i>(${entry.plan.ageLabel})</i>` : "";
+    const plan = entry.plan.plan ? ` · ${escapeHtml(entry.plan.plan)}` : "";
+    lines.push("", `<b>${name}</b>${plan}${age}`);
+    for (const w of entry.plan.windows) {
+      const reset = w.resetLabel ? ` reset ${w.resetLabel}` : "";
+      lines.push(
+        `  <code>${escapeHtml(w.label.padEnd(6))}${w.bar} ${String(w.percent).padStart(3)}%</code>${reset}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
 export function renderDoctorMessage(report: DoctorReport): string {
   const lines = ["<b>🩺 Talon Doctor</b>", "", "<b>Environment</b>"];
 

--- a/src/frontend/telegram/helpers/diagnostics.ts
+++ b/src/frontend/telegram/helpers/diagnostics.ts
@@ -211,11 +211,20 @@ const DOCTOR_ICONS: Record<string, string> = {
 export function renderDoctorMessage(report: DoctorReport): string {
   const lines = ["<b>🩺 Talon Doctor</b>", "", "<b>Environment</b>"];
 
-  for (const check of report.checks) {
+  const render = (check: DoctorReport["checks"][number]): string => {
     const detail = check.detail ? ` (${escapeHtml(check.detail)})` : "";
-    lines.push(
-      `${DOCTOR_ICONS[check.status]} ${escapeHtml(check.label)}${detail}`,
-    );
+    return `${DOCTOR_ICONS[check.status]} ${escapeHtml(check.label)}${detail}`;
+  };
+
+  for (const check of report.checks.filter((c) => !c.inactive)) {
+    lines.push(render(check));
+  }
+
+  // Configured-but-idle backends get their own block: they describe what a
+  // switch would run into, not the state of the running deployment.
+  const idle = report.checks.filter((c) => c.inactive);
+  if (idle.length > 0) {
+    lines.push("", "<b>Other backends</b>", ...idle.map(render));
   }
 
   lines.push("", "<b>Native modules</b>");


### PR DESCRIPTION
Stacked on #716 (which stacks on #715) — the change to review is the last commit. Rebase once those land.

Plan limits landed in `/status`, which answers *how close is the backend serving this chat*. That isn't the question someone about to start long work asks — they want to know how close **the account** is. A chat on OpenCode showed no view of the Claude weekly window at all, even while the heartbeat and cron jobs were spending it.

`/usage` reports every backend the config exposes, in config order, on **both Telegram and Discord**:

```
📊 Plan usage

Anthropic · max
  5h    █░░░░░░░░░░░░░░░░░░░   4%  reset 23:00
  7d    ██▌░░░░░░░░░░░░░░░░░  12%  reset Aug 6 14:00

Codex · plus
  7d    █████░░░░░░░░░░░░░░░  26%  reset Aug 8 23:50

Kilo — no plan limits on this backend
OpenCode — not running
```

Backends with nothing to report say **why** rather than being omitted. A gateway bills through whichever provider it fronts; an API-key install pays per token with no window to be near the end of; a backend that isn't running says so. Silence would be indistinguishable from "you're fine".

### Codex

The Codex backend learns to report its ChatGPT plan. The CLI reads the same windows from an endpoint on the ChatGPT backend and caches them in its session transcripts — its own `/status` renders that cache rather than re-fetching, and points at the web dashboard for anything current. Talon queries the endpoint directly, with the OAuth token `codex login` already stored, so the report is the live state.

Window labels are derived from `limit_window_seconds` rather than hardcoded, which matters right now: the shorter window was recently retired, so a plan that used to report two windows reports one. Deriving the label means that shows up as one window instead of a mislabelled or missing one.

An API-key install has no plan and reports nothing, as does an expired token — both fall through to the "no usage information available" line.

### Cost

Only running backends are queried. Booting one to read a number would spawn a subprocess or an HTTP server per idle provider, which is far more than a status command should cost — hence the explicit "not running" rather than a silent gap. Reads are cached for a minute, so a burst of `/usage` makes one request per backend.

11 new tests: window labelling and clamping, both-windows and single-window plans, malformed and empty responses, plus the collector's behaviour for a backend with no plan concept, one that isn't running, one that answers nothing, and one that throws.
