### PR TITLE
feat(codex): show banked usage-limit resets on the usage command

### DIFF
--- a/src/backend/codex/plan-usage.ts
+++ b/src/backend/codex/plan-usage.ts
@@ -95,6 +95,10 @@ export function parseCodexUsage(body: unknown): PlanUsage | undefined {
       primary_window?: RawWindow | null;
       secondary_window?: RawWindow | null;
     };
+    rate_limit_reset_credits?: {
+      available_count?: number;
+      applicable_available_count?: number;
+    } | null;
   } | null;
   const limit = data?.rate_limit;
   if (!limit) return undefined;
@@ -108,6 +112,10 @@ export function parseCodexUsage(body: unknown): PlanUsage | undefined {
   return {
     ...(data?.plan_type ? { plan: data.plan_type } : {}),
     windows,
+    ...(typeof data?.rate_limit_reset_credits?.available_count === "number" &&
+    data.rate_limit_reset_credits.available_count > 0
+      ? { resetsAvailable: data.rate_limit_reset_credits.available_count }
+      : {}),
     fetchedAt: Date.now(),
   };
 }

--- a/src/core/agent-runtime/capabilities.ts
+++ b/src/core/agent-runtime/capabilities.ts
@@ -245,6 +245,8 @@ export interface PlanUsage {
   /** Subscription tier (`max`, `pro`, …) when known. */
   plan?: string;
   windows: PlanWindow[];
+  /** How many one-shot rate-limit resets are still banked, when the plan has them. */
+  resetsAvailable?: number;
   /** Epoch ms of the read, so renderers can flag figures as aged. */
   fetchedAt: number;
 }

--- a/src/frontend/discord/helpers.ts
+++ b/src/frontend/discord/helpers.ts
@@ -293,6 +293,12 @@ export function renderUsageMessage(entries: BackendUsageEntry[]): string {
     const age = entry.plan.ageLabel ? ` *(${entry.plan.ageLabel})*` : "";
     const plan = entry.plan.plan ? ` · ${entry.plan.plan}` : "";
     lines.push("", `**${name}**${plan}${age}`);
+    if (entry.plan.resetsAvailable) {
+      const n = entry.plan.resetsAvailable;
+      lines.push(
+        `  • You have **${n}** usage limit reset${n === 1 ? "" : "s"} available`,
+      );
+    }
     for (const w of entry.plan.windows) {
       const reset = w.resetLabel ? ` reset ${w.resetLabel}` : "";
       lines.push(

--- a/src/frontend/shared/status-context.ts
+++ b/src/frontend/shared/status-context.ts
@@ -303,7 +303,9 @@ export interface PlanWindowDisplay {
 export interface PlanDisplay {
   plan: string | undefined;
   windows: PlanWindowDisplay[];
-  /** Set only once the figures have aged, e.g. "12m ago". */
+  /** Set only when the account still has one-shot rate-limit resets left. */
+  resetsAvailable: number | undefined;
+  /** Set only when the figures have aged, e.g. "12m ago". */
   ageLabel: string | undefined;
 }
 
@@ -330,6 +332,7 @@ export function buildPlanDisplay(
   const age = Date.now() - usage.fetchedAt;
   return {
     plan: usage.plan,
+    resetsAvailable: usage.resetsAvailable,
     ageLabel:
       age > PLAN_STALE_AFTER_MS
         ? formatRelativeAge(usage.fetchedAt)

--- a/src/frontend/telegram/helpers/diagnostics.ts
+++ b/src/frontend/telegram/helpers/diagnostics.ts
@@ -222,6 +222,12 @@ export function renderUsageMessage(entries: BackendUsageEntry[]): string {
     const age = entry.plan.ageLabel ? ` <i>(${entry.plan.ageLabel})</i>` : "";
     const plan = entry.plan.plan ? ` · ${escapeHtml(entry.plan.plan)}` : "";
     lines.push("", `<b>${name}</b>${plan}${age}`);
+    if (entry.plan.resetsAvailable) {
+      const n = entry.plan.resetsAvailable;
+      lines.push(
+        `  • You have <b>${n}</b> usage limit reset${n === 1 ? "" : "s"} available`,
+      );
+    }
     for (const w of entry.plan.windows) {
       const reset = w.resetLabel ? ` reset ${w.resetLabel}` : "";
       lines.push(


### PR DESCRIPTION
`/usage` shows how full each ChatGPT plan window is, but not the other half of Codex's rate-limit model: the one-shot resets a Plus/Pro account can bank and redeem manually, on its own schedule instead of waiting for the automatic periodic refresh. The codex CLI prints it — *"You have 1 usage limit reset available"* — and the very same endpoint `/usage` already reads carries it (`rate_limit_reset_credits.available_count`). Nothing new to fetch, just a field nobody was reading.

It renders as a line under the Codex entry when resets are banked, and only then:

```
• You have 1 usage limit reset available
```

This is a Codex/OpenAI-only concept — the other backends front an API key or a windowed subscription, neither of which has a stockable, redeemable reset — so the field only ever appears on the codex row.

### Details

- **Only while there's one.** An account with nothing banked (the default) sees the panel exactly as before — no line, no `0`. The field is emitted only when `available_count > 0`, so a plain install renders byte-for-byte unchanged.
- **Pluralised.** `reset` / `resets` follows the count.
- **Both frontends.** Telegram and Discord render the same line (HTML and Markdown respectively), matching how `/usage` reports the rest.

### Cost

Free — it rides the same request the windows already read, so a busy `/usage` burst adds no new outbound calls.

No new tests: it flows through the same parse-and-render path the windows exercise; the only new branch is the `> 0` presence guard.
