### PR TITLE
fix(userbot): don't let a mid-probe shutdown trigger a reconnect

### DIFF
--- a/src/frontend/telegram/userbot.ts
+++ b/src/frontend/telegram/userbot.ts
@@ -129,10 +129,17 @@ export async function disconnectUserClient(): Promise<void> {
 const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 let reconnecting = false;
+// Bumped by stopConnectionMonitor so a tick whose awaits straddle a shutdown
+// can tell that its own client was torn down under it — the liveness probe
+// rejecting because *we* disconnected must not trigger a reconnect, or
+// shutdown resurrects the client it just closed.
+let monitorGeneration = 0;
 
 function startConnectionMonitor(): void {
   if (reconnectTimer) return;
+  const gen = monitorGeneration;
   reconnectTimer = setInterval(async () => {
+    if (gen !== monitorGeneration) return;
     if (!client) return;
     if (reconnecting) return; // prevent overlapping reconnect attempts
 
@@ -146,10 +153,12 @@ function startConnectionMonitor(): void {
         await client.getMe();
         return; // genuinely alive
       } catch {
+        if (gen !== monitorGeneration) return; // monitor stopped mid-probe
         logWarn("userbot", "Liveness check failed — treating socket as dead.");
       }
     }
 
+    if (!client) return; // torn down while the probe was in flight
     reconnecting = true;
     logWarn("userbot", "Connection lost, attempting reconnect...");
     try {
@@ -160,6 +169,7 @@ function startConnectionMonitor(): void {
         logWarn("userbot", "Reconnected but not authorized.");
       }
     } catch (err) {
+      if (gen !== monitorGeneration) return; // stopped while reconnecting
       logError("userbot", "Reconnect failed", err);
       // Try a full re-init on next check
       if (storedApiId && storedApiHash) {
@@ -189,6 +199,7 @@ function startConnectionMonitor(): void {
 }
 
 function stopConnectionMonitor(): void {
+  monitorGeneration++;
   if (reconnectTimer) {
     clearInterval(reconnectTimer);
     reconnectTimer = null;


### PR DESCRIPTION
Follow-up to #753, addressing the shutdown race Copilot flagged there.

## The race

The connection monitor's liveness probe (`client.getMe()`) is a full API round-trip, so a tick can be in flight when `disconnectUserClient()` runs. `stopConnectionMonitor()` only cancels *future* ticks:

1. Tick starts, `getMe()` is awaiting.
2. Shutdown clears the interval, disconnects, and nulls `client`.
3. The disconnect makes `getMe()` reject — the tick treats its own shutdown as a dead socket and proceeds to reconnect.
4. `client` is null by now, so `client.connect()` throws a TypeError, which lands in the reconnect `catch` — whose fallback is a **full re-init** that builds a fresh `TelegramClient` and connects it, after shutdown already finished.

## The fix

`stopConnectionMonitor()` bumps a `monitorGeneration` counter; each tick captures the generation at monitor start and re-checks it after every await before acting (post-probe, pre-reconnect, and at the top of the reconnect `catch`). A stopped monitor can observe, but never mutate — no warning spam, no reconnect, no resurrection.

`tsc --noEmit` and prettier clean; the monitor has no unit harness (module-private, GramJS-backed), so validation is CI + review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)