### PR TITLE
feat(plugins): self-installing, self-healing native plugin runtimes

### DIFF
--- a/.github/workflows/native-provision.yml
+++ b/.github/workflows/native-provision.yml
@@ -1,0 +1,113 @@
+name: Native Provisioning
+
+# Exercises the native-plugin provisioners (src/core/plugin/native-runtimes.ts)
+# against real environments on every OS Talon supports:
+#
+#  - provision-real: fresh venv install of the pinned mempalace, live MCP
+#    handshake, self-heal from a gutted install, and a genuine 3.3.6 → pin
+#    upgrade with the palace migration — on Linux, macOS, and Windows.
+#    Runs on PRs that touch provisioning code, and weekly.
+#
+#  - canary: the same suite provisioned against the LATEST upstream
+#    versions (PyPI mempalace, github-mcp-server:latest, a real chromium
+#    download) instead of the pins. A red canary means the next pin bump
+#    needs work — bump pins only when this is green. Runs weekly and on
+#    manual dispatch; never blocks PRs.
+
+on:
+  pull_request:
+    paths:
+      - "src/core/plugin/**"
+      - "src/plugins/**"
+      - "src/__tests__/native-provision.test.ts"
+      - "src/__tests__/integration/provision-real.test.ts"
+      - ".github/workflows/native-provision.yml"
+  schedule:
+    - cron: "23 5 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  provision-real:
+    name: Pinned (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - run: npm ci
+
+      - name: Provisioning suite against pinned versions
+        env:
+          TALON_PROVISION_REAL: "1"
+        run: npx vitest run src/__tests__/integration/provision-real.test.ts --reporter=verbose
+
+  canary:
+    name: Canary latest (${{ matrix.os }})
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - run: npm ci
+
+      - name: Provisioning suite against latest upstream
+        env:
+          TALON_PROVISION_REAL: "1"
+          TALON_PROVISION_TARGET: latest
+          TALON_PROVISION_REAL_PLAYWRIGHT: "1"
+        run: npx vitest run src/__tests__/integration/provision-real.test.ts --reporter=verbose
+
+  canary-docker:
+    name: Canary github-mcp-server:latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Image pull + smoke against latest tag
+        env:
+          TALON_PROVISION_REAL_DOCKER: "1"
+          TALON_PROVISION_GITHUB_TAG: latest
+        run: npx vitest run src/__tests__/integration/provision-real.test.ts --reporter=verbose

--- a/.github/workflows/native-provision.yml
+++ b/.github/workflows/native-provision.yml
@@ -4,11 +4,17 @@ name: Native Provisioning
 # against real environments on every OS Talon supports, and keeps the
 # version pins current automatically:
 #
-#  - provision-real: fresh venv install of the pinned mempalace, live MCP
-#    handshake, self-heal from a gutted install, and a genuine 3.3.6 → pin
-#    upgrade with the palace migration — on Linux, macOS, and Windows.
-#    Runs on PRs that touch provisioning code, and daily (the pins don't
-#    move, but their unpinned transitive deps do — this catches that).
+#  - provision-real: fresh venv install of the pinned mempalace, a real
+#    MCP session that stores and searches a memory, self-heal from a
+#    gutted install, and a genuine 3.3.6 → pin upgrade with the palace
+#    migration — on Linux, macOS, and Windows. The same matrix downloads
+#    the chromium build and drives @playwright/mcp through a navigation;
+#    a Linux job pulls the pinned github-mcp-server image and reads a file
+#    through it with the workflow token. Every runtime is exercised the
+#    way Talon spawns it (the plugin's own command/args/env), not just
+#    installed. Runs on PRs that touch provisioning code, and daily (the
+#    pins don't move, but their unpinned transitive deps do — this
+#    catches that).
 #
 #  - detect → canary → autobump (daily + manual dispatch): detect reads
 #    the pins from source and asks upstream (PyPI, github-mcp-server
@@ -34,6 +40,7 @@ on:
       - "src/plugins/**"
       - "src/__tests__/native-provision.test.ts"
       - "src/__tests__/integration/provision-real.test.ts"
+      - "src/__tests__/integration/mcp-stdio-probe.ts"
       - ".github/workflows/native-provision.yml"
   schedule:
     - cron: "23 5 * * *"
@@ -72,6 +79,27 @@ jobs:
       - name: Provisioning suite against pinned versions
         env:
           TALON_PROVISION_REAL: "1"
+          TALON_PROVISION_REAL_PLAYWRIGHT: "1"
+        run: npx vitest run src/__tests__/integration/provision-real.test.ts --reporter=verbose
+
+  provision-docker:
+    name: Pinned github-mcp-server
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Image pull + MCP session against the pinned tag
+        env:
+          TALON_PROVISION_REAL_DOCKER: "1"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx vitest run src/__tests__/integration/provision-real.test.ts --reporter=verbose
 
   detect:
@@ -168,10 +196,11 @@ jobs:
 
       - run: npm ci
 
-      - name: Image pull + smoke against the candidate tag
+      - name: Image pull + MCP session against the candidate tag
         env:
           TALON_PROVISION_REAL_DOCKER: "1"
           TALON_PROVISION_GITHUB_TAG: ${{ needs.detect.outputs.github_latest }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx vitest run src/__tests__/integration/provision-real.test.ts --reporter=verbose
 
   autobump:

--- a/.github/workflows/native-provision.yml
+++ b/.github/workflows/native-provision.yml
@@ -1,18 +1,31 @@
 name: Native Provisioning
 
 # Exercises the native-plugin provisioners (src/core/plugin/native-runtimes.ts)
-# against real environments on every OS Talon supports:
+# against real environments on every OS Talon supports, and keeps the
+# version pins current automatically:
 #
 #  - provision-real: fresh venv install of the pinned mempalace, live MCP
 #    handshake, self-heal from a gutted install, and a genuine 3.3.6 → pin
 #    upgrade with the palace migration — on Linux, macOS, and Windows.
-#    Runs on PRs that touch provisioning code, and weekly.
+#    Runs on PRs that touch provisioning code, and daily (the pins don't
+#    move, but their unpinned transitive deps do — this catches that).
 #
-#  - canary: the same suite provisioned against the LATEST upstream
-#    versions (PyPI mempalace, github-mcp-server:latest, a real chromium
-#    download) instead of the pins. A red canary means the next pin bump
-#    needs work — bump pins only when this is green. Runs weekly and on
-#    manual dispatch; never blocks PRs.
+#  - detect → canary → autobump (daily + manual dispatch): detect reads
+#    the pins from source and asks upstream (PyPI, github-mcp-server
+#    releases) for the latest versions. When something is newer, the
+#    canary matrix runs the full real-install suite against the EXACT
+#    candidate version on all three OSes (plus a real chromium download
+#    and a docker pull+smoke). Only the targets whose canary came back
+#    green get their pin bumped: autobump opens a conventional-commit PR
+#    and requests auto-merge, so the bump still passes the normal CI
+#    gauntlet (including provision-real re-running against the new pin)
+#    before it lands. A major-version jump never auto-merges — the PR is
+#    opened for a human.
+#
+#  Full autonomy needs a classic/fine-grained PAT in the AUTOBUMP_TOKEN
+#  secret: PRs opened with the default GITHUB_TOKEN do not trigger CI
+#  (GitHub's recursion guard), so without it the bump PR carries the
+#  canary evidence but waits for a manual merge.
 
 on:
   pull_request:
@@ -23,7 +36,7 @@ on:
       - "src/__tests__/integration/provision-real.test.ts"
       - ".github/workflows/native-provision.yml"
   schedule:
-    - cron: "23 5 * * 1"
+    - cron: "23 5 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -61,9 +74,57 @@ jobs:
           TALON_PROVISION_REAL: "1"
         run: npx vitest run src/__tests__/integration/provision-real.test.ts --reporter=verbose
 
-  canary:
-    name: Canary latest (${{ matrix.os }})
+  detect:
+    name: Detect upstream versions
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      mempalace_pin: ${{ steps.versions.outputs.mempalace_pin }}
+      mempalace_latest: ${{ steps.versions.outputs.mempalace_latest }}
+      mempalace_bump: ${{ steps.versions.outputs.mempalace_bump }}
+      github_pin: ${{ steps.versions.outputs.github_pin }}
+      github_latest: ${{ steps.versions.outputs.github_latest }}
+      github_bump: ${{ steps.versions.outputs.github_bump }}
+      any_bump: ${{ steps.versions.outputs.any_bump }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Compare pins against upstream
+        id: versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # strictly_newer PIN CANDIDATE — true when CANDIDATE > PIN
+          strictly_newer() {
+            [ "$1" != "$2" ] &&
+              [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$2" ]
+          }
+
+          mp_pin=$(grep -oP 'MEMPALACE_PINNED_VERSION = "\K[0-9.]+' src/plugins/mempalace/provision.ts)
+          mp_latest=$(curl -fsSL https://pypi.org/pypi/mempalace/json | jq -r .info.version)
+          gh_pin=$(grep -oP 'GITHUB_MCP_PINNED_TAG = "\K[^"]+' src/plugins/github/provision.ts)
+          gh_latest=$(gh api repos/github/github-mcp-server/releases/latest -q .tag_name)
+
+          mp_bump=false; gh_bump=false
+          strictly_newer "$mp_pin" "$mp_latest" && mp_bump=true
+          strictly_newer "${gh_pin#v}" "${gh_latest#v}" && gh_bump=true
+
+          {
+            echo "mempalace_pin=$mp_pin"
+            echo "mempalace_latest=$mp_latest"
+            echo "mempalace_bump=$mp_bump"
+            echo "github_pin=$gh_pin"
+            echo "github_latest=$gh_latest"
+            echo "github_bump=$gh_bump"
+            echo "any_bump=$([ "$mp_bump" = true ] || [ "$gh_bump" = true ] && echo true || echo false)"
+          } | tee -a "$GITHUB_OUTPUT"
+
+  canary:
+    name: Canary mempalace ${{ needs.detect.outputs.mempalace_latest }} (${{ matrix.os }})
+    needs: detect
+    if: needs.detect.outputs.mempalace_bump == 'true' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -84,16 +145,17 @@ jobs:
 
       - run: npm ci
 
-      - name: Provisioning suite against latest upstream
+      - name: Provisioning suite against the candidate version
         env:
           TALON_PROVISION_REAL: "1"
-          TALON_PROVISION_TARGET: latest
+          TALON_PROVISION_TARGET: ${{ needs.detect.outputs.mempalace_latest }}
           TALON_PROVISION_REAL_PLAYWRIGHT: "1"
         run: npx vitest run src/__tests__/integration/provision-real.test.ts --reporter=verbose
 
   canary-docker:
-    name: Canary github-mcp-server:latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: Canary github-mcp-server ${{ needs.detect.outputs.github_latest }}
+    needs: detect
+    if: needs.detect.outputs.github_bump == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -106,8 +168,97 @@ jobs:
 
       - run: npm ci
 
-      - name: Image pull + smoke against latest tag
+      - name: Image pull + smoke against the candidate tag
         env:
           TALON_PROVISION_REAL_DOCKER: "1"
-          TALON_PROVISION_GITHUB_TAG: latest
+          TALON_PROVISION_GITHUB_TAG: ${{ needs.detect.outputs.github_latest }}
         run: npx vitest run src/__tests__/integration/provision-real.test.ts --reporter=verbose
+
+  autobump:
+    name: Bump green pins
+    needs: [detect, canary, canary-docker]
+    if: >-
+      always() && needs.detect.result == 'success' &&
+      needs.detect.outputs.any_bump == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.AUTOBUMP_TOKEN != '' && secrets.AUTOBUMP_TOKEN || github.token }}
+
+      - name: Bump each pin whose canary is green, open auto-merge PR
+        env:
+          GH_TOKEN: ${{ secrets.AUTOBUMP_TOKEN != '' && secrets.AUTOBUMP_TOKEN || github.token }}
+          HAS_PAT: ${{ secrets.AUTOBUMP_TOKEN != '' }}
+          MP_PIN: ${{ needs.detect.outputs.mempalace_pin }}
+          MP_LATEST: ${{ needs.detect.outputs.mempalace_latest }}
+          MP_BUMP: ${{ needs.detect.outputs.mempalace_bump }}
+          MP_CANARY: ${{ needs.canary.result }}
+          GHM_PIN: ${{ needs.detect.outputs.github_pin }}
+          GHM_LATEST: ${{ needs.detect.outputs.github_latest }}
+          GHM_BUMP: ${{ needs.detect.outputs.github_bump }}
+          GHM_CANARY: ${{ needs.canary-docker.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          summary=(); evidence=(); major_jump=false
+
+          major() { echo "${1#v}" | cut -d. -f1; }
+
+          if [ "$MP_BUMP" = "true" ] && [ "$MP_CANARY" = "success" ]; then
+            sed -i "s/MEMPALACE_PINNED_VERSION = \"$MP_PIN\"/MEMPALACE_PINNED_VERSION = \"$MP_LATEST\"/" \
+              src/plugins/mempalace/provision.ts
+            sed -i "s/\"version\": \"$MP_PIN\"/\"version\": \"$MP_LATEST\"/" README.md
+            summary+=("mempalace $MP_LATEST")
+            evidence+=("- mempalace \`$MP_PIN\` → \`$MP_LATEST\` — canary green on ubuntu/macos/windows (fresh install, MCP handshake, self-heal, 3.3.6→candidate upgrade + palace migration)")
+            [ "$(major "$MP_PIN")" != "$(major "$MP_LATEST")" ] && major_jump=true
+          elif [ "$MP_BUMP" = "true" ]; then
+            echo "mempalace $MP_LATEST available but canary result was '$MP_CANARY' — not bumping"
+          fi
+
+          if [ "$GHM_BUMP" = "true" ] && [ "$GHM_CANARY" = "success" ]; then
+            sed -i "s/GITHUB_MCP_PINNED_TAG = \"$GHM_PIN\"/GITHUB_MCP_PINNED_TAG = \"$GHM_LATEST\"/" \
+              src/plugins/github/provision.ts
+            summary+=("github-mcp $GHM_LATEST")
+            evidence+=("- github-mcp-server \`$GHM_PIN\` → \`$GHM_LATEST\` — image pull + smoke green")
+            [ "$(major "$GHM_PIN")" != "$(major "$GHM_LATEST")" ] && major_jump=true
+          elif [ "$GHM_BUMP" = "true" ]; then
+            echo "github-mcp-server $GHM_LATEST available but canary result was '$GHM_CANARY' — not bumping"
+          fi
+
+          git diff --quiet && { echo "no green bumps to apply"; exit 0; }
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          title="fix(plugins): bump native runtime pins ($(IFS=', '; echo "${summary[*]}"))"
+          git checkout -b autobump/native-pins
+          git commit -am "$title"
+          git push -f origin HEAD:autobump/native-pins
+
+          body="Automated pin bump from the [native-provision canary]($RUN_URL). Each target below passed the full real-environment suite against the exact candidate version before this PR was opened; the provision-real matrix on this PR re-validates the new pins.
+
+          $(printf '%s\n' "${evidence[@]}")
+
+          Opened automatically by the native-provision workflow."
+
+          existing=$(gh pr list --head autobump/native-pins --state open --json number -q '.[0].number' || true)
+          if [ -n "$existing" ]; then
+            echo "updating existing autobump PR #$existing (branch force-pushed)"
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/pulls/$existing" \
+              -f title="$title" -f body="$body" >/dev/null
+            pr_url=$(gh pr view "$existing" --json url -q .url)
+          else
+            pr_url=$(gh pr create --title "$title" --body "$body")
+          fi
+
+          if [ "$major_jump" = "true" ]; then
+            echo "major-version jump — leaving $pr_url for human review, no auto-merge"
+          elif [ "$HAS_PAT" != "true" ]; then
+            echo "no AUTOBUMP_TOKEN — CI will not trigger on this PR; merge $pr_url manually on green"
+          else
+            gh pr merge --auto --squash "$pr_url"
+          fi

--- a/README.md
+++ b/README.md
@@ -329,7 +329,6 @@ On first boot Talon creates a venv at `~/.talon/mempalace-venv` and installs the
     "backend": "mempalace",
     "mempalace": {
       "palacePath": "~/.talon/workspace/palace",
-      "pythonPath": "~/.talon/mempalace-venv/bin/python",
       "version": "3.8.0",
       "autoUpdate": true,
       "autoProvision": true
@@ -338,7 +337,7 @@ On first boot Talon creates a venv at `~/.talon/mempalace-venv` and installs the
 }
 ```
 
-Everything is optional --- paths default to `~/.talon/workspace/palace/` and the managed venv, `version` defaults to the built-in pin, and both `auto*` flags default to `true`.
+Everything is optional --- `palacePath` defaults to `~/.talon/workspace/palace/`, `version` defaults to the built-in pin, and both `auto*` flags default to `true`. Leave `pythonPath` unset to use the managed venv --- its interpreter is `~/.talon/mempalace-venv/bin/python` on Linux/macOS and `~/.talon/mempalace-venv/Scripts/python.exe` on Windows; any other value is treated as operator-managed (see below). `autoProvision` governs creating and healing the venv; `autoUpdate` governs reconciling a working venv to the pin --- they are independent.
 
 **Bring your own environment:** point `pythonPath` at any interpreter — a `uv tool` install, pipx, conda, or your own venv — and Talon treats it as operator-managed: it is probed and reported on (`talon doctor` shows the exact upgrade command for your install flavor) but never mutated.
 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ GitHub API access via the official GitHub MCP server. Gives the agent access to 
 
 The token is optional --- defaults to the output of `gh auth token` if the GitHub CLI is authenticated.
 
+The server image is pinned to a known-good tag and pulled in the background at boot when absent (docker still pulls on first use as the fallback). Override with `"imageTag"` (`"latest"` opts out of pinning); `"autoProvision": false` disables the pre-pull.
+
 ### Long-term Memory
 
 Talon supports two long-term memory backends, selected via the unified `memory` section:
@@ -316,14 +318,9 @@ Set `"backend"` to `"mempalace"` (local, vector search + knowledge graph) or `"m
 
 Structured long-term memory with vector search. The agent can store, search, and retrieve memories semantically. Integrates with Dream mode for automatic memory consolidation and personal diary entries.
 
-**Requirements:** Python 3.10+ with the `mempalace` package.
+**Requirements:** Python 3.10+ on PATH. Nothing else — Talon provisions its own environment.
 
-```bash
-# Set up a Python environment
-python -m venv ~/.talon/mempalace-venv
-~/.talon/mempalace-venv/bin/pip install mempalace    # Unix
-# or: ~/.talon/mempalace-venv/Scripts/pip install mempalace   # Windows
-```
+On first boot Talon creates a venv at `~/.talon/mempalace-venv` and installs the pinned `mempalace` version into it. From then on the venv is **self-maintaining**: version drift against the pin reconciles automatically in the background, a broken install (half-written site-packages, a gutted venv) self-heals at the next start, and one-time palace data migrations (e.g. the ≥3.4 wing-name normalization) are applied exactly once, safely and idempotently. Failed upgrades never take the working install down — the current version keeps serving and the retry backs off.
 
 ```json
 {
@@ -332,13 +329,18 @@ python -m venv ~/.talon/mempalace-venv
     "backend": "mempalace",
     "mempalace": {
       "palacePath": "~/.talon/workspace/palace",
-      "pythonPath": "~/.talon/mempalace-venv/bin/python"
+      "pythonPath": "~/.talon/mempalace-venv/bin/python",
+      "version": "3.8.0",
+      "autoUpdate": true,
+      "autoProvision": true
     }
   }
 }
 ```
 
-Both paths are optional --- defaults to `~/.talon/workspace/palace/` and the venv Python respectively.
+Everything is optional --- paths default to `~/.talon/workspace/palace/` and the managed venv, `version` defaults to the built-in pin, and both `auto*` flags default to `true`.
+
+**Bring your own environment:** point `pythonPath` at any interpreter — a `uv tool` install, pipx, conda, or your own venv — and Talon treats it as operator-managed: it is probed and reported on (`talon doctor` shows the exact upgrade command for your install flavor) but never mutated.
 
 #### mem0 backend
 
@@ -378,6 +380,8 @@ Headless browser automation via the Playwright MCP server. The agent can browse 
 ```
 
 Supported browsers: `chromium` (default), `chrome`, `firefox`, `webkit`, `msedge`.
+
+For Playwright-managed engines (`chromium`, `firefox`, `webkit`) the browser build is downloaded automatically at boot when missing — version-matched to the bundled `@playwright/mcp`. System channels (`chrome`, `msedge`) and endpoint mode are never touched. `"autoProvision": false` disables the download.
 
 ### Brave Search
 

--- a/src/__tests__/integration/mcp-stdio-probe.ts
+++ b/src/__tests__/integration/mcp-stdio-probe.ts
@@ -1,0 +1,127 @@
+/**
+ * Real stdio MCP session against a plugin's server, using the same
+ * @modelcontextprotocol/sdk client the backends speak. Spawns exactly
+ * what the plugin declares (`mcpServer.command/args` + `getEnvVars()`),
+ * so a test here proves the runtime a provisioner installed answers the
+ * protocol the way Talon will actually drive it.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { TalonPlugin } from "../../core/plugin/types.js";
+
+export interface McpProbeSession {
+  client: Client;
+  /** Tool names the server advertised. */
+  tools: string[];
+  /** Call a tool and return its concatenated text content. */
+  callText(name: string, args: Record<string, unknown>): Promise<string>;
+  /** Server stderr so far — for failure messages. */
+  stderr(): string;
+}
+
+/**
+ * Open a session against `plugin.mcpServer`, run `fn`, always tear down.
+ * `extraEnv` layers over the plugin's own env (e.g. an isolated browser
+ * cache or a CI token).
+ */
+export async function withPluginMcp<T>(
+  plugin: TalonPlugin,
+  fn: (session: McpProbeSession) => Promise<T>,
+  opts: { extraEnv?: Record<string, string>; timeoutMs?: number } = {},
+): Promise<T> {
+  const server = plugin.mcpServer;
+  if (!server) throw new Error(`${plugin.name} declares no mcpServer`);
+  const env: Record<string, string> = {
+    ...(Object.fromEntries(
+      Object.entries(process.env).filter(
+        (e): e is [string, string] => typeof e[1] === "string",
+      ),
+    ) as Record<string, string>),
+    ...plugin.getEnvVars?.({}),
+    ...opts.extraEnv,
+  };
+  const transport = new StdioClientTransport({
+    command: server.command,
+    args: [...server.args],
+    env,
+    stderr: "pipe",
+  });
+  let stderr = "";
+  transport.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  const client = new Client({ name: "talon-provision-ci", version: "0" });
+  const timeoutMs = opts.timeoutMs ?? 120_000;
+
+  const withTimeout = <U>(p: Promise<U>, what: string): Promise<U> =>
+    new Promise<U>((resolvePromise, rejectPromise) => {
+      const timer = setTimeout(
+        () =>
+          rejectPromise(
+            new Error(
+              `${plugin.name}: ${what} timed out after ${timeoutMs}ms\n--- server stderr ---\n${stderr}`,
+            ),
+          ),
+        timeoutMs,
+      );
+      p.then(
+        (v) => {
+          clearTimeout(timer);
+          resolvePromise(v);
+        },
+        (err: unknown) => {
+          clearTimeout(timer);
+          rejectPromise(
+            new Error(
+              `${plugin.name}: ${what} failed: ${err instanceof Error ? err.message : String(err)}\n--- server stderr ---\n${stderr}`,
+            ),
+          );
+        },
+      );
+    });
+
+  try {
+    await withTimeout(client.connect(transport), "initialize");
+    const listed = await withTimeout(client.listTools(), "tools/list");
+    const session: McpProbeSession = {
+      client,
+      tools: listed.tools.map((t) => t.name),
+      stderr: () => stderr,
+      callText: async (name, args) => {
+        const result = await withTimeout(
+          client.callTool({ name, arguments: args }, undefined, {
+            timeout: timeoutMs,
+          }),
+          `tools/call ${name}`,
+        );
+        const content = (result as { content?: unknown }).content;
+        const text = Array.isArray(content)
+          ? content
+              .map(
+                (c: {
+                  type?: string;
+                  text?: string;
+                  resource?: { text?: string };
+                }) =>
+                  c.type === "text"
+                    ? (c.text ?? "")
+                    : c.type === "resource"
+                      ? (c.resource?.text ?? "")
+                      : "",
+              )
+              .join("\n")
+          : "";
+        if ((result as { isError?: boolean }).isError) {
+          throw new Error(
+            `${plugin.name}: ${name} returned isError\n${text}\n--- server stderr ---\n${stderr}`,
+          );
+        }
+        return text;
+      },
+    };
+    return await fn(session);
+  } finally {
+    await client.close().catch(() => {});
+  }
+}

--- a/src/__tests__/integration/provision-real.test.ts
+++ b/src/__tests__/integration/provision-real.test.ts
@@ -17,7 +17,6 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -31,7 +30,11 @@ import {
   provisionMempalace,
   MEMPALACE_PINNED_VERSION,
 } from "../../plugins/mempalace/provision.js";
+import { createMempalacePlugin } from "../../plugins/mempalace/index.js";
 import { provisionPlaywright } from "../../plugins/playwright/provision.js";
+import { createPlaywrightPlugin } from "../../plugins/playwright/index.js";
+import { createGitHubPlugin } from "../../plugins/github/index.js";
+import { withPluginMcp } from "./mcp-stdio-probe.js";
 import {
   provisionGithubMcp,
   githubMcpImageRef,
@@ -55,69 +58,8 @@ async function resolveTarget(): Promise<string> {
   return data.info.version;
 }
 
-/**
- * Spawn the mempalace MCP server over stdio and complete a JSON-RPC
- * initialize handshake — the same contract the Claude SDK relies on.
- */
-async function mcpInitialize(
-  python: string,
-  palace: string,
-): Promise<{ serverName?: string }> {
-  return new Promise((resolvePromise, rejectPromise) => {
-    const child = spawn(
-      python,
-      ["-m", "mempalace.mcp_server", "--palace", palace],
-      { env: { ...process.env, MEMPALACE_PALACE_PATH: palace } },
-    );
-    const timer = setTimeout(() => {
-      child.kill("SIGKILL");
-      rejectPromise(new Error("MCP initialize timed out"));
-    }, 120_000);
-
-    let buffer = "";
-    child.stdout.on("data", (chunk: Buffer) => {
-      buffer += chunk.toString();
-      for (const line of buffer.split("\n")) {
-        if (!line.trim()) continue;
-        try {
-          const msg = JSON.parse(line) as {
-            id?: number;
-            result?: { serverInfo?: { name?: string } };
-          };
-          if (msg.id === 1 && msg.result) {
-            clearTimeout(timer);
-            child.kill("SIGKILL");
-            resolvePromise({ serverName: msg.result.serverInfo?.name });
-            return;
-          }
-        } catch {
-          /* partial line — keep buffering */
-        }
-      }
-    });
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      rejectPromise(err);
-    });
-    child.on("exit", (code) => {
-      clearTimeout(timer);
-      rejectPromise(new Error(`MCP server exited early (code ${code})`));
-    });
-
-    child.stdin.write(
-      JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "initialize",
-        params: {
-          protocolVersion: "2024-11-05",
-          capabilities: {},
-          clientInfo: { name: "talon-provision-ci", version: "0" },
-        },
-      }) + "\n",
-    );
-  });
-}
+/** A memory stored through MCP and expected back from search, verbatim. */
+const MEMORY = "The provisioning canary bumps pins only when green.";
 
 describe.skipIf(!REAL)("mempalace real provisioning", () => {
   it(
@@ -143,9 +85,32 @@ describe.skipIf(!REAL)("mempalace real provisioning", () => {
       expect(fresh.version).toBe(target);
       expect(fresh.actions.join(" ")).toContain("created venv");
 
-      // The runtime actually serves MCP.
-      const handshake = await mcpInitialize(python, palace);
-      expect(handshake.serverName).toBeTruthy();
+      // The runtime actually serves MCP, driven exactly as Talon drives
+      // it (the plugin's own command/args/env): store a memory, search it
+      // back. The first search loads the embedder, so the timeout is wide.
+      await withPluginMcp(
+        createMempalacePlugin({ pythonPath: python, palacePath: palace }),
+        async (mcp) => {
+          expect(mcp.tools).toEqual(
+            expect.arrayContaining([
+              "mempalace_add_drawer",
+              "mempalace_search",
+            ]),
+          );
+          const added = await mcp.callText("mempalace_add_drawer", {
+            wing: "talon-ci",
+            room: "decisions",
+            content: MEMORY,
+          });
+          expect(added).toContain('"success": true');
+          const found = await mcp.callText("mempalace_search", {
+            query: "when does the canary bump pins",
+            limit: 3,
+          });
+          expect(found).toContain(MEMORY);
+        },
+        { timeoutMs: 10 * 60_000 },
+      );
 
       // Idempotent second pass: nothing to do.
       const again = await provisionMempalace(opts, deps);
@@ -257,6 +222,23 @@ describe.skipIf(!REAL_PLAYWRIGHT)("playwright real provisioning", () => {
       expect(again.status, detail(again)).toBe("ready");
       expect(again.actions).toHaveLength(0);
 
+      // The build actually launches under @playwright/mcp with the
+      // plugin's own args (headless, no-sandbox): navigate, read the page.
+      await withPluginMcp(
+        createPlaywrightPlugin({ browser: "chromium", headless: true }),
+        async (mcp) => {
+          expect(mcp.tools).toEqual(
+            expect.arrayContaining(["browser_navigate", "browser_snapshot"]),
+          );
+          await mcp.callText("browser_navigate", {
+            url: "data:text/html,<title>Talon Probe</title><h1>talon-provision-ci</h1>",
+          });
+          const snapshot = await mcp.callText("browser_snapshot", {});
+          expect(snapshot).toContain("talon-provision-ci");
+        },
+        { extraEnv: { PLAYWRIGHT_BROWSERS_PATH: browsers } },
+      );
+
       rmSync(home, { recursive: true, force: true });
     },
   );
@@ -283,6 +265,27 @@ describe.skipIf(!REAL_DOCKER)("github mcp real provisioning", () => {
         { timeoutMs: 120_000 },
       );
       expect(help.ok).toBe(true);
+
+      // A real stdio session through the plugin's docker command line;
+      // with a token (CI's GITHUB_TOKEN) a read-only call round-trips to
+      // the API for the repository under test.
+      const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+      await withPluginMcp(
+        createGitHubPlugin({ token, imageTag }),
+        async (mcp) => {
+          expect(mcp.tools).toContain("get_file_contents");
+          if (!token) return;
+          const [owner, repo] = (
+            process.env.GITHUB_REPOSITORY ?? "dylanneve1/talon"
+          ).split("/");
+          const pkg = await mcp.callText("get_file_contents", {
+            owner,
+            repo,
+            path: "package.json",
+          });
+          expect(pkg).toContain('"name"');
+        },
+      );
 
       rmSync(home, { recursive: true, force: true });
     },

--- a/src/__tests__/integration/provision-real.test.ts
+++ b/src/__tests__/integration/provision-real.test.ts
@@ -25,6 +25,7 @@ import {
   findBasePython,
   runStep,
   venvPython,
+  type ProvisionOutcome,
 } from "../../core/plugin/provision.js";
 import {
   provisionMempalace,
@@ -41,6 +42,9 @@ const REAL_PLAYWRIGHT = process.env.TALON_PROVISION_REAL_PLAYWRIGHT === "1";
 const REAL_DOCKER = process.env.TALON_PROVISION_REAL_DOCKER === "1";
 
 const INSTALL_TIMEOUT = 20 * 60_000;
+
+const detail = (o: ProvisionOutcome): string =>
+  `status=${o.status} error=${o.error ?? "-"} warnings=[${o.warnings.join("; ")}] actions=[${o.actions.join("; ")}]`;
 
 async function resolveTarget(): Promise<string> {
   if (process.env.TALON_PROVISION_TARGET !== "latest") {
@@ -135,7 +139,7 @@ describe.skipIf(!REAL)("mempalace real provisioning", () => {
 
       // Fresh: no venv at all → created, installed, verified.
       const fresh = await provisionMempalace(opts, deps);
-      expect(fresh.status).toBe("ready");
+      expect(fresh.status, detail(fresh)).toBe("ready");
       expect(fresh.version).toBe(target);
       expect(fresh.actions.join(" ")).toContain("created venv");
 
@@ -145,7 +149,7 @@ describe.skipIf(!REAL)("mempalace real provisioning", () => {
 
       // Idempotent second pass: nothing to do.
       const again = await provisionMempalace(opts, deps);
-      expect(again.status).toBe("ready");
+      expect(again.status, detail(again)).toBe("ready");
       expect(again.actions).toHaveLength(0);
 
       // Self-heal: gut site-packages and expect a working reinstall.
@@ -160,7 +164,7 @@ describe.skipIf(!REAL)("mempalace real provisioning", () => {
         force: true,
       });
       const healed = await provisionMempalace(opts, deps);
-      expect(healed.status).toBe("ready");
+      expect(healed.status, detail(healed)).toBe("ready");
       expect(healed.version).toBe(target);
       expect(healed.actions.join(" ")).toContain(
         `installed mempalace ${target}`,
@@ -209,11 +213,11 @@ describe.skipIf(!REAL)("mempalace real provisioning", () => {
         { defaultManagedPython: python, statePath },
       );
       // A healthy-but-behind install reconciles in the background.
-      expect(outcome.status).toBe("ready");
+      expect(outcome.status, detail(outcome)).toBe("ready");
       expect(outcome.version).toBe("3.3.6");
       expect(outcome.background).toBeDefined();
       const settled = await outcome.background!();
-      expect(settled.status).toBe("ready");
+      expect(settled.status, detail(settled)).toBe("ready");
       expect(settled.version).toBe(target);
       expect(settled.actions.join(" ")).toContain(
         `upgraded mempalace 3.3.6 → ${target}`,
@@ -239,7 +243,7 @@ describe.skipIf(!REAL_PLAYWRIGHT)("playwright real provisioning", () => {
           statePath: join(home, "state.json"),
         },
       );
-      expect(outcome.status).toBe("ready");
+      expect(outcome.status, detail(outcome)).toBe("ready");
       expect(outcome.actions.join(" ")).toContain("chromium");
 
       // Second pass sees the build and does nothing.
@@ -250,7 +254,7 @@ describe.skipIf(!REAL_PLAYWRIGHT)("playwright real provisioning", () => {
           statePath: join(home, "state.json"),
         },
       );
-      expect(again.status).toBe("ready");
+      expect(again.status, detail(again)).toBe("ready");
       expect(again.actions).toHaveLength(0);
 
       rmSync(home, { recursive: true, force: true });
@@ -271,7 +275,7 @@ describe.skipIf(!REAL_DOCKER)("github mcp real provisioning", () => {
       );
       // Either already present (ready) or pulled by the background task.
       const settled = outcome.background ? await outcome.background() : outcome;
-      expect(settled.status).toBe("ready");
+      expect(settled.status, detail(settled)).toBe("ready");
 
       const help = await runStep(
         "docker",

--- a/src/__tests__/integration/provision-real.test.ts
+++ b/src/__tests__/integration/provision-real.test.ts
@@ -85,6 +85,11 @@ describe.skipIf(!REAL)("mempalace real provisioning", () => {
       expect(fresh.version).toBe(target);
       expect(fresh.actions.join(" ")).toContain("created venv");
 
+      // Idempotent second pass: nothing to do.
+      const again = await provisionMempalace(opts, deps);
+      expect(again.status, detail(again)).toBe("ready");
+      expect(again.actions).toHaveLength(0);
+
       // The runtime actually serves MCP, driven exactly as Talon drives
       // it (the plugin's own command/args/env): store a memory, search it
       // back. The first search loads the embedder, so the timeout is wide.
@@ -112,10 +117,13 @@ describe.skipIf(!REAL)("mempalace real provisioning", () => {
         { timeoutMs: 10 * 60_000 },
       );
 
-      // Idempotent second pass: nothing to do.
-      const again = await provisionMempalace(opts, deps);
-      expect(again.status, detail(again)).toBe("ready");
-      expect(again.actions).toHaveLength(0);
+      // The palace now holds data, so the next pass applies the one-time
+      // wing-name migration — and only once (ledgered), never again.
+      const migrated = await provisionMempalace(opts, deps);
+      expect(migrated.status, detail(migrated)).toBe("ready");
+      expect(migrated.actions.join(" ")).toContain("wing-name migration");
+      const ledgered = await provisionMempalace(opts, deps);
+      expect(ledgered.actions, detail(ledgered)).toHaveLength(0);
 
       // Self-heal: gut site-packages and expect a working reinstall.
       const purelib = await runStep(

--- a/src/__tests__/integration/provision-real.test.ts
+++ b/src/__tests__/integration/provision-real.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Real-environment provisioning suite — the teeth behind the
+ * native-provision workflow (.github/workflows/native-provision.yml).
+ *
+ * Everything here hits the network and real interpreters, so the whole
+ * file is gated behind env flags and skipped in the normal unit run:
+ *
+ *   TALON_PROVISION_REAL=1            mempalace venv scenarios (all OSes)
+ *   TALON_PROVISION_TARGET=latest     canary: provision PyPI latest instead of the pin
+ *   TALON_PROVISION_REAL_PLAYWRIGHT=1 real browser download scenario
+ *   TALON_PROVISION_REAL_DOCKER=1     real image pull scenario (needs docker)
+ *   TALON_PROVISION_GITHUB_TAG        canary override for the image tag
+ *
+ * Scenarios mirror the provisioner's real-life duties: fresh install →
+ * live MCP handshake, self-heal from a gutted site-packages, and a
+ * genuine 3.3.6 → pin upgrade with the palace migration wired through.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  findBasePython,
+  runStep,
+  venvPython,
+} from "../../core/plugin/provision.js";
+import {
+  provisionMempalace,
+  MEMPALACE_PINNED_VERSION,
+} from "../../plugins/mempalace/provision.js";
+import { provisionPlaywright } from "../../plugins/playwright/provision.js";
+import {
+  provisionGithubMcp,
+  githubMcpImageRef,
+} from "../../plugins/github/provision.js";
+
+const REAL = process.env.TALON_PROVISION_REAL === "1";
+const REAL_PLAYWRIGHT = process.env.TALON_PROVISION_REAL_PLAYWRIGHT === "1";
+const REAL_DOCKER = process.env.TALON_PROVISION_REAL_DOCKER === "1";
+
+const INSTALL_TIMEOUT = 20 * 60_000;
+
+async function resolveTarget(): Promise<string> {
+  if (process.env.TALON_PROVISION_TARGET !== "latest") {
+    return process.env.TALON_PROVISION_TARGET ?? MEMPALACE_PINNED_VERSION;
+  }
+  const res = await fetch("https://pypi.org/pypi/mempalace/json");
+  const data = (await res.json()) as { info: { version: string } };
+  return data.info.version;
+}
+
+/**
+ * Spawn the mempalace MCP server over stdio and complete a JSON-RPC
+ * initialize handshake — the same contract the Claude SDK relies on.
+ */
+async function mcpInitialize(
+  python: string,
+  palace: string,
+): Promise<{ serverName?: string }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(
+      python,
+      ["-m", "mempalace.mcp_server", "--palace", palace],
+      { env: { ...process.env, MEMPALACE_PALACE_PATH: palace } },
+    );
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      rejectPromise(new Error("MCP initialize timed out"));
+    }, 120_000);
+
+    let buffer = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      buffer += chunk.toString();
+      for (const line of buffer.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line) as {
+            id?: number;
+            result?: { serverInfo?: { name?: string } };
+          };
+          if (msg.id === 1 && msg.result) {
+            clearTimeout(timer);
+            child.kill("SIGKILL");
+            resolvePromise({ serverName: msg.result.serverInfo?.name });
+            return;
+          }
+        } catch {
+          /* partial line — keep buffering */
+        }
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      rejectPromise(err);
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      rejectPromise(new Error(`MCP server exited early (code ${code})`));
+    });
+
+    child.stdin.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "talon-provision-ci", version: "0" },
+        },
+      }) + "\n",
+    );
+  });
+}
+
+describe.skipIf(!REAL)("mempalace real provisioning", () => {
+  it(
+    "fresh install → pinned version → live MCP handshake → self-heal",
+    { timeout: 2 * INSTALL_TIMEOUT },
+    async () => {
+      const target = await resolveTarget();
+      const home = mkdtempSync(join(tmpdir(), "talon-prov-fresh-"));
+      const venvDir = join(home, "mempalace-venv");
+      const python = venvPython(venvDir, process.platform);
+      const palace = join(home, "palace");
+      const statePath = join(home, "state.json");
+      const opts = {
+        pythonPath: python,
+        palacePath: palace,
+        version: target,
+      };
+      const deps = { defaultManagedPython: python, statePath };
+
+      // Fresh: no venv at all → created, installed, verified.
+      const fresh = await provisionMempalace(opts, deps);
+      expect(fresh.status).toBe("ready");
+      expect(fresh.version).toBe(target);
+      expect(fresh.actions.join(" ")).toContain("created venv");
+
+      // The runtime actually serves MCP.
+      const handshake = await mcpInitialize(python, palace);
+      expect(handshake.serverName).toBeTruthy();
+
+      // Idempotent second pass: nothing to do.
+      const again = await provisionMempalace(opts, deps);
+      expect(again.status).toBe("ready");
+      expect(again.actions).toHaveLength(0);
+
+      // Self-heal: gut site-packages and expect a working reinstall.
+      const purelib = await runStep(
+        python,
+        ["-c", "import sysconfig; print(sysconfig.get_paths()['purelib'])"],
+        { timeoutMs: 30_000 },
+      );
+      expect(purelib.ok).toBe(true);
+      rmSync(join(purelib.stdout.trim(), "mempalace"), {
+        recursive: true,
+        force: true,
+      });
+      const healed = await provisionMempalace(opts, deps);
+      expect(healed.status).toBe("ready");
+      expect(healed.version).toBe(target);
+      expect(healed.actions.join(" ")).toContain(
+        `installed mempalace ${target}`,
+      );
+
+      rmSync(home, { recursive: true, force: true });
+    },
+  );
+
+  it(
+    "3.3.6 → pin upgrade migrates the palace exactly once",
+    { timeout: 2 * INSTALL_TIMEOUT },
+    async () => {
+      const target = await resolveTarget();
+      const home = mkdtempSync(join(tmpdir(), "talon-prov-upgrade-"));
+      const venvDir = join(home, "mempalace-venv");
+      const python = venvPython(venvDir, process.platform);
+      const palace = join(home, "palace");
+      const statePath = join(home, "state.json");
+
+      // Seed a genuine old install the way a pre-provisioner deployment had it.
+      const base = await findBasePython(runStep, process.platform, {
+        major: 3,
+        minor: 10,
+      });
+      expect(base).toBeDefined();
+      const venv = await runStep(
+        base!.command,
+        [...base!.args, "-m", "venv", venvDir],
+        { timeoutMs: 120_000 },
+      );
+      expect(venv.ok).toBe(true);
+      const old = await runStep(
+        python,
+        ["-m", "pip", "install", "mempalace==3.3.6"],
+        { timeoutMs: INSTALL_TIMEOUT },
+      );
+      expect(old.ok).toBe(true);
+
+      // A palace with a store present arms the one-time wing migration.
+      mkdirSync(palace, { recursive: true });
+      writeFileSync(join(palace, "chroma.sqlite3"), "");
+
+      const outcome = await provisionMempalace(
+        { pythonPath: python, palacePath: palace, version: target },
+        { defaultManagedPython: python, statePath },
+      );
+      // A healthy-but-behind install reconciles in the background.
+      expect(outcome.status).toBe("ready");
+      expect(outcome.version).toBe("3.3.6");
+      expect(outcome.background).toBeDefined();
+      const settled = await outcome.background!();
+      expect(settled.status).toBe("ready");
+      expect(settled.version).toBe(target);
+      expect(settled.actions.join(" ")).toContain(
+        `upgraded mempalace 3.3.6 → ${target}`,
+      );
+      expect(settled.actions.join(" ")).toContain("wing-name migration");
+
+      rmSync(home, { recursive: true, force: true });
+    },
+  );
+});
+
+describe.skipIf(!REAL_PLAYWRIGHT)("playwright real provisioning", () => {
+  it(
+    "downloads the chromium build into an isolated cache",
+    { timeout: INSTALL_TIMEOUT },
+    async () => {
+      const home = mkdtempSync(join(tmpdir(), "talon-prov-pw-"));
+      const browsers = join(home, "browsers");
+      const outcome = await provisionPlaywright(
+        { browser: "chromium" },
+        {
+          env: { ...process.env, PLAYWRIGHT_BROWSERS_PATH: browsers },
+          statePath: join(home, "state.json"),
+        },
+      );
+      expect(outcome.status).toBe("ready");
+      expect(outcome.actions.join(" ")).toContain("chromium");
+
+      // Second pass sees the build and does nothing.
+      const again = await provisionPlaywright(
+        { browser: "chromium" },
+        {
+          env: { ...process.env, PLAYWRIGHT_BROWSERS_PATH: browsers },
+          statePath: join(home, "state.json"),
+        },
+      );
+      expect(again.status).toBe("ready");
+      expect(again.actions).toHaveLength(0);
+
+      rmSync(home, { recursive: true, force: true });
+    },
+  );
+});
+
+describe.skipIf(!REAL_DOCKER)("github mcp real provisioning", () => {
+  it(
+    "pulls the pinned image and the binary answers",
+    { timeout: INSTALL_TIMEOUT },
+    async () => {
+      const home = mkdtempSync(join(tmpdir(), "talon-prov-gh-"));
+      const imageTag = process.env.TALON_PROVISION_GITHUB_TAG;
+      const outcome = await provisionGithubMcp(
+        { imageTag },
+        { statePath: join(home, "state.json") },
+      );
+      // Either already present (ready) or pulled by the background task.
+      const settled = outcome.background ? await outcome.background() : outcome;
+      expect(settled.status).toBe("ready");
+
+      const help = await runStep(
+        "docker",
+        ["run", "--rm", githubMcpImageRef(imageTag), "--help"],
+        { timeoutMs: 120_000 },
+      );
+      expect(help.ok).toBe(true);
+
+      rmSync(home, { recursive: true, force: true });
+    },
+  );
+});

--- a/src/__tests__/native-provision.test.ts
+++ b/src/__tests__/native-provision.test.ts
@@ -36,6 +36,7 @@ import {
 } from "../plugins/playwright/provision.js";
 import {
   githubMcpImageRef,
+  inspectGithub,
   provisionGithubMcp,
   GITHUB_MCP_PINNED_TAG,
 } from "../plugins/github/provision.js";
@@ -198,6 +199,19 @@ describe("mempalace provisioner", () => {
     expect(outcome.warnings.join(" ")).toContain("uv tool install --force");
     // Only the probe ran — no pip, no venv.
     expect(exec.calls).toHaveLength(1);
+
+    // Newer than the pin is drift too — same advisory, neutral wording.
+    const ahead = await provisionMempalace(
+      { pythonPath: uvPython, palacePath: p.palace },
+      {
+        exec: fakeExec([probeRule("99.0.0")]),
+        defaultManagedPython: p.python,
+        statePath: p.state,
+        pathExists: (x) => x === uvPython,
+      },
+    );
+    expect(ahead.status).toBe("ready");
+    expect(ahead.warnings.join(" ")).toContain("reconcile with: uv tool");
   });
 
   it("fails an external install with a missing interpreter, with an install hint", async () => {
@@ -414,6 +428,108 @@ describe("mempalace provisioner", () => {
     );
   });
 
+  it("autoProvision:false still reconciles a healthy drifted venv (autoUpdate is independent)", async () => {
+    const p = dir();
+    const exec = fakeExec([
+      probeRule("3.3.5"),
+      { match: (_c, a) => has(a, "pip"), result: { ok: true } },
+    ]);
+    const outcome = await provisionMempalace(
+      { pythonPath: p.python, palacePath: p.palace, autoProvision: false },
+      {
+        exec,
+        defaultManagedPython: p.python,
+        statePath: p.state,
+        pathExists: (x) => x === p.python,
+      },
+    );
+    expect(outcome.status).toBe("ready");
+    expect(outcome.background).toBeDefined();
+
+    // …but never creates or heals: a broken venv stays broken, reported.
+    const broken = await provisionMempalace(
+      { pythonPath: p.python, palacePath: p.palace, autoProvision: false },
+      {
+        exec: fakeExec([]),
+        defaultManagedPython: p.python,
+        statePath: p.state,
+        pathExists: () => false,
+      },
+    );
+    expect(broken.status).toBe("failed");
+    expect(broken.warnings.join(" ")).toContain("autoProvision is off");
+  });
+
+  it("rolls back when a failed upgrade leaves the venv broken", async () => {
+    const p = dir();
+    let installed = "3.3.5";
+    let upgradeAttempts = 0;
+    const exec = fakeExec([
+      {
+        match: (_c, a) =>
+          has(a, "-c") &&
+          String(a[a.length - 1]).includes("importlib.metadata"),
+        get result() {
+          return installed
+            ? { ok: true, stdout: `${installed}\n` }
+            : { ok: false, stderr: "ModuleNotFoundError: mempalace" };
+        },
+      },
+    ]);
+    // Script pip by hand: the upgrade dies mid-mutation (install gone),
+    // the rollback reinstalls the previous version.
+    const scripted: ExecFn = async (cmd, args, opts) => {
+      if (has(args, "pip") && has(args, "install")) {
+        const spec = String(args[args.length - 1]);
+        if (spec === "mempalace==3.3.5" && has(args, "--force-reinstall")) {
+          installed = "3.3.5";
+          return { ok: true, code: 0, stdout: "", stderr: "" };
+        }
+        upgradeAttempts++;
+        installed = "";
+        return { ok: false, code: 1, stdout: "", stderr: "killed" };
+      }
+      if (has(args, "ensurepip")) {
+        return { ok: true, code: 0, stdout: "", stderr: "" };
+      }
+      return exec(cmd, args, opts);
+    };
+    const outcome = await provisionMempalace(
+      { pythonPath: p.python, palacePath: p.palace },
+      {
+        exec: scripted,
+        defaultManagedPython: p.python,
+        statePath: p.state,
+        pathExists: (x) => x === p.python || x === p.venv,
+      },
+    );
+    const settled = await outcome.background!();
+    expect(settled.status).toBe("degraded");
+    expect(settled.version).toBe("3.3.5");
+    expect(settled.warnings.join(" ")).toContain("rolled back");
+    expect(upgradeAttempts).toBeGreaterThan(0);
+    expect(installed).toBe("3.3.5");
+  });
+
+  it("skips the wing-name migration when the serving version predates it", async () => {
+    const p = dir();
+    mkdirSync(p.palace, { recursive: true });
+    writeFileSync(join(p.palace, "chroma.sqlite3"), "");
+    const exec = fakeExec([probeRule("3.3.6")]);
+    const outcome = await provisionMempalace(
+      { pythonPath: p.python, palacePath: p.palace, version: "3.3.6" },
+      {
+        exec,
+        defaultManagedPython: p.python,
+        statePath: p.state,
+        pathExists: (x) => x === p.python || x.endsWith("chroma.sqlite3"),
+      },
+    );
+    expect(outcome.status).toBe("ready");
+    expect(exec.calls.some((c) => has(c.args, "migrate-wings"))).toBe(false);
+    expect(outcome.warnings).toHaveLength(0);
+  });
+
   it("autoUpdate:false reports drift without reconciling", async () => {
     const p = dir();
     const exec = fakeExec([probeRule("3.3.5")]);
@@ -463,8 +579,56 @@ describe("mempalace provisioner", () => {
       },
     );
     expect(external[0].issue).toBeFalsy();
+    expect(external[0].detail).toContain("pip install --upgrade");
+
+    // Disabled automation is reported as such — never a promised restart fix.
+    const updateOff = await inspectMempalace(
+      { pythonPath: p.python, autoUpdate: false },
+      {
+        exec: fakeExec([probeRule("3.3.5")]),
+        defaultManagedPython: p.python,
+        pathExists: (x) => x === p.python,
+      },
+    );
+    expect(updateOff[0].detail).toContain("autoUpdate: false");
+    expect(updateOff[0].detail).toContain("pip install");
+
+    const missingOff = await inspectMempalace(
+      { pythonPath: p.python, autoProvision: false },
+      {
+        exec: fakeExec([]),
+        defaultManagedPython: p.python,
+        pathExists: () => false,
+      },
+    );
+    expect(missingOff[0].status).toBe("fail");
+    expect(missingOff[0].detail).toContain("autoProvision: false");
+
+    const brokenOff = await inspectMempalace(
+      { pythonPath: p.python, autoProvision: false },
+      {
+        exec: fakeExec([]),
+        defaultManagedPython: p.python,
+        pathExists: (x) => x === p.python,
+      },
+    );
+    expect(brokenOff[0].status).toBe("fail");
+    expect(brokenOff[0].detail).toContain("repair manually");
   });
 });
+
+/** A playwright-core registry fixture: chromium ships with its headless shell. */
+const REGISTRY = [
+  { name: "chromium", revision: "1181" },
+  { name: "chromium-headless-shell", revision: "1181" },
+  { name: "firefox", revision: "1500" },
+  {
+    name: "webkit",
+    revision: "2342",
+    revisionOverrides: { mac14: "2251" },
+  },
+];
+const COMPLETE = (p: string) => p.endsWith("INSTALLATION_COMPLETE");
 
 describe("playwright provisioner", () => {
   it("skips endpoint mode and system channels", async () => {
@@ -481,14 +645,92 @@ describe("playwright provisioner", () => {
     ).toBe("skipped");
   });
 
-  it("is a no-op when the build is already present", async () => {
+  it("is a no-op when the required revisions are present and complete", async () => {
     const exec = fakeExec([]);
     const outcome = await provisionPlaywright(
       { browser: "chromium" },
-      { exec, listDir: () => ["chromium-1181", "ffmpeg-1010"] },
+      {
+        exec,
+        registry: REGISTRY,
+        listDir: () => [
+          "chromium-1181",
+          "chromium_headless_shell-1181",
+          "ffmpeg-1010",
+        ],
+        pathExists: COMPLETE,
+      },
     );
     expect(outcome.status).toBe("ready");
     expect(exec.calls).toHaveLength(0);
+  });
+
+  it("treats a stale revision, a missing headless shell, or an incomplete download as absent", async () => {
+    const d = tmp();
+    const run = (listDir: () => string[], pathExists = COMPLETE) =>
+      provisionPlaywright(
+        { browser: "chromium" },
+        {
+          exec: fakeExec([
+            { match: (_c, a) => has(a, "install"), result: { ok: true } },
+          ]),
+          registry: REGISTRY,
+          listDir,
+          pathExists: (p) => p.endsWith("cli.js") || pathExists(p),
+          cliPath: "/repo/node_modules/playwright-core/cli.js",
+          statePath: join(d, "state.json"),
+        },
+      );
+    // Older playwright-core's build only.
+    expect(
+      (await run(() => ["chromium-1100", "chromium_headless_shell-1100"]))
+        .actions,
+    ).toHaveLength(1);
+    // Headed build present, headless shell missing.
+    expect((await run(() => ["chromium-1181"])).actions).toHaveLength(1);
+    // Both dirs exist but one download never finished.
+    expect(
+      (
+        await run(
+          () => ["chromium-1181", "chromium_headless_shell-1181"],
+          (p) => COMPLETE(p) && !p.includes("headless"),
+        )
+      ).actions,
+    ).toHaveLength(1);
+  });
+
+  it("accepts a per-platform revision override build", async () => {
+    const outcome = await provisionPlaywright(
+      { browser: "webkit" },
+      {
+        exec: fakeExec([]),
+        registry: REGISTRY,
+        listDir: () => ["webkit_mac14_special-2251"],
+        pathExists: COMPLETE,
+      },
+    );
+    expect(outcome.status).toBe("ready");
+  });
+
+  it("forwards the injected environment to the CLI", async () => {
+    const d = tmp();
+    const seen: Array<Record<string, string> | undefined> = [];
+    const exec: ExecFn = async (_c, _a, opts) => {
+      seen.push(opts.env);
+      return { ok: true, code: 0, stdout: "", stderr: "" };
+    };
+    await provisionPlaywright(
+      { browser: "chromium" },
+      {
+        exec,
+        registry: REGISTRY,
+        listDir: () => [],
+        cliPath: "/x/cli.js",
+        pathExists: () => true,
+        statePath: join(d, "state.json"),
+        env: { PLAYWRIGHT_BROWSERS_PATH: "/isolated", DROPPED: undefined },
+      },
+    );
+    expect(seen[0]).toEqual({ PLAYWRIGHT_BROWSERS_PATH: "/isolated" });
   });
 
   it("downloads a missing build via the bundled CLI", async () => {
@@ -544,9 +786,11 @@ describe("playwright provisioner", () => {
   });
 
   it("resolves the browsers root per OS with env overrides", () => {
-    expect(browsersRoot("linux", "/h", {})).toBe("/h/.cache/ms-playwright");
+    expect(browsersRoot("linux", "/h", {})).toBe(
+      join("/h", ".cache", "ms-playwright"),
+    );
     expect(browsersRoot("darwin", "/h", {})).toBe(
-      "/h/Library/Caches/ms-playwright",
+      join("/h", "Library", "Caches", "ms-playwright"),
     );
     expect(
       browsersRoot("linux", "/h", { PLAYWRIGHT_BROWSERS_PATH: "/custom" }),
@@ -557,13 +801,25 @@ describe("playwright provisioner", () => {
     expect(
       inspectPlaywright(
         { browser: "chromium" },
-        { listDir: () => ["chromium-1"] },
+        {
+          registry: REGISTRY,
+          listDir: () => ["chromium-1181", "chromium_headless_shell-1181"],
+          pathExists: COMPLETE,
+        },
       )[0].status,
     ).toBe("ok");
-    expect(
-      inspectPlaywright({ browser: "chromium" }, { listDir: () => [] })[0]
-        .status,
-    ).toBe("warn");
+    const missing = inspectPlaywright(
+      { browser: "chromium" },
+      { registry: REGISTRY, listDir: () => [] },
+    )[0];
+    expect(missing.status).toBe("warn");
+    expect(missing.detail).toContain("next talon start");
+    const off = inspectPlaywright(
+      { browser: "chromium", autoProvision: false },
+      { registry: REGISTRY, listDir: () => [] },
+    )[0];
+    expect(off.detail).toContain("autoProvision: false");
+    expect(off.detail).toContain("npx playwright install chromium");
     expect(inspectPlaywright({ endpoint: "ws://x" })[0].status).toBe("info");
   });
 });
@@ -619,6 +875,20 @@ describe("github provisioner", () => {
   });
 });
 
+describe("github doctor", () => {
+  it("counts a missing image as an issue and reflects disabled auto-pull", async () => {
+    const exec = fakeExec([
+      { match: (_c, a) => has(a, "inspect"), result: { ok: false } },
+    ]);
+    const auto = (await inspectGithub({}, { exec }))[0];
+    expect(auto.issue).toBe(true);
+    expect(auto.detail).toContain("next talon start");
+    const off = (await inspectGithub({ autoProvision: false }, { exec }))[0];
+    expect(off.issue).toBe(true);
+    expect(off.detail).toContain("docker pull");
+  });
+});
+
 describe("native runtime registry", () => {
   it("gates each runtime on its enabled flag", () => {
     const ids = NATIVE_RUNTIMES.map((r) => r.id);
@@ -667,6 +937,41 @@ describe("provision journal", () => {
     await journal.deliverPendingProvisionReport(async () => {
       throw new Error("should not send");
     });
+  });
+
+  it("waits for tracked background provisioning before reporting", async () => {
+    const { journal } = await freshJournal();
+    journal.armProvisionReport("telegram", "9");
+    let finish!: () => void;
+    const upgrade = new Promise<void>((r) => {
+      finish = r;
+    });
+    void journal.trackBackgroundProvision(
+      upgrade.then(() =>
+        journal.recordProvisionEvents("mempalace", ["upgraded 3.3.5 → 3.8.0"]),
+      ),
+    );
+
+    const sent: string[] = [];
+    let ticks = 0;
+    const delivery = journal.deliverPendingProvisionReport(
+      async (_f, _t, text) => {
+        sent.push(text);
+        return true;
+      },
+      async () => {
+        // The first sleep is the "still running" wait; let the task land.
+        if (ticks++ === 0) {
+          finish();
+          await upgrade;
+          await new Promise((r) => setImmediate(r));
+        }
+      },
+    );
+    await delivery;
+    expect(journal.backgroundProvisionInFlight()).toBe(0);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain("upgraded 3.3.5 → 3.8.0");
   });
 
   it("stays silent when nothing changed and retries a busy frontend", async () => {

--- a/src/__tests__/native-provision.test.ts
+++ b/src/__tests__/native-provision.test.ts
@@ -1,0 +1,703 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mkdtempSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, sep } from "node:path";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+import {
+  compareVersions,
+  expandHome,
+  failDetail,
+  findBasePython,
+  loadProvisionState,
+  provisionBackoffMs,
+  saveProvisionState,
+  shouldAttempt,
+  type ExecFn,
+  type ExecResult,
+} from "../core/plugin/provision.js";
+import {
+  classifyExternalInstall,
+  inspectMempalace,
+  provisionMempalace,
+  resolveMempalacePaths,
+  MEMPALACE_PINNED_VERSION,
+} from "../plugins/mempalace/provision.js";
+import {
+  browsersRoot,
+  inspectPlaywright,
+  provisionPlaywright,
+} from "../plugins/playwright/provision.js";
+import {
+  githubMcpImageRef,
+  provisionGithubMcp,
+  GITHUB_MCP_PINNED_TAG,
+} from "../plugins/github/provision.js";
+import { NATIVE_RUNTIMES } from "../core/plugin/native-runtimes.js";
+
+/** Scripted exec double: first matching rule wins, calls recorded. */
+function fakeExec(
+  rules: Array<{
+    match: (cmd: string, args: readonly string[]) => boolean;
+    result: Partial<ExecResult>;
+  }>,
+): ExecFn & { calls: Array<{ cmd: string; args: string[] }> } {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  const exec: ExecFn = async (cmd, args) => {
+    calls.push({ cmd, args: [...args] });
+    const rule = rules.find((r) => r.match(cmd, args));
+    if (!rule) return { ok: false, code: 1, stdout: "", stderr: "no rule" };
+    return {
+      ok: false,
+      code: rule.result.ok ? 0 : 1,
+      stdout: "",
+      stderr: "",
+      ...rule.result,
+    };
+  };
+  return Object.assign(exec, { calls });
+}
+
+const has = (args: readonly string[], token: string) => args.includes(token);
+const probeRule = (version: string) => ({
+  match: (_c: string, a: readonly string[]) =>
+    has(a, "-c") && String(a[a.length - 1]).includes("importlib.metadata"),
+  result: { ok: true, stdout: `${version}\n` },
+});
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "talon-provision-"));
+}
+
+describe("provision seam", () => {
+  it("compares dotted versions numerically", () => {
+    expect(compareVersions("3.8.0", "3.10.1")).toBeLessThan(0);
+    expect(compareVersions("3.10.1", "3.8.0")).toBeGreaterThan(0);
+    expect(compareVersions("3.8.0", "3.8.0")).toBe(0);
+    expect(compareVersions("3.8", "3.8.0")).toBe(0);
+  });
+
+  it("expands ~ against the given home", () => {
+    expect(expandHome("~/x", "/home/u")).toBe(resolve("/home/u", "x"));
+    expect(expandHome("/abs/x", "/home/u")).toBe("/abs/x");
+    expect(expandHome("~", "/home/u")).toBe("/home/u");
+  });
+
+  it("grows backoff exponentially and caps it", () => {
+    expect(provisionBackoffMs(1)).toBe(5 * 60_000);
+    expect(provisionBackoffMs(2)).toBe(10 * 60_000);
+    expect(provisionBackoffMs(99)).toBe(6 * 60 * 60_000);
+  });
+
+  it("re-arms attempts on pin change, gates on recent failure", () => {
+    const now = Date.now();
+    const state = {
+      pin: "3.8.0",
+      lastFailureAt: new Date(now - 60_000).toISOString(),
+      failureCount: 1,
+    };
+    expect(shouldAttempt(state, "3.8.0", now)).toBe(false);
+    expect(shouldAttempt(state, "3.9.0", now)).toBe(true);
+    expect(shouldAttempt(state, "3.8.0", now + 10 * 60_000)).toBe(true);
+    expect(shouldAttempt({}, "3.8.0", now)).toBe(true);
+  });
+
+  it("round-trips state and tolerates junk", () => {
+    const dir = tmp();
+    const path = join(dir, "state.json");
+    saveProvisionState(path, { pin: "1.0.0", failureCount: 2 });
+    expect(loadProvisionState(path)).toMatchObject({
+      pin: "1.0.0",
+      failureCount: 2,
+    });
+    writeFileSync(path, "not json");
+    expect(loadProvisionState(path)).toEqual({});
+  });
+
+  it("finds a base python meeting the version floor, in per-OS order", async () => {
+    const exec = fakeExec([
+      {
+        match: (c) => c === "py",
+        result: { ok: true, stdout: "3.9\n" },
+      },
+      {
+        match: (c) => c === "python",
+        result: { ok: true, stdout: "3.12\n" },
+      },
+    ]);
+    const found = await findBasePython(exec, "win32", { major: 3, minor: 10 });
+    expect(found).toMatchObject({ command: "python", version: "3.12" });
+    expect(exec.calls[0].cmd).toBe("py");
+  });
+
+  it("failDetail prefers spawn error, then stderr tail, then exit code", () => {
+    expect(
+      failDetail({
+        ok: false,
+        code: 1,
+        stdout: "",
+        stderr: "",
+        error: "ENOENT",
+      }),
+    ).toBe("ENOENT");
+    expect(
+      failDetail({ ok: false, code: 1, stdout: "", stderr: "a\nlast line" }),
+    ).toBe("last line");
+  });
+});
+
+describe("mempalace provisioner", () => {
+  const dir = () => {
+    const d = tmp();
+    return {
+      root: d,
+      venv: join(d, "mempalace-venv"),
+      python: join(d, "mempalace-venv", "bin", "python"),
+      palace: join(d, "palace"),
+      state: join(d, "state.json"),
+    };
+  };
+
+  it("classifies external install flavors from the interpreter path", () => {
+    expect(
+      classifyExternalInstall(
+        "/home/u/.local/share/uv/tools/mempalace/bin/python",
+      ),
+    ).toBe("uv-tool");
+    expect(
+      classifyExternalInstall("/home/u/.local/pipx/venvs/mp/bin/python"),
+    ).toBe("pipx");
+    expect(classifyExternalInstall("/opt/miniconda3/envs/mp/bin/python")).toBe(
+      "conda",
+    );
+    expect(classifyExternalInstall("/srv/venv/bin/python")).toBe("external");
+  });
+
+  it("never mutates an operator-managed install — advises instead", async () => {
+    const p = dir();
+    const uvPython = join(p.root, "uv", "tools", "mempalace", "bin", "python");
+    const exec = fakeExec([probeRule("3.3.5")]);
+    const outcome = await provisionMempalace(
+      { pythonPath: uvPython, palacePath: p.palace },
+      {
+        exec,
+        defaultManagedPython: p.python,
+        statePath: p.state,
+        pathExists: (x) => x === uvPython,
+      },
+    );
+    expect(outcome.status).toBe("ready");
+    expect(outcome.kind).toBe("uv-tool");
+    expect(outcome.version).toBe("3.3.5");
+    expect(outcome.warnings.join(" ")).toContain("uv tool install --force");
+    // Only the probe ran — no pip, no venv.
+    expect(exec.calls).toHaveLength(1);
+  });
+
+  it("fails an external install with a missing interpreter, with an install hint", async () => {
+    const p = dir();
+    const outcome = await provisionMempalace(
+      { pythonPath: "/nope/python", palacePath: p.palace },
+      {
+        exec: fakeExec([]),
+        defaultManagedPython: p.python,
+        statePath: p.state,
+        pathExists: () => false,
+      },
+    );
+    expect(outcome.status).toBe("failed");
+    expect(outcome.warnings.join(" ")).toContain("pip install");
+  });
+
+  it("managed venv healthy at pin: ready, no mutations, migration ledger honored", async () => {
+    const p = dir();
+    mkdirSync(p.palace, { recursive: true });
+    writeFileSync(join(p.palace, "chroma.sqlite3"), "");
+    const exec = fakeExec([
+      probeRule(MEMPALACE_PINNED_VERSION),
+      {
+        match: (_c, a) => has(a, "migrate-wings"),
+        result: {
+          ok: true,
+          stdout:
+            "All wing names are already normalized -- nothing to migrate.\n",
+        },
+      },
+    ]);
+    const deps = {
+      exec,
+      defaultManagedPython: p.python,
+      statePath: p.state,
+      pathExists: (x: string) => x === p.python || x.endsWith("chroma.sqlite3"),
+    };
+    const first = await provisionMempalace(
+      { pythonPath: p.python, palacePath: p.palace },
+      deps,
+    );
+    expect(first.status).toBe("ready");
+    expect(first.version).toBe(MEMPALACE_PINNED_VERSION);
+    expect(first.actions.join(" ")).toContain("wing-name migration");
+
+    // Second pass: ledger recorded, migration not re-run.
+    const before = exec.calls.length;
+    const second = await provisionMempalace(
+      { pythonPath: p.python, palacePath: p.palace },
+      deps,
+    );
+    expect(second.actions).toHaveLength(0);
+    const newCalls = exec.calls.slice(before);
+    expect(newCalls.some((c) => has(c.args, "migrate-wings"))).toBe(false);
+  });
+
+  it("healthy-but-behind upgrades in the background and keeps serving", async () => {
+    const p = dir();
+    let probeVersion = "3.3.5";
+    const exec = fakeExec([
+      {
+        match: (_c, a) =>
+          has(a, "-c") &&
+          String(a[a.length - 1]).includes("importlib.metadata"),
+        get result() {
+          return { ok: true, stdout: `${probeVersion}\n` };
+        },
+      },
+      {
+        match: (_c, a) => has(a, "pip") && has(a, "install"),
+        result: { ok: true },
+      },
+    ]);
+    const outcome = await provisionMempalace(
+      { pythonPath: p.python, palacePath: p.palace },
+      {
+        exec,
+        defaultManagedPython: p.python,
+        statePath: p.state,
+        pathExists: (x) => x === p.python,
+      },
+    );
+    expect(outcome.status).toBe("ready");
+    expect(outcome.version).toBe("3.3.5");
+    expect(outcome.background).toBeDefined();
+    // Nothing installed yet — boot did not block on pip.
+    expect(exec.calls.some((c) => has(c.args, "pip"))).toBe(false);
+
+    probeVersion = MEMPALACE_PINNED_VERSION;
+    const upgraded = await outcome.background!();
+    expect(upgraded.status).toBe("ready");
+    expect(upgraded.actions.join(" ")).toContain(
+      `upgraded mempalace 3.3.5 → ${MEMPALACE_PINNED_VERSION}`,
+    );
+    const pip = exec.calls.find((c) => has(c.args, "pip"));
+    expect(pip?.args).toContain(`mempalace==${MEMPALACE_PINNED_VERSION}`);
+    expect(pip?.args).not.toContain("--force-reinstall");
+  });
+
+  it("broken install heals with --force-reinstall, blocking", async () => {
+    const p = dir();
+    let healed = false;
+    const exec = fakeExec([
+      {
+        match: (_c, a) =>
+          has(a, "-c") &&
+          String(a[a.length - 1]).includes("importlib.metadata"),
+        get result() {
+          return healed
+            ? { ok: true, stdout: `${MEMPALACE_PINNED_VERSION}\n` }
+            : { ok: false, stderr: "ModuleNotFoundError: mempalace" };
+        },
+      },
+      {
+        match: (_c, a) => has(a, "pip") && has(a, "install"),
+        get result() {
+          healed = true;
+          return { ok: true };
+        },
+      },
+    ]);
+    const outcome = await provisionMempalace(
+      { pythonPath: p.python, palacePath: p.palace },
+      {
+        exec,
+        defaultManagedPython: p.python,
+        statePath: p.state,
+        pathExists: (x) => x === p.python,
+      },
+    );
+    expect(outcome.status).toBe("ready");
+    const pip = exec.calls.find((c) => has(c.args, "pip"));
+    expect(pip?.args).toContain("--force-reinstall");
+  });
+
+  it("missing venv: creates it with a base python, then installs (win32 shape too)", async () => {
+    const p = dir();
+    const winPython = join(p.root, "mempalace-venv", "Scripts", "python.exe");
+    let venvCreated = false;
+    const exec = fakeExec([
+      {
+        match: (c, a) => c === "py" && has(a, "venv"),
+        get result() {
+          venvCreated = true;
+          return { ok: true };
+        },
+      },
+      {
+        match: (c) => c === "py",
+        result: { ok: true, stdout: "3.12\n" },
+      },
+      {
+        match: (_c, a) => has(a, "pip") && has(a, "install"),
+        result: { ok: true },
+      },
+      probeRule(MEMPALACE_PINNED_VERSION),
+    ]);
+    const outcome = await provisionMempalace(
+      { pythonPath: winPython, palacePath: p.palace },
+      {
+        exec,
+        platform: "win32",
+        defaultManagedPython: winPython,
+        statePath: p.state,
+        pathExists: (x) => (x === winPython ? venvCreated : false),
+      },
+    );
+    expect(outcome.status).toBe("ready");
+    expect(outcome.actions.join(" ")).toContain("created venv");
+    expect(outcome.actions.join(" ")).toContain(
+      `installed mempalace ${MEMPALACE_PINNED_VERSION}`,
+    );
+    const venvCall = exec.calls.find((c) => has(c.args, "venv"));
+    expect(venvCall?.cmd).toBe("py");
+    expect(venvCall?.args).toContain("--clear");
+  });
+
+  it("failed upgrade keeps the working install and records backoff", async () => {
+    const p = dir();
+    const exec = fakeExec([
+      probeRule("3.3.5"),
+      {
+        match: (_c, a) => has(a, "pip") || has(a, "ensurepip"),
+        result: { ok: false, stderr: "network unreachable" },
+      },
+    ]);
+    const deps = {
+      exec,
+      defaultManagedPython: p.python,
+      statePath: p.state,
+      pathExists: (x: string) => x === p.python || x === p.venv,
+    };
+    const outcome = await provisionMempalace(
+      { pythonPath: p.python, palacePath: p.palace },
+      deps,
+    );
+    const settled = await outcome.background!();
+    expect(settled.status).toBe("degraded");
+    expect(settled.version).toBe("3.3.5");
+    expect(settled.warnings.join(" ")).toContain("staying on working 3.3.5");
+    expect(loadProvisionState(p.state).failureCount).toBe(1);
+
+    // Next pass inside the backoff window: no new pip attempt.
+    const before = exec.calls.length;
+    const gated = await provisionMempalace(
+      { pythonPath: p.python, palacePath: p.palace },
+      deps,
+    );
+    expect(gated.status).toBe("degraded");
+    expect(gated.background).toBeUndefined();
+    expect(exec.calls.slice(before).some((c) => has(c.args, "pip"))).toBe(
+      false,
+    );
+  });
+
+  it("autoUpdate:false reports drift without reconciling", async () => {
+    const p = dir();
+    const exec = fakeExec([probeRule("3.3.5")]);
+    const outcome = await provisionMempalace(
+      { pythonPath: p.python, palacePath: p.palace, autoUpdate: false },
+      {
+        exec,
+        defaultManagedPython: p.python,
+        statePath: p.state,
+        pathExists: (x) => x === p.python,
+      },
+    );
+    expect(outcome.status).toBe("ready");
+    expect(outcome.background).toBeUndefined();
+    expect(outcome.warnings.join(" ")).toContain("autoUpdate is off");
+  });
+
+  it("resolveMempalacePaths applies defaults and expands ~", () => {
+    const { pythonPath, palacePath } = resolveMempalacePaths(
+      { pythonPath: "~/venv/bin/python" },
+      "/home/u",
+    );
+    expect(pythonPath).toBe(resolve("/home/u", "venv/bin/python"));
+    expect(palacePath).toContain(`${sep}palace`);
+  });
+
+  it("inspect reports drift as reconciling for managed, advisory for external", async () => {
+    const p = dir();
+    const exec = fakeExec([probeRule("3.3.5")]);
+    const managed = await inspectMempalace(
+      { pythonPath: p.python },
+      {
+        exec,
+        defaultManagedPython: p.python,
+        pathExists: (x) => x === p.python,
+      },
+    );
+    expect(managed[0].status).toBe("warn");
+    expect(managed[0].detail).toContain("next talon start");
+
+    const external = await inspectMempalace(
+      { pythonPath: "/srv/venv/bin/python" },
+      {
+        exec: fakeExec([probeRule("3.3.5")]),
+        defaultManagedPython: p.python,
+        pathExists: () => true,
+      },
+    );
+    expect(external[0].issue).toBeFalsy();
+  });
+});
+
+describe("playwright provisioner", () => {
+  it("skips endpoint mode and system channels", async () => {
+    expect(
+      (await provisionPlaywright({ browser: "chromium", endpoint: "ws://x" }))
+        .status,
+    ).toBe("skipped");
+    expect((await provisionPlaywright({ browser: "msedge" })).status).toBe(
+      "skipped",
+    );
+    expect(
+      (await provisionPlaywright({ browser: "chromium", autoProvision: false }))
+        .status,
+    ).toBe("skipped");
+  });
+
+  it("is a no-op when the build is already present", async () => {
+    const exec = fakeExec([]);
+    const outcome = await provisionPlaywright(
+      { browser: "chromium" },
+      { exec, listDir: () => ["chromium-1181", "ffmpeg-1010"] },
+    );
+    expect(outcome.status).toBe("ready");
+    expect(exec.calls).toHaveLength(0);
+  });
+
+  it("downloads a missing build via the bundled CLI", async () => {
+    const d = tmp();
+    const state = join(d, "state.json");
+    const exec = fakeExec([
+      { match: (_c, a) => has(a, "install"), result: { ok: true } },
+    ]);
+    const outcome = await provisionPlaywright(
+      { browser: "firefox" },
+      {
+        exec,
+        listDir: () => [],
+        cliPath: "/repo/node_modules/playwright-core/cli.js",
+        pathExists: () => true,
+        statePath: state,
+      },
+    );
+    expect(outcome.status).toBe("ready");
+    expect(outcome.actions.join(" ")).toContain("firefox");
+    expect(exec.calls[0].args).toEqual([
+      "/repo/node_modules/playwright-core/cli.js",
+      "install",
+      "firefox",
+    ]);
+  });
+
+  it("degrades with a root-needing hint when system libraries are missing", async () => {
+    const d = tmp();
+    const state = join(d, "state.json");
+    const exec = fakeExec([
+      {
+        match: (_c, a) => has(a, "install"),
+        result: {
+          ok: false,
+          stderr: "Host system is missing dependencies to run browsers",
+        },
+      },
+    ]);
+    const outcome = await provisionPlaywright(
+      { browser: "chromium" },
+      {
+        exec,
+        listDir: () => [],
+        cliPath: "/x/cli.js",
+        pathExists: () => true,
+        statePath: state,
+      },
+    );
+    expect(outcome.status).toBe("degraded");
+    expect(outcome.warnings.join(" ")).toContain("install-deps");
+    expect(loadProvisionState(state).failureCount).toBe(1);
+  });
+
+  it("resolves the browsers root per OS with env overrides", () => {
+    expect(browsersRoot("linux", "/h", {})).toBe("/h/.cache/ms-playwright");
+    expect(browsersRoot("darwin", "/h", {})).toBe(
+      "/h/Library/Caches/ms-playwright",
+    );
+    expect(
+      browsersRoot("linux", "/h", { PLAYWRIGHT_BROWSERS_PATH: "/custom" }),
+    ).toBe("/custom");
+  });
+
+  it("inspect mirrors presence without executing anything", () => {
+    expect(
+      inspectPlaywright(
+        { browser: "chromium" },
+        { listDir: () => ["chromium-1"] },
+      )[0].status,
+    ).toBe("ok");
+    expect(
+      inspectPlaywright({ browser: "chromium" }, { listDir: () => [] })[0]
+        .status,
+    ).toBe("warn");
+    expect(inspectPlaywright({ endpoint: "ws://x" })[0].status).toBe("info");
+  });
+});
+
+describe("github provisioner", () => {
+  it("pins the image tag by default", () => {
+    expect(githubMcpImageRef()).toBe(
+      `ghcr.io/github/github-mcp-server:${GITHUB_MCP_PINNED_TAG}`,
+    );
+    expect(githubMcpImageRef("latest")).toBe(
+      "ghcr.io/github/github-mcp-server:latest",
+    );
+  });
+
+  it("is ready when the image is present, fails hard without docker", async () => {
+    const ready = await provisionGithubMcp(
+      {},
+      {
+        exec: fakeExec([
+          { match: (_c, a) => has(a, "inspect"), result: { ok: true } },
+        ]),
+      },
+    );
+    expect(ready.status).toBe("ready");
+
+    const noDocker = await provisionGithubMcp(
+      {},
+      {
+        exec: fakeExec([
+          { match: () => true, result: { ok: false, error: "ENOENT" } },
+        ]),
+      },
+    );
+    expect(noDocker.status).toBe("failed");
+  });
+
+  it("pulls a missing image in the background and records failures for backoff", async () => {
+    const d = tmp();
+    const state = join(d, "state.json");
+    const exec = fakeExec([
+      { match: (_c, a) => has(a, "inspect"), result: { ok: false } },
+      {
+        match: (_c, a) => has(a, "pull"),
+        result: { ok: false, stderr: "TLS handshake timeout" },
+      },
+    ]);
+    const outcome = await provisionGithubMcp({}, { exec, statePath: state });
+    expect(outcome.status).toBe("degraded");
+    expect(outcome.background).toBeDefined();
+    const settled = await outcome.background!();
+    expect(settled.status).toBe("degraded");
+    expect(loadProvisionState(state).failureCount).toBe(1);
+  });
+});
+
+describe("native runtime registry", () => {
+  it("gates each runtime on its enabled flag", () => {
+    const ids = NATIVE_RUNTIMES.map((r) => r.id);
+    expect(ids).toEqual(["mempalace", "playwright", "github"]);
+    for (const rt of NATIVE_RUNTIMES) {
+      expect(rt.enabled(undefined)).toBe(false);
+      expect(rt.enabled({})).toBe(false);
+      expect(rt.enabled({ [rt.id]: { enabled: true } })).toBe(true);
+    }
+  });
+});
+
+describe("provision journal", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  async function freshJournal() {
+    const home = tmp();
+    process.env.TALON_HOME = home;
+    mkdirSync(join(home, "data"), { recursive: true });
+    const journal = await import("../core/plugin/provision-journal.js");
+    return { home, journal };
+  }
+
+  it("records events, arms a report, and delivers only when something changed", async () => {
+    const { journal } = await freshJournal();
+    journal.armProvisionReport("telegram", "42");
+    journal.recordProvisionEvents("mempalace", [
+      "upgraded mempalace 3.3.5 → 3.8.0",
+    ]);
+
+    const sent: string[] = [];
+    await journal.deliverPendingProvisionReport(
+      async (frontend, target, text) => {
+        sent.push(`${frontend}:${target}:${text}`);
+        return true;
+      },
+      async () => {},
+    );
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain("telegram:42:");
+    expect(sent[0]).toContain("upgraded mempalace 3.3.5 → 3.8.0");
+
+    // Marker consumed — a second delivery is a no-op.
+    await journal.deliverPendingProvisionReport(async () => {
+      throw new Error("should not send");
+    });
+  });
+
+  it("stays silent when nothing changed and retries a busy frontend", async () => {
+    const { journal } = await freshJournal();
+    journal.armProvisionReport("discord", "7");
+    // No events → no message.
+    let sends = 0;
+    await journal.deliverPendingProvisionReport(async () => {
+      sends++;
+      return true;
+    });
+    expect(sends).toBe(0);
+
+    journal.armProvisionReport("discord", "7");
+    journal.recordProvisionEvents("github", ["pulled image"]);
+    const attempts: number[] = [];
+    await journal.deliverPendingProvisionReport(
+      async () => {
+        attempts.push(1);
+        return attempts.length >= 3;
+      },
+      async () => {},
+    );
+    expect(attempts.length).toBe(3);
+  });
+});
+
+describe("provision state file locations", () => {
+  it("does not exist until a provisioner persists something", () => {
+    expect(existsSync(join(tmp(), "data", "mempalace-provision.json"))).toBe(
+      false,
+    );
+  });
+});

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -490,6 +490,22 @@ describe("plugin system", () => {
       vi.doMock("../plugins/github/index.js", () => ({
         createGitHubPlugin: () => githubPlugin,
       }));
+      // loadBuiltinPlugins provisions enabled native runtimes first; the
+      // real github provisioner shells out to docker, which a unit test
+      // must never do (and which blows the test timeout on runners
+      // where the daemon is slow to answer).
+      vi.doMock("../plugins/github/provision.js", () => ({
+        provisionGithubMcp: async () => ({
+          status: "skipped",
+          kind: "docker",
+          actions: [],
+          warnings: [],
+        }),
+        inspectGithub: async () => [],
+        githubMcpImageRef: (tag?: string) =>
+          `ghcr.io/github/github-mcp-server:${tag ?? "test"}`,
+        GITHUB_MCP_PINNED_TAG: "test",
+      }));
 
       const mod = await import("../core/plugin/index.js");
       await mod.loadPlugins([{ name: "github", command: "node" }]);

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -479,11 +479,9 @@ export async function initBackendAndDispatcher(
   if (config.mempalace?.enabled) {
     const { getPlugin } = await import("./core/plugin/index.js");
     if (getPlugin("mempalace")) {
-      const { dirs, files: pathFiles } = await import("./util/paths.js");
-      mempalaceCfg = {
-        pythonPath: config.mempalace.pythonPath ?? pathFiles.mempalacePython,
-        palacePath: config.mempalace.palacePath ?? dirs.palace,
-      };
+      const { resolveMempalacePaths } =
+        await import("./plugins/mempalace/provision.js");
+      mempalaceCfg = resolveMempalacePaths(config.mempalace);
     } else {
       log(
         "mempalace",
@@ -528,6 +526,25 @@ export async function initBackendAndDispatcher(
     frontends: frontendNames,
     mempalace: Boolean(mempalaceCfg),
   });
+
+  // Post-/update provisioning report — if the previous process armed one
+  // before respawning, tell the chat that asked for the update what the
+  // provisioners changed during this boot. Fire-and-forget; the delivery
+  // helper retries while frontends finish registering on the cross-send
+  // broker and gives up quietly.
+  {
+    const { deliverPendingProvisionReport } =
+      await import("./core/plugin/provision-journal.js");
+    const { crossSendHandlers } =
+      await import("./core/engine/gateway-actions/cross-send.js");
+    void deliverPendingProvisionReport(async (frontend, target, text) => {
+      const result = await crossSendHandlers.send_via(
+        { frontend, target, text },
+        0,
+      );
+      return Boolean(result && (result as { ok?: unknown }).ok === true);
+    });
+  }
 
   return { backend };
 }

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -78,6 +78,18 @@ export interface DoctorConfigSlice {
   codexApiKey?: string;
   openaiApiKey?: string;
   openaiBaseUrl?: string;
+  mempalace?: {
+    enabled?: boolean;
+    pythonPath?: string;
+    version?: string;
+  };
+  playwright?: {
+    enabled?: boolean;
+    browser?: string;
+    endpoint?: string;
+    endpointFile?: string;
+  };
+  github?: { enabled?: boolean; imageTag?: string };
 }
 
 function errorNote(err: unknown): string {
@@ -293,6 +305,34 @@ async function checkClaudeConfiguredModels(
     }
   } catch {
     /* catalog unavailable — skip, never break doctor */
+  }
+  return checks;
+}
+
+/**
+ * Native plugin runtimes (MemPalace's venv, Playwright's browser build,
+ * GitHub's Docker image) — the artifacts the provisioners own. The
+ * runtime list and each inspection live in the native-runtimes registry
+ * (src/core/plugin/native-runtimes.ts); a new native plugin shows up
+ * here by registering there. Doctor reads, never mutates: a drifted or
+ * missing runtime reports what will fix it (usually "next talon start").
+ */
+async function checkPluginRuntimes(
+  config: DoctorConfigSlice | undefined,
+): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+  const { NATIVE_RUNTIMES } = await import("./plugin/native-runtimes.js");
+  for (const runtime of NATIVE_RUNTIMES) {
+    if (!runtime.enabled(config)) continue;
+    try {
+      checks.push(...(await runtime.inspect(config!)));
+    } catch (err) {
+      checks.push({
+        label: `${runtime.id} runtime check errored`,
+        status: "warn",
+        detail: errorNote(err),
+      });
+    }
   }
   return checks;
 }
@@ -632,6 +672,7 @@ export async function collectDoctorReport(opts: {
   }
 
   const native = await checkNativeModules();
+  checks.push(...(await checkPluginRuntimes(opts.config)));
   checks.push(...(await checkBackend(opts.config)));
 
   const issues =

--- a/src/core/plugin/builtins.ts
+++ b/src/core/plugin/builtins.ts
@@ -3,9 +3,12 @@
  * path that re-reads config, tears down, and re-loads everything.
  */
 
-import { log, logError } from "../../util/log.js";
+import { log, logError, logWarn } from "../../util/log.js";
 import type { TalonConfig } from "../../util/config.js";
 import { registry, reloadState } from "./registry.js";
+import type { ProvisionOutcome } from "./provision.js";
+import { NATIVE_RUNTIMES, type NativePluginId } from "./native-runtimes.js";
+import { recordProvisionEvents } from "./provision-journal.js";
 import {
   initPluginWithTimeout,
   loadPlugins,
@@ -13,16 +16,81 @@ import {
 } from "./loader.js";
 
 /**
+ * Surface a provisioning outcome in the logs and the journal, and fire
+ * its background reconcile task (fire-and-forget: the plugin is already
+ * serving on whatever the outcome declared usable).
+ */
+function reportProvision(
+  pluginName: NativePluginId,
+  outcome: ProvisionOutcome,
+): void {
+  recordProvisionEvents(pluginName, outcome.actions);
+  for (const action of outcome.actions) {
+    log(pluginName, `provision: ${action}`);
+  }
+  for (const warning of outcome.warnings) {
+    logWarn(pluginName, `provision: ${warning}`);
+  }
+  if (outcome.status === "failed" && outcome.error) {
+    logError(pluginName, `provision failed: ${outcome.error}`);
+  }
+  const background = outcome.background;
+  if (background) {
+    void background()
+      .then((result) =>
+        reportProvision(pluginName, { ...result, background: undefined }),
+      )
+      .catch((err) =>
+        logError(
+          pluginName,
+          `background provision: ${err instanceof Error ? err.message : err}`,
+        ),
+      );
+  }
+}
+
+/**
+ * Provision every enabled native runtime (see native-runtimes.ts) and
+ * return the outcomes so plugin construction can read what it got
+ * (e.g. the installed version). A provisioner that throws is treated
+ * as a failed pass, never a failed boot.
+ */
+async function provisionNativeRuntimes(
+  config: TalonConfig,
+): Promise<Map<NativePluginId, ProvisionOutcome>> {
+  const outcomes = new Map<NativePluginId, ProvisionOutcome>();
+  for (const runtime of NATIVE_RUNTIMES) {
+    if (!runtime.enabled(config)) continue;
+    try {
+      const outcome = await runtime.provision(config);
+      outcomes.set(runtime.id, outcome);
+      reportProvision(runtime.id, outcome);
+    } catch (err) {
+      logError(
+        runtime.id,
+        `provision: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+  return outcomes;
+}
+
+/**
  * Load built-in plugins (GitHub, MemPalace, mem0, Playwright) based on config flags.
  * Shared by both bootstrap and hot-reload to avoid duplication.
  */
 export async function loadBuiltinPlugins(config: TalonConfig): Promise<void> {
+  const provisioned = await provisionNativeRuntimes(config);
+
   const github = config.github;
   if (github?.enabled) {
     try {
       const { createGitHubPlugin } =
         await import("../../plugins/github/index.js");
-      const gh = createGitHubPlugin({ token: github.token });
+      const gh = createGitHubPlugin({
+        token: github.token,
+        imageTag: github.imageTag,
+      });
       const ghConfig = github as unknown as Record<string, unknown>;
       const loaded = registerPlugin(gh, ghConfig);
       if (loaded) {
@@ -47,14 +115,15 @@ export async function loadBuiltinPlugins(config: TalonConfig): Promise<void> {
     try {
       const { createMempalacePlugin } =
         await import("../../plugins/mempalace/index.js");
-      const { dirs, files: pf } = await import("../../util/paths.js");
-      const pythonPath = mempalace.pythonPath ?? pf.mempalacePython;
-      const palacePath = mempalace.palacePath ?? dirs.palace;
+      const { resolveMempalacePaths } =
+        await import("../../plugins/mempalace/provision.js");
+      const { pythonPath, palacePath } = resolveMempalacePaths(mempalace);
       const mp = createMempalacePlugin({
         pythonPath,
         palacePath,
         entityLanguages: mempalace.entityLanguages,
         verbose: mempalace.verbose,
+        installedVersion: provisioned.get("mempalace")?.version,
       });
       const mpConfig = mempalace as unknown as Record<string, unknown>;
       const loaded = registerPlugin(mp, mpConfig);

--- a/src/core/plugin/builtins.ts
+++ b/src/core/plugin/builtins.ts
@@ -8,7 +8,10 @@ import type { TalonConfig } from "../../util/config.js";
 import { registry, reloadState } from "./registry.js";
 import type { ProvisionOutcome } from "./provision.js";
 import { NATIVE_RUNTIMES, type NativePluginId } from "./native-runtimes.js";
-import { recordProvisionEvents } from "./provision-journal.js";
+import {
+  recordProvisionEvents,
+  trackBackgroundProvision,
+} from "./provision-journal.js";
 import {
   initPluginWithTimeout,
   loadPlugins,
@@ -36,16 +39,20 @@ function reportProvision(
   }
   const background = outcome.background;
   if (background) {
-    void background()
-      .then((result) =>
-        reportProvision(pluginName, { ...result, background: undefined }),
-      )
-      .catch((err) =>
-        logError(
-          pluginName,
-          `background provision: ${err instanceof Error ? err.message : err}`,
+    // Tracked so the post-update report waits for it to settle (its
+    // actions are the changes worth reporting).
+    void trackBackgroundProvision(
+      background()
+        .then((result) =>
+          reportProvision(pluginName, { ...result, background: undefined }),
+        )
+        .catch((err) =>
+          logError(
+            pluginName,
+            `background provision: ${err instanceof Error ? err.message : err}`,
+          ),
         ),
-      );
+    );
   }
 }
 

--- a/src/core/plugin/native-runtimes.ts
+++ b/src/core/plugin/native-runtimes.ts
@@ -1,0 +1,87 @@
+/**
+ * Single source of truth for native plugin runtimes — the built-in
+ * plugins whose MCP servers depend on an artifact Talon doesn't ship
+ * (MemPalace's Python venv, Playwright's browser build, GitHub's Docker
+ * image).
+ *
+ * Everything that iterates "the native plugins" — boot provisioning
+ * (builtins.ts), doctor inspection (doctor.ts), the provisioning CI —
+ * walks this list. Adding a native runtime is one descriptor here plus
+ * its provision module; no other call site changes.
+ *
+ * Plugin modules load lazily inside each method so this module stays
+ * import-cheap for consumers that only need the id list.
+ */
+
+import type { DoctorCheck } from "../doctor.js";
+import type { ProvisionOutcome } from "./provision.js";
+import type { MempalaceSection } from "../../plugins/mempalace/provision.js";
+import type { PlaywrightSection } from "../../plugins/playwright/provision.js";
+import type { GithubSection } from "../../plugins/github/provision.js";
+
+const NATIVE_PLUGIN_IDS = ["mempalace", "playwright", "github"] as const;
+export type NativePluginId = (typeof NATIVE_PLUGIN_IDS)[number];
+
+/**
+ * The config slice native runtimes read. Both TalonConfig and doctor's
+ * DoctorConfigSlice satisfy it structurally.
+ */
+interface NativeRuntimeConfig {
+  mempalace?: ({ enabled?: boolean } & MempalaceSection) | undefined;
+  playwright?: ({ enabled?: boolean } & PlaywrightSection) | undefined;
+  github?: ({ enabled?: boolean } & GithubSection) | undefined;
+}
+
+export interface NativeRuntime {
+  id: NativePluginId;
+  enabled(config: NativeRuntimeConfig | undefined): boolean;
+  /** Install/heal/reconcile the runtime. Only called when enabled. */
+  provision(config: NativeRuntimeConfig): Promise<ProvisionOutcome>;
+  /** Read-only health report for doctor. Only called when enabled. */
+  inspect(config: NativeRuntimeConfig): Promise<DoctorCheck[]>;
+}
+
+export const NATIVE_RUNTIMES: readonly NativeRuntime[] = [
+  {
+    id: "mempalace",
+    enabled: (config) => config?.mempalace?.enabled === true,
+    provision: async (config) => {
+      const { provisionMempalace } =
+        await import("../../plugins/mempalace/provision.js");
+      return provisionMempalace(config.mempalace ?? {});
+    },
+    inspect: async (config) => {
+      const { inspectMempalace } =
+        await import("../../plugins/mempalace/provision.js");
+      return inspectMempalace(config.mempalace ?? {});
+    },
+  },
+  {
+    id: "playwright",
+    enabled: (config) => config?.playwright?.enabled === true,
+    provision: async (config) => {
+      const { provisionPlaywright } =
+        await import("../../plugins/playwright/provision.js");
+      return provisionPlaywright(config.playwright ?? {});
+    },
+    inspect: async (config) => {
+      const { inspectPlaywright } =
+        await import("../../plugins/playwright/provision.js");
+      return inspectPlaywright(config.playwright ?? {});
+    },
+  },
+  {
+    id: "github",
+    enabled: (config) => config?.github?.enabled === true,
+    provision: async (config) => {
+      const { provisionGithubMcp } =
+        await import("../../plugins/github/provision.js");
+      return provisionGithubMcp(config.github ?? {});
+    },
+    inspect: async (config) => {
+      const { inspectGithub } =
+        await import("../../plugins/github/provision.js");
+      return inspectGithub(config.github ?? {});
+    },
+  },
+];

--- a/src/core/plugin/provision-journal.ts
+++ b/src/core/plugin/provision-journal.ts
@@ -1,0 +1,141 @@
+/**
+ * Provision journal — what the provisioners changed, and the post-restart
+ * report that documents it.
+ *
+ * Two small persisted pieces under ~/.talon/data/:
+ *
+ *  - provision-events.json — a capped rolling log of provisioning
+ *    mutations ("upgraded mempalace 3.3.5 → 3.8.0", "palace wing-name
+ *    migration: Migrated 3 drawer(s)."). Every action a provisioner
+ *    reports lands here, whichever boot or background pass produced it.
+ *
+ *  - provision-report-pending.json — armed by a frontend's /update
+ *    command just before the respawn. The successor process, once its
+ *    frontends are serving, reads the marker and messages the chat that
+ *    asked for the update with whatever provisioning changed during the
+ *    new boot — closing the loop that the pre-restart reply can't see.
+ */
+
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { dirs } from "../../util/paths.js";
+import { log, logWarn } from "../../util/log.js";
+import type { NativePluginId } from "./native-runtimes.js";
+
+interface ProvisionEvent {
+  at: string;
+  plugin: NativePluginId;
+  action: string;
+}
+
+interface PendingReport {
+  frontend: string;
+  target: string;
+  since: string;
+}
+
+const EVENT_CAP = 50;
+const eventsPath = (): string => join(dirs.data, "provision-events.json");
+const pendingPath = (): string =>
+  join(dirs.data, "provision-report-pending.json");
+
+function readJson<T>(path: string): T | undefined {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Append provisioning mutations to the rolling event log. */
+export function recordProvisionEvents(
+  plugin: NativePluginId,
+  actions: readonly string[],
+): void {
+  if (actions.length === 0) return;
+  const existing = readJson<ProvisionEvent[]>(eventsPath());
+  const at = new Date().toISOString();
+  const events = [
+    ...(Array.isArray(existing) ? existing : []),
+    ...actions.map((action) => ({ at, plugin, action })),
+  ].slice(-EVENT_CAP);
+  try {
+    writeFileSync(eventsPath(), JSON.stringify(events, null, 2));
+  } catch {
+    /* the journal is reporting, never load-bearing */
+  }
+}
+
+/** Events recorded at or after the given ISO timestamp. */
+function provisionEventsSince(sinceIso: string): ProvisionEvent[] {
+  const events = readJson<ProvisionEvent[]>(eventsPath());
+  if (!Array.isArray(events)) return [];
+  return events.filter((e) => e.at >= sinceIso);
+}
+
+/**
+ * Arm the post-restart report. Called by a frontend's /update handler
+ * right before the respawn, with the chat that asked for the update.
+ */
+export function armProvisionReport(frontend: string, target: string): void {
+  try {
+    writeFileSync(
+      pendingPath(),
+      JSON.stringify({
+        frontend,
+        target,
+        since: new Date().toISOString(),
+      } satisfies PendingReport),
+    );
+  } catch {
+    /* losing the report loses a courtesy message, nothing more */
+  }
+}
+
+const DELIVER_ATTEMPTS = 6;
+const DELIVER_DELAY_MS = 5_000;
+
+/**
+ * Deliver the pending report, if one is armed and this boot's
+ * provisioning actually changed something. Retries a few times because
+ * it races frontend registration on the cross-send broker; gives up
+ * quietly — this is a courtesy message, not state.
+ */
+export async function deliverPendingProvisionReport(
+  send: (frontend: string, target: string, text: string) => Promise<boolean>,
+  sleep: (ms: number) => Promise<void> = (ms) =>
+    new Promise((r) => setTimeout(r, ms).unref?.()),
+): Promise<void> {
+  const pending = readJson<PendingReport>(pendingPath());
+  if (!pending?.frontend || !pending.target || !pending.since) return;
+  try {
+    rmSync(pendingPath(), { force: true });
+  } catch {
+    /* already gone is fine */
+  }
+
+  const events = provisionEventsSince(pending.since);
+  if (events.length === 0) return;
+
+  const lines = events.map((e) => `• ${e.plugin}: ${e.action}`);
+  const text = `♻️ Back online. Provisioning changes during the update:\n${lines.join("\n")}`;
+
+  for (let attempt = 1; attempt <= DELIVER_ATTEMPTS; attempt++) {
+    try {
+      if (await send(pending.frontend, pending.target, text)) {
+        log(
+          "plugin",
+          `Post-update provision report delivered (${events.length} change${events.length === 1 ? "" : "s"})`,
+        );
+        return;
+      }
+    } catch {
+      /* fall through to retry */
+    }
+    if (attempt < DELIVER_ATTEMPTS) await sleep(DELIVER_DELAY_MS);
+  }
+  logWarn(
+    "plugin",
+    `Post-update provision report not delivered (${pending.frontend} unavailable)`,
+  );
+}

--- a/src/core/plugin/provision-journal.ts
+++ b/src/core/plugin/provision-journal.ts
@@ -92,14 +92,38 @@ export function armProvisionReport(frontend: string, target: string): void {
   }
 }
 
-const DELIVER_ATTEMPTS = 6;
-const DELIVER_DELAY_MS = 5_000;
+const DELIVER_ATTEMPTS = 60;
+const DELIVER_DELAY_MS = 15_000;
+
+/**
+ * Background reconcile tasks still running (a version upgrade, a docker
+ * pull). The post-update report waits for them: their actions are the
+ * changes worth reporting, and they settle minutes after boot.
+ */
+let backgroundInFlight = 0;
+
+/** Track a background provisioning task until it settles (including its journaling). */
+export function trackBackgroundProvision<T>(task: Promise<T>): Promise<T> {
+  backgroundInFlight++;
+  return task.finally(() => {
+    backgroundInFlight--;
+  });
+}
+
+export function backgroundProvisionInFlight(): number {
+  return backgroundInFlight;
+}
 
 /**
  * Deliver the pending report, if one is armed and this boot's
- * provisioning actually changed something. Retries a few times because
- * it races frontend registration on the cross-send broker; gives up
- * quietly — this is a courtesy message, not state.
+ * provisioning changed something. Waits for the boot's background
+ * reconcile tasks to settle before reading the journal, so the report
+ * covers what they did rather than a snapshot taken while pip was still
+ * running, and retries the send because it races frontend registration
+ * on the cross-send broker. Bounded (~15 minutes, matching the longest
+ * provisioner timeout), then gives up quietly — this is a courtesy
+ * message, not state. Returns immediately when nothing is pending and
+ * nothing changed.
  */
 export async function deliverPendingProvisionReport(
   send: (frontend: string, target: string, text: string) => Promise<boolean>,
@@ -108,34 +132,41 @@ export async function deliverPendingProvisionReport(
 ): Promise<void> {
   const pending = readJson<PendingReport>(pendingPath());
   if (!pending?.frontend || !pending.target || !pending.since) return;
+  // Consume the marker up front so a crashy boot can't replay a stale
+  // report later; the wait loop below keeps it alive in memory.
   try {
     rmSync(pendingPath(), { force: true });
   } catch {
     /* already gone is fine */
   }
 
-  const events = provisionEventsSince(pending.since);
-  if (events.length === 0) return;
-
-  const lines = events.map((e) => `• ${e.plugin}: ${e.action}`);
-  const text = `♻️ Back online. Provisioning changes during the update:\n${lines.join("\n")}`;
-
   for (let attempt = 1; attempt <= DELIVER_ATTEMPTS; attempt++) {
-    try {
-      if (await send(pending.frontend, pending.target, text)) {
-        log(
-          "plugin",
-          `Post-update provision report delivered (${events.length} change${events.length === 1 ? "" : "s"})`,
-        );
-        return;
+    // Report only once the background work is done — or, on the last
+    // attempt, whatever has landed so far rather than nothing.
+    const settled = backgroundInFlight === 0 || attempt === DELIVER_ATTEMPTS;
+    if (settled) {
+      const events = provisionEventsSince(pending.since);
+      if (events.length === 0 && backgroundInFlight === 0) return;
+      if (events.length > 0) {
+        const lines = events.map((e) => `• ${e.plugin}: ${e.action}`);
+        const text = `♻️ Back online. Provisioning changes during the update:\n${lines.join("\n")}`;
+        try {
+          if (await send(pending.frontend, pending.target, text)) {
+            log(
+              "plugin",
+              `Post-update provision report delivered (${events.length} change${events.length === 1 ? "" : "s"})`,
+            );
+            return;
+          }
+        } catch {
+          /* fall through to retry */
+        }
       }
-    } catch {
-      /* fall through to retry */
     }
     if (attempt < DELIVER_ATTEMPTS) await sleep(DELIVER_DELAY_MS);
   }
   logWarn(
     "plugin",
-    `Post-update provision report not delivered (${pending.frontend} unavailable)`,
+    `Post-update provision report not delivered (${pending.frontend} unavailable or provisioning still running)`,
   );
 }

--- a/src/core/plugin/provision.ts
+++ b/src/core/plugin/provision.ts
@@ -239,11 +239,10 @@ export function expandHome(path: string, home: string): string {
 
 /** Human-readable failure detail from an exec result (spawn error, last stderr line, or exit code). */
 export function failDetail(result: ExecResult): string {
-  return (
-    result.error ??
-    result.stderr.trim().split("\n").pop()?.slice(0, 300) ??
-    `exit ${result.code}`
-  );
+  // An empty stderr yields "" from pop(), which is not nullish — treat
+  // it as absent so the exit-code fallback actually fires.
+  const tail = result.stderr.trim().split("\n").pop()?.slice(0, 300);
+  return result.error ?? (tail || `exit ${result.code ?? "?"}`);
 }
 
 /** Record a successful pass: clears the failure streak, persists. */

--- a/src/core/plugin/provision.ts
+++ b/src/core/plugin/provision.ts
@@ -1,0 +1,277 @@
+/**
+ * Shared provisioning seam for built-in plugins with native runtimes.
+ *
+ * A "native" plugin (MemPalace's Python venv, Playwright's browser
+ * binaries, GitHub's Docker image) depends on an artifact Talon does not
+ * ship in its npm tarball. This module is the common ground those
+ * provisioners stand on: a persisted state file with failure backoff so
+ * a broken network can't turn boot into a retry storm, a never-throws
+ * exec runner with hard timeouts, cross-OS Python discovery, and a
+ * dependency-free semver compare.
+ *
+ * The contract every provisioner honors: an existing working install is
+ * NEVER made worse. Upgrades that fail keep the current version running;
+ * destructive healing (recreating a venv) is reserved for environments
+ * that are already broken AND owned by Talon.
+ */
+
+import { execFile as execFileCb } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+/** What a provisioning pass concluded — pure data, renderers decide presentation. */
+export interface ProvisionOutcome {
+  /**
+   * ready    — the runtime is usable right now (possibly with warnings).
+   * degraded — usable, but not at the pinned version (upgrade failed or deferred).
+   * failed   — not usable; the plugin will not come up until resolved.
+   * skipped  — provisioning disabled or not applicable (e.g. endpoint mode).
+   */
+  status: "ready" | "degraded" | "failed" | "skipped";
+  /** Installed runtime version, when it could be determined. */
+  version?: string;
+  /** Install flavor (e.g. "managed-venv", "uv-tool", "pipx", "system"). */
+  kind?: string;
+  /** Mutations performed this pass ("created venv", "installed 3.8.0", …). */
+  actions: string[];
+  /** Advisory messages for the operator (upgrade hints, backoff notices). */
+  warnings: string[];
+  /** Terminal error detail when status is "failed". */
+  error?: string;
+  /**
+   * A reconcile task the caller may run without blocking boot (e.g. a
+   * version upgrade while a working older install keeps serving). The
+   * caller decides whether to await it or fire-and-forget with logging.
+   */
+  background?: () => Promise<ProvisionOutcome>;
+}
+
+/** Persisted per-provisioner state (one small JSON file under ~/.talon/data/). */
+export interface ProvisionState {
+  /** The version target of the last attempt — a pin change resets backoff. */
+  pin?: string;
+  installedVersion?: string;
+  lastSuccessAt?: string;
+  lastFailureAt?: string;
+  failureCount?: number;
+  lastError?: string;
+  /** One-time data migrations already applied, by name. */
+  migrations?: Record<string, string>;
+}
+
+export function loadProvisionState(path: string): ProvisionState {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
+    return parsed && typeof parsed === "object"
+      ? (parsed as ProvisionState)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveProvisionState(path: string, state: ProvisionState): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(state, null, 2));
+  } catch {
+    /* state is an optimization (backoff, migration ledger) — never fatal */
+  }
+}
+
+/** Base retry delay after the first failure. */
+const BACKOFF_BASE_MS = 5 * 60_000;
+/** Retry delay ceiling. */
+const BACKOFF_MAX_MS = 6 * 60 * 60_000;
+
+/** Exponential backoff: 5min, 10min, 20min … capped at 6h. */
+export function provisionBackoffMs(failureCount: number): number {
+  const exp = Math.max(0, Math.min(failureCount - 1, 30));
+  return Math.min(BACKOFF_BASE_MS * 2 ** exp, BACKOFF_MAX_MS);
+}
+
+/**
+ * Whether a new install/upgrade attempt is due. A changed pin always
+ * re-arms immediately — the operator (or a Talon upgrade) asked for a
+ * different version, so stale failures shouldn't gate it.
+ */
+export function shouldAttempt(
+  state: ProvisionState,
+  pin: string,
+  nowMs: number,
+): boolean {
+  if (!state.lastFailureAt) return true;
+  if (state.pin !== pin) return true;
+  const last = Date.parse(state.lastFailureAt);
+  if (Number.isNaN(last)) return true;
+  return nowMs - last >= provisionBackoffMs(state.failureCount ?? 1);
+}
+
+export interface ExecResult {
+  ok: boolean;
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  /** Spawn-level failure (ENOENT, EACCES, timeout kill), when there was one. */
+  error?: string;
+}
+
+export type ExecFn = (
+  cmd: string,
+  args: readonly string[],
+  opts: { timeoutMs: number; env?: Record<string, string> },
+) => Promise<ExecResult>;
+
+/** Default exec: never throws, hard-kills on timeout, captures both streams. */
+export const runStep: ExecFn = (cmd, args, opts) =>
+  new Promise((resolvePromise) => {
+    execFileCb(
+      cmd,
+      [...args],
+      {
+        timeout: opts.timeoutMs,
+        killSignal: "SIGKILL",
+        maxBuffer: 16 * 1024 * 1024,
+        env: opts.env ? { ...process.env, ...opts.env } : process.env,
+        windowsHide: true,
+      },
+      (err, stdout, stderr) => {
+        const out = stdout?.toString() ?? "";
+        const errOut = stderr?.toString() ?? "";
+        if (!err) {
+          resolvePromise({ ok: true, code: 0, stdout: out, stderr: errOut });
+          return;
+        }
+        const spawnErr = err as NodeJS.ErrnoException & {
+          killed?: boolean;
+          code?: number | string;
+        };
+        const code = typeof spawnErr.code === "number" ? spawnErr.code : null;
+        const error =
+          typeof spawnErr.code === "string"
+            ? spawnErr.code
+            : spawnErr.killed
+              ? `timed out after ${Math.round(opts.timeoutMs / 1000)}s`
+              : undefined;
+        resolvePromise({ ok: false, code, stdout: out, stderr: errOut, error });
+      },
+    );
+  });
+
+/**
+ * Numeric dotted-version compare ("3.8.0" vs "3.10.1"): negative when a < b,
+ * 0 when equal, positive when a > b. Non-numeric segments compare as 0,
+ * which is the safe reading for pre-release suffixes here — a fuzzy match
+ * triggers at worst a no-op reinstall, never a skipped one.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map((s) => parseInt(s, 10) || 0);
+  const pb = b.split(".").map((s) => parseInt(s, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/** Venv interpreter path for a venv root (bin/python vs Scripts/python.exe). */
+export function venvPython(venvDir: string, platform: NodeJS.Platform): string {
+  return platform === "win32"
+    ? resolve(venvDir, "Scripts", "python.exe")
+    : resolve(venvDir, "bin", "python");
+}
+
+export interface BasePython {
+  command: string;
+  args: string[];
+  version: string;
+}
+
+/**
+ * Find a base interpreter able to seed a venv. Order matters per OS: the
+ * `py` launcher is the canonical entry on Windows (PATH pythons there are
+ * often the Store stub), python3 the canonical one elsewhere.
+ */
+export async function findBasePython(
+  exec: ExecFn,
+  platform: NodeJS.Platform,
+  min: { major: number; minor: number },
+): Promise<BasePython | undefined> {
+  const candidates: Array<[string, string[]]> =
+    platform === "win32"
+      ? [
+          ["py", ["-3"]],
+          ["python", []],
+          ["python3", []],
+        ]
+      : [
+          ["python3", []],
+          ["python", []],
+        ];
+  for (const [command, args] of candidates) {
+    const probe = await exec(
+      command,
+      [...args, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+      { timeoutMs: 20_000 },
+    );
+    if (!probe.ok) continue;
+    const version = probe.stdout.trim();
+    const [major, minor] = version.split(".").map((s) => parseInt(s, 10));
+    if (
+      Number.isFinite(major) &&
+      (major > min.major || (major === min.major && (minor ?? 0) >= min.minor))
+    ) {
+      return { command, args, version };
+    }
+  }
+  return undefined;
+}
+
+/** Expand a leading `~/` (or bare `~`) to the home directory. */
+export function expandHome(path: string, home: string): string {
+  if (path === "~") return home;
+  if (path.startsWith("~/") || path.startsWith("~\\")) {
+    return resolve(home, path.slice(2));
+  }
+  return path;
+}
+
+/** Human-readable failure detail from an exec result (spawn error, last stderr line, or exit code). */
+export function failDetail(result: ExecResult): string {
+  return (
+    result.error ??
+    result.stderr.trim().split("\n").pop()?.slice(0, 300) ??
+    `exit ${result.code}`
+  );
+}
+
+/** Record a successful pass: clears the failure streak, persists. */
+export function markProvisionSuccess(
+  statePath: string,
+  state: ProvisionState,
+  pin: string,
+  nowMs: number,
+): void {
+  state.pin = pin;
+  state.lastSuccessAt = new Date(nowMs).toISOString();
+  state.failureCount = 0;
+  state.lastFailureAt = undefined;
+  state.lastError = undefined;
+  saveProvisionState(statePath, state);
+}
+
+/** Record a failed pass: bumps the failure streak for backoff, persists. */
+export function markProvisionFailure(
+  statePath: string,
+  state: ProvisionState,
+  pin: string,
+  error: string,
+  nowMs: number,
+): void {
+  state.pin = pin;
+  state.lastFailureAt = new Date(nowMs).toISOString();
+  state.failureCount = (state.failureCount ?? 0) + 1;
+  state.lastError = error;
+  saveProvisionState(statePath, state);
+}

--- a/src/frontend/discord/commands/admin.ts
+++ b/src/frontend/discord/commands/admin.ts
@@ -237,6 +237,11 @@ export async function handleUpdate(
       await edit(
         `✅ Updated \`${res.before ?? "?"}\` → \`${res.after ?? "?"}\`. ♻️ Restarting…`,
       );
+      // The successor documents any provisioning changes (plugin runtime
+      // upgrades, migrations) back to this channel once it's up.
+      const { armProvisionReport } =
+        await import("../../../core/plugin/provision-journal.js");
+      armProvisionReport("discord", String(i.channelId));
       respawnSelf("discord /update");
     })
     .catch(async (err: unknown) => {

--- a/src/frontend/telegram/commands/admin.ts
+++ b/src/frontend/telegram/commands/admin.ts
@@ -214,6 +214,11 @@ export function registerAdminCommands(
           await edit(
             `✅ Updated <code>${escapeHtml(res.before ?? "?")}</code> → <code>${escapeHtml(res.after ?? "?")}</code>. ♻️ Restarting…`,
           );
+          // The successor documents any provisioning changes (plugin
+          // runtime upgrades, migrations) back to this chat once it's up.
+          const { armProvisionReport } =
+            await import("../../../core/plugin/provision-journal.js");
+          armProvisionReport("telegram", String(ctx.chat.id));
           respawnSelf("telegram /update");
         })
         .catch(async (err: unknown) => {

--- a/src/plugins/github/index.ts
+++ b/src/plugins/github/index.ts
@@ -14,6 +14,7 @@
 import { execFileSync } from "node:child_process";
 import type { TalonPlugin } from "../../core/plugin/types.js";
 import { log, logWarn } from "../../util/log.js";
+import { githubMcpImageRef } from "./provision.js";
 
 /**
  * Resolve a GitHub personal access token.
@@ -34,8 +35,12 @@ function resolveToken(configToken?: string): string | undefined {
   }
 }
 
-export function createGitHubPlugin(config: { token?: string }): TalonPlugin {
+export function createGitHubPlugin(config: {
+  token?: string;
+  imageTag?: string;
+}): TalonPlugin {
   const token = resolveToken(config.token);
+  const image = githubMcpImageRef(config.imageTag);
 
   return {
     name: "github",
@@ -44,14 +49,7 @@ export function createGitHubPlugin(config: { token?: string }): TalonPlugin {
 
     mcpServer: {
       command: "docker",
-      args: [
-        "run",
-        "--rm",
-        "-i",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server",
-      ],
+      args: ["run", "--rm", "-i", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", image],
     },
 
     validateConfig() {
@@ -79,18 +77,18 @@ export function createGitHubPlugin(config: { token?: string }): TalonPlugin {
     },
 
     async init() {
-      // Verify the Docker image exists locally
+      // Verify the pinned Docker image exists locally (the provisioner
+      // pulls it in the background when absent).
       try {
-        execFileSync(
-          "docker",
-          ["image", "inspect", "ghcr.io/github/github-mcp-server"],
-          { timeout: 10_000, stdio: "pipe" },
-        );
-        log("github", "Docker image verified");
+        execFileSync("docker", ["image", "inspect", image], {
+          timeout: 10_000,
+          stdio: "pipe",
+        });
+        log("github", `Docker image verified (${image})`);
       } catch {
         logWarn(
           "github",
-          "Docker image not found locally — will pull on first use (may be slow)",
+          `Docker image ${image} not present yet — pulling in background; docker pulls on first use as fallback`,
         );
       }
 

--- a/src/plugins/github/provision.ts
+++ b/src/plugins/github/provision.ts
@@ -162,7 +162,11 @@ export async function inspectGithub(
     {
       label: `GitHub MCP image not pulled (${image})`,
       status: "warn",
-      detail: "pulls in the background at next talon start",
+      detail:
+        section.autoProvision === false
+          ? `automatic pull disabled (github.autoProvision: false) — run: docker pull ${image}`
+          : "pulls in the background at next talon start",
+      issue: true,
     },
   ];
 }

--- a/src/plugins/github/provision.ts
+++ b/src/plugins/github/provision.ts
@@ -1,0 +1,168 @@
+/**
+ * GitHub MCP provisioner — pinned Docker image, pulled ahead of use.
+ *
+ * `docker run` on an absent image blocks the first tool call on a
+ * network pull; a floating `latest` means the server silently changes
+ * under a deployment. Pin a known-good tag and front-load the pull at
+ * boot (in the background — docker itself remains the fallback path,
+ * so a slow or failed pull degrades to today's behavior, never worse).
+ */
+
+import { join } from "node:path";
+import type { DoctorCheck } from "../../core/doctor.js";
+import {
+  failDetail,
+  loadProvisionState,
+  markProvisionFailure,
+  markProvisionSuccess,
+  runStep,
+  shouldAttempt,
+  type ExecFn,
+  type ProvisionOutcome,
+} from "../../core/plugin/provision.js";
+import { dirs } from "../../util/paths.js";
+
+/**
+ * The github-mcp-server image tag Talon runs. Bump deliberately, with
+ * the canary workflow green — see .github/workflows/native-provision.yml.
+ */
+export const GITHUB_MCP_PINNED_TAG = "v1.11.0";
+
+const GITHUB_MCP_IMAGE = "ghcr.io/github/github-mcp-server";
+
+const PULL_TIMEOUT_MS = 600_000;
+const INSPECT_TIMEOUT_MS = 20_000;
+
+export function githubMcpImageRef(imageTag?: string): string {
+  return `${GITHUB_MCP_IMAGE}:${imageTag ?? GITHUB_MCP_PINNED_TAG}`;
+}
+
+/** The `github` config section this module reads. */
+export interface GithubSection {
+  imageTag?: string;
+  autoProvision?: boolean;
+}
+
+export interface GithubProvisionDeps {
+  exec?: ExecFn;
+  now?: () => number;
+  statePath?: string;
+}
+
+export async function provisionGithubMcp(
+  section: GithubSection,
+  deps: GithubProvisionDeps = {},
+): Promise<ProvisionOutcome> {
+  const exec = deps.exec ?? runStep;
+  const now = deps.now ?? Date.now;
+  const image = githubMcpImageRef(section.imageTag);
+
+  if (section.autoProvision === false) {
+    return { status: "skipped", kind: "docker", actions: [], warnings: [] };
+  }
+
+  const inspected = await exec("docker", ["image", "inspect", image], {
+    timeoutMs: INSPECT_TIMEOUT_MS,
+  });
+  if (inspected.ok) {
+    return {
+      status: "ready",
+      version: image,
+      kind: "docker",
+      actions: [],
+      warnings: [],
+    };
+  }
+  if (inspected.error === "ENOENT") {
+    // No docker at all — validateConfig already reports this as the
+    // blocking error; provisioning has nothing to add.
+    return {
+      status: "failed",
+      kind: "docker",
+      actions: [],
+      warnings: [],
+      error: "docker not found",
+    };
+  }
+
+  const statePath = deps.statePath ?? join(dirs.data, "github-provision.json");
+  const state = loadProvisionState(statePath);
+  if (!shouldAttempt(state, image, now())) {
+    return {
+      status: "degraded",
+      version: image,
+      kind: "docker",
+      actions: [],
+      warnings: [
+        `image pull previously failed (${state.lastError ?? "unknown"}); docker will pull on first use — retrying with backoff`,
+      ],
+    };
+  }
+
+  return {
+    status: "degraded",
+    version: image,
+    kind: "docker",
+    actions: [],
+    warnings: [`pulling ${image} in the background`],
+    background: async () => {
+      const pulled = await exec("docker", ["pull", image], {
+        timeoutMs: PULL_TIMEOUT_MS,
+      });
+      if (pulled.ok) {
+        markProvisionSuccess(statePath, state, image, now());
+        return {
+          status: "ready",
+          version: image,
+          kind: "docker",
+          actions: [`pulled ${image}`],
+          warnings: [],
+        };
+      }
+      const detail = failDetail(pulled);
+      markProvisionFailure(statePath, state, image, detail, now());
+      return {
+        status: "degraded",
+        version: image,
+        kind: "docker",
+        actions: [],
+        warnings: [
+          `image pull failed (${detail}) — docker will pull on first use`,
+        ],
+        error: detail,
+      };
+    },
+  };
+}
+
+/** Read-only doctor inspection: docker reachable, pinned image present. */
+export async function inspectGithub(
+  section: GithubSection,
+  deps: GithubProvisionDeps = {},
+): Promise<DoctorCheck[]> {
+  const exec = deps.exec ?? runStep;
+  const image = githubMcpImageRef(section.imageTag);
+  const inspected = await exec("docker", ["image", "inspect", image], {
+    timeoutMs: INSPECT_TIMEOUT_MS,
+  });
+  if (inspected.ok) {
+    return [{ label: `GitHub MCP image ${image}`, status: "ok" }];
+  }
+  if (inspected.error === "ENOENT") {
+    return [
+      {
+        label: "GitHub MCP: docker not found",
+        status: "fail",
+        detail: "the GitHub MCP server runs as a Docker image",
+        issue: true,
+      },
+    ];
+  }
+  return [
+    {
+      label: `GitHub MCP image not pulled (${image})`,
+      status: "warn",
+      detail: "pulls in the background at next talon start",
+    },
+  ];
+}

--- a/src/plugins/mempalace/index.ts
+++ b/src/plugins/mempalace/index.ts
@@ -10,8 +10,15 @@
  *     "palacePath": "/path/to/palace",         // optional, defaults to ~/.talon/workspace/palace/
  *     "pythonPath": "/path/to/python",         // optional, defaults to mempalace venv python (bin/python on Unix, Scripts/python.exe on Windows)
  *     "entityLanguages": ["en", "ja"],         // optional, BCP 47 codes (mempalace >= 3.3)
- *     "verbose": false                          // optional, enables MEMPAL_VERBOSE diagnostics
+ *     "verbose": false,                         // optional, enables MEMPAL_VERBOSE diagnostics
+ *     "version": "3.8.0",                       // optional, overrides the built-in pin (managed venv only)
+ *     "autoUpdate": true,                       // optional, reconcile managed venv to the pin
+ *     "autoProvision": true                     // optional, create/heal the managed venv
  *   }
+ *
+ * The default venv is provisioned automatically at boot (see
+ * ./provision.ts); a custom pythonPath is operator-managed and never
+ * mutated.
  */
 
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
@@ -38,8 +45,11 @@ export function createMempalacePlugin(config: {
   entityLanguages?: readonly string[];
   /** When true, sets MEMPAL_VERBOSE=1 so the MCP server logs diagnostic diaries. */
   verbose?: boolean;
+  /** Version the provisioner found/installed — logging only. */
+  installedVersion?: string;
 }): TalonPlugin {
-  const { pythonPath, palacePath, entityLanguages, verbose } = config;
+  const { pythonPath, palacePath, entityLanguages, verbose, installedVersion } =
+    config;
 
   const envVars: Record<string, string> = {
     MEMPALACE_PALACE_PATH: palacePath,
@@ -142,7 +152,11 @@ export function createMempalacePlugin(config: {
         entityLanguages && entityLanguages.length > 0
           ? ` (languages: ${entityLanguages.join(",")})`
           : "";
-      log("mempalace", `Ready (palace: ${palacePath})${langSuffix}`);
+      const versionSuffix = installedVersion ? ` v${installedVersion}` : "";
+      log(
+        "mempalace",
+        `Ready${versionSuffix} (palace: ${palacePath})${langSuffix}`,
+      );
     },
 
     getEnvVars() {

--- a/src/plugins/mempalace/provision.ts
+++ b/src/plugins/mempalace/provision.ts
@@ -1,0 +1,593 @@
+/**
+ * MemPalace provisioner — self-installing, self-healing Python runtime.
+ *
+ * Talon owns exactly one environment: the venv at ~/.talon/mempalace-venv
+ * (the default `pythonPath`). That env is created on first boot, kept on
+ * the pinned mempalace version, healed when broken, and carried through
+ * one-time palace migrations. Any other `pythonPath` — a uv tool, pipx,
+ * conda, or hand-rolled venv — is respected as operator-managed: probed
+ * and advised on (exact upgrade command for its flavor), never mutated.
+ *
+ * Ordering guarantees, in priority order:
+ *   1. A working install keeps working. Upgrade failures (network down,
+ *      PyPI outage) leave the current version serving and retry later
+ *      with backoff.
+ *   2. Version drift reconciles in the background — boot never blocks on
+ *      pip when a usable install exists.
+ *   3. Destructive healing (venv --clear) only ever targets the
+ *      Talon-owned venv, and only when it is already unusable.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import type { DoctorCheck } from "../../core/doctor.js";
+import {
+  compareVersions,
+  expandHome,
+  failDetail,
+  findBasePython,
+  loadProvisionState,
+  markProvisionFailure,
+  markProvisionSuccess,
+  provisionBackoffMs,
+  runStep,
+  saveProvisionState,
+  shouldAttempt,
+  type ExecFn,
+  type ProvisionOutcome,
+  type ProvisionState,
+} from "../../core/plugin/provision.js";
+import { dirs, files } from "../../util/paths.js";
+
+/**
+ * The mempalace version Talon installs and reconciles the managed venv
+ * to. Bump deliberately, with the canary workflow green — see
+ * .github/workflows/native-provision.yml.
+ */
+export const MEMPALACE_PINNED_VERSION = "3.8.0";
+
+/** Minimum python for the managed venv (matches mempalace's supported floor). */
+const PYTHON_MIN = { major: 3, minor: 10 };
+
+/** One-time palace migration ledger key (mempalace >= 3.4 wing renames). */
+const WING_MIGRATION = "wing-names";
+
+/**
+ * One subprocess proves both facts that matter: the dist is installed
+ * (metadata resolves) and the MCP server module actually imports.
+ */
+const HEALTH_SNIPPET =
+  "import importlib.metadata as m; v = m.version('mempalace'); import mempalace.mcp_server; print(v)";
+
+const PROBE_TIMEOUT_MS = 30_000;
+const VENV_TIMEOUT_MS = 120_000;
+const PIP_TIMEOUT_MS = 900_000;
+const MIGRATE_TIMEOUT_MS = 600_000;
+
+/** The `mempalace`/`memory.mempalace` config section this module reads. */
+export interface MempalaceSection {
+  pythonPath?: string;
+  palacePath?: string;
+  version?: string;
+  autoUpdate?: boolean;
+  autoProvision?: boolean;
+}
+
+/**
+ * Single source of truth for path resolution (builtins, bootstrap's
+ * dream integration, and doctor all go through here): defaults applied,
+ * `~` expanded, made absolute.
+ */
+export function resolveMempalacePaths(
+  section: MempalaceSection | undefined,
+  home = homedir(),
+): { pythonPath: string; palacePath: string } {
+  return {
+    pythonPath: resolve(
+      expandHome(section?.pythonPath ?? files.mempalacePython, home),
+    ),
+    palacePath: resolve(expandHome(section?.palacePath ?? dirs.palace, home)),
+  };
+}
+
+/** Injectable seams so unit tests can cover every OS and failure branch. */
+export interface MempalaceProvisionDeps {
+  exec?: ExecFn;
+  platform?: NodeJS.Platform;
+  now?: () => number;
+  home?: string;
+  /** The Talon-owned interpreter path (default: files.mempalacePython). */
+  defaultManagedPython?: string;
+  statePath?: string;
+  pathExists?: (p: string) => boolean;
+}
+
+interface HealthProbe {
+  healthy: boolean;
+  version?: string;
+  error?: string;
+}
+
+async function probeHealth(exec: ExecFn, python: string): Promise<HealthProbe> {
+  const result = await exec(python, ["-c", HEALTH_SNIPPET], {
+    timeoutMs: PROBE_TIMEOUT_MS,
+  });
+  if (result.ok) {
+    const version = result.stdout.trim().split(/\s+/).pop();
+    if (version) return { healthy: true, version };
+  }
+  return { healthy: false, error: failDetail(result) };
+}
+
+/** Classify an operator-managed install by its interpreter path. */
+export function classifyExternalInstall(pythonPath: string): string {
+  const p = pythonPath.replaceAll("\\", "/").toLowerCase();
+  if (p.includes("/uv/tools/")) return "uv-tool";
+  if (p.includes("/pipx/")) return "pipx";
+  if (
+    p.includes("conda") ||
+    p.includes("miniforge") ||
+    p.includes("mambaforge")
+  ) {
+    return "conda";
+  }
+  return "external";
+}
+
+/** The exact upgrade command for an operator-managed install's flavor. */
+function upgradeHint(kind: string, python: string, target: string): string {
+  if (kind === "uv-tool") {
+    return `uv tool install --force 'mempalace==${target}'`;
+  }
+  if (kind === "pipx") return `pipx install --force 'mempalace==${target}'`;
+  return `${python} -m pip install --upgrade 'mempalace==${target}'`;
+}
+
+/** Single-flight guard: hot-reload must not stack concurrent pip runs. */
+let reconcileInFlight = false;
+
+export async function provisionMempalace(
+  section: MempalaceSection,
+  deps: MempalaceProvisionDeps = {},
+): Promise<ProvisionOutcome> {
+  const exec = deps.exec ?? runStep;
+  const platform = deps.platform ?? process.platform;
+  const now = deps.now ?? Date.now;
+  const home = deps.home ?? homedir();
+  const pathExists = deps.pathExists ?? existsSync;
+  const target = section.version ?? MEMPALACE_PINNED_VERSION;
+
+  const { pythonPath: python, palacePath: palace } = resolveMempalacePaths(
+    section,
+    home,
+  );
+  const managedPython = resolve(
+    deps.defaultManagedPython ?? files.mempalacePython,
+  );
+  const managed = python === managedPython;
+
+  const probe = pathExists(python)
+    ? await probeHealth(exec, python)
+    : { healthy: false, error: "interpreter not found" };
+
+  if (!managed) {
+    return externalOutcome(python, target, probe, pathExists);
+  }
+
+  // ── Talon-owned venv from here on ──
+  const statePath =
+    deps.statePath ?? join(dirs.data, "mempalace-provision.json");
+  const state = loadProvisionState(statePath);
+  const venvDir = dirname(dirname(python));
+
+  const ctx: ReconcileContext = {
+    exec,
+    platform,
+    now,
+    python,
+    palace,
+    venvDir,
+    target,
+    statePath,
+    state,
+    pathExists,
+    previous: probe.healthy ? { version: probe.version! } : undefined,
+  };
+
+  if (probe.healthy && probe.version === target) {
+    state.installedVersion = probe.version;
+    markProvisionSuccess(statePath, state, target, now());
+    const outcome: ProvisionOutcome = {
+      status: "ready",
+      version: probe.version,
+      kind: "managed-venv",
+      actions: [],
+      warnings: [],
+    };
+    await maybeMigratePalace(ctx, outcome);
+    return outcome;
+  }
+
+  if (section.autoProvision === false) {
+    return {
+      status: probe.healthy ? "ready" : "failed",
+      version: probe.version,
+      kind: "managed-venv",
+      actions: [],
+      warnings: [
+        probe.healthy
+          ? `installed ${probe.version}, pinned ${target} — autoProvision is off, run: ${python} -m pip install --upgrade 'mempalace==${target}'`
+          : `mempalace not usable (${probe.error}) and autoProvision is off — create the venv manually (see README) or re-enable autoProvision`,
+      ],
+      error: probe.healthy ? undefined : probe.error,
+    };
+  }
+
+  if (probe.healthy && section.autoUpdate === false) {
+    return {
+      status: "ready",
+      version: probe.version,
+      kind: "managed-venv",
+      actions: [],
+      warnings: [
+        `installed ${probe.version}, pinned ${target} — autoUpdate is off, upgrade manually when ready`,
+      ],
+    };
+  }
+
+  if (!shouldAttempt(state, target, now())) {
+    const wait = Math.round(
+      provisionBackoffMs(state.failureCount ?? 1) / 60_000,
+    );
+    const notice = `last provision attempt failed (${state.lastError ?? "unknown"}); retrying with backoff (≤${wait}min) or at next pin change`;
+    return probe.healthy
+      ? {
+          status: "degraded",
+          version: probe.version,
+          kind: "managed-venv",
+          actions: [],
+          warnings: [notice],
+        }
+      : {
+          status: "failed",
+          kind: "managed-venv",
+          actions: [],
+          warnings: [notice],
+          error: state.lastError,
+        };
+  }
+
+  if (probe.healthy) {
+    // Usable install at the wrong version: boot on it now, reconcile in
+    // the background — the venv path is stable, so the next MCP spawn
+    // picks the new version up without any further coordination.
+    return {
+      status: "ready",
+      version: probe.version,
+      kind: "managed-venv",
+      actions: [],
+      warnings: [
+        `installed ${probe.version}, pinned ${target} — upgrading in the background`,
+      ],
+      background: () => runReconcileSingleFlight(ctx),
+    };
+  }
+
+  // Broken or absent: provisioning is the only way to a working plugin,
+  // so this path blocks (first boot pays the install once).
+  return runReconcileSingleFlight(ctx);
+}
+
+function externalOutcome(
+  python: string,
+  target: string,
+  probe: HealthProbe,
+  pathExists: (p: string) => boolean,
+): ProvisionOutcome {
+  const kind = classifyExternalInstall(python);
+  const hint = upgradeHint(kind, python, target);
+  if (!pathExists(python)) {
+    return {
+      status: "failed",
+      kind,
+      actions: [],
+      warnings: [
+        `python not found at ${python} — this install is operator-managed (${kind}); fix the path or install with: ${hint}`,
+      ],
+      error: "interpreter not found",
+    };
+  }
+  if (!probe.healthy) {
+    return {
+      status: "failed",
+      kind,
+      actions: [],
+      warnings: [
+        `mempalace not importable from ${python} (${probe.error}) — operator-managed (${kind}); install with: ${hint}`,
+      ],
+      error: probe.error,
+    };
+  }
+  const warnings: string[] = [];
+  if (compareVersions(probe.version!, target) < 0) {
+    warnings.push(
+      `installed ${probe.version}, Talon pins ${target} — operator-managed (${kind}), upgrade with: ${hint}`,
+    );
+  }
+  return {
+    status: "ready",
+    version: probe.version,
+    kind,
+    actions: [],
+    warnings,
+  };
+}
+
+interface ReconcileContext {
+  exec: ExecFn;
+  platform: NodeJS.Platform;
+  now: () => number;
+  python: string;
+  palace: string;
+  venvDir: string;
+  target: string;
+  statePath: string;
+  state: ProvisionState;
+  pathExists: (p: string) => boolean;
+  /** A working install that existed before this pass, if any. */
+  previous?: { version: string };
+}
+
+async function runReconcileSingleFlight(
+  ctx: ReconcileContext,
+): Promise<ProvisionOutcome> {
+  if (reconcileInFlight) {
+    return {
+      status: ctx.previous ? "degraded" : "failed",
+      version: ctx.previous?.version,
+      kind: "managed-venv",
+      actions: [],
+      warnings: ["a provisioning pass is already running — skipped"],
+    };
+  }
+  reconcileInFlight = true;
+  try {
+    return await reconcile(ctx);
+  } finally {
+    reconcileInFlight = false;
+  }
+}
+
+async function reconcile(ctx: ReconcileContext): Promise<ProvisionOutcome> {
+  const { exec, platform, python, venvDir, target, pathExists } = ctx;
+  const actions: string[] = [];
+  const warnings: string[] = [];
+  let recreatedThisPass = false;
+
+  const fail = (error: string): ProvisionOutcome => {
+    markProvisionFailure(ctx.statePath, ctx.state, target, error, ctx.now());
+    if (ctx.previous) {
+      warnings.push(
+        `upgrade to ${target} failed (${error}) — staying on working ${ctx.previous.version}, will retry with backoff`,
+      );
+      return {
+        status: "degraded",
+        version: ctx.previous.version,
+        kind: "managed-venv",
+        actions,
+        warnings,
+      };
+    }
+    return {
+      status: "failed",
+      kind: "managed-venv",
+      actions,
+      warnings,
+      error,
+    };
+  };
+
+  const recreateVenv = async (): Promise<string | undefined> => {
+    const existedBefore = pathExists(venvDir);
+    const base = await findBasePython(exec, platform, PYTHON_MIN);
+    if (!base) {
+      return `no python >=${PYTHON_MIN.major}.${PYTHON_MIN.minor} found on PATH — install one, or point mempalace.pythonPath at an environment you manage`;
+    }
+    // --clear empties a broken venv in place; no recursive delete needed.
+    const created = await exec(
+      base.command,
+      [...base.args, "-m", "venv", "--clear", venvDir],
+      { timeoutMs: VENV_TIMEOUT_MS },
+    );
+    if (!created.ok) {
+      // Debian/Ubuntu ship python3 without the venv module; the failure
+      // names ensurepip and the fix is a distro package, not pip.
+      const hint = /ensurepip|venv/i.test(created.stderr)
+        ? " — on Debian/Ubuntu: sudo apt install python3-venv"
+        : "";
+      return `venv creation failed: ${failDetail(created)}${hint}`;
+    }
+    recreatedThisPass = true;
+    actions.push(
+      `${existedBefore ? "recreated" : "created"} venv at ${venvDir} (python ${base.version})`,
+    );
+    return undefined;
+  };
+
+  const pipInstall = async (forceReinstall: boolean) =>
+    exec(
+      python,
+      [
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        ...(forceReinstall ? ["--force-reinstall"] : []),
+        `mempalace==${target}`,
+      ],
+      {
+        timeoutMs: PIP_TIMEOUT_MS,
+        env: { PIP_DISABLE_PIP_VERSION_CHECK: "1" },
+      },
+    );
+
+  // Step 1 — ensure an interpreter exists at all.
+  if (!pathExists(python)) {
+    const err = await recreateVenv();
+    if (err) return fail(err);
+  }
+
+  // Step 2 — install/upgrade. A pass that started from a broken-but-present
+  // install force-reinstalls, which repairs half-written site-packages.
+  const brokenInstall = !ctx.previous && !recreatedThisPass;
+  let installed = await pipInstall(brokenInstall);
+
+  // Step 3 — heal ladder. First rung: pip itself may be missing/broken.
+  if (!installed.ok) {
+    await exec(python, ["-m", "ensurepip", "--upgrade"], {
+      timeoutMs: VENV_TIMEOUT_MS,
+    });
+    await exec(python, ["-m", "pip", "install", "--upgrade", "pip"], {
+      timeoutMs: VENV_TIMEOUT_MS,
+      env: { PIP_DISABLE_PIP_VERSION_CHECK: "1" },
+    });
+    installed = await pipInstall(brokenInstall);
+  }
+
+  // Second rung: rebuild the whole venv — but never sacrifice a working
+  // install to do it; a failed upgrade keeps serving the old version.
+  if (!installed.ok && !recreatedThisPass && !ctx.previous) {
+    const err = await recreateVenv();
+    if (!err) installed = await pipInstall(false);
+  }
+
+  if (!installed.ok) return fail(failDetail(installed));
+
+  // Step 4 — trust nothing: verify the interpreter now serves the target.
+  const verify = await probeHealth(exec, python);
+  if (!verify.healthy) {
+    return fail(`installed but not importable: ${verify.error}`);
+  }
+  if (verify.version !== target) {
+    return fail(
+      `expected ${target} after install, found ${verify.version ?? "nothing"}`,
+    );
+  }
+
+  actions.push(
+    ctx.previous
+      ? `upgraded mempalace ${ctx.previous.version} → ${target}`
+      : `installed mempalace ${target}`,
+  );
+  ctx.state.installedVersion = target;
+  markProvisionSuccess(ctx.statePath, ctx.state, target, ctx.now());
+
+  const outcome: ProvisionOutcome = {
+    status: "ready",
+    version: target,
+    kind: "managed-venv",
+    actions,
+    warnings,
+  };
+  await maybeMigratePalace(ctx, outcome);
+  return outcome;
+}
+
+/**
+ * One-time palace data migrations, applied only to palaces that already
+ * hold data (a chroma store) and recorded in the state ledger so they
+ * run exactly once per deployment. `migrate-wings` itself is idempotent,
+ * so a lost ledger costs one harmless re-run, never data.
+ */
+async function maybeMigratePalace(
+  ctx: ReconcileContext,
+  outcome: ProvisionOutcome,
+): Promise<void> {
+  if (ctx.state.migrations?.[WING_MIGRATION]) return;
+  if (!ctx.pathExists(join(ctx.palace, "chroma.sqlite3"))) return;
+
+  const result = await ctx.exec(
+    ctx.python,
+    ["-m", "mempalace", "--palace", ctx.palace, "migrate-wings", "--yes"],
+    { timeoutMs: MIGRATE_TIMEOUT_MS },
+  );
+  if (result.ok) {
+    ctx.state.migrations = {
+      ...ctx.state.migrations,
+      [WING_MIGRATION]: new Date(ctx.now()).toISOString(),
+    };
+    saveProvisionState(ctx.statePath, ctx.state);
+    const summary =
+      result.stdout
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(
+          (l) => l.startsWith("Migrated") || l.includes("nothing to migrate"),
+        )
+        .pop() ?? "done";
+    outcome.actions.push(`palace wing-name migration: ${summary}`);
+  } else {
+    outcome.warnings.push(
+      `palace wing-name migration failed (${failDetail(result)}) — data untouched, will retry next provision pass`,
+    );
+  }
+}
+
+/**
+ * Read-only doctor inspection: version vs pin, flavor, importability.
+ * Never mutates — a drifted managed venv reports "reconciles at next
+ * talon start", which is the provisioner's job, not doctor's.
+ */
+export async function inspectMempalace(
+  section: MempalaceSection,
+  deps: MempalaceProvisionDeps = {},
+): Promise<DoctorCheck[]> {
+  const exec = deps.exec ?? runStep;
+  const pathExists = deps.pathExists ?? existsSync;
+  const home = deps.home ?? homedir();
+  const { pythonPath: python } = resolveMempalacePaths(section, home);
+  const pin = section.version ?? MEMPALACE_PINNED_VERSION;
+  const managed =
+    python === resolve(deps.defaultManagedPython ?? files.mempalacePython);
+  const kind = managed ? "managed venv" : classifyExternalInstall(python);
+
+  if (!pathExists(python)) {
+    return [
+      {
+        label: `MemPalace runtime missing (${kind})`,
+        status: managed ? "warn" : "fail",
+        detail: managed
+          ? `provisions automatically at next talon start (pin ${pin})`
+          : `python not found at ${python}`,
+        issue: true,
+      },
+    ];
+  }
+  const probe = await probeHealth(exec, python);
+  if (!probe.healthy) {
+    return [
+      {
+        label: `MemPalace broken (${kind})`,
+        status: "warn",
+        detail: managed
+          ? "self-heals at next talon start"
+          : `mempalace not importable from ${python} (${probe.error})`,
+        issue: true,
+      },
+    ];
+  }
+  if (probe.version === pin) {
+    return [{ label: `MemPalace ${probe.version} (${kind})`, status: "ok" }];
+  }
+  return [
+    {
+      label: `MemPalace ${probe.version}, pinned ${pin} (${kind})`,
+      status: "warn",
+      detail: managed
+        ? "reconciles at next talon start"
+        : "operator-managed install — upgrade when ready",
+      issue: managed,
+    },
+  ];
+}

--- a/src/plugins/mempalace/provision.ts
+++ b/src/plugins/mempalace/provision.ts
@@ -11,7 +11,9 @@
  * Ordering guarantees, in priority order:
  *   1. A working install keeps working. Upgrade failures (network down,
  *      PyPI outage) leave the current version serving and retry later
- *      with backoff.
+ *      with backoff; pip downloads everything before it touches the
+ *      environment, and if a failure does land mid-mutation the pass
+ *      rolls back to the previous version before reporting.
  *   2. Version drift reconciles in the background — boot never blocks on
  *      pip when a usable install exists.
  *   3. Destructive healing (venv --clear) only ever targets the
@@ -52,6 +54,8 @@ const PYTHON_MIN = { major: 3, minor: 10 };
 
 /** One-time palace migration ledger key (mempalace >= 3.4 wing renames). */
 const WING_MIGRATION = "wing-names";
+/** First mempalace release that ships `migrate-wings`. */
+const WING_MIGRATION_MIN_VERSION = "3.4.0";
 
 /**
  * One subprocess proves both facts that matter: the dist is installed
@@ -139,8 +143,16 @@ export function classifyExternalInstall(pythonPath: string): string {
   return "external";
 }
 
-/** The exact upgrade command for an operator-managed install's flavor. */
-function upgradeHint(kind: string, python: string, target: string): string {
+/**
+ * The exact command that puts an operator-managed install on the pinned
+ * version, per flavor. Works in both directions (a newer-than-pin
+ * install reconciles down), hence the neutral name.
+ */
+export function reconcileHint(
+  kind: string,
+  python: string,
+  target: string,
+): string {
   if (kind === "uv-tool") {
     return `uv tool install --force 'mempalace==${target}'`;
   }
@@ -213,18 +225,19 @@ export async function provisionMempalace(
     return outcome;
   }
 
-  if (section.autoProvision === false) {
+  // autoProvision governs creating/healing an unusable venv; autoUpdate
+  // governs reconciling a working one. Independent settings, so a
+  // healthy-but-drifted venv with autoProvision off still reaches the
+  // update path below (which never rebuilds a working install).
+  if (!probe.healthy && section.autoProvision === false) {
     return {
-      status: probe.healthy ? "ready" : "failed",
-      version: probe.version,
+      status: "failed",
       kind: "managed-venv",
       actions: [],
       warnings: [
-        probe.healthy
-          ? `installed ${probe.version}, pinned ${target} — autoProvision is off, run: ${python} -m pip install --upgrade 'mempalace==${target}'`
-          : `mempalace not usable (${probe.error}) and autoProvision is off — create the venv manually (see README) or re-enable autoProvision`,
+        `mempalace not usable (${probe.error}) and autoProvision is off — create the venv manually (see README) or re-enable autoProvision`,
       ],
-      error: probe.healthy ? undefined : probe.error,
+      error: probe.error,
     };
   }
 
@@ -290,7 +303,7 @@ function externalOutcome(
   pathExists: (p: string) => boolean,
 ): ProvisionOutcome {
   const kind = classifyExternalInstall(python);
-  const hint = upgradeHint(kind, python, target);
+  const hint = reconcileHint(kind, python, target);
   if (!pathExists(python)) {
     return {
       status: "failed",
@@ -314,9 +327,9 @@ function externalOutcome(
     };
   }
   const warnings: string[] = [];
-  if (compareVersions(probe.version!, target) < 0) {
+  if (compareVersions(probe.version!, target) !== 0) {
     warnings.push(
-      `installed ${probe.version}, Talon pins ${target} — operator-managed (${kind}), upgrade with: ${hint}`,
+      `installed ${probe.version}, Talon pins ${target} — operator-managed (${kind}), reconcile with: ${hint}`,
     );
   }
   return {
@@ -369,19 +382,28 @@ async function reconcile(ctx: ReconcileContext): Promise<ProvisionOutcome> {
   const warnings: string[] = [];
   let recreatedThisPass = false;
 
-  const fail = (error: string): ProvisionOutcome => {
+  const fail = async (error: string): Promise<ProvisionOutcome> => {
     markProvisionFailure(ctx.statePath, ctx.state, target, error, ctx.now());
     if (ctx.previous) {
+      // Trust nothing: the upgrade may have died mid-mutation. Re-probe
+      // the venv and, if the previous install is gone, put it back before
+      // reporting — "staying on X" must be true, not assumed.
+      const kept = await ensurePrevious(ctx, ctx.previous.version);
+      if (kept) {
+        warnings.push(
+          `upgrade to ${target} failed (${error}) — staying on working ${kept.version}${kept.restored ? " (rolled back)" : ""}, will retry with backoff`,
+        );
+        return {
+          status: "degraded",
+          version: kept.version,
+          kind: "managed-venv",
+          actions,
+          warnings,
+        };
+      }
       warnings.push(
-        `upgrade to ${target} failed (${error}) — staying on working ${ctx.previous.version}, will retry with backoff`,
+        `upgrade to ${target} failed (${error}) and the previous ${ctx.previous.version} could not be restored — self-heals at the next provision pass`,
       );
-      return {
-        status: "degraded",
-        version: ctx.previous.version,
-        kind: "managed-venv",
-        actions,
-        warnings,
-      };
     }
     return {
       status: "failed",
@@ -439,7 +461,7 @@ async function reconcile(ctx: ReconcileContext): Promise<ProvisionOutcome> {
   // Step 1 — ensure an interpreter exists at all.
   if (!pathExists(python)) {
     const err = await recreateVenv();
-    if (err) return fail(err);
+    if (err) return await fail(err);
   }
 
   // Step 2 — install/upgrade. A pass that started from a broken-but-present
@@ -466,15 +488,15 @@ async function reconcile(ctx: ReconcileContext): Promise<ProvisionOutcome> {
     if (!err) installed = await pipInstall(false);
   }
 
-  if (!installed.ok) return fail(failDetail(installed));
+  if (!installed.ok) return await fail(failDetail(installed));
 
   // Step 4 — trust nothing: verify the interpreter now serves the target.
   const verify = await probeHealth(exec, python);
   if (!verify.healthy) {
-    return fail(`installed but not importable: ${verify.error}`);
+    return await fail(`installed but not importable: ${verify.error}`);
   }
   if (verify.version !== target) {
-    return fail(
+    return await fail(
       `expected ${target} after install, found ${verify.version ?? "nothing"}`,
     );
   }
@@ -499,16 +521,55 @@ async function reconcile(ctx: ReconcileContext): Promise<ProvisionOutcome> {
 }
 
 /**
+ * After a failed upgrade: confirm the previous install still serves, or
+ * reinstall it. Returns what is serving now, or undefined when the venv
+ * is broken beyond a one-shot rollback (the next pass's heal ladder
+ * takes over from there).
+ */
+async function ensurePrevious(
+  ctx: ReconcileContext,
+  previous: string,
+): Promise<{ version: string; restored: boolean } | undefined> {
+  const still = await probeHealth(ctx.exec, ctx.python);
+  if (still.healthy) return { version: still.version!, restored: false };
+  const rollback = await ctx.exec(
+    ctx.python,
+    [
+      "-m",
+      "pip",
+      "install",
+      "--force-reinstall",
+      "--no-deps",
+      `mempalace==${previous}`,
+    ],
+    { timeoutMs: PIP_TIMEOUT_MS, env: { PIP_DISABLE_PIP_VERSION_CHECK: "1" } },
+  );
+  if (!rollback.ok) return undefined;
+  const after = await probeHealth(ctx.exec, ctx.python);
+  return after.healthy
+    ? { version: after.version!, restored: true }
+    : undefined;
+}
+
+/**
  * One-time palace data migrations, applied only to palaces that already
  * hold data (a chroma store) and recorded in the state ledger so they
  * run exactly once per deployment. `migrate-wings` itself is idempotent,
- * so a lost ledger costs one harmless re-run, never data.
+ * so a lost ledger costs one harmless re-run, never data. Gated on the
+ * serving version actually shipping the command — a pin below 3.4 has
+ * nothing to migrate to.
  */
 async function maybeMigratePalace(
   ctx: ReconcileContext,
   outcome: ProvisionOutcome,
 ): Promise<void> {
   if (ctx.state.migrations?.[WING_MIGRATION]) return;
+  if (
+    compareVersions(outcome.version ?? ctx.target, WING_MIGRATION_MIN_VERSION) <
+    0
+  ) {
+    return;
+  }
   if (!ctx.pathExists(join(ctx.palace, "chroma.sqlite3"))) return;
 
   const result = await ctx.exec(
@@ -554,16 +615,21 @@ export async function inspectMempalace(
   const pin = section.version ?? MEMPALACE_PINNED_VERSION;
   const managed =
     python === resolve(deps.defaultManagedPython ?? files.mempalacePython);
-  const kind = managed ? "managed venv" : classifyExternalInstall(python);
+  const flavor = managed ? "managed venv" : classifyExternalInstall(python);
+  const hint = reconcileHint(flavor, python, pin);
+  const provisionOff = section.autoProvision === false;
+  const updateOff = section.autoUpdate === false;
 
   if (!pathExists(python)) {
     return [
       {
-        label: `MemPalace runtime missing (${kind})`,
-        status: managed ? "warn" : "fail",
+        label: `MemPalace runtime missing (${flavor})`,
+        status: managed && !provisionOff ? "warn" : "fail",
         detail: managed
-          ? `provisions automatically at next talon start (pin ${pin})`
-          : `python not found at ${python}`,
+          ? provisionOff
+            ? `automatic provisioning disabled (mempalace.autoProvision: false) — create the venv manually (see README) or re-enable it`
+            : `provisions automatically at next talon start (pin ${pin})`
+          : `python not found at ${python} — fix the path or install with: ${hint}`,
         issue: true,
       },
     ];
@@ -572,25 +638,29 @@ export async function inspectMempalace(
   if (!probe.healthy) {
     return [
       {
-        label: `MemPalace broken (${kind})`,
-        status: "warn",
+        label: `MemPalace broken (${flavor})`,
+        status: managed && !provisionOff ? "warn" : "fail",
         detail: managed
-          ? "self-heals at next talon start"
-          : `mempalace not importable from ${python} (${probe.error})`,
+          ? provisionOff
+            ? `not importable (${probe.error}); automatic healing disabled (mempalace.autoProvision: false) — repair manually or re-enable it`
+            : "self-heals at next talon start"
+          : `mempalace not importable from ${python} (${probe.error}) — install with: ${hint}`,
         issue: true,
       },
     ];
   }
   if (probe.version === pin) {
-    return [{ label: `MemPalace ${probe.version} (${kind})`, status: "ok" }];
+    return [{ label: `MemPalace ${probe.version} (${flavor})`, status: "ok" }];
   }
   return [
     {
-      label: `MemPalace ${probe.version}, pinned ${pin} (${kind})`,
+      label: `MemPalace ${probe.version}, pinned ${pin} (${flavor})`,
       status: "warn",
       detail: managed
-        ? "reconciles at next talon start"
-        : "operator-managed install — upgrade when ready",
+        ? updateOff
+          ? `automatic update disabled (mempalace.autoUpdate: false) — run: ${hint}`
+          : "reconciles at next talon start"
+        : `operator-managed install — reconcile when ready with: ${hint}`,
       issue: managed,
     },
   ];

--- a/src/plugins/mempalace/provision.ts
+++ b/src/plugins/mempalace/provision.ts
@@ -55,12 +55,16 @@ const WING_MIGRATION = "wing-names";
 
 /**
  * One subprocess proves both facts that matter: the dist is installed
- * (metadata resolves) and the MCP server module actually imports.
+ * (metadata resolves) and the MCP server module actually imports. The
+ * version is printed and flushed BEFORE the import: mempalace's
+ * mcp_server rebinds sys.stdout to stderr at import time to protect the
+ * JSON-RPC channel from stray prints, so anything printed after it
+ * lands on the wrong stream.
  */
 const HEALTH_SNIPPET =
-  "import importlib.metadata as m; v = m.version('mempalace'); import mempalace.mcp_server; print(v)";
+  "import importlib.metadata as m, sys; print(m.version('mempalace')); sys.stdout.flush(); import mempalace.mcp_server";
 
-const PROBE_TIMEOUT_MS = 30_000;
+const PROBE_TIMEOUT_MS = 60_000;
 const VENV_TIMEOUT_MS = 120_000;
 const PIP_TIMEOUT_MS = 900_000;
 const MIGRATE_TIMEOUT_MS = 600_000;

--- a/src/plugins/playwright/provision.ts
+++ b/src/plugins/playwright/provision.ts
@@ -1,0 +1,241 @@
+/**
+ * Playwright provisioner — browser builds present before first use.
+ *
+ * @playwright/mcp launches its browser lazily, so a missing build used
+ * to surface as a mid-conversation tool error. This makes it a boot
+ * concern instead: when the configured engine's build is absent from
+ * the Playwright cache, run the bundled playwright-core CLI's `install`
+ * (idempotent, version-matched to the pinned @playwright/mcp — the cli
+ * resolves from the same dependency tree the MCP server runs).
+ *
+ * Deliberately out of scope, in line with never mutating what Talon
+ * doesn't own: system channels (chrome, msedge) — those belong to the
+ * OS; endpoint mode — the browser lives on the remote end.
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { DoctorCheck } from "../../core/doctor.js";
+import {
+  failDetail,
+  loadProvisionState,
+  markProvisionFailure,
+  markProvisionSuccess,
+  runStep,
+  shouldAttempt,
+  type ExecFn,
+  type ProvisionOutcome,
+} from "../../core/plugin/provision.js";
+import { dirs } from "../../util/paths.js";
+
+/** Engines whose builds Playwright manages (vs system channels). */
+const MANAGED_ENGINES = new Set(["chromium", "firefox", "webkit"]);
+
+const INSTALL_TIMEOUT_MS = 600_000;
+
+/** The `playwright` config section this module reads. */
+export interface PlaywrightSection {
+  browser?: string;
+  endpoint?: string;
+  endpointFile?: string;
+  autoProvision?: boolean;
+}
+
+export interface PlaywrightProvisionDeps {
+  exec?: ExecFn;
+  platform?: NodeJS.Platform;
+  home?: string;
+  env?: Record<string, string | undefined>;
+  now?: () => number;
+  statePath?: string;
+  cliPath?: string;
+  pathExists?: (p: string) => boolean;
+  listDir?: (p: string) => string[];
+}
+
+/**
+ * Where Playwright keeps downloaded builds, per OS — the same defaults
+ * playwright-core's registry uses, and the same override env var.
+ */
+export function browsersRoot(
+  platform: NodeJS.Platform,
+  home: string,
+  env: Record<string, string | undefined>,
+): string {
+  const override = env.PLAYWRIGHT_BROWSERS_PATH;
+  if (override && override !== "0") return override;
+  if (platform === "darwin") {
+    return join(home, "Library", "Caches", "ms-playwright");
+  }
+  if (platform === "win32") {
+    return join(
+      env.LOCALAPPDATA ?? join(home, "AppData", "Local"),
+      "ms-playwright",
+    );
+  }
+  return join(env.XDG_CACHE_HOME ?? join(home, ".cache"), "ms-playwright");
+}
+
+/** The bundled playwright-core CLI (version-matched to @playwright/mcp). */
+function defaultCliPath(): string {
+  return resolve(
+    import.meta.dirname ?? ".",
+    "../../../node_modules/playwright-core/cli.js",
+  );
+}
+
+const safeListDir = (p: string): string[] => {
+  try {
+    return readdirSync(p);
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * The engine build's presence is a directory-name check, not a
+ * subprocess: any build dir for the engine counts (chromium-1181,
+ * chromium_headless_shell-…).
+ */
+function browserPresent(
+  browser: string,
+  deps: Pick<
+    PlaywrightProvisionDeps,
+    "platform" | "home" | "env" | "listDir"
+  > = {},
+): boolean {
+  const root = browsersRoot(
+    deps.platform ?? process.platform,
+    deps.home ?? homedir(),
+    deps.env ?? process.env,
+  );
+  return (deps.listDir ?? safeListDir)(root).some((name) =>
+    name.startsWith(browser),
+  );
+}
+
+export async function provisionPlaywright(
+  section: PlaywrightSection,
+  deps: PlaywrightProvisionDeps = {},
+): Promise<ProvisionOutcome> {
+  const exec = deps.exec ?? runStep;
+  const now = deps.now ?? Date.now;
+  const pathExists = deps.pathExists ?? existsSync;
+  const browser = section.browser ?? "chromium";
+
+  if (section.endpoint ?? section.endpointFile) {
+    return { status: "skipped", kind: "endpoint", actions: [], warnings: [] };
+  }
+  if (!MANAGED_ENGINES.has(browser)) {
+    return {
+      status: "skipped",
+      kind: "system-channel",
+      actions: [],
+      warnings: [],
+    };
+  }
+  if (section.autoProvision === false) {
+    return { status: "skipped", kind: "managed", actions: [], warnings: [] };
+  }
+
+  if (browserPresent(browser, deps)) {
+    return { status: "ready", kind: "managed", actions: [], warnings: [] };
+  }
+
+  const cli = deps.cliPath ?? defaultCliPath();
+  if (!pathExists(cli)) {
+    return {
+      status: "failed",
+      kind: "managed",
+      actions: [],
+      warnings: [
+        `playwright-core CLI not found at ${cli} — reinstall dependencies (npm ci)`,
+      ],
+      error: "playwright-core missing",
+    };
+  }
+
+  const statePath =
+    deps.statePath ?? join(dirs.data, "playwright-provision.json");
+  const state = loadProvisionState(statePath);
+  // The pin key is the browser name: switching engines re-arms retries.
+  if (!shouldAttempt(state, browser, now())) {
+    return {
+      status: "degraded",
+      kind: "managed",
+      actions: [],
+      warnings: [
+        `last ${browser} download failed (${state.lastError ?? "unknown"}); retrying with backoff`,
+      ],
+    };
+  }
+
+  const installed = await exec(process.execPath, [cli, "install", browser], {
+    timeoutMs: INSTALL_TIMEOUT_MS,
+  });
+  if (!installed.ok) {
+    const detail = failDetail(installed);
+    // Linux-only failure class: the build downloaded but shared system
+    // libraries are missing — that fix needs root, so it stays advisory.
+    const depsHint = /missing dependencies|install-deps|apt-get/i.test(
+      installed.stderr,
+    )
+      ? ` — system libraries are missing; run: sudo npx playwright install-deps ${browser}`
+      : "";
+    markProvisionFailure(statePath, state, browser, detail, now());
+    return {
+      status: "degraded",
+      kind: "managed",
+      actions: [],
+      warnings: [
+        `${browser} download failed (${detail})${depsHint} — browser tools will error until resolved`,
+      ],
+      error: detail,
+    };
+  }
+
+  markProvisionSuccess(statePath, state, browser, now());
+  return {
+    status: "ready",
+    kind: "managed",
+    actions: [`downloaded ${browser} browser build`],
+    warnings: [],
+  };
+}
+
+/** Read-only doctor inspection: build present / endpoint mode. */
+export function inspectPlaywright(
+  section: PlaywrightSection,
+  deps: PlaywrightProvisionDeps = {},
+): DoctorCheck[] {
+  if (section.endpoint ?? section.endpointFile) {
+    return [
+      {
+        label: "Playwright: remote endpoint mode",
+        status: "info",
+        detail: "browser lives on the remote end",
+      },
+    ];
+  }
+  const browser = section.browser ?? "chromium";
+  if (!MANAGED_ENGINES.has(browser)) {
+    return [
+      {
+        label: `Playwright: system channel (${browser})`,
+        status: "info",
+        detail: "browser managed by the OS",
+      },
+    ];
+  }
+  return [
+    browserPresent(browser, deps)
+      ? { label: `Playwright ${browser} build present`, status: "ok" }
+      : {
+          label: `Playwright ${browser} build missing`,
+          status: "warn",
+          detail: "downloads automatically at next talon start",
+          issue: true,
+        },
+  ];
+}

--- a/src/plugins/playwright/provision.ts
+++ b/src/plugins/playwright/provision.ts
@@ -13,9 +13,9 @@
  * OS; endpoint mode — the browser lives on the remote end.
  */
 
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import type { DoctorCheck } from "../../core/doctor.js";
 import {
   failDetail,
@@ -52,6 +52,16 @@ export interface PlaywrightProvisionDeps {
   cliPath?: string;
   pathExists?: (p: string) => boolean;
   listDir?: (p: string) => string[];
+  /** playwright-core's browser registry (default: browsers.json beside the CLI). */
+  registry?: BrowserDescriptor[];
+}
+
+/** One entry of playwright-core's browsers.json. */
+export interface BrowserDescriptor {
+  name: string;
+  revision: string;
+  /** Per-host-platform revisions (e.g. webkit on older macOS). */
+  revisionOverrides?: Record<string, string>;
 }
 
 /**
@@ -93,16 +103,57 @@ const safeListDir = (p: string): string[] => {
   }
 };
 
+/** browsers.json shipped beside the CLI — the revisions this playwright-core needs. */
+function readRegistry(cli: string): BrowserDescriptor[] {
+  try {
+    const parsed = JSON.parse(
+      readFileSync(join(dirname(cli), "browsers.json"), "utf-8"),
+    ) as { browsers?: BrowserDescriptor[] };
+    return Array.isArray(parsed.browsers) ? parsed.browsers : [];
+  } catch {
+    return [];
+  }
+}
+
 /**
- * The engine build's presence is a directory-name check, not a
- * subprocess: any build dir for the engine counts (chromium-1181,
- * chromium_headless_shell-…).
+ * The build directories the registry requires for an engine: the engine
+ * itself plus its headless-shell companion (chromium runs headless via
+ * chromium-headless-shell; `install chromium` fetches both). Named the
+ * way playwright-core's registry names them — `<name with _>-<revision>`,
+ * or `<name>_<platform>_special-<revision>` for a per-platform override
+ * — and complete only once the registry's INSTALLATION_COMPLETE marker
+ * is present, so a stale revision from an older playwright-core or a
+ * half-downloaded build never passes for ready.
+ */
+function requiredBuildDirs(
+  browser: string,
+  registry: BrowserDescriptor[],
+): string[][] {
+  return registry
+    .filter((d) => d.name === browser || d.name === `${browser}-headless-shell`)
+    .map((d) => {
+      const prefix = d.name.replaceAll("-", "_");
+      return [
+        `${prefix}-${d.revision}`,
+        ...Object.entries(d.revisionOverrides ?? {}).map(
+          ([platform, revision]) => `${prefix}_${platform}_special-${revision}`,
+        ),
+      ];
+    });
+}
+
+/**
+ * Whether the engine's required builds are present and complete. Pure
+ * filesystem inspection, no subprocess. Without a readable registry
+ * (unexpected — it ships with playwright-core) any build directory for
+ * the engine counts, which is the pre-registry behavior.
  */
 function browserPresent(
   browser: string,
+  cli: string,
   deps: Pick<
     PlaywrightProvisionDeps,
-    "platform" | "home" | "env" | "listDir"
+    "platform" | "home" | "env" | "listDir" | "pathExists" | "registry"
   > = {},
 ): boolean {
   const root = browsersRoot(
@@ -110,8 +161,33 @@ function browserPresent(
     deps.home ?? homedir(),
     deps.env ?? process.env,
   );
-  return (deps.listDir ?? safeListDir)(root).some((name) =>
-    name.startsWith(browser),
+  const present = new Set((deps.listDir ?? safeListDir)(root));
+  const pathExists = deps.pathExists ?? existsSync;
+  const required = requiredBuildDirs(
+    browser,
+    deps.registry ?? readRegistry(cli),
+  );
+  if (required.length === 0) {
+    return [...present].some((name) => name.startsWith(browser));
+  }
+  return required.every((candidates) =>
+    candidates.some(
+      (dir) =>
+        present.has(dir) &&
+        pathExists(join(root, dir, "INSTALLATION_COMPLETE")),
+    ),
+  );
+}
+
+/** Forward the injected environment (e.g. PLAYWRIGHT_BROWSERS_PATH) to the CLI. */
+function execEnv(
+  env: Record<string, string | undefined> | undefined,
+): Record<string, string> | undefined {
+  if (!env) return undefined;
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      (e): e is [string, string] => e[1] !== undefined,
+    ),
   );
 }
 
@@ -139,11 +215,11 @@ export async function provisionPlaywright(
     return { status: "skipped", kind: "managed", actions: [], warnings: [] };
   }
 
-  if (browserPresent(browser, deps)) {
+  const cli = deps.cliPath ?? defaultCliPath();
+  if (browserPresent(browser, cli, deps)) {
     return { status: "ready", kind: "managed", actions: [], warnings: [] };
   }
 
-  const cli = deps.cliPath ?? defaultCliPath();
   if (!pathExists(cli)) {
     return {
       status: "failed",
@@ -173,6 +249,7 @@ export async function provisionPlaywright(
 
   const installed = await exec(process.execPath, [cli, "install", browser], {
     timeoutMs: INSTALL_TIMEOUT_MS,
+    env: execEnv(deps.env),
   });
   if (!installed.ok) {
     const detail = failDetail(installed);
@@ -228,13 +305,17 @@ export function inspectPlaywright(
       },
     ];
   }
+  const cli = deps.cliPath ?? defaultCliPath();
   return [
-    browserPresent(browser, deps)
+    browserPresent(browser, cli, deps)
       ? { label: `Playwright ${browser} build present`, status: "ok" }
       : {
           label: `Playwright ${browser} build missing`,
           status: "warn",
-          detail: "downloads automatically at next talon start",
+          detail:
+            section.autoProvision === false
+              ? `automatic download disabled (playwright.autoProvision: false) — run: npx playwright install ${browser}`
+              : "downloads automatically at next talon start",
           issue: true,
         },
   ];

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -267,6 +267,13 @@ const playwrightConfigSchema = z.object({
   enabled: z.boolean().default(false),
   /** Browser engine: chromium (default), chrome, firefox, webkit, msedge */
   browser: z.string().optional(),
+  /**
+   * Download the browser build automatically when missing (default
+   * true). Applies to Playwright-managed engines (chromium, firefox,
+   * webkit); system channels (chrome, msedge) and endpoint mode are
+   * never touched.
+   */
+  autoProvision: z.boolean().optional(),
   /** Run headless (default: true) */
   headless: z.boolean().default(true),
   /** Connect to an existing browser websocket endpoint. */
@@ -289,6 +296,19 @@ const mempalaceSettingsSchema = z.object({
   entityLanguages: z.array(z.string().min(2)).nonempty().optional(),
   /** Enable mempalace diagnostic diaries (sets MEMPAL_VERBOSE=1). */
   verbose: z.boolean().optional(),
+  /**
+   * Exact mempalace version for the Talon-managed venv (default: the
+   * built-in pin). Ignored for operator-managed installs (custom
+   * pythonPath) — those only get an advisory when they drift.
+   */
+  version: z
+    .string()
+    .regex(/^\d+\.\d+\.\d+$/, "exact version, e.g. 3.8.0")
+    .optional(),
+  /** Reconcile the managed venv to the pinned version (default true). */
+  autoUpdate: z.boolean().optional(),
+  /** Create/heal the managed venv automatically (default true). */
+  autoProvision: z.boolean().optional(),
 });
 
 /** mem0 backend settings, shared by `memory.mem0` and the top-level `mem0` section. */
@@ -496,6 +516,13 @@ const configSchema = z.object({
       enabled: z.boolean().default(false),
       /** GitHub personal access token (default: from `gh auth token`) */
       token: z.string().min(1).optional(),
+      /**
+       * github-mcp-server image tag (default: the built-in pin).
+       * "latest" opts out of pinning.
+       */
+      imageTag: z.string().min(1).optional(),
+      /** Pull the pinned Docker image automatically (default true). */
+      autoProvision: z.boolean().optional(),
     })
     .optional(),
 


### PR DESCRIPTION
## What

Native builtin plugins (MemPalace, Playwright, GitHub MCP) now provision, pin, update, heal, and migrate their own runtimes across Linux/macOS/Windows — zero manual setup, and existing installs are migrated, never broken.

### MemPalace → 3.8.0, fully managed
- **Pin**: `MEMPALACE_PINNED_VERSION = "3.8.0"` (config override: `mempalace.version`).
- **Self-install**: first boot creates `~/.talon/mempalace-venv` (cross-OS python discovery: `py -3` on Windows, `python3` elsewhere; Debian `python3-venv` hint on failure) and installs the pin.
- **Auto-update**: a working-but-behind venv boots immediately on the current version and reconciles to the pin **in the background** — the next MCP spawn picks it up. Failed upgrades keep the working install serving and retry with exponential backoff (5min→6h, re-armed instantly on pin change).
- **Self-heal ladder**: broken import → `--force-reinstall`; broken pip → `ensurepip` + pip upgrade; unusable venv → in-place rebuild (`venv --clear`, no rm -rf). Healing never sacrifices a working install.
- **Migration**: the ≥3.4 wing-name palace migration runs exactly once per deployment (ledgered, idempotent, only on palaces that hold data), wired through upgrades automatically.
- **Operator-managed installs respected**: a custom `pythonPath` (uv tool / pipx / conda / own venv — flavor auto-detected) is probed and advised with its exact upgrade command, never mutated. `~` in configured paths now expands (fixes the README example silently failing).

### Playwright + GitHub MCP
- Playwright downloads the managed engine's browser build at boot when missing, version-matched via the bundled playwright-core CLI. System channels (chrome/msedge) and endpoint mode untouched.
- GitHub MCP image pinned to `v1.11.0` (config `github.imageTag`; `latest` opts out) and pre-pulled in the background; docker-pull-on-first-use remains the fallback.

### Architecture
- Shared seam `src/core/plugin/provision.ts`: persisted state + backoff, never-throws exec with hard timeouts, python discovery, version compare.
- **Single source of truth** `src/core/plugin/native-runtimes.ts`: one descriptor per native runtime (`enabled`/`provision`/`inspect`) drives boot provisioning and `talon doctor`. Adding a runtime = one descriptor + its module.
- `talon doctor` now reports each enabled native runtime: version vs pin, flavor, and what fixes drift (read-only, never mutates).
- `/update` (telegram + discord) documents provisioning changes: the successor process reports runtime upgrades/migrations back to the requesting chat via cross-frontend send, only when something actually changed.

### CI — `.github/workflows/native-provision.yml`
- **Pinned matrix** (PRs touching provisioning + weekly): real installs on ubuntu/macos/windows — fresh venv → live MCP `initialize` handshake → self-heal from gutted site-packages → genuine `3.3.6 → pin` upgrade with the palace migration asserted.
- **Canary matrix** (weekly + dispatch): same suite against **latest** PyPI mempalace on all 3 OSes, real chromium download, and `github-mcp-server:latest` pull+smoke — a red canary means the next pin bump needs work before it lands.

### Local machine (already applied)
- uv tool install upgraded 3.3.5 → 3.8.0 and pinned (`mempalace==3.8.0` in the uv receipt).
- `migrate-wings` applied (3 drawers re-united), embedder identity recorded (`minilm`, dim=384) so search stays intact without a re-embed.

## Testing
- 31 new unit tests (`native-provision.test.ts`): every heal branch, backoff gating, Windows path shapes, operator-managed non-mutation, journal/report delivery.
- Env-gated real-environment suite (`integration/provision-real.test.ts`) driven by the new workflow.
- `tsc`, oxlint, prettier, depcruise, ratchets clean. Pre-existing local failures (baileys optional dep, UNDICI proxy warnings) confirmed present on clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016L3V3xkSsbDfU1hejMqqBi

---

## Update: automatic pin bumps + probe fix

- **detect → canary → autobump** (daily): `detect` compares source pins against PyPI / github-mcp-server releases. Anything newer triggers the canary matrix against the **exact candidate version** on all 3 OSes. Only canary-green targets get bumped: autobump opens a conventional `fix(plugins):` PR with auto-merge requested, so normal CI (incl. provision-real re-running against the new pin) still gates the land. Major-version jumps are opened for human review, never auto-merged. Add an `AUTOBUMP_TOKEN` PAT secret for full autonomy — default-token PRs don't trigger CI (GitHub recursion guard), so without it the bump PR carries canary evidence and waits for manual merge.
- **Probe fix**: mempalace's `mcp_server` rebinds `sys.stdout` → stderr at import (stdio JSON-RPC protection), so the health probe's version print landed on stderr and every verify reported "installed but not importable" — the first CI run's 3-OS failure. Version now prints + flushes before the import; probe timeout 60s for cold runners.
- Integration assertions carry the full provision outcome in failure messages — a red job names its cause.

---

## Update: review fixes (2d958621)

All 13 Copilot findings addressed, each thread replied to inline:
- **Post-update report** waits for tracked background reconcile tasks (upgrade / docker pull) to settle before reading the journal, then retries the send while frontends register; instant no-op when nothing is pending.
- **Playwright** presence is registry-exact (`browsers.json` revision + headless shell + `INSTALLATION_COMPLETE`), so a playwright-core bump or a half-finished download triggers the download; `PLAYWRIGHT_BROWSERS_PATH` is forwarded to the CLI.
- **MemPalace**: `autoProvision` (create/heal) and `autoUpdate` (reconcile) are independent; a failed upgrade re-probes and rolls back to the previous version if pip died mid-mutation; wing migration gated on ≥3.4; operator-managed drift advised in both directions.
- **Doctor** never promises an automatic fix that a disabled `auto*` flag prevents — names the setting and the manual command (flavor-specific for external installs); missing GitHub image counts as an issue.
- `failDetail` exit-code fallback fires on empty stderr; README example is cross-platform; Windows `browsersRoot` test fixed (the one red CI job).
