### PR TITLE
feat(companion): root execution tier for device control

### DIFF
--- a/apps/companion/android/app/src/main/kotlin/org/talon/companion/MainActivity.kt
+++ b/apps/companion/android/app/src/main/kotlin/org/talon/companion/MainActivity.kt
@@ -7,6 +7,7 @@ import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
     private var shizuku: ShizukuBridge? = null
+    private var root: RootBridge? = null
     private var voice: VoiceBridge? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -21,6 +22,16 @@ class MainActivity : FlutterActivity() {
         // activity's lifecycle (the mesh answers exec commands while the app is
         // backgrounded).
         shizuku = ShizukuBridge(channel, applicationContext)
+
+        // Root tier (su / adb-root agent), the rung above Shizuku. Same
+        // application-context reasoning: the su shell is process-wide and must
+        // outlive this activity, since the mesh answers commands with the app
+        // backgrounded.
+        val rootChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            RootBridge.CHANNEL,
+        )
+        root = RootBridge(rootChannel, applicationContext)
 
         // Voice mode: STT/TTS + default-assistant plumbing. Activity-scoped
         // (unlike Shizuku) because it drives runtime-permission prompts and

--- a/apps/companion/android/app/src/main/kotlin/org/talon/companion/RootBridge.kt
+++ b/apps/companion/android/app/src/main/kotlin/org/talon/companion/RootBridge.kt
@@ -1,0 +1,731 @@
+package org.talon.companion
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileFilter
+import java.io.OutputStreamWriter
+import java.util.UUID
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+/**
+ * MethodChannel bridge for the *root* execution tier — the rung above Shizuku
+ * in [org.talon.companion] device control.
+ *
+ * Dart (`DeviceExec`) calls:
+ *   - getStatus {probe} → the current privilege tier and everything needed to
+ *                         explain/repair it (uid, su binary, agent liveness,
+ *                         build type). `probe:true` may spawn `su`, which can
+ *                         raise a Magisk-style grant dialog; `probe:false`
+ *                         never does.
+ *   - exec {cmd,cwd,timeoutMs} → run at uid 0, return {stdout,stderr,exitCode,via}
+ *   - installAgent    → materialise the adb-root agent script, return the
+ *                       one-liner the user runs over adb
+ *   - stopAgent       → ask a running agent to exit
+ *
+ * Three ways this process can reach uid 0, tried in that order:
+ *
+ *  1. **Already root** — the process itself runs as uid 0 (a ROM that launches
+ *     Talon from a root context). Plain `sh -c` is already root, no wrapper.
+ *  2. **`su`** — Magisk / KernelSU / APatch, or any ROM whose `su` accepts an
+ *     app uid. [RootShell] keeps ONE long-lived su shell for the whole
+ *     process, so the user is prompted once and every later command is a
+ *     write + read on an open pipe instead of a fresh grant round trip.
+ *  3. **The adb-root agent** ([RootAgent]) — for a `userdebug` build where
+ *     `adb root` works but `su` refuses app uids (AOSP's `su` only allows uid
+ *     0 and uid 2000/shell, so a system app cannot use it either). The user
+ *     starts a small shell agent once over root adb; it runs as uid 0 until
+ *     reboot and takes commands through a spool directory inside Talon's own
+ *     private storage — which only root and this app can reach.
+ *
+ * A fourth, non-root tier is *reported* but needs no wrapper: when the APK is
+ * built into a ROM with `android:sharedUserId="android.uid.system"` and signed
+ * with the platform key, the process is uid 1000 (`system`) and ordinary
+ * `sh -c` already runs there. Being in `/system/priv-app` on its own does NOT
+ * do this — see docs/companion-root.md.
+ *
+ * Every path degrades: nothing here throwing or missing changes the outcome
+ * beyond "root unavailable", and Dart falls through to Shizuku and then to
+ * app-uid execution.
+ */
+class RootBridge(
+    channel: MethodChannel,
+    private val context: Context,
+) : MethodChannel.MethodCallHandler {
+
+    companion object {
+        const val CHANNEL = "talon/root"
+
+        /**
+         * Logcat tag for the whole root path. Release builds don't route
+         * Dart's `developer.log` to logcat, so when elevation silently fails
+         * this is the only trail. Diagnose with:
+         *   adb logcat -s TalonRoot
+         */
+        internal const val TAG = "TalonRoot"
+
+        /** uid of the Android `system` user — what a platform-signed build gets. */
+        private const val SYSTEM_UID = 1000
+    }
+
+    private val agent = RootAgent(context)
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    init {
+        channel.setMethodCallHandler(this)
+    }
+
+    private fun replySuccess(result: MethodChannel.Result, value: Any?) {
+        mainHandler.post { result.success(value) }
+    }
+
+    private fun replyError(result: MethodChannel.Result, code: String, message: String?) {
+        mainHandler.post { result.error(code, message, null) }
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "getStatus" -> {
+                val probe = call.argument<Boolean>("probe") == true
+                Thread { replySuccess(result, status(probe)) }.start()
+            }
+            "exec" -> exec(call, result)
+            "installAgent" -> Thread {
+                val ok = agent.install()
+                replySuccess(
+                    result,
+                    mapOf(
+                        "installed" to ok,
+                        "script" to agent.script.absolutePath,
+                        "command" to agent.adbCommand(),
+                    ),
+                )
+            }.start()
+            "stopAgent" -> Thread {
+                agent.stop()
+                replySuccess(result, null)
+            }.start()
+            else -> result.notImplemented()
+        }
+    }
+
+    // ── status ────────────────────────────────────────────────────────────────
+
+    /**
+     * Snapshot of the privilege tier. Runs off the platform thread: [probe]
+     * can spawn `su`, and even the cheap path stats the agent spool.
+     */
+    private fun status(probe: Boolean): Map<String, Any?> {
+        val uid = android.os.Process.myUid()
+        val agentAlive = agent.alive()
+        val suUsable = when {
+            uid == 0 -> false // already root; su is irrelevant
+            probe -> RootShell.ensure()
+            else -> RootShell.usable()
+        }
+        val method = when {
+            uid == 0 -> "uid0"
+            suUsable -> "su"
+            agentAlive -> "agent"
+            uid == SYSTEM_UID -> "system-uid"
+            else -> "none"
+        }
+        val tier = when (method) {
+            "uid0", "su", "agent" -> "root"
+            "system-uid" -> "system"
+            else -> "app"
+        }
+        val info = context.applicationInfo
+        return mapOf(
+            "tier" to tier,
+            "method" to method,
+            "state" to describe(method, agentAlive),
+            "uid" to uid,
+            "suDetected" to (RootShell.detectedSuPath() != null),
+            "suPath" to RootShell.activeSuPath(),
+            "suError" to RootShell.lastError,
+            "agentAlive" to agentAlive,
+            "agentScript" to agent.script.absolutePath,
+            "agentCommand" to agent.adbCommand(),
+            "buildType" to Build.TYPE,
+            "debuggable" to isDebuggableBuild(),
+            "systemApp" to ((info.flags and ApplicationInfo.FLAG_SYSTEM) != 0),
+            "privilegedApp" to isPrivilegedApp(info),
+        )
+    }
+
+    /** One human sentence for the settings row and for mesh status payloads. */
+    private fun describe(method: String, agentAlive: Boolean): String = when (method) {
+        "uid0" -> "root (process already runs as uid 0)"
+        "su" -> "root via su (${RootShell.activeSuPath() ?: "su"})"
+        "agent" -> "root via the adb agent"
+        "system-uid" -> "system uid 1000 (platform-signed build)"
+        else -> when {
+            agentAlive -> "agent running but not answering"
+            isDebuggableBuild() ->
+                "no root yet — userdebug build: flash Magisk, or start the " +
+                    "adb agent for this boot"
+            else -> "no root — no usable su. Flash Magisk to make it permanent."
+        }
+    }
+
+    /**
+     * `ro.debuggable=1` — true on `userdebug`/`eng` builds. Read through
+     * SystemProperties (hidden but stable and greylisted-max-target-o, so
+     * still reachable) with a Build.TYPE fallback for when reflection is
+     * blocked.
+     */
+    private fun isDebuggableBuild(): Boolean {
+        val prop = try {
+            val cls = Class.forName("android.os.SystemProperties")
+            cls.getMethod("get", String::class.java, String::class.java)
+                .invoke(null, "ro.debuggable", "0") as? String
+        } catch (_: Throwable) {
+            null
+        }
+        if (prop == "1") return true
+        return Build.TYPE == "userdebug" || Build.TYPE == "eng"
+    }
+
+    /**
+     * Whether the APK sits in `/system/priv-app` (privileged permissions).
+     * `ApplicationInfo.isPrivilegedApp()` is hidden, so fall back to the
+     * PRIVATE_FLAG_PRIVILEGED bit read reflectively.
+     */
+    private fun isPrivilegedApp(info: ApplicationInfo): Boolean {
+        try {
+            val m = info.javaClass.getMethod("isPrivilegedApp")
+            return m.invoke(info) as Boolean
+        } catch (_: Throwable) {
+            // fall through
+        }
+        return try {
+            val field = ApplicationInfo::class.java.getDeclaredField("privateFlags")
+            field.isAccessible = true
+            val flags = field.getInt(info)
+            (flags and (1 shl 3)) != 0 // PRIVATE_FLAG_PRIVILEGED
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
+    // ── exec ──────────────────────────────────────────────────────────────────
+
+    private fun exec(call: MethodCall, result: MethodChannel.Result) {
+        val cmd = call.argument<String>("cmd") ?: ""
+        val cwd = call.argument<String>("cwd")
+        val timeoutMs = (call.argument<Number>("timeoutMs")?.toLong()) ?: 60_000L
+        Thread {
+            val uid = android.os.Process.myUid()
+            // Already uid 0: the ordinary shell IS the root shell. Going
+            // through su here would be a pointless (and on some ROMs failing)
+            // round trip.
+            if (uid == 0) {
+                val res = RootShell.execDirect(cmd, cwd, timeoutMs)
+                if (res != null) {
+                    replySuccess(result, res.toMap("uid0"))
+                    return@Thread
+                }
+            }
+            if (uid != 0 && RootShell.ensure()) {
+                val res = RootShell.exec(cmd, cwd, timeoutMs)
+                if (res != null) {
+                    replySuccess(result, res.toMap("su"))
+                    return@Thread
+                }
+                Log.w(TAG, "su shell failed for: ${cmd.take(120)} — trying the agent")
+            }
+            if (agent.alive()) {
+                val res = agent.exec(cmd, cwd, timeoutMs)
+                if (res != null) {
+                    replySuccess(result, res.toMap("agent"))
+                    return@Thread
+                }
+                Log.w(TAG, "root agent failed for: ${cmd.take(120)}")
+            }
+            replyError(
+                result,
+                "root_unavailable",
+                "No root path available (uid=$uid, su=${RootShell.usable()}, " +
+                    "agent=${agent.alive()}, suError=${RootShell.lastError})",
+            )
+        }.start()
+    }
+}
+
+/** stdout/stderr/exit of one elevated command. */
+internal data class ShellResult(val stdout: String, val stderr: String, val exitCode: Int) {
+    fun toMap(via: String): Map<String, Any?> = mapOf(
+        "stdout" to stdout,
+        "stderr" to stderr,
+        "exitCode" to exitCode,
+        "via" to via,
+    )
+}
+
+/**
+ * One process-wide `su` shell, kept open.
+ *
+ * Process-wide (an `object`, not a per-bridge field) because the activity
+ * engine and the foreground-service engine each construct their own
+ * [RootBridge] inside the SAME OS process: a shell per bridge would mean two
+ * grant prompts and two root shells for one app.
+ *
+ * Long-lived rather than `su -c <cmd>` per command for three reasons: the root
+ * manager prompts once instead of per command, each later command costs a pipe
+ * write instead of a process spawn plus policy check, and a failed/denied
+ * grant is remembered so the next mesh command doesn't re-prompt in a loop.
+ */
+internal object RootShell {
+    /** Sentinel pushed by a reader thread when its stream hits EOF. */
+    private const val EOF = " __TALON_EOF__"
+
+    /**
+     * How long a dead-end `su` probe is remembered before we try again. Without
+     * this, every mesh exec on a stock phone would spawn (and fail) the whole
+     * candidate list — the common case, since most devices have no root at all.
+     */
+    private const val FAILURE_TTL_MS = 60_000L
+
+    /**
+     * Candidate `su` binaries. Bare "su" first so PATH resolution finds the
+     * root manager's own shim (Magisk relocates its binary and hides the path
+     * from app-visible stats). `--mount-master` is tried first per candidate so
+     * a Magisk shell sees the global mount namespace — otherwise `/sdcard` and
+     * other per-app mounts differ from what the daemon expects.
+     */
+    private val CANDIDATES = listOf(
+        "su",
+        "/system/bin/su",
+        "/system/xbin/su",
+        "/sbin/su",
+        "/debug_ramdisk/su",
+        "/su/bin/su",
+        "/magisk/.core/bin/su",
+    )
+
+    private val lock = Any()
+    private var proc: Process? = null
+    private var stdin: OutputStreamWriter? = null
+    private val outQ = LinkedBlockingQueue<String>()
+    private val errQ = LinkedBlockingQueue<String>()
+    private var failedAt = 0L
+
+    @Volatile
+    var lastError: String? = null
+        private set
+
+    @Volatile
+    private var suPath: String? = null
+
+    fun activeSuPath(): String? = suPath
+
+    /** A `su` binary we can see without executing anything. Best-effort: a
+     *  hidden Magisk install reports null here yet still works when run. */
+    fun detectedSuPath(): String? =
+        CANDIDATES.firstOrNull { it.startsWith("/") && File(it).exists() }
+
+    /** True when a root shell is open right now — never spawns or prompts. */
+    fun usable(): Boolean = synchronized(lock) { isLive() }
+
+    private fun isLive(): Boolean {
+        val p = proc ?: return false
+        return try {
+            p.exitValue()
+            false
+        } catch (_: IllegalThreadStateException) {
+            true
+        }
+    }
+
+    /** Open a root shell if there isn't one. May prompt the root manager. */
+    fun ensure(): Boolean = synchronized(lock) {
+        if (isLive()) return true
+        close()
+        if (System.currentTimeMillis() - failedAt < FAILURE_TTL_MS) return false
+        for (path in CANDIDATES) {
+            if (tryOpen(arrayOf(path, "--mount-master"))) return true
+            if (tryOpen(arrayOf(path))) return true
+        }
+        failedAt = System.currentTimeMillis()
+        Log.i(RootBridge.TAG, "no usable su (last error: $lastError)")
+        return false
+    }
+
+    private fun tryOpen(args: Array<String>): Boolean {
+        val p = try {
+            ProcessBuilder(*args).redirectErrorStream(false).start()
+        } catch (t: Throwable) {
+            lastError = "${args.first()}: ${t.message}"
+            return false
+        }
+        proc = p
+        stdin = OutputStreamWriter(p.outputStream)
+        outQ.clear()
+        errQ.clear()
+        drain(p.inputStream.bufferedReader(), outQ)
+        drain(p.errorStream.bufferedReader(), errQ)
+        // Prove it: a shell that opened but didn't elevate (a denied grant
+        // that still exec'd a normal shell) must not be mistaken for root.
+        val probe = execLocked("id -u", null, 10_000L)
+        if (probe != null && probe.stdout.trim() == "0") {
+            suPath = args.first()
+            lastError = null
+            Log.i(RootBridge.TAG, "root shell open via ${args.joinToString(" ")}")
+            return true
+        }
+        lastError = "${args.joinToString(" ")} did not yield uid 0" +
+            (probe?.stderr?.trim()?.takeIf { it.isNotEmpty() }?.let { ": $it" } ?: "")
+        close()
+        return false
+    }
+
+    private fun drain(reader: BufferedReader, queue: LinkedBlockingQueue<String>) {
+        Thread {
+            try {
+                while (true) {
+                    val line = reader.readLine() ?: break
+                    queue.put(line)
+                }
+            } catch (_: Throwable) {
+                // Stream closed under us — the EOF sentinel below unblocks any
+                // command still waiting on it.
+            }
+            queue.put(EOF)
+        }.apply { isDaemon = true }.start()
+    }
+
+    private fun close() {
+        try {
+            stdin?.close()
+        } catch (_: Throwable) {
+        }
+        try {
+            proc?.destroy()
+        } catch (_: Throwable) {
+        }
+        stdin = null
+        proc = null
+    }
+
+    fun exec(cmd: String, cwd: String?, timeoutMs: Long): ShellResult? = synchronized(lock) {
+        if (!isLive()) return null
+        execLocked(cmd, cwd, timeoutMs)
+    }
+
+    /**
+     * Run [cmd] in the open shell and read back its output.
+     *
+     * The shell is a single long-lived pipe shared by every command, so a
+     * command's end has to be *in band*: a random marker is echoed on both
+     * streams after the command, carrying the exit status on stdout. Both
+     * streams are marked because stderr has no other end-of-command signal and
+     * would otherwise leak into the next command's output.
+     *
+     * The command runs as `sh -c` inside a group with stdin closed, so a
+     * program that reads stdin (`read`, an interactive prompt) can't eat the
+     * protocol out of the pipe and desynchronise every later command.
+     */
+    private fun execLocked(cmd: String, cwd: String?, timeoutMs: Long): ShellResult? {
+        val w = stdin ?: return null
+        val mark = "__TALON_" + UUID.randomUUID().toString().replace("-", "") + "__"
+        outQ.clear()
+        errQ.clear()
+        val script = buildString {
+            append("{ ")
+            if (!cwd.isNullOrEmpty()) append("cd ").append(shQuote(cwd)).append(" 2>/dev/null; ")
+            append("sh -c ").append(shQuote(cmd))
+            append("; } </dev/null\n")
+            append("__talon_rc=$?\n")
+            append("echo \"$mark\$__talon_rc\"\n")
+            append("echo \"$mark\" 1>&2\n")
+        }
+        try {
+            w.write(script)
+            w.flush()
+        } catch (t: Throwable) {
+            lastError = "write to root shell failed: ${t.message}"
+            close()
+            return null
+        }
+        val deadline = System.currentTimeMillis() + timeoutMs
+        val out = StringBuilder()
+        val exit = collect(outQ, mark, out, deadline) ?: run {
+            // Timed out or the shell died mid-command: its pipe state is now
+            // unknown (a half-read marker would corrupt the NEXT command), so
+            // the shell is torn down rather than reused.
+            close()
+            return null
+        }
+        val err = StringBuilder()
+        collect(errQ, mark, err, deadline)
+        return ShellResult(out.toString(), err.toString(), exit.trim().toIntOrNull() ?: -1)
+    }
+
+    /**
+     * Drain [queue] into [sink] until the marker. Returns whatever followed the
+     * marker on that line (the exit code, for stdout), or null if the stream
+     * ended or the deadline passed first.
+     *
+     * The marker is searched for anywhere in the line, not just at its start:
+     * a command whose output has no trailing newline (`printf abc`) leaves the
+     * marker echo appended to that same line.
+     */
+    private fun collect(
+        queue: LinkedBlockingQueue<String>,
+        mark: String,
+        sink: StringBuilder,
+        deadline: Long,
+    ): String? {
+        while (true) {
+            val wait = deadline - System.currentTimeMillis()
+            if (wait <= 0) return null
+            val line = queue.poll(wait, TimeUnit.MILLISECONDS) ?: return null
+            if (line === EOF) return null
+            val at = line.indexOf(mark)
+            if (at < 0) {
+                sink.append(line).append('\n')
+                continue
+            }
+            if (at > 0) sink.append(line, 0, at)
+            return line.substring(at + mark.length)
+        }
+    }
+
+    /**
+     * Run a command in a plain shell — used only when the process is ALREADY
+     * uid 0, where `sh -c` needs no elevation wrapper.
+     */
+    fun execDirect(cmd: String, cwd: String?, timeoutMs: Long): ShellResult? {
+        return try {
+            val pb = ProcessBuilder("sh", "-c", cmd)
+            if (!cwd.isNullOrEmpty()) {
+                val dir = File(cwd)
+                if (dir.isDirectory) pb.directory(dir)
+            }
+            val p = pb.start()
+            val out = StringBuilder()
+            val err = StringBuilder()
+            val to = Thread { p.inputStream.bufferedReader().copyInto(out) }
+            val te = Thread { p.errorStream.bufferedReader().copyInto(err) }
+            to.start()
+            te.start()
+            // Not Process.waitFor(long, TimeUnit): that overload is API 26+,
+            // and desugaring doesn't cover java.lang.Process. A waiter thread
+            // bounded by join() works on every level we ship to.
+            val waiter = Thread {
+                try {
+                    p.waitFor()
+                } catch (_: InterruptedException) {
+                }
+            }
+            waiter.start()
+            waiter.join(timeoutMs)
+            val finished = !waiter.isAlive
+            to.join(1_000)
+            te.join(1_000)
+            if (!finished) {
+                p.destroy()
+                ShellResult(out.toString(), err.toString() + "\n[killed: timeout]", -1)
+            } else {
+                ShellResult(out.toString(), err.toString(), p.exitValue())
+            }
+        } catch (t: Throwable) {
+            lastError = "direct exec failed: ${t.message}"
+            null
+        }
+    }
+
+    /** POSIX single-quote for safe interpolation into a shell command. */
+    fun shQuote(s: String): String = "'" + s.replace("'", "'\\''") + "'"
+}
+
+private fun BufferedReader.copyInto(sb: StringBuilder) {
+    use { reader ->
+        val buf = CharArray(4096)
+        while (true) {
+            val n = reader.read(buf)
+            if (n < 0) break
+            sb.append(buf, 0, n)
+        }
+    }
+}
+
+/**
+ * The adb-root agent: root on a `userdebug` device that has no `su` an app may
+ * use.
+ *
+ * The gap it fills: on a userdebug build `adb root` restarts adbd as uid 0, so
+ * *the developer* has root — but the app still doesn't. AOSP's `su` refuses
+ * every uid except 0 and 2000/shell, so neither an ordinary app nor a
+ * system-uid app can call it. Something started from outside has to hold the
+ * privilege and hand it over.
+ *
+ * That something is a ~20-line shell loop the user starts once over root adb.
+ * It runs as uid 0 until reboot and polls a spool directory for work:
+ *
+ *   files/rootd/agent.sh   the loop itself, written by [install]
+ *   files/rootd/alive      touched every tick — the liveness heartbeat
+ *   files/rootd/q/<id>.cmd a request (renamed into place, never written there)
+ *   files/rootd/q/<id>.{out,err,code,done}  the reply
+ *
+ * The spool lives in Talon's private storage, which is the access control: on
+ * a stock Android only uid 0 and this app can enter that directory, so no
+ * other app can queue work for a root shell. The agent chmods its replies so
+ * the app can read files that root created.
+ *
+ * A request is written to `<id>.tmp` and *renamed* to `<id>.cmd` because rename
+ * is atomic — a plain write would let the agent pick up a half-written command.
+ */
+internal class RootAgent(private val context: Context) {
+
+    val dir: File get() = File(context.filesDir, "rootd")
+    val script: File get() = File(dir, "agent.sh")
+    private val queue: File get() = File(dir, "q")
+    private val heartbeat: File get() = File(dir, "alive")
+
+    /** Heartbeat older than this and the agent is treated as gone. */
+    private val staleMs = 15_000L
+
+    /** How often the reply spool is checked while a command is in flight. */
+    private val pollMs = 25L
+
+    fun alive(): Boolean {
+        val hb = heartbeat
+        return hb.exists() && System.currentTimeMillis() - hb.lastModified() < staleMs
+    }
+
+    /** Write (or refresh) the agent script. Idempotent. */
+    fun install(): Boolean = try {
+        dir.mkdirs()
+        queue.mkdirs()
+        if (!script.exists() || script.readText() != SCRIPT) script.writeText(SCRIPT)
+        // World-readable so the root adb shell can read it out of app storage
+        // without first having to chase SELinux labels.
+        script.setReadable(true, false)
+        dir.setExecutable(true, false)
+        true
+    } catch (t: Throwable) {
+        Log.w(RootBridge.TAG, "agent install failed", t)
+        false
+    }
+
+    /** The one-liner a user runs to start the agent. */
+    fun adbCommand(): String =
+        "adb root && adb shell \"setsid sh ${script.absolutePath} " +
+            ">/dev/null 2>&1 </dev/null &\""
+
+    fun stop() {
+        try {
+            File(dir, "stop").writeText("1")
+        } catch (_: Throwable) {
+        }
+    }
+
+    fun exec(cmd: String, cwd: String?, timeoutMs: Long): ShellResult? {
+        if (!install()) return null
+        val id = "t${System.currentTimeMillis()}-${UUID.randomUUID().toString().take(8)}"
+        val tmp = File(queue, "$id.tmp")
+        val req = File(queue, "$id.cmd")
+        val done = File(queue, "$id.done")
+        try {
+            if (!cwd.isNullOrEmpty()) File(queue, "$id.cwd").writeText(cwd)
+            // Trailing newline: the agent runs this file with `sh <file>`, and
+            // a last line without one is a needless portability gamble.
+            tmp.writeText(if (cmd.endsWith("\n")) cmd else "$cmd\n")
+            if (!tmp.renameTo(req)) return null
+            val deadline = System.currentTimeMillis() + timeoutMs
+            while (System.currentTimeMillis() < deadline) {
+                if (done.exists()) {
+                    return ShellResult(
+                        File(queue, "$id.out").readTextOrEmpty(),
+                        File(queue, "$id.err").readTextOrEmpty(),
+                        File(queue, "$id.code").readTextOrEmpty().trim().toIntOrNull() ?: -1,
+                    )
+                }
+                // The agent may have died between the liveness check and now;
+                // don't burn the caller's whole timeout waiting on a corpse.
+                if (!alive()) return null
+                Thread.sleep(pollMs)
+            }
+            Log.w(RootBridge.TAG, "agent command timed out: ${cmd.take(120)}")
+            return null
+        } catch (t: Throwable) {
+            Log.w(RootBridge.TAG, "agent command failed", t)
+            return null
+        } finally {
+            // Explicit FileFilter: File.listFiles is overloaded for both
+            // FileFilter and FilenameFilter, and a bare lambda leaves the
+            // conversion to overload resolution.
+            queue.listFiles(FileFilter { f -> f.name.startsWith("$id.") })
+                ?.forEach { it.delete() }
+        }
+    }
+
+    private fun File.readTextOrEmpty(): String = try {
+        if (exists()) readText() else ""
+    } catch (_: Throwable) {
+        ""
+    }
+
+    private companion object {
+        /**
+         * Deliberately plain `/system/bin/sh` (mksh) + toybox: this has to run
+         * on a bare AOSP userdebug image with nothing installed.
+         *
+         * The command runs in a subshell so a `cd` inside it can't leak into
+         * the next request, and with stdin closed so an interactive program
+         * can't stall the loop forever. Replies are chmod 666 because root
+         * creates them inside the app's directory, where the app would
+         * otherwise not be able to read its own results.
+         */
+        val SCRIPT = """
+            #!/system/bin/sh
+            # Talon root agent — started once over `adb root` on a userdebug
+            # device; serves elevated commands to the Talon companion until
+            # reboot. See docs/companion-root.md.
+            case "${'$'}0" in */*) DIR=${'$'}{0%/*};; *) DIR=.;; esac
+            Q="${'$'}DIR/q"
+            mkdir -p "${'$'}Q"
+            echo ${'$'}${'$'} > "${'$'}DIR/pid"; chmod 0666 "${'$'}DIR/pid" 2>/dev/null
+            ticks=0
+            while :; do
+              if [ -f "${'$'}DIR/stop" ]; then
+                rm -f "${'$'}DIR/stop" "${'$'}DIR/alive" "${'$'}DIR/pid"
+                exit 0
+              fi
+              : > "${'$'}DIR/alive"; chmod 0666 "${'$'}DIR/alive" 2>/dev/null
+              for req in "${'$'}Q"/*.cmd; do
+                [ -f "${'$'}req" ] || continue
+                id=${'$'}{req%.cmd}
+                [ -f "${'$'}id.done" ] && continue
+                cwd=""
+                [ -f "${'$'}id.cwd" ] && cwd=${'$'}(cat "${'$'}id.cwd")
+                (
+                  [ -n "${'$'}cwd" ] && cd "${'$'}cwd" 2>/dev/null
+                  sh "${'$'}req"
+                ) > "${'$'}id.out" 2> "${'$'}id.err" < /dev/null
+                echo ${'$'}? > "${'$'}id.code"
+                chmod 0666 "${'$'}id.out" "${'$'}id.err" "${'$'}id.code" 2>/dev/null
+                : > "${'$'}id.done"; chmod 0666 "${'$'}id.done" 2>/dev/null
+              done
+              # A command the app gave up on leaves its spool files behind
+              # (the app cleans up only what it waited for). Sweep anything
+              # older than 10 minutes, roughly once a minute.
+              ticks=${'$'}((ticks + 1))
+              if [ ${'$'}((ticks % 600)) -eq 0 ]; then
+                find "${'$'}Q" -type f -mmin +10 -delete 2>/dev/null
+              fi
+              sleep 0.1
+            done
+        """.trimIndent() + "\n"
+    }
+}

--- a/apps/companion/android/app/src/main/kotlin/org/talon/companion/ShizukuBridge.kt
+++ b/apps/companion/android/app/src/main/kotlin/org/talon/companion/ShizukuBridge.kt
@@ -200,8 +200,17 @@ class ShizukuBridge(
             } catch (_: Throwable) {
                 "unavailable"
             }
-            Log.i(TAG, "getStatus -> ready=$granted state=$state uid=${shizukuUid()}")
-            replySuccess(result, mapOf("ready" to granted, "state" to state))
+            val uid = shizukuUid()
+            Log.i(TAG, "getStatus -> ready=$granted state=$state uid=$uid")
+            // The uid is the difference between "shell privilege" and actual
+            // root: a Shizuku server started while adbd itself was root (the
+            // `adb root` path on a userdebug device) runs at uid 0, and every
+            // command through this bridge is then a ROOT command. Reporting it
+            // lets Dart advertise the real tier instead of always saying shell.
+            replySuccess(
+                result,
+                mapOf("ready" to granted, "state" to state, "uid" to uid),
+            )
         }.start()
     }
 

--- a/apps/companion/android/app/src/main/kotlin/org/talon/companion/TalonApplication.kt
+++ b/apps/companion/android/app/src/main/kotlin/org/talon/companion/TalonApplication.kt
@@ -8,8 +8,8 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
 /**
- * Registers the `talon/shizuku` platform channel on the FOREGROUND SERVICE's
- * Flutter engine.
+ * Registers the `talon/shizuku` and `talon/root` platform channels on the
+ * FOREGROUND SERVICE's Flutter engine.
  *
  * The mesh loop (SSE + exec) runs inside the foreground service's own isolate
  * so teleport keeps working after the activity is gone — but that engine is
@@ -30,6 +30,7 @@ class TalonApplication : Application() {
         FlutterForegroundTaskPlugin.addTaskLifecycleListener(
             object : FlutterForegroundTaskLifecycleListener {
                 private var shizuku: ShizukuBridge? = null
+                private var root: RootBridge? = null
 
                 override fun onEngineCreate(flutterEngine: FlutterEngine?) {
                     val engine = flutterEngine ?: return
@@ -38,6 +39,11 @@ class TalonApplication : Application() {
                         ShizukuBridge.CHANNEL,
                     )
                     shizuku = ShizukuBridge(channel, applicationContext)
+                    val rootChannel = MethodChannel(
+                        engine.dartExecutor.binaryMessenger,
+                        RootBridge.CHANNEL,
+                    )
+                    root = RootBridge(rootChannel, applicationContext)
                 }
 
                 override fun onTaskStart(starter: FlutterForegroundTaskStarter) {}
@@ -48,6 +54,11 @@ class TalonApplication : Application() {
 
                 override fun onEngineWillDestroy() {
                     shizuku = null
+                    // The su shell itself is process-wide (RootShell) and
+                    // deliberately survives this — the service engine is torn
+                    // down and rebuilt on restarts, and re-prompting for root
+                    // each time would defeat the point.
+                    root = null
                 }
             },
         )

--- a/apps/companion/lib/src/services/device_exec.dart
+++ b/apps/companion/lib/src/services/device_exec.dart
@@ -12,25 +12,38 @@ import 'log.dart';
 /// `stat`/`delete`/`mkdir`/`move` commands over the mesh; this runs them here
 /// and returns a structured payload.
 ///
-/// Two privilege tiers:
-///   - app-UID (default): commands run as the app's own user via the
-///     platform shell (see [DeviceExec.shellInvocation]), and file IO uses
-///     dart:io. This can reach shared storage (Downloads,
-///     DCIM, …) when the app holds All-files access (MANAGE_EXTERNAL_STORAGE),
-///     but not other apps' private data.
+/// Three privilege tiers, each tried in turn and each degrading into the next:
+///   - root (Android, best): uid 0 via the `talon/root` channel — a `su`
+///     binary (Magisk/KernelSU/APatch), a process that already runs as root,
+///     or the adb-root agent for a `userdebug` device whose `su` refuses app
+///     uids. Also reached when Shizuku itself was started as root (`adb root`
+///     before Shizuku's start script), in which case the Shizuku path below
+///     already IS root and is reported as such.
 ///   - Shizuku (optional, Android): when Shizuku is installed, running, and
 ///     has granted permission, commands run at shell (ADB) privilege via the
 ///     `talon/shizuku` platform channel — enough to reach far more of the
 ///     system without root. Falls back to app-UID whenever Shizuku is absent
 ///     or denied.
+///   - app-UID (default, always available): commands run as the app's own
+///     user via the platform shell (see [DeviceExec.shellInvocation]), and
+///     file IO uses dart:io. This can reach shared storage (Downloads, DCIM,
+///     …) when the app holds All-files access (MANAGE_EXTERNAL_STORAGE), but
+///     not other apps' private data.
+///
+/// A platform-signed system build (uid 1000) is a fourth tier that needs no
+/// wrapper — plain `sh -c` already runs at uid 1000 there — so it uses the
+/// app-UID path and is only *reported* differently. See docs/companion-root.md.
 class DeviceExec {
   DeviceExec({
     MethodChannel? shizukuChannel,
+    MethodChannel? rootChannel,
     bool Function()? isAndroid,
   })  : _shizuku = shizukuChannel ?? const MethodChannel('talon/shizuku'),
+        _root = rootChannel ?? const MethodChannel('talon/root'),
         _isAndroid = isAndroid ?? (() => !kIsWeb && Platform.isAndroid);
 
   final MethodChannel _shizuku;
+  final MethodChannel _root;
   final bool Function() _isAndroid;
   Future<bool>? _pendingShizukuPermission;
 
@@ -39,6 +52,22 @@ class DeviceExec {
   /// readiness probe so an app-UID fallback can say *why* Shizuku wasn't used,
   /// in the command result that travels back over the mesh — no adb needed.
   String? _lastShizukuState;
+
+  /// Last root-tier snapshot from the `talon/root` bridge, and when it was
+  /// taken. Probing costs a `su` spawn (and, the first time, a grant dialog),
+  /// so the answer is reused for [_rootProbeTtl] rather than re-derived on
+  /// every mesh command.
+  Map<String, dynamic>? _lastRoot;
+  DateTime? _rootProbedAt;
+  Future<Map<String, dynamic>?>? _pendingRootProbe;
+
+  /// Why the root path was last abandoned mid-command, and when. Held apart
+  /// from [_lastRoot] because the bridge's own snapshot is refreshed on every
+  /// status read and would otherwise wipe the demotion the moment anything
+  /// asked for the tier — leaving the executor retrying a path it has already
+  /// watched fail.
+  String? _rootFailure;
+  DateTime? _rootFailedAt;
 
   /// Commands this executor can answer — merged into the device's advertised
   /// mesh capabilities so the daemon gates cleanly.
@@ -51,9 +80,9 @@ class DeviceExec {
     'delete',
     'mkdir',
     'move',
-    // Silent self-update: install a pushed APK via Shizuku. Advertised
-    // everywhere device control is on; answers with a clear "only on
-    // Android / needs Shizuku" when it can't actually run.
+    // Silent self-update: install a pushed APK at an elevated tier (root or
+    // Shizuku). Advertised everywhere device control is on; answers with a
+    // clear "only on Android / needs elevation" when it can't actually run.
     'install_apk',
   ];
 
@@ -86,6 +115,12 @@ class DeviceExec {
   static const int _maxChunkBytes = 256 * 1024;
   static const Duration _shizukuPermissionWait = Duration(seconds: 12);
 
+  /// How long a root probe's answer is trusted before asking the bridge again.
+  /// Short enough that starting the adb agent (or granting su) takes effect
+  /// without restarting the app, long enough that a stock phone with no root
+  /// isn't re-probed on every single command.
+  static const Duration _rootProbeTtl = Duration(seconds: 30);
+
   /// How long to wait for stdout/stderr to close after the shell itself has
   /// exited. A backgrounded child holding the inherited pipes must not pin
   /// the exec call open past this.
@@ -95,6 +130,92 @@ class DeviceExec {
   /// the very END of stdout, and losing it would break cwd tracking.
   static const int _execOutputHeadBytes = 192 * 1024;
   static const int _execOutputTailBytes = 64 * 1024;
+
+  /// The root bridge's view of this device: tier, how root was reached (or
+  /// why it wasn't), the adb-agent one-liner, and the build's own properties.
+  /// `null` off Android.
+  ///
+  /// [probe] `false` (the default) never spawns `su`, so it can't raise a
+  /// grant dialog — that's the mode status payloads and the settings screen
+  /// use. [probe] `true` actually tries to acquire root.
+  Future<Map<String, dynamic>?> rootStatus({bool probe = false}) async {
+    if (!_isAndroid()) return null;
+    try {
+      final status = await _root.invokeMapMethod<String, dynamic>(
+        'getStatus',
+        {'probe': probe},
+      );
+      if (status != null) {
+        _lastRoot = status;
+        AppLog.info(
+          'root',
+          'getStatus tier=${status['tier']} method=${status['method']} '
+              'uid=${status['uid']}',
+        );
+      }
+      return status;
+    } catch (e) {
+      // No bridge at all (older build, non-Android engine): not an error, just
+      // the absence of the root tier.
+      _lastRoot = {'tier': 'app', 'method': 'none', 'state': 'unavailable: $e'};
+      return _lastRoot;
+    }
+  }
+
+  /// Write the adb-root agent script to disk and return the one-liner that
+  /// starts it. Android only; `null` elsewhere.
+  Future<Map<String, dynamic>?> installRootAgent() async {
+    if (!_isAndroid()) return null;
+    try {
+      return await _root.invokeMapMethod<String, dynamic>('installAgent');
+    } catch (e) {
+      AppLog.warn('root', 'installAgent failed', e);
+      return null;
+    }
+  }
+
+  /// True when a root path is available now, acquiring one if needed. The
+  /// answer is cached for [_rootProbeTtl] and concurrent callers share one
+  /// probe, so a burst of mesh commands can't stack up `su` spawns (or grant
+  /// dialogs) on top of each other.
+  Future<bool> ensureRootReady() async {
+    if (!_isAndroid()) return false;
+    if (_rootDemoted) return false;
+    final cached = _lastRoot;
+    final probedAt = _rootProbedAt;
+    if (cached != null &&
+        probedAt != null &&
+        DateTime.now().difference(probedAt) < _rootProbeTtl) {
+      return cached['tier'] == 'root';
+    }
+    final probe = _pendingRootProbe ??=
+        rootStatus(probe: true).whenComplete(() {
+      _pendingRootProbe = null;
+      _rootProbedAt = DateTime.now();
+    });
+    final status = await probe;
+    return status?['tier'] == 'root';
+  }
+
+  /// Stop trusting the cached "root is available" answer after the root path
+  /// itself failed, so the next command falls straight through to Shizuku
+  /// instead of paying for a doomed elevation attempt each time.
+  void _demoteRoot(String why) {
+    _rootFailure = why;
+    _rootFailedAt = DateTime.now();
+  }
+
+  /// Whether a recent root failure still stands. Expires with the same TTL as
+  /// a probe, so genuinely transient breakage (an agent restarted, a revoked
+  /// grant re-granted) heals without an app restart.
+  bool get _rootDemoted {
+    final at = _rootFailedAt;
+    if (at == null) return false;
+    if (DateTime.now().difference(at) < _rootProbeTtl) return true;
+    _rootFailure = null;
+    _rootFailedAt = null;
+    return false;
+  }
 
   /// True when Shizuku is available AND has granted permission right now.
   Future<bool> shizukuReady() async {
@@ -158,22 +279,56 @@ class DeviceExec {
     return requestShizuku();
   }
 
+  /// The tier this device would execute at right now, for the mesh `status`
+  /// payload and the settings screen. Never prompts: it reports what is
+  /// already available rather than trying to acquire anything.
   Future<Map<String, String>> privilegeStatus() async {
     // Desktop platforms run commands as the logged-in OS user; the
-    // shizuku/app distinction is Android-only.
+    // root/shizuku/app distinction is Android-only.
     if (!_isAndroid()) return const {'execPrivilege': 'user'};
+    Map<String, dynamic>? shizuku;
     try {
-      final status =
-          await _shizuku.invokeMapMethod<String, dynamic>('getStatus');
-      final ready = status?['ready'] == true;
-      final state = status?['state'];
-      return {
-        'execPrivilege': ready ? 'shizuku' : 'app',
-        'shizuku': state is String ? state : 'unavailable',
-      };
+      shizuku = await _shizuku.invokeMapMethod<String, dynamic>('getStatus');
     } catch (_) {
-      return const {'execPrivilege': 'app', 'shizuku': 'unavailable'};
+      shizuku = null;
     }
+    final root = await rootStatus();
+    final shizukuReady = shizuku?['ready'] == true;
+    // A Shizuku server started while adbd was root runs at uid 0, so this
+    // "shell" path is really root. Report the privilege the commands actually
+    // get, not the mechanism that carries them.
+    final shizukuUid = (shizuku?['uid'] as num?)?.toInt();
+    final shizukuIsRoot = shizukuReady && shizukuUid == 0;
+    final rootMethod = root?['method'];
+    // A root path that failed mid-command is not the tier this device runs at,
+    // however healthy the bridge's own snapshot looks.
+    final rootTier = _rootDemoted ? 'app' : root?['tier'];
+    final (privilege, method) = switch ((rootTier, shizukuIsRoot)) {
+      ('root', _) => ('root', rootMethod is String ? rootMethod : 'root'),
+      (_, true) => ('root', 'shizuku'),
+      _ when shizukuReady => ('shizuku', 'shizuku'),
+      ('system', _) => ('system', 'system-uid'),
+      _ => ('app', 'none'),
+    };
+    return {
+      'execPrivilege': privilege,
+      'execVia': method,
+      'shizuku': shizuku?['state'] is String
+          ? '${shizuku!['state']}${shizukuIsRoot ? ' (uid 0)' : ''}'
+          : 'unavailable',
+      if (_rootStateLabel() != null) 'root': _rootStateLabel()!,
+    };
+  }
+
+  /// Human description of the root tier for status payloads and the settings
+  /// row — the bridge's own words, or the failure that overrode them.
+  String? _rootStateLabel() {
+    final failure = _rootDemoted ? _rootFailure : null;
+    final state = _lastRoot?['state'];
+    if (failure != null) {
+      return state is String ? '$state, then $failure' : failure;
+    }
+    return state is String ? state : null;
   }
 
   /// Dispatch a mesh command by name; returns `null` for names this executor
@@ -235,7 +390,23 @@ class DeviceExec {
     }
     final budget =
         Duration(milliseconds: (timeoutMs ?? 60000).clamp(1000, 300000));
-    // Prefer Shizuku (shell UID). If it is installed but permission has not
+    // Root first — it is the only tier that reaches other apps' data, /data,
+    // and the whole system, so anything the daemon asks for lands where the
+    // operator expects rather than inside a scoped-storage view.
+    if (await ensureRootReady()) {
+      try {
+        final res = await _root.invokeMapMethod<String, dynamic>('exec', {
+          'cmd': cmd,
+          if (cwd != null) 'cwd': cwd,
+          'timeoutMs': budget.inMilliseconds,
+        });
+        if (res != null) return _nativeOutcome(res, 'root');
+      } catch (e) {
+        AppLog.warn('exec', 'root exec failed, falling back', e);
+        _demoteRoot('exec failed: $e');
+      }
+    }
+    // Then Shizuku (shell UID). If it is installed but permission has not
     // been granted yet, ask once; otherwise a remote filesystem command can
     // silently run as the app UID and return a misleading scoped-storage view.
     if (await ensureShizukuReady()) {
@@ -245,17 +416,7 @@ class DeviceExec {
           if (cwd != null) 'cwd': cwd,
           'timeoutMs': budget.inMilliseconds,
         });
-        if (res != null) {
-          return CommandOutcome(
-            ok: (res['exitCode'] as num?)?.toInt() == 0,
-            data: {
-              'stdout': _CappedOutput.clamp('${res['stdout'] ?? ''}'),
-              'stderr': _CappedOutput.clamp('${res['stderr'] ?? ''}'),
-              'exitCode': (res['exitCode'] as num?)?.toInt() ?? -1,
-              'via': 'shizuku',
-            },
-          );
-        }
+        if (res != null) return _nativeOutcome(res, 'shizuku');
       } catch (e) {
         AppLog.warn('exec', 'shizuku exec failed, falling back', e);
         return _execAppUid(
@@ -271,9 +432,26 @@ class DeviceExec {
       cwd: cwd,
       budget: budget,
       privilegeWarning: _isAndroid()
-          ? 'Shizuku not used (state=${_lastShizukuState ?? 'unknown'}); '
-              'ran as app UID.'
+          ? 'Elevation not used (root=${_rootStateLabel() ?? 'unknown'}, '
+              'shizuku=${_lastShizukuState ?? 'unknown'}); ran as app UID.'
           : null,
+    );
+  }
+
+  /// One elevated result (root or Shizuku bridge) as a [CommandOutcome].
+  /// `via` names the tier; `rootMethod` (su / agent / uid0) is carried through
+  /// so a mesh reply says *how* root was reached, not merely that it was.
+  CommandOutcome _nativeOutcome(Map<String, dynamic> res, String via) {
+    final exit = (res['exitCode'] as num?)?.toInt();
+    return CommandOutcome(
+      ok: exit == 0,
+      data: {
+        'stdout': _CappedOutput.clamp('${res['stdout'] ?? ''}'),
+        'stderr': _CappedOutput.clamp('${res['stderr'] ?? ''}'),
+        'exitCode': exit ?? -1,
+        'via': via,
+        if (via == 'root' && res['via'] is String) 'rootMethod': res['via'],
+      },
     );
   }
 
@@ -350,9 +528,9 @@ class DeviceExec {
   /// is being swapped, with no manual reopen.
   ///
   /// Three things make it robust:
-  ///   1. It requires Shizuku (shell/ADB UID). The app UID cannot install a
-  ///      package without a user tapping through PackageInstaller, which a
-  ///      headless mesh command can't do.
+  ///   1. It requires an elevated tier — root, or Shizuku's shell/ADB UID. The
+  ///      app UID cannot install a package without a user tapping through
+  ///      PackageInstaller, which a headless mesh command can't do.
   ///   2. The APK is RE-STAGED into /data/local/tmp before `pm install`. The
   ///      daemon pushes to app storage (/sdcard/Download), which the shell can
   ///      read but the system installer cannot — `pm install` straight off an
@@ -376,10 +554,13 @@ class DeviceExec {
       return CommandOutcome.fail('install_apk is only supported on Android.');
     }
     if (path.isEmpty) return CommandOutcome.fail('No APK path given.');
-    if (!await ensureShizukuReady()) {
+    final elevated = await ensureRootReady() || await ensureShizukuReady();
+    if (!elevated) {
       return CommandOutcome.fail(
-        'Silent install needs Shizuku (state=${_lastShizukuState ?? 'unavailable'}). '
-        'Install Shizuku, grant Talon permission, and retry.',
+        'Silent install needs root or Shizuku '
+        '(root=${_rootStateLabel() ?? 'unavailable'}, '
+        'shizuku=${_lastShizukuState ?? 'unavailable'}). '
+        'Grant root, or install Shizuku and grant Talon permission, then retry.',
       );
     }
     // Existence is probed through the elevated shell, not dart:io — the shell
@@ -387,7 +568,7 @@ class DeviceExec {
     // shell-owned locations like /data/local/tmp at all.
     try {
       final probe =
-          await _shizukuExec('test -f ${_shQuote(path)} && echo ok', 15000);
+          await _elevatedExec('test -f ${_shQuote(path)} && echo ok', 15000);
       if ('${probe?['stdout'] ?? ''}'.trim() != 'ok') {
         return CommandOutcome.fail('No such APK on device: $path');
       }
@@ -401,7 +582,7 @@ class DeviceExec {
     if (!path.startsWith('$stageDir/')) {
       staged = '$stageDir/talon-companion-update.apk';
       try {
-        final cp = await _shizukuExec(
+        final cp = await _elevatedExec(
           'cp -f ${_shQuote(path)} ${_shQuote(staged)}',
           120000,
         );
@@ -423,7 +604,7 @@ class DeviceExec {
     if (sha256 != null && sha256.isNotEmpty) {
       try {
         final check =
-            await _shizukuExec('sha256sum ${_shQuote(staged)}', 30000);
+            await _elevatedExec('sha256sum ${_shQuote(staged)}', 30000);
         final line = '${check?['stdout'] ?? ''}'.trim();
         final digest = line.isEmpty ? '' : line.split(RegExp(r'\s+')).first;
         if (digest.isEmpty) {
@@ -451,7 +632,7 @@ class DeviceExec {
         'echo "exit=\$?" >> ${_shQuote(logPath)}'
         '${copied ? '; rm -f ${_shQuote(staged)}' : ''}';
     try {
-      await _shizukuExec(
+      await _elevatedExec(
         'setsid sh -c ${_shQuote(worker)} >/dev/null 2>&1 &',
         5000,
       );
@@ -467,16 +648,33 @@ class DeviceExec {
         'stagedPath': staged,
         'delayMs': delay,
         'log': logPath,
-        'via': 'shizuku',
+        'via': (!_rootDemoted && _lastRoot?['tier'] == 'root')
+            ? 'root'
+            : 'shizuku',
       },
     );
   }
 
-  Future<Map<String, dynamic>?> _shizukuExec(String cmd, int timeoutMs) =>
-      _shizuku.invokeMapMethod<String, dynamic>('exec', {
-        'cmd': cmd,
-        'timeoutMs': timeoutMs,
-      });
+  /// Run one command at the highest tier available, for the install pipeline's
+  /// own staging steps. Root when we have it, Shizuku otherwise — the caller
+  /// has already established that one of the two is available.
+  Future<Map<String, dynamic>?> _elevatedExec(String cmd, int timeoutMs) async {
+    if (await ensureRootReady()) {
+      try {
+        return await _root.invokeMapMethod<String, dynamic>('exec', {
+          'cmd': cmd,
+          'timeoutMs': timeoutMs,
+        });
+      } catch (e) {
+        AppLog.warn('exec', 'root exec failed, falling back', e);
+        _demoteRoot('exec failed: $e');
+      }
+    }
+    return _shizuku.invokeMapMethod<String, dynamic>('exec', {
+      'cmd': cmd,
+      'timeoutMs': timeoutMs,
+    });
+  }
 
   /// POSIX single-quote a string for safe interpolation into a shell command.
   static String _shQuote(String s) => "'${s.replaceAll("'", "'\\''")}'";

--- a/apps/companion/lib/src/services/mesh_service.dart
+++ b/apps/companion/lib/src/services/mesh_service.dart
@@ -137,6 +137,21 @@ class MeshService {
     // file bodies) to the claiming client only, and checks transfer tokens
     // against the device they were minted for.
     client.meshDeviceId = await deviceId();
+    // Warm the privilege ladder now rather than on the first command. On a
+    // device that reboots constantly (a car head unit powering up with the
+    // ignition) the root grant would otherwise be acquired mid-command, with
+    // the root manager's dialog appearing while someone is driving and the
+    // command blocked behind it. Fire-and-forget: nothing here gates the mesh.
+    if (prefs.meshDeviceControl) {
+      unawaited(
+        _exec.ensureRootReady().catchError(
+          (Object e) {
+            AppLog.debug('mesh', 'root warm-up failed', e);
+            return false;
+          },
+        ),
+      );
+    }
     await _foregroundStarter();
     try {
       await register();

--- a/apps/companion/lib/src/ui/settings_screen.dart
+++ b/apps/companion/lib/src/ui/settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../models/bridge_models.dart';
 import '../services/autostart.dart';
+import '../services/device_exec.dart';
 import '../services/dynamic_accent.dart';
 import '../services/haptics.dart';
 import '../services/message_notifications.dart';
@@ -122,6 +123,20 @@ class _SettingsScreenState extends State<SettingsScreen>
   bool _voicesLoading = false;
   int _voicePreviewSeq = 0;
 
+  /// Android's execution-privilege ladder for device control (root → Shizuku →
+  /// app UID). Read from the platform bridges, not from prefs — the tier is a
+  /// property of the device, not a setting. Its own executor rather than the
+  /// mesh service's: the channels are process-wide, so a grant obtained here
+  /// is the same grant the background mesh isolate then uses.
+  final DeviceExec _exec = DeviceExec();
+  Map<String, dynamic>? _rootInfo;
+  Map<String, String>? _privilege;
+  bool _rootBusy = false;
+
+  /// Android only — every other platform runs commands as the logged-in user
+  /// and has no ladder to show.
+  bool get _showsPrivilege => defaultTargetPlatform == TargetPlatform.android;
+
   @override
   void initState() {
     super.initState();
@@ -152,6 +167,7 @@ class _SettingsScreenState extends State<SettingsScreen>
       _refreshAssistantStatus();
       _loadVoices();
     }
+    if (_showsPrivilege) unawaited(_refreshPrivilege());
   }
 
   @override
@@ -321,6 +337,79 @@ class _SettingsScreenState extends State<SettingsScreen>
       // the platform query fails; the config UI must remain usable.
       AppLog.warn('settings', 'mesh status refresh failed', e);
     }
+  }
+
+  /// Re-read the privilege ladder. [probe] `true` actually *tries* to take
+  /// root (spawning `su`, which raises the root manager's grant dialog), so it
+  /// is only ever passed from the explicit button — opening Settings must not
+  /// pop a root prompt.
+  Future<void> _refreshPrivilege({bool probe = false}) async {
+    if (!_showsPrivilege) return;
+    if (probe) setState(() => _rootBusy = true);
+    try {
+      final root = await _exec.rootStatus(probe: probe);
+      final privilege = await _exec.privilegeStatus();
+      if (!mounted) return;
+      setState(() {
+        _rootInfo = root;
+        _privilege = privilege;
+      });
+    } catch (e) {
+      AppLog.warn('settings', 'privilege refresh failed', e);
+    } finally {
+      if (mounted && probe) setState(() => _rootBusy = false);
+    }
+  }
+
+  /// The adb-root path: write the agent script, then show the one-liner to run
+  /// from a computer. This is the tier for a `userdebug` phone where `adb root`
+  /// works but no `su` will serve an app uid.
+  Future<void> _showRootAgentSetup() async {
+    final info = await _exec.installRootAgent();
+    if (!mounted) return;
+    final command = '${info?['command'] ?? _rootInfo?['agentCommand'] ?? ''}';
+    if (command.isEmpty) {
+      _toast('Could not prepare the root agent on this device.');
+      return;
+    }
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Root via adb'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'On a userdebug build, run this once from a computer with the '
+              'device connected. Talon picks the agent up within 30 seconds.\n\n'
+              'It stops at the next reboot — for a device that power-cycles '
+              'on its own, flash Magisk instead and use Request root.',
+              style: TextStyle(fontSize: 13, color: TalonColors.textDim),
+            ),
+            const SizedBox(height: 12),
+            SelectableText(
+              command,
+              style: const TextStyle(fontSize: 12, fontFamily: 'monospace'),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: command));
+              _toast('Command copied');
+            },
+            child: const Text('Copy'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Done'),
+          ),
+        ],
+      ),
+    );
+    await _refreshPrivilege();
   }
 
   Future<void> _apply(Map<String, dynamic> update) async {
@@ -1272,12 +1361,14 @@ class _SettingsScreenState extends State<SettingsScreen>
           _switchRow(
             'Device control',
             'Let Talon run shell + file commands on this device (teleport). '
-                'Uses app permissions, or Shizuku if available for elevated access.',
+                'Runs at the highest privilege available: root, else Shizuku, '
+                'else the app itself.',
             prefs.meshDeviceControl,
             prefs.meshSharing
                 ? (v) => widget.state.setMeshDeviceControl(v)
                 : null,
           ),
+          if (_showsPrivilege && prefs.meshDeviceControl) _privilegeRow(),
           const Divider(height: 22),
           Row(
             children: [
@@ -1317,6 +1408,58 @@ class _SettingsScreenState extends State<SettingsScreen>
       case MeshForegroundHealthKind.stale:
         return _Health.bad;
     }
+  }
+
+  /// The live privilege tier for device control, plus the two ways to raise
+  /// it. Read-only status by design — the tier is what the device grants, not
+  /// something a switch here can turn on.
+  Widget _privilegeRow() {
+    final tier = _privilege?['execPrivilege'];
+    final (label, health) = switch (tier) {
+      'root' => ('Root', _Health.ok),
+      'system' => ('System (uid 1000)', _Health.ok),
+      'shizuku' => ('Shizuku (shell)', _Health.ok),
+      'app' => ('App only', _Health.warn),
+      _ => ('Checking…', _Health.info),
+    };
+    final detail = _privilege?['root'] ?? 'reading privilege…';
+    // The adb agent is only worth offering where `adb root` can actually
+    // work — a user build has no root adbd to start it with.
+    final debuggable = _rootInfo?['debuggable'] == true;
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _check(health, label, detail),
+          Row(
+            children: [
+              TextButton.icon(
+                onPressed: _rootBusy
+                    ? null
+                    : () => _refreshPrivilege(probe: tier != 'root'),
+                icon: _rootBusy
+                    ? const SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.shield_outlined, size: 16),
+                // Probing when we already have root is just a refresh; when we
+                // don't, it is the request that raises the su grant dialog.
+                label: Text(tier == 'root' ? 'Recheck' : 'Request root'),
+              ),
+              if (debuggable && tier != 'root')
+                TextButton.icon(
+                  onPressed: _rootBusy ? null : _showRootAgentSetup,
+                  icon: const Icon(Icons.usb, size: 16),
+                  label: const Text('Root via adb'),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
   }
 
   Widget _meshDeviceRow(DeviceInfo device, DeviceLocation? loc) {

--- a/apps/companion/test/device_exec_test.dart
+++ b/apps/companion/test/device_exec_test.dart
@@ -124,8 +124,136 @@ void main() {
     expect(result.data!['via'], 'app');
     // The fallback warning surfaces the actual Shizuku state (why it wasn't
     // used) so a remote caller can diagnose without adb.
-    expect(result.data!['privilegeWarning'], contains('state=not-running'));
+    expect(result.data!['privilegeWarning'], contains('shizuku=not-running'));
     expect(result.data!['privilegeWarning'], contains('app UID'));
+  });
+
+  test('root outranks Shizuku and never falls through to it', () async {
+    const root = MethodChannel('talon/root-test-ready');
+    const shizuku = MethodChannel('talon/shizuku-test-outranked');
+    var shizukuCalls = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(root, (call) async {
+      switch (call.method) {
+        case 'getStatus':
+          return {'tier': 'root', 'method': 'su', 'state': 'root via su', 'uid': 10123};
+        case 'exec':
+          return {
+            'stdout': 'uid=0',
+            'stderr': '',
+            'exitCode': 0,
+            'via': 'su',
+          };
+      }
+      return null;
+    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(shizuku, (call) async {
+      shizukuCalls++;
+      return null;
+    });
+    addTearDown(() {
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(root, null);
+      messenger.setMockMethodCallHandler(shizuku, null);
+    });
+
+    final elevated = DeviceExec(
+      rootChannel: root,
+      shizukuChannel: shizuku,
+      isAndroid: () => true,
+    );
+    final result = await elevated.exec('id -u');
+
+    expect(shizukuCalls, 0);
+    expect(result.ok, isTrue);
+    expect(result.data!['via'], 'root');
+    // How root was reached travels with the result, so a mesh reply
+    // distinguishes a Magisk grant from the adb agent without another probe.
+    expect(result.data!['rootMethod'], 'su');
+    expect(result.data!['stdout'], 'uid=0');
+  });
+
+  test('a failing root path degrades to Shizuku for the same command',
+      () async {
+    const root = MethodChannel('talon/root-test-broken');
+    const shizuku = MethodChannel('talon/shizuku-test-rescue');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(root, (call) async {
+      if (call.method == 'getStatus') {
+        return {'tier': 'root', 'method': 'agent', 'state': 'root via the adb agent'};
+      }
+      // The agent died between the probe and the command.
+      throw PlatformException(code: 'root_unavailable');
+    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(shizuku, (call) async {
+      switch (call.method) {
+        case 'getStatus':
+          return {'ready': true, 'state': 'ready', 'uid': 2000};
+        case 'exec':
+          return {'stdout': 'shell', 'stderr': '', 'exitCode': 0};
+      }
+      return null;
+    });
+    addTearDown(() {
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(root, null);
+      messenger.setMockMethodCallHandler(shizuku, null);
+    });
+
+    final dev = DeviceExec(
+      rootChannel: root,
+      shizukuChannel: shizuku,
+      isAndroid: () => true,
+    );
+    final result = await dev.exec('id -u');
+
+    expect(result.ok, isTrue);
+    expect(result.data!['via'], 'shizuku');
+    // Root was demoted, so the tier reported afterwards matches what actually
+    // ran rather than the stale probe.
+    expect((await dev.privilegeStatus())['execPrivilege'], 'shizuku');
+  });
+
+  test('a Shizuku server started as root is reported as root, not shell',
+      () async {
+    const root = MethodChannel('talon/root-test-absent');
+    const shizuku = MethodChannel('talon/shizuku-test-uid0');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(root, (call) async {
+      if (call.method == 'getStatus') {
+        return {'tier': 'app', 'method': 'none', 'state': 'no root'};
+      }
+      return null;
+    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(shizuku, (call) async {
+      if (call.method == 'getStatus') {
+        // uid 0 = Shizuku's own server was started from a root adb shell.
+        return {'ready': true, 'state': 'ready', 'uid': 0};
+      }
+      return null;
+    });
+    addTearDown(() {
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(root, null);
+      messenger.setMockMethodCallHandler(shizuku, null);
+    });
+
+    final dev = DeviceExec(
+      rootChannel: root,
+      shizukuChannel: shizuku,
+      isAndroid: () => true,
+    );
+    final privilege = await dev.privilegeStatus();
+
+    expect(privilege['execPrivilege'], 'root');
+    expect(privilege['execVia'], 'shizuku');
+    expect(privilege['shizuku'], contains('uid 0'));
   });
 
   test('caps runaway exec output but keeps the tail (cwd marker survives)',

--- a/docs/companion-root.md
+++ b/docs/companion-root.md
@@ -1,0 +1,180 @@
+# Companion root access (Android)
+
+Device control (teleport) runs at the **highest privilege the device will give
+it**, picked per command with no configuration:
+
+| Tier | uid | How it's reached | What it adds |
+| --- | --- | --- | --- |
+| `root` | 0 | `su`, an already-root process, the adb agent, or a Shizuku server started as root | Everything: `/data`, other apps' data, `pm`, `settings`, `service call` |
+| `system` | 1000 | The APK built into a ROM, platform-signed, with `sharedUserId=android.uid.system` | Most system state; still SELinux-confined to `system_app` |
+| `shizuku` | 2000 | The [Shizuku](https://shizuku.rikka.app/) app (see [companion-shizuku.md](companion-shizuku.md)) | Shell/ADB reach without rooting |
+| `app` | 10xxx | Always | The app's own storage, plus shared storage with All-files access |
+
+The tier in force is reported in the mesh `status` payload as `execPrivilege`
+(with `execVia` naming the mechanism), and shown in the app under
+**Settings → Mesh → Device control**. Every `exec` result carries `via`, and a
+root result also carries `rootMethod` (`su` / `agent` / `uid0`), so a command's
+reply says what it actually ran as.
+
+## Which path to use
+
+**If the bootloader is unlocked, flash Magisk and stop reading.** It is a
+one-time job, root then survives every reboot, and Talon needs no setup at all:
+the first elevated command takes the grant and keeps it. This is the only
+sensible answer for a device that power-cycles constantly — a car head unit
+comes up with the ignition, and anything that needs a laptop plugged in per
+boot is not a solution there.
+
+The adb agent below is a **workbench tool**: it dies at reboot by design (it is
+just a shell process). Use it to try things on a userdebug device you have on a
+desk, not as the standing arrangement for an embedded unit.
+
+Talon warms the ladder when the mesh starts rather than on the first command,
+so on a device that reboots often the grant is taken at boot instead of a root
+dialog appearing mid-drive with a command stuck behind it.
+
+## Two things that are commonly assumed and are not true
+
+**Installing the APK as a system app does not grant root.** Dropping an APK in
+`/system/app` or `/system/priv-app` sets `FLAG_SYSTEM` and makes the app
+eligible for privileged permissions — it does not change its uid. To actually
+run as uid 1000 the build needs *both* `android:sharedUserId="android.uid.system"`
+in its manifest *and* a signature from the ROM's platform key. That is a ROM
+build, not an install (see [Building a system-uid APK](#building-a-system-uid-apk)).
+
+**`adb root` on a userdebug device does not give the app root either.** It
+restarts `adbd` as uid 0, so *the developer* has root over adb. AOSP's `su`
+(`system/extras/su`) refuses every caller except uid 0 and uid 2000/shell — so
+neither an ordinary app nor even a system-uid app can call it. Something
+started from outside has to hold the privilege and hand it over. Two supported
+ways to do that are below.
+
+## 1. `su` (Magisk, KernelSU, APatch, or a permissive ROM)
+
+Nothing to set up in Talon. The first elevated command (or **Request root** in
+settings) spawns `su`, the root manager prompts once, and the grant sticks
+across reboots.
+
+With an unlocked bootloader this is the whole job: patch the device's
+`boot.img` with the Magisk app, `fastboot flash boot magisk_patched.img`, then
+open Talon and press **Request root**. Many aftermarket Android head units also
+ship with `su` already present, in which case even that is unnecessary — press
+the button and see what the tier row says.
+
+In Magisk, set Talon's superuser grant to **Allow** (and leave the timeout at
+"forever"); a prompt that nobody is there to tap is what turns a rooted device
+back into an app-uid one.
+
+`RootShell` keeps **one long-lived su shell for the whole process** rather than
+running `su -c <cmd>` per command: one grant prompt instead of one per command,
+each later command costing a pipe write instead of a process spawn, and a
+denial remembered so a burst of mesh commands can't re-prompt in a loop. The
+same shell serves both Flutter engines (the activity's and the foreground
+service's) because they share one OS process.
+
+Commands are framed in that shared pipe with a random end-of-command marker
+echoed on **both** streams, carrying the exit status on stdout. The command
+itself runs as `sh -c` in a group with **stdin closed**, so a program that
+reads stdin can't eat the framing out of the pipe and desynchronise every
+later command. A timeout tears the shell down rather than reusing a pipe whose
+state is unknown.
+
+`su --mount-master` is tried before plain `su` so a Magisk shell sees the
+global mount namespace — otherwise `/sdcard` and other per-app mounts differ
+from what the daemon expects.
+
+## 2. The adb-root agent (userdebug / eng, no usable `su`)
+
+This is the path for an AOSP `userdebug` build: `adb root` works, but no `su`
+will serve an app uid. **It does not survive a reboot** — the agent is a shell
+process, and only a root adb session can start another one. Fine on a desk,
+wrong for anything embedded; flash Magisk instead (§1).
+
+In the app: **Settings → Mesh → Device control → Root via adb**. It writes the
+agent script and shows the one-liner to run from a computer:
+
+```sh
+adb root && adb shell "setsid sh /data/user/0/org.talon.companion/files/rootd/agent.sh >/dev/null 2>&1 </dev/null &"
+```
+
+The agent is ~20 lines of `/system/bin/sh` and toybox — no binary to build, no
+extra app. It runs as uid 0 until the phone reboots and polls a spool
+directory:
+
+```
+files/rootd/agent.sh              the loop
+files/rootd/alive                 touched every tick — the liveness heartbeat
+files/rootd/q/<id>.cmd            a request
+files/rootd/q/<id>.{out,err,code,done}   the reply
+```
+
+Design notes worth keeping:
+
+- **The spool lives in Talon's private storage, and that is the access
+  control.** Only uid 0 and this app can enter that directory, so no other app
+  can queue work for a root shell. Do not move it somewhere world-writable.
+- A request is written to `<id>.tmp` and **renamed** into place, because rename
+  is atomic — a plain write would let the agent pick up a half-written command.
+- The agent `chmod 0666`s its replies: root creates them inside the app's own
+  directory, where the app would otherwise not be able to read its own results.
+- Each command runs in a subshell with stdin closed, so a `cd` can't leak into
+  the next request and an interactive program can't stall the loop.
+- The heartbeat is what the app trusts. A stale `alive` file (>15s) means the
+  agent is gone — after a reboot, run the one-liner again.
+
+Stop it with the `stop` file (the bridge's `stopAgent`), or just reboot.
+
+## 3. Shizuku started as root
+
+If Shizuku's own server was started while `adbd` was root, the server runs at
+uid 0 and **every command through the Shizuku bridge is already a root
+command**. Talon reads `Shizuku.getUid()` and reports the real tier (`root`,
+`execVia: shizuku`) rather than calling it shell privilege.
+
+```sh
+adb root && adb shell sh /storage/emulated/0/Android/data/moe.shizuku.privileged.api/start.sh
+```
+
+## Building a system-uid APK
+
+For a ROM you build yourself, `system` (uid 1000) is a real tier and needs no
+runtime setup. It requires all three:
+
+1. `android:sharedUserId="android.uid.system"` on `<manifest>`.
+2. Signing with that ROM's `platform` key (`build/target/product/security/platform.{x509.pem,pk8}`).
+3. The APK installed to `/system/priv-app/` (or bundled into the image).
+
+This is **not** the shipped build: `sharedUserId` changes the app's identity, so
+a device that already has the normal APK must uninstall it first, and an APK
+signed with a platform key can't be installed over a Play-signed one. Talon
+detects uid 1000 at runtime and reports it, so a ROM build works without any
+code change — but the tier still runs commands through the ordinary app-uid
+shell, because at uid 1000 `sh -c` already *is* the elevated shell.
+
+Being in `/system/priv-app` without the platform signature gets you privileged
+*permissions* (if whitelisted in `privapp-permissions`) and nothing else — not
+uid 1000, and not root.
+
+## Diagnosing
+
+Dart's `developer.log` doesn't reach logcat in release builds, so the native
+side logs every decision itself:
+
+```sh
+adb logcat -s TalonRoot     # root tier: su probes, agent, exec failures
+adb logcat -s TalonShizuku  # the Shizuku tier
+```
+
+The mesh `status` payload also carries `execPrivilege`, `execVia`, `root` and
+`shizuku` — enough to tell "no root on this device" from "root broke mid-command"
+without touching adb. A command that fell back to the app uid says why in its
+own `stderr`.
+
+## Order and failure handling
+
+`exec` tries root, then Shizuku, then the app uid. Probes are cached for 30s
+(and a dead-end `su` probe is remembered natively for 60s) so a stock phone
+with no root isn't re-probing on every command. If a root path fails *during* a
+command, that tier is demoted for 30s and the command is retried down the
+ladder — so one broken agent doesn't cost every later command an elevation
+attempt, and a restarted agent heals without restarting the app.

--- a/docs/companion-shizuku.md
+++ b/docs/companion-shizuku.md
@@ -1,7 +1,9 @@
 # Companion device control (teleport) + Shizuku
 
 The Talon companion answers remote **exec / filesystem** commands over the
-mesh — the device half of `teleport`. Two privilege tiers:
+mesh — the device half of `teleport`. This page covers the app-UID and Shizuku
+tiers; **root** (and the system-uid ROM build) is
+[companion-root.md](companion-root.md), and it outranks everything here.
 
 ## 1. App-UID (default, always available)
 
@@ -29,6 +31,10 @@ off, the device advertises no exec/fs capabilities and refuses those commands.
 When the [Shizuku](https://shizuku.rikka.app/) app is installed and running
 (started via wireless ADB or root), exec commands run at **shell (ADB) UID** —
 far more of the system than the app UID, without rooting the device.
+
+If Shizuku's own server was started while `adbd` was root (`adb root` first),
+that server runs at uid 0 and these commands are really **root** commands.
+Talon reads `Shizuku.getUid()` and reports the tier it actually gets.
 
 Wiring (already in this repo):
 

--- a/src/core/mesh/service.ts
+++ b/src/core/mesh/service.ts
@@ -888,7 +888,7 @@ export class MeshService {
 
   /**
    * `update_device`: remote self-update for the companion. Streams a new APK
-   * to the device, then tells it to silently install (via Shizuku) and
+   * to the device, then tells it to silently install (root or Shizuku) and
    * restart. The mesh foreground service's autoRunOnMyPackageReplaced brings
    * the connection back on its own — the link drops only for the seconds the
    * process is swapped, no manual reopen.
@@ -914,7 +914,7 @@ export class MeshService {
     if (target.capabilities && !target.capabilities.includes("install_apk")) {
       return {
         ok: false,
-        text: `${target.name} can't self-update — it needs a companion build with the install_apk capability and Shizuku enabled (device control on).`,
+        text: `${target.name} can't self-update — it needs a companion build with the install_apk capability and root or Shizuku enabled (device control on).`,
       };
     }
 

--- a/src/core/tools/mesh.ts
+++ b/src/core/tools/mesh.ts
@@ -85,7 +85,7 @@ export const meshTools: ToolDefinition[] = [
   {
     name: "device_exec",
     description:
-      "Run a shell command ON a Talon companion device (e.g. the phone) and return its stdout/stderr/exit code. The device executes it in its own sandbox (Android: app UID, or elevated via Shizuku if available). Use for on-device tasks like tidying a folder. Prefer `teleport` for a sustained session. For persistent streams (log tailing, watchers), background with output redirected to a file — `cmd > /tmp/out.log 2>&1 &` returns immediately; poll the file with device_read_file.",
+      "Run a shell command ON a Talon companion device (e.g. the phone) and return its stdout/stderr/exit code. The device executes it at the highest privilege it has (Android: root if the device grants it, else Shizuku's shell UID, else the app UID; the result's `via` says which). Use for on-device tasks like tidying a folder. Prefer `teleport` for a sustained session. For persistent streams (log tailing, watchers), background with output redirected to a file — `cmd > /tmp/out.log 2>&1 &` returns immediately; poll the file with device_read_file.",
     schema: {
       device: deviceParam,
       cmd: z.string().describe("The shell command to run on the device."),
@@ -167,7 +167,7 @@ export const meshTools: ToolDefinition[] = [
   {
     name: "update_device",
     description:
-      "Remotely update a Talon companion (Android): stream a new APK from the daemon to the device and silently reinstall it via Shizuku, keeping app data. The companion's mesh runs in a foreground service that auto-restarts after the package is replaced, so the connection returns on its own within seconds — no manual reopen. The APK is hashed and the device verifies it before installing (a truncated push is refused; a differently-signed APK is refused by Android). Requires the device to have device control on and Shizuku granted. Confirm success with get_device_status afterwards (appVersion should change).",
+      "Remotely update a Talon companion (Android): stream a new APK from the daemon to the device and silently reinstall it at an elevated tier (root or Shizuku), keeping app data. The companion's mesh runs in a foreground service that auto-restarts after the package is replaced, so the connection returns on its own within seconds — no manual reopen. The APK is hashed and the device verifies it before installing (a truncated push is refused; a differently-signed APK is refused by Android). Requires the device to have device control on and either root or Shizuku granted. Confirm success with get_device_status afterwards (appVersion should change).",
     schema: {
       device: deviceParam,
       apk_path: z


### PR DESCRIPTION
## What

Device control (teleport) now runs at the **highest privilege the device will give it**, picked per command with no configuration: **root → Shizuku → app UID**. Before this, a rooted or `userdebug` phone still executed at app UID unless Shizuku happened to be installed.

Three ways to uid 0, tried in that order:

1. **Already root** — the process itself is uid 0; plain `sh -c` needs no wrapper.
2. **`su`** — Magisk / KernelSU / APatch, or any ROM whose `su` serves an app uid.
3. **The adb-root agent** — for a `userdebug` build where `adb root` works but no `su` will serve an app uid (AOSP's `su` refuses everything but uid 0 and 2000/shell, so a system-uid app cannot use it either). A ~20-line `sh` loop the user starts once over root adb, serving commands through a spool inside the app's private storage.

A fourth tier, **system (uid 1000)** for a platform-signed ROM build, is detected and reported but needs no wrapper — `sh -c` is already elevated there.

## Notable pieces

- **One long-lived `su` shell per process** (`RootShell`), not `su -c` per command: one grant prompt, a pipe write instead of a spawn per command, and a denial remembered for 60s so a burst of mesh commands can't re-prompt in a loop. Shared by the activity engine and the foreground-service engine, which live in the same OS process.
- **In-band command framing**: a random end marker echoed on *both* streams, carrying the exit status on stdout; the command runs as `sh -c` with **stdin closed**, so a program that reads stdin can't eat the framing and desynchronise every later command. Verified against `dash` — including the marker landing mid-line after `printf` with no trailing newline.
- **Shizuku's uid is now read.** A Shizuku server started while `adbd` was root runs at uid 0, so those commands were always *root* commands; they're reported as root rather than as shell privilege.
- **The ladder is warmed when the mesh starts**, not on the first command. On a device that power-cycles on its own, the grant would otherwise be taken mid-command with the root manager's dialog waiting for nobody.
- **Failure demotion**: a root path that breaks *during* a command is demoted for 30s and the command retried down the ladder, so one dead agent doesn't cost every later command an elevation attempt — and a restarted agent heals without restarting the app.

## Agent spool design

Lives in the app's private storage, and **that is the access control**: only uid 0 and this app can enter the directory, so no other app can queue work for a root shell. Requests are renamed into place (atomic, so the agent can't read a half-written command); the agent `chmod 0666`s its replies because root creates them inside the app's own directory; each command runs in a subshell with stdin closed so a `cd` can't leak and an interactive program can't stall the loop.

## Surfaces

- Settings → Mesh → Device control: live tier row, **Request root**, and **Root via adb** (only on a debuggable build) with the copyable one-liner.
- Mesh `status`: `execPrivilege`, `execVia`, `root`, `shizuku`.
- Every `exec` result carries `via`, and a root result also `rootMethod` (`su` / `agent` / `uid0`).
- `install_apk` / `update_device` now accept root as well as Shizuku.

## Docs

`docs/companion-root.md` — including the two things commonly assumed and untrue: installing as a system app does **not** grant root (that needs `sharedUserId=android.uid.system` *and* the platform key), and `adb root` on a userdebug device does not give the *app* root either.

## Verification

- `flutter analyze --fatal-infos` clean; `flutter test` 239 passed (4 new tests: root outranks Shizuku, failure degrades to Shizuku, Shizuku-at-uid-0 reported as root).
- Agent script syntax-checked under `dash`/`sh` and run end-to-end against a real spool: exit codes, stdout/stderr separation, cwd honoured and not leaking into the next command, a stdin-reading command not hanging the loop, stop file.
- Command framing simulated under `dash`, including the mid-line marker and stdin-eating cases.
- Kotlin compiles only in CI here (no local Android SDK) — the Android matrix build is the check to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DW7AXcnWNfL2uubPy45axh