### PR TITLE
fix(ci): make the architecture gate actually cruise the codebase

### DIFF
--- a/docs/code-health.md
+++ b/docs/code-health.md
@@ -1,0 +1,167 @@
+# Code health
+
+A static + dynamic analysis pass over the tree (2026-09-01, v3.31.0), the
+findings it produced, and which are fixed.
+
+Read this as a worklist, not a scorecard. The headline is that the codebase is
+in good shape — the problems below are specific and bounded, and the largest
+one was a gate that had stopped working rather than anything wrong with the
+code it was guarding.
+
+## Baseline
+
+| Measure | Value |
+| --- | --- |
+| Tracked lines of code | ~189,500 across 1,135 files (~177,400 excluding `package-lock.json`) |
+| Daemon TypeScript | 135,771 (70,434 of it tests) |
+| Companion Dart | 23,591 (5,144 of it tests) |
+| Tests | 4,640 daemon, 244 companion |
+| Daemon coverage (CI) | 72.1% statements · 63.7% branches · 75.0% functions · 73.3% lines |
+| Coverage thresholds | 65 / 60 / 65 / 65 |
+| Companion coverage | 57.4% of lines |
+| `TODO` / `FIXME` / `HACK` / `XXX` in shipping source | **0** |
+| `@ts-ignore` / `@ts-expect-error` | **0** |
+| Explicit `any` | 13 |
+| npm vulnerabilities | **0** (39 production dependencies) |
+| Files over 1,500 lines (non-test TS/Dart) | 3 of 577; 512 are under 400 |
+
+Tooling used: `tsc`, `oxlint`, `dependency-cruiser`, `knip`, `madge`,
+`npm audit`, `cloc`, `vitest --coverage`, `flutter test --coverage`.
+
+## 1. The architecture gate was enforcing nothing — **fixed**
+
+`npm run depcruise` reported:
+
+```
+✔ no dependency violations found (3 modules, 2 dependencies cruised)
+```
+
+Three modules out of ~590. The repo compiles with **typescript@7**, whose API
+dependency-cruiser cannot drive ("Support for typescript@>=7 will follow when
+its API is published and stable"), so `.dependency-cruiser.cjs` already selects
+**swc** as the parser — but `@swc/core` was never in `devDependencies`. With no
+parser, dependency-cruiser doesn't fail; it parses almost nothing and reports a
+green tick.
+
+The consequence: every rule in `.dependency-cruiser.cjs` — `core-not-to-frontend`,
+`core-not-to-backend`, `no-circular`, `util-is-a-leaf`, and the rest — was
+inert, while the "Architecture boundaries" step in the Code Quality workflow
+passed on every commit.
+
+**Fixed** by adding `@swc/core` to `devDependencies` and replacing the raw
+`depcruise src` invocation with `scripts/check-architecture.mjs`, which asserts
+two things instead of one:
+
+1. no `error`-severity violations, and
+2. the cruise actually covered the codebase (`MODULE_FLOOR`, currently 450).
+
+The floor is the part that matters. A gate that goes blind must fail loudly,
+because "no violations found" on 0.5% of the tree is indistinguishable from a
+real pass in a CI log. Verified in both directions: with `@swc/core` removed
+the gate exits 1 and names the likely cause; with it present it exits 0 after
+cruising 587 modules and 2,325 dependencies.
+
+**The good news underneath:** once the gate ran, it found **0 errors**. Every
+ratified boundary holds. The 18 warnings are the in-flight migrations the
+config documents by name (`backend-sessions-move-to-thread` 11,
+`config-belongs-in-core` 3, `doctor-probes-move-behind-registry` 4), each
+already annotated with the migration that ratchets it to `error`.
+
+## 2. Circular dependencies — **not a defect; withdrawn**
+
+`madge` reports six import cycles:
+
+```
+1) core/agent-runtime/events.ts > core/types.ts
+2) core/doctor.ts > core/plugin/native-runtimes.ts
+3) …> plugins/github/provision.ts
+4) …> plugins/mempalace/provision.ts
+5) …> plugins/playwright/provision.ts
+6) core/plugin/index.ts > core/plugin/builtins.ts > core/mcp-hub/index.ts
+```
+
+All six are false positives, and they are worth writing down so the next person
+running `madge` doesn't "fix" them:
+
+- **(1)** is closed by two *type-only* edges — `import type { ReasoningEffortLevel }`
+  one way, an inline `import("./agent-runtime/events.js").AgentEvent` type
+  position the other. Nothing exists at runtime.
+- **(2)–(5)** are closed by a **dynamic** `await import("./plugin/native-runtimes.js")`
+  in `doctor.ts`, with `import type { DoctorCheck }` coming back. The lazy edge
+  is the deliberate cycle-break.
+- **(6)** is closed by a **dynamic** `await import("../mcp-hub/index.js")` in
+  `builtins.ts`.
+
+dependency-cruiser's `no-circular` rule models exactly this — it exempts cycles
+closed only through a dynamic import — and reports **zero** violations now that
+it runs. madge models neither type-only imports nor dynamic-import cycle
+breaks. Prefer the `no-circular` rule; treat madge as a smoke test only.
+
+## 3. The native bridge is the thinnest-covered security surface — open
+
+`src/frontend/native` sits at **38.7% statements / 35.3% branches**, against
+`src/core` at 86.2%.
+
+That is the code doing bearer-token authentication, the failed-auth lockout,
+the pre-auth routes (`/health`, `/pair`, `/node/install`, `/node/binary`), and
+transfer-token scoping — the parts where a missed branch is a security bug
+rather than a cosmetic one. Coverage effort belongs here before anywhere else,
+notably ahead of `src/cli` (14.3%), which is composition-root glue that
+integration tests already exercise end to end.
+
+Other thin areas, in rough priority order: `frontend/discord/handlers` (5.2%),
+`frontend/telegram/commands` (27.2%), `frontend/telegram/callbacks` (29.5%),
+`frontend/whatsapp/actions` (26.3%).
+
+## 4. 255 unused exports, ungated — open
+
+`knip` reports 130 unused exports and 125 unused exported types, and **knip is
+not part of the Code Quality gate** (which runs `tsc`, `lint`, `depcruise`,
+`ratchets`, `format:check`), so the number only grows.
+
+Most are barrel files re-exporting types nothing imports — `core/mesh/index.ts`
+alone accounts for seven (`MeshServiceOptions`, `MeshToolResult`,
+`DeviceCommand`, `DeviceCommandResult`, `DeviceInfo`, `DeviceLocation`,
+`DevicePlatform`). Also flagged: 8 binaries used by CI scripts but undeclared
+(`where.exe`, `gofmt`).
+
+Suggested shape: prune the obvious dead exports, then add knip to CI at a
+ratcheted baseline in the style of `scripts/check-ratchets.mjs`, so the residue
+can only shrink.
+
+## 5. `settings_screen.dart` is a god file — open
+
+3,434 lines, twice the next-largest file in the repo, at 49% line coverage. It
+is the one place where the size discipline that holds everywhere else (512 of
+577 files under 400 lines) has broken down, and it is measurably where changes
+cost the most.
+
+Natural seams: the per-card builders (`_meshCard`, `_voiceCard`,
+`_appearanceCard`, `_diagnosticsCard`, `_statusCard`, `_aboutCard`) are already
+independent and could each become their own widget file, leaving the shell and
+the shared row helpers behind.
+
+## 6. Companion coverage gaps — open
+
+57.4% of lines overall. The gap that matters is **`mesh_background.dart` at
+9.2%** — the Android foreground-service isolate that owns the mesh connection,
+answers exec commands, and has to survive reboots and `MY_PACKAGE_REPLACED`.
+It is the least-tested code in the app and among the most load-bearing.
+
+Six UI files sit near zero and matter much less: `logs_screen` (0%),
+`model_sheet` (0%), `context_sheet` (0%), `extensions_screen` (0.7%),
+`quick_switcher` (0.9%), `activity_card` (1.6%).
+
+## 7. Known-deferred, tracked elsewhere
+
+Recorded here only so a future pass doesn't re-report them as new:
+
+- **`noUncheckedIndexedAccess` (666 errors) and `exactOptionalPropertyTypes`
+  (303)** are measured and deliberately off, with the counts written into
+  `tsconfig.json`. Each is its own fix wave.
+- **`naked-throw-in-core` sits at its baseline of 38** (`scripts/check-ratchets.mjs`).
+- **Node `engines` requires `>=24.15`** and `.npmrc` sets `engine-strict=true`,
+  so `npm ci` refuses on older toolchains by design (it protects the lockfile —
+  see the comment in `.npmrc`). On Node 22 three suites fail locally because
+  `baileys` and `qrcode` can't install; both are declared dependencies and CI
+  is unaffected.

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "talon": "bin/talon.js"
       },
       "devDependencies": {
+        "@swc/core": "^1.16.1",
         "@types/node": "^26.0.0",
         "@types/qrcode-terminal": "^0.12.2",
         "@types/write-file-atomic": "^4.0.3",
@@ -3453,6 +3454,286 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
+    },
+    "node_modules/@swc/core": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.16.1.tgz",
+      "integrity": "sha512-nUaeu91O5QZKrQdaDCHd402ogUIoNOOjpkZNq0UomWK0G6gDaGmLhvddF1/3BXf5O8aLyo6ZPY/aMDWvaJQ/hg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.28"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.16.1",
+        "@swc/core-darwin-x64": "1.16.1",
+        "@swc/core-linux-arm-gnueabihf": "1.16.1",
+        "@swc/core-linux-arm64-gnu": "1.16.1",
+        "@swc/core-linux-arm64-musl": "1.16.1",
+        "@swc/core-linux-ppc64-gnu": "1.16.1",
+        "@swc/core-linux-s390x-gnu": "1.16.1",
+        "@swc/core-linux-x64-gnu": "1.16.1",
+        "@swc/core-linux-x64-musl": "1.16.1",
+        "@swc/core-win32-arm64-msvc": "1.16.1",
+        "@swc/core-win32-ia32-msvc": "1.16.1",
+        "@swc/core-win32-x64-msvc": "1.16.1"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.16.1.tgz",
+      "integrity": "sha512-zlJblJ8ncErD43lKdxjbUaUskJQf+LxiPXYcWXD8/8ZMV+7uuAT+CwjciLXpyZBd5Pq/S726bMpeeAwSeL1hhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.16.1.tgz",
+      "integrity": "sha512-IN0BmPWb0YAh/17mmlWB/HDBtTw2MfuW4hulf/tQAgTQBRH17l+z499bNJLK6LizSjqs0P7V+jU38Zj+vJC1DA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.16.1.tgz",
+      "integrity": "sha512-EYgrx2YOCQ2Twz2S793kqNjPkpvYVUPzzR95bIb7by+VQcyaai4lZZ2iz/tZvcFVKSNcN3/JTKwx+aBn2ZL52A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.16.1.tgz",
+      "integrity": "sha512-moyKm0YZlHdHohzm1YwgAyesqnE853rO0REMfJLFAova51wF9BNi+3ZW2PeS7Vqvn6HeJuepLpAHbBdZctxpHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.16.1.tgz",
+      "integrity": "sha512-kKGBO9wdapiSzuf5ZzZ2fYtlu1BNSYtIIUxvH1ir/gcelTOREEHGDCLTDFx/2Knf878nU11A40z7LxwasEFxqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.16.1.tgz",
+      "integrity": "sha512-nZ6qahtLxC3PM54cWOQZHxt4lTCF/3J4LIoWWzz6v7A+rLs8Dx54anYQf7mH3eIi8KlNpgKci/ie8ZSqFN8O7A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.16.1.tgz",
+      "integrity": "sha512-4ji5PNzhYq193Z4/4xUaSoNJza6iCkDJSzhetrbB6KOYxsr+kxtQr8ePWhMJUiMt6JUWtXaZ1PYT8FhtED+nGA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.16.1.tgz",
+      "integrity": "sha512-VJQxqrisHV+B394IgrOu8YsIIXZgffnf5tO+yc9Z/hoUpuZEvuQTjWwlnpZdpyD+0nx6LTD1/3k646JYm43yJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.16.1.tgz",
+      "integrity": "sha512-r9oV1mwxxsIGcLV1IQ/tw76MW3doatKze1QFWuC+a7QqJUkhY/bKTSVk6NpKKUGm2LDsE33Va8VqSClfA7vSiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.16.1.tgz",
+      "integrity": "sha512-6huNRessoBLxWEqBm5zJXyCQ27TO7anvkdiuQ5MDO4CJni0nOXEqKtV9RllQ2TdyENKKsUMXVnIfW2hIXx/R5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.16.1.tgz",
+      "integrity": "sha512-OVKJFUzphrGmsh+BGtcZDesx0YryV7/Yvy5XGgTqnrZfjnyfcr5uaqYQugCckdIlupc5Vs3XtDjRAj12z4ZPlw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.16.1.tgz",
+      "integrity": "sha512-Bt+VIhWYCGk4urklnkkteLUOeLv1VxigwTCeB/xC6rBZxY6IIKdDwCJf6on3E3SUGsIqmQS6QqtuJQc1VxF4Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.28.tgz",
+      "integrity": "sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
     },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint src/",
-    "depcruise": "depcruise src",
+    "depcruise": "node scripts/check-architecture.mjs",
     "ratchets": "node scripts/check-ratchets.mjs",
     "knip": "knip",
     "format": "prettier --write src/ prompts/",
@@ -138,6 +138,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@swc/core": "^1.16.1",
     "@types/node": "^26.0.0",
     "@types/qrcode-terminal": "^0.12.2",
     "@types/write-file-atomic": "^4.0.3",

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Architecture gate — dependency-cruiser, with a floor on how much it saw.
+ *
+ * Running `depcruise src` on its own is not enough, and this script exists
+ * because of how that failed in practice: the repo compiles with
+ * typescript@7, whose API dependency-cruiser cannot drive, so
+ * `.dependency-cruiser.cjs` selects swc as the parser instead. When
+ * `@swc/core` is absent, dependency-cruiser does not fail — it parses almost
+ * nothing and reports
+ *
+ *     ✔ no dependency violations found (3 modules, 2 dependencies cruised)
+ *
+ * out of ~590. A green tick on 0.5% of the codebase is indistinguishable
+ * from a real pass in CI logs, so the boundary rules in
+ * `.dependency-cruiser.cjs` were enforcing nothing at all while looking
+ * healthy.
+ *
+ * So the gate asserts two things, not one:
+ *   1. no `error`-severity violations (the ratified boundaries hold), and
+ *   2. the cruise actually covered the codebase (MODULE_FLOOR).
+ *
+ * `warn`-severity violations are printed and do NOT fail: those are the
+ * in-flight migrations documented in the config, each ratcheting to `error`
+ * when its migration lands.
+ *
+ * MODULE_FLOOR is a ratchet in the same spirit as scripts/check-ratchets.mjs
+ * — raise it when the tree grows; never lower it to make a red build green,
+ * because a drop is the exact symptom this guards against.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/**
+ * Fewest modules a healthy cruise may report. The tree cruises ~587 today;
+ * the floor sits below that so ordinary file deletions don't trip it, and
+ * far above the ~3 a parser-less cruise produces.
+ */
+const MODULE_FLOOR = 450;
+
+const run = spawnSync(
+  "npx",
+  ["depcruise", "src", "--output-type", "json"],
+  // A large tree easily exceeds the default pipe buffer; JSON truncated
+  // mid-parse would look like a crash rather than a result.
+  { encoding: "utf8", maxBuffer: 256 * 1024 * 1024 },
+);
+
+if (run.error) {
+  console.error(`✖ could not run dependency-cruiser: ${run.error.message}`);
+  process.exit(1);
+}
+
+let report;
+try {
+  report = JSON.parse(run.stdout);
+} catch {
+  // depcruise exits non-zero when it finds violations, so a parse failure —
+  // not the exit code — is what tells us it never produced a report.
+  console.error("✖ dependency-cruiser produced no parsable report");
+  if (run.stderr.trim()) console.error(run.stderr.trim());
+  process.exit(1);
+}
+
+const summary = report.summary ?? {};
+const modules = summary.totalCruised ?? 0;
+const violations = summary.violations ?? [];
+const errors = violations.filter((v) => v.rule.severity === "error");
+const warnings = violations.filter((v) => v.rule.severity === "warn");
+
+let failed = false;
+
+if (modules < MODULE_FLOOR) {
+  failed = true;
+  console.error(
+    `✖ architecture gate saw only ${modules} modules (floor ${MODULE_FLOOR}) — ` +
+      "the cruise is blind, not clean.",
+  );
+  console.error(
+    "  Almost always a missing parser: `.dependency-cruiser.cjs` selects swc " +
+      "(typescript@7 can't drive dependency-cruiser), so @swc/core must be " +
+      "installed. Check `npm ls @swc/core`.",
+  );
+}
+
+for (const violation of errors) {
+  console.error(
+    `✖ ${violation.rule.name}: ${violation.from} → ${violation.to}`,
+  );
+}
+if (errors.length > 0) failed = true;
+
+if (warnings.length > 0) {
+  const byRule = new Map();
+  for (const violation of warnings) {
+    byRule.set(violation.rule.name, (byRule.get(violation.rule.name) ?? 0) + 1);
+  }
+  const listed = [...byRule]
+    .map(([name, count]) => `${name} (${count})`)
+    .join(", ");
+  console.log(`→ ${warnings.length} in-flight migration warnings: ${listed}`);
+}
+
+if (!failed) {
+  console.log(
+    `✔ architecture gate: ${modules} modules, ` +
+      `${summary.totalDependenciesCruised ?? 0} dependencies, 0 errors`,
+  );
+}
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Fixes findings **1** and **2** from a static + dynamic analysis pass, now written up in `docs/code-health.md`.

## The bug

```
$ npm run depcruise
✔ no dependency violations found (3 modules, 2 dependencies cruised)
```

Three modules out of ~590.

The repo compiles with **typescript@7**, whose API dependency-cruiser cannot drive, so `.dependency-cruiser.cjs` already selects **swc** as its parser — but `@swc/core` was never in `devDependencies`. With no parser, dependency-cruiser doesn't error; it parses almost nothing and reports a green tick.

So every rule in `.dependency-cruiser.cjs` — `core-not-to-frontend`, `core-not-to-backend`, `no-circular`, `util-is-a-leaf`, `storage-below-the-engine`, all of them — has been inert, while the "Architecture boundaries" step of Code Quality passed on every commit.

## The fix

Add `@swc/core`, and replace `depcruise src` with `scripts/check-architecture.mjs`, which asserts **two** things instead of one:

1. no `error`-severity violations, and
2. the cruise actually covered the codebase (`MODULE_FLOOR`, currently 450 against ~587 real).

The floor is the load-bearing half. A gate that goes blind must fail loudly — "no violations found" across 0.5% of the tree is indistinguishable from a real pass in a CI log, which is precisely how this survived. `warn`-severity violations still print without failing; they're the documented in-flight migrations.

Verified in both directions:

| | exit | output |
|---|---|---|
| `@swc/core` removed | **1** | `✖ architecture gate saw only 3 modules (floor 450) — the cruise is blind, not clean.` + names the likely cause |
| normal | **0** | `✔ architecture gate: 587 modules, 2325 dependencies, 0 errors` |

## The good news underneath

Once the gate ran, it found **zero errors**. Every ratified boundary holds. The 18 warnings are the in-flight migrations the config already documents by name: `backend-sessions-move-to-thread` (11), `config-belongs-in-core` (3), `doctor-probes-move-behind-registry` (4).

## Finding 2 — withdrawn, and documented as such

`madge` reports six import cycles. **All six are false positives**, and the doc records them so nobody "fixes" them later:

- `events.ts ↔ types.ts` is two *type-only* edges — nothing exists at runtime.
- The four `doctor.ts ↔ native-runtimes.ts` cycles are closed by a **dynamic** `await import(...)` with `import type` coming back.
- `plugin/index → builtins → mcp-hub` is closed by a **dynamic** `await import("../mcp-hub/index.js")`.

dependency-cruiser's `no-circular` rule models exactly this and reports zero. madge models neither type-only imports nor dynamic-import cycle breaks.

## Also in `docs/code-health.md`

The remaining findings, left open with suggested shapes: the native bridge at 38.7% statements being the thinnest-covered *security* surface; 255 unused exports with knip ungated; `settings_screen.dart` at 3,434 lines; `mesh_background.dart` at 9.2%; plus the already-tracked deferrals (`noUncheckedIndexedAccess`, the `naked-throw-in-core` ratchet) so a future pass doesn't re-report them.

## Verification

- All five Code Quality gates pass: `tsc --noEmit` clean, `lint` (4 pre-existing warnings, none new — lint covers `src/` only), `depcruise`, `ratchets`, `format:check`.
- Full suite green on Node 24 with a complete install: **4,616 passed, 0 failed**, 46 skipped.
- Lockfile diff is **281 insertions, 0 deletions** — only `@swc/core` and its platform variants. Generated under Node 24.20 as `.npmrc`'s `engine-strict` requires, so no transitive pruning of platform-gated optionals (the hazard that comment warns about).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DW7AXcnWNfL2uubPy45axh