### PR TITLE
chore(quality): sweep 255 dead exports and gate knip in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
       - name: Architecture boundaries (dependency-cruiser)
         run: npm run depcruise
 
+      # Dead exports/types/deps. Zero tolerance: the tree was swept clean in
+      # the 2026-09 code-health pass (docs/code-health.md §4); anything new
+      # is a fresh regression, not baseline.
+      - name: Dead code (knip)
+        run: npm run knip
+
       - name: Ratchet gates
         run: npm run ratchets
 

--- a/docs/code-health.md
+++ b/docs/code-health.md
@@ -3,7 +3,9 @@
 A static + dynamic analysis pass over the tree (2026-09-01, v3.31.0), the
 findings it produced, and which are fixed.
 
-Read this as a worklist, not a scorecard. The headline is that the codebase is
+Read this as a worklist, not a scorecard. The structural companion —
+the dependency map and the consolidation order — is
+[consolidation-plan.md](consolidation-plan.md). The headline is that the codebase is
 in good shape — the problems below are specific and bounded, and the largest
 one was a gate that had stopped working rather than anything wrong with the
 code it was guarding.

--- a/docs/consolidation-plan.md
+++ b/docs/consolidation-plan.md
@@ -1,0 +1,175 @@
+# Consolidation plan
+
+A map of the tree as of 2026-09-02 (v3.32.0) and the ordered worklist that
+falls out of it. Companion to [code-health.md](code-health.md), which is
+the static/dynamic analysis pass; this is the structural one. Numbers are
+from that day's `cloc`, `vitest --coverage`, and `dependency-cruiser`
+runs.
+
+## Map
+
+### Size and coverage by area (non-test lines; statement / branch coverage)
+
+| Area | Lines | Cov (stmt / br) | Fan-in | Role |
+| --- | ---: | ---: | ---: | --- |
+| `core/` | 31,278 | 82–95% | 87 + per-module | Platform-agnostic engine |
+| `frontend/` | 25,433 | 25–99% | 22 (shared) | Six chat surfaces |
+| `backend/` | 20,478 | 64–91% | 47 (shared) | Five agent backends |
+| `storage/` | 6,291 | 92% / 88% | 133 | SQLite repos + stores |
+| `util/` | 2,918 | 80% / 81% | 338 | Leaf helpers (+ config, see below) |
+| `cli/` | 2,777 | 14% / 21% | — | Composition-root glue |
+| `plugins/` | 1,858 | 78% / 69% | 9 | Built-in plugins + provisioning |
+| `native/` | 1,427 | 40% / 29% | 20 | WASM/napi bricks with TS fallbacks |
+| tests | 86,731 | — | — | 4,640 daemon tests |
+
+Thinnest-covered areas, in the order that matters: `cli` 14% (glue,
+exercised end-to-end by integration tests), `frontend/discord` 25%
+(handlers 5%), `frontend/native` 39% (the bearer-token bridge — the one
+that is a security surface), `native` 40%, `frontend/whatsapp` 46%,
+`frontend/telegram` 54%.
+
+### Dependency shape
+
+The architecture gate (`scripts/check-architecture.mjs`) cruises 588
+modules and finds **0 errors** against every ratified boundary
+(`core-not-to-frontend`, `core-not-to-backend`, `backend-not-to-frontend`,
+`frontend-not-to-backend`, `util-is-a-leaf`, `native-is-a-leaf`,
+`storage-below-the-engine`, `no-circular`). The 18 warnings are the three
+in-flight migrations `.dependency-cruiser.cjs` documents by name.
+
+Heaviest cross-area edges: `frontend/telegram → util` 39,
+`frontend/discord → util` 38, `storage → util` 31, `frontend/telegram →
+storage` 24, `core/engine → util` 23. Frontends reach `storage` directly
+(telegram 24, discord 19, native 9) — the sessions/history/settings stores
+are the frontends' data layer as much as the engine's, which is by design
+but worth knowing before moving anything.
+
+### Largest files
+
+| File | Lines | Shape |
+| --- | ---: | --- |
+| `core/mesh/service.ts` | 1,863 | One class; three sections already delimited by comments (device commands, streaming file transfer, node provisioning + pairing) |
+| `frontend/native/index.ts` | 1,416 | `createNativeFrontend` is a single 1,260-line closure |
+| `frontend/native/server.ts` | 1,101 | `BridgeServer.handle()` is a 430-line `if` chain over ~40 routes |
+| `core/engine/gateway-actions/native.ts` | 1,035 | Flat handler table, fine |
+| `util/config.ts` | 843 | Engine configuration filed as a leaf util (see migration) |
+| `apps/companion/.../settings_screen.dart` | 3,434 | Twice the next-largest Dart file |
+
+## Findings, ordered by value over risk
+
+### 1. Dead exports were ungated — done in #820
+
+255 unused exports/types, no gate. Swept to zero, `knip` added to the
+Code Quality workflow. Nothing further.
+
+### 2. Kilo and OpenCode were two copies of one backend — #822
+
+`backend/kilo/` (1,498 lines) and `backend/opencode/` (1,331) were
+identical after name normalisation except for five knobs: SDK package,
+port, delivery contract, stored-model parser, picker limits. The turn
+driver, chat-turn orchestration, server wrappers, and factory now live
+once in `backend/remote-server/`; each backend is a `RemoteBackendProfile`
+plus re-exports. Net −913 lines.
+
+**Left open on purpose:** the model-picker knobs in `*/models/index.ts`
+(`maxCallbackIdLength`, `allowCallbackSeparators`, `quickPickLimit`) are
+described as "Kilo renders through Discord select menus, OpenCode through
+Telegram inline keyboards". Those are frontend constraints filed under a
+backend. They should become per-frontend presentation limits the model
+catalog reads from the requesting frontend's descriptor; until then a
+Kilo user on Telegram gets Discord-sized callback ids.
+
+### 3. Frontend access control and rate limiting are duplicated
+
+`frontend/telegram/handlers/access.ts` (313 lines) + `queue.ts` and
+`frontend/discord/handlers/access.ts` (243) carry the same sliding-window
+rate limiter (`isUserRateLimited`, identical bodies, one keyed by number
+and one by string) and near-identical allowlist / admin / DM-tracking
+state. WhatsApp and Teams have their own partial versions.
+
+**Shape:** `core/frontend-runtime/access.ts` — a generic
+`createAccessGate<SenderId>({ allowlist, admins, rateLimit })` returning
+`isAllowed`, `isAdmin`, `isRateLimited`, `trackDm`. Frontends keep only
+the config mapping and the platform-specific "who is the sender" step.
+Est. −350 lines, and one place to fix rate-limit semantics.
+
+### 4. The native bridge: a route table, split closure, and tests
+
+The bridge is the security surface (bearer auth, failed-auth lockout,
+pre-auth routes `/health` `/pair` `/node/install` `/node/binary`,
+transfer-token scoping) and the least-covered frontend after Discord.
+
+- `server.ts` `handle()`: replace the 430-line `if` chain with a route
+  table `Map<"METHOD /path", { auth: "none" | "bearer" | "transfer";
+  handler }>`. The auth tier per route then *is* the security property,
+  and a test can assert it for every route in one loop instead of one
+  hand-written request per route.
+- `index.ts` `createNativeFrontend`: split the closure along the seams
+  its inner functions already mark — chat/queue state (`toQueued`,
+  `setQueued`, `liveTurnEvents`, `toClientChat`), the turn runner
+  (`runTurn`, `emit*`), and control (`listModels`, `setBackend`,
+  `control`, `spawnDaemonRestart`).
+- Coverage: `settings.ts` 20%, `extensions.ts` 0%, `index.ts` 4%. Note
+  `native-bridge-extensions.test.ts` tests `storage/history`, not
+  `frontend/native/extensions.ts`; rename it and write the real one.
+
+### 5. `core/mesh/service.ts` (1,863 lines)
+
+Split along the section comments already in the file: `mesh/transfer.ts`
+(the streaming bridge surface, pull/push bytes, `acceptFileUpload`,
+`openFileDownload`), `mesh/provision.ts` (`getNodeBinary`,
+`makeNodeInstallLink`, `openNodeInstall/Binary`, `updateNodeBinary`,
+companion pairing links), leaving `service.ts` as the device
+registry + command façade. No behaviour change; the class already
+delegates to private methods at those boundaries.
+
+### 6. The three planned migrations in `.dependency-cruiser.cjs`
+
+Already documented there; listed here so the order is explicit.
+
+- **`config-belongs-in-core`** (3 edges): move `util/config.ts` to
+  `core/config/`. Mechanical — it imports `core/agent-runtime/model-ref`,
+  `core/models/reasoning-levels`, `core/prompt/assemble`; ~100 import
+  sites move with it. Ratchet the rule to `error` in the same PR.
+- **`doctor-probes-move-behind-registry`** (4 edges): doctor hardcodes
+  claude-sdk and codex probes, so kilo, opencode, and openai-agents get
+  no doctor checks. Add an optional `doctorChecks()` slot to
+  `BackendFactory`; doctor composes whatever is registered.
+- **`backend-sessions-move-to-thread`** (10 edges after #822): deferred by
+  design per `docs/weaver.md`; do not add importers. Revisit when the
+  Weaver gets a write-capable `ThreadSession`.
+
+### 7. Soul kernel — no investment
+
+`core/soul/` is 4,657 lines at 93% coverage with ten importers
+(bootstrap, dream, gateway, prompt assembly, and admin/middleware in
+telegram and discord). `docs/memory-persona-plan.md` §2 keeps ~460 lines
+and deletes ~4,300 + 26 test files. That is its own rollout; nothing here
+should touch soul except to remove it when that lands.
+
+### 8. Companion
+
+`settings_screen.dart` (3,434 lines, 49% covered): the per-card builders
+(`_meshCard`, `_voiceCard`, `_appearanceCard`, `_diagnosticsCard`,
+`_statusCard`, `_aboutCard`) are independent and become one widget file
+each. `mesh_background.dart` at 9% is the Android foreground-service
+isolate — the least-tested, most load-bearing code in the app.
+
+### 9. Test brittleness
+
+`package.functional.test.ts` asserts the spawned CLI's stderr is exactly
+empty. Any Node process warning (here: `NODE_USE_ENV_PROXY` making undici
+print its experimental-agent notice) fails both cases on a machine where
+CI is green. Filter `(node:NNN)` warning lines before the assertion.
+
+## Order
+
+1. #820 — knip sweep + gate. *(merging)*
+2. #822 — remote-server unification. *(open, stacked on 1)*
+3. Frontend access gate (§3).
+4. Native bridge route table + closure split + tests (§4).
+5. `config → core/config`, doctor probes via registry (§6).
+6. `mesh/service.ts` split (§5).
+7. `settings_screen.dart` split (§8).
+8. Test brittleness (§9) — rides along with whichever PR touches tests
+   next.

--- a/docs/weaver.md
+++ b/docs/weaver.md
@@ -80,7 +80,7 @@ carries the weft across the warp.**
    messagesSent, numeric/string ids) now lives on the Thread. The Loom carries a
    numeric secondary index; the gateway delegates and owns no per-chat state.
 4. ✅ **Bind the warp**: each Thread records its resolved model + backend id per
-   turn and logs drift; `weaver.snapshot()` / `dispatcher.snapshot()` surface
+   turn and logs drift; `weaver.snapshot()` surfaces
    the live warp for `/status`, drift detection, and remote frontends.
 5. ✅ **Session handle**: `Thread.session` gives chat-scoped access to the
    session store (read handle this PR; see Non-goals).

--- a/knip.json
+++ b/knip.json
@@ -14,6 +14,22 @@
     "native/scheduler-core/embed.mjs",
     ".github/scripts/**"
   ],
-  "project": ["src/**/*.ts", "scripts/**/*.ts"],
-  "ignoreDependencies": ["@playwright/mcp", "@brave/brave-search-mcp-server"]
+  "project": [
+    "src/**/*.ts",
+    "scripts/**/*.ts"
+  ],
+  "ignoreDependencies": [
+    "@brave/brave-search-mcp-server",
+    "@playwright/mcp",
+    "@swc/core"
+  ],
+  "ignoreBinaries": [
+    "gleam",
+    "gofmt",
+    "talon",
+    "taskkill.exe",
+    "umount",
+    "where.exe",
+    "zig"
+  ]
 }

--- a/src/__tests__/integration/dummy-openai-server.ts
+++ b/src/__tests__/integration/dummy-openai-server.ts
@@ -27,7 +27,7 @@ import { createServer, type Server } from "node:http";
 import { randomBytes } from "node:crypto";
 import type { AddressInfo } from "node:net";
 
-export interface DummyModel {
+interface DummyModel {
   id: string;
   name?: string;
   context_length?: number;
@@ -35,7 +35,7 @@ export interface DummyModel {
   pricing?: { prompt: string; completion?: string };
 }
 
-export interface ToolCallSpec {
+interface ToolCallSpec {
   name: string;
   /** Arguments — serialised to a JSON string by the server (matches OpenAI's API). */
   arguments: Record<string, unknown>;
@@ -48,7 +48,7 @@ export interface ToolCallSpec {
  * both be present (an assistant chunk that also requests tools); when
  * `toolCalls` is set, `finishReason` defaults to `"tool_calls"`.
  */
-export interface ScriptedResponse {
+interface ScriptedResponse {
   text?: string;
   toolCalls?: ToolCallSpec[];
   finishReason?: "stop" | "tool_calls";
@@ -56,7 +56,7 @@ export interface ScriptedResponse {
   model?: string;
 }
 
-export interface RecordedRequest {
+interface RecordedRequest {
   path: string;
   method: string;
   body: unknown;

--- a/src/__tests__/integration/recording-handler.ts
+++ b/src/__tests__/integration/recording-handler.ts
@@ -12,7 +12,7 @@
 
 import type { FrontendActionHandler, ActionResult } from "../../core/types.js";
 
-export interface CapturedAction {
+interface CapturedAction {
   body: Record<string, unknown>;
   chatId: number;
   /** Sequence number — first capture is 0, second is 1, etc. */

--- a/src/__tests__/integration/stub-claude/protocol.ts
+++ b/src/__tests__/integration/stub-claude/protocol.ts
@@ -37,12 +37,12 @@ export interface StubScript {
   dispatchMcp?: boolean;
 }
 
-export interface StubTurn {
+interface StubTurn {
   /** Messages to write to stdout when this turn fires, in order. */
   emit?: StubEmit[];
 }
 
-export type StubEmit = StubAssistant | StubResult | StubFireHook | StubRaw;
+type StubEmit = StubAssistant | StubResult | StubFireHook | StubRaw;
 
 /**
  * Pseudo-emit handled by `fake-claude.mjs` — synthesizes a `hook_callback`
@@ -95,7 +95,7 @@ export interface StubResult {
  * Escape hatch for raw protocol messages (e.g. `system`, `stream_event`,
  * arbitrary control responses) that don't fit the high-level helpers.
  */
-export interface StubRaw {
+interface StubRaw {
   type: string;
   [key: string]: unknown;
 }
@@ -116,7 +116,7 @@ export interface ToolUseBlock {
   input: Record<string, unknown>;
 }
 
-export interface ThinkingBlock {
+interface ThinkingBlock {
   type: "thinking";
   thinking: string;
   signature?: string;

--- a/src/__tests__/integration/stub-codex/helpers.ts
+++ b/src/__tests__/integration/stub-codex/helpers.ts
@@ -2,16 +2,7 @@
  * Script builders for the fake codex binary. Mirror the stub-claude helpers so
  * tests read the same way across backends.
  */
-import type {
-  CodexAgentMessage,
-  CodexMcpToolCall,
-  CodexStubTurn,
-} from "./protocol.js";
-
-/** The model's final reply text. */
-export function agentMessage(text: string): CodexAgentMessage {
-  return { type: "agent_message", text };
-}
+import type { CodexMcpToolCall } from "./protocol.js";
 
 /** An MCP tool call (e.g. the `end_turn` delivery tool on `telegram-tools`). */
 export function mcpToolCall(
@@ -20,17 +11,4 @@ export function mcpToolCall(
   args: Record<string, unknown> = {},
 ): CodexMcpToolCall {
   return { type: "mcp_tool_call", server, tool, arguments: args };
-}
-
-/**
- * Convenience: a turn that delivers `text` via the canonical `end_turn` tool on
- * the telegram-tools MCP server — the production delivery path for codex.
- */
-export function endTurnTurn(text: string): CodexStubTurn {
-  return { emit: [mcpToolCall("telegram-tools", "end_turn", { text })] };
-}
-
-/** A turn that just emits trailing `agent_message` prose (no delivery tool). */
-export function proseTurn(text: string): CodexStubTurn {
-  return { emit: [agentMessage(text)] };
 }

--- a/src/__tests__/integration/stub-codex/protocol.ts
+++ b/src/__tests__/integration/stub-codex/protocol.ts
@@ -39,18 +39,18 @@ export interface CodexStubTurn {
   fail?: string;
 }
 
-export interface CodexUsage {
+interface CodexUsage {
   input_tokens?: number;
   output_tokens?: number;
   cached_input_tokens?: number;
   reasoning_output_tokens?: number;
 }
 
-export type CodexEmit =
+type CodexEmit =
   CodexAgentMessage | CodexMcpToolCall | CodexReasoning | CodexRawItem;
 
 /** The model's final reply text (Codex coalesces deltas into one block). */
-export interface CodexAgentMessage {
+interface CodexAgentMessage {
   type: "agent_message";
   text: string;
 }
@@ -70,13 +70,13 @@ export interface CodexMcpToolCall {
 }
 
 /** Private reasoning — the handler ignores it, but tests may want to emit it. */
-export interface CodexReasoning {
+interface CodexReasoning {
   type: "reasoning";
   text: string;
 }
 
 /** Escape hatch: emit an arbitrary `ThreadItem` verbatim as `item.completed`. */
-export interface CodexRawItem {
+interface CodexRawItem {
   type: string;
   [key: string]: unknown;
 }

--- a/src/__tests__/integration/stub-remote/fake-remote-server.ts
+++ b/src/__tests__/integration/stub-remote/fake-remote-server.ts
@@ -22,7 +22,7 @@ import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
-export interface RemoteTurnItem {
+interface RemoteTurnItem {
   type: "text" | "tool";
   /** For text. */
   text?: string;

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -72,8 +72,11 @@ describe("plugin system", () => {
   async function setup(plugin: ReturnType<typeof createMockPlugin>) {
     vi.doMock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
     const mod = await import("../core/plugin/index.js");
+    // registerPlugin is loader-internal (builtins call it); the barrel no
+    // longer re-exports it, so reach it on the same module instance directly.
+    const { registerPlugin } = await import("../core/plugin/loader.js");
     mod._deps.importModule = async () => ({ default: plugin });
-    return mod;
+    return { ...mod, registerPlugin };
   }
 
   describe("PluginRegistry", () => {

--- a/src/backend/claude-sdk/constants.ts
+++ b/src/backend/claude-sdk/constants.ts
@@ -6,14 +6,9 @@
  * additions live next to the rest of the chat-handler config).
  */
 
-import {
-  ALLOWED_TOOLS_CORE,
-  ALLOWED_TOOLS_BACKGROUND,
-} from "../../core/constants.js";
+import { ALLOWED_TOOLS_CORE } from "../../core/constants.js";
 
 // Re-export so existing backend imports keep working
-export { ALLOWED_TOOLS_CORE, ALLOWED_TOOLS_BACKGROUND };
-
 /**
  * Whitelist of built-in tools available to the main chat handler.
  *

--- a/src/backend/claude-sdk/index.ts
+++ b/src/backend/claude-sdk/index.ts
@@ -8,14 +8,5 @@
 export { initAgent, updateSystemPrompt } from "./state.js";
 export { warmSession } from "./warm.js";
 export { getActiveQuery } from "./handler.js";
-export {
-  buildMcpServers,
-  buildPluginMcpServers,
-  getActiveFrontends,
-} from "./options.js";
-export { getBridgePort } from "./state.js";
-export {
-  runOneShotAgent,
-  evictOrphanSubprocesses,
-  initClaudeOneShot,
-} from "./one-shot.js";
+export { buildMcpServers, buildPluginMcpServers } from "./options.js";
+export { runOneShotAgent, evictOrphanSubprocesses } from "./one-shot.js";

--- a/src/backend/claude-sdk/models/parsing.ts
+++ b/src/backend/claude-sdk/models/parsing.ts
@@ -167,7 +167,7 @@ export function describeSdkModel(model: SdkModelInfo): ParsedModelIdentity {
   };
 }
 
-export function buildFamilyKey(identity: ParsedModelIdentity): string | null {
+function buildFamilyKey(identity: ParsedModelIdentity): string | null {
   return identity.family
     ? `${identity.family}:${identity.version ?? "*"}`
     : null;
@@ -178,7 +178,7 @@ export function buildFamilyKey(identity: ParsedModelIdentity): string | null {
  * context size. Base and 1M variants of one family+version land in separate
  * buckets so both surface in the picker, while redundant longhand ids collapse.
  */
-export function buildVariantKey(identity: ParsedModelIdentity): string | null {
+function buildVariantKey(identity: ParsedModelIdentity): string | null {
   const familyKey = buildFamilyKey(identity);
   if (!familyKey) return null;
   return `${familyKey}:${identity.isOneMillion ? "1m" : "base"}`;

--- a/src/backend/claude-sdk/plan-usage.ts
+++ b/src/backend/claude-sdk/plan-usage.ts
@@ -163,8 +163,3 @@ export async function getPlanUsage(): Promise<PlanUsage | undefined> {
 export function invalidatePlanUsage(): void {
   if (cache) cache.fetchedAt = 0;
 }
-
-export function resetPlanUsageForTest(): void {
-  cache = undefined;
-  inFlight = undefined;
-}

--- a/src/backend/claude-sdk/stream.ts
+++ b/src/backend/claude-sdk/stream.ts
@@ -214,7 +214,7 @@ export function processStreamDelta(
 }
 
 /** A tool call extracted from an assistant message. */
-export type ToolCall = {
+type ToolCall = {
   /** The SDK's tool_use block id — matches the later tool_result. */
   id: string;
   name: string;

--- a/src/backend/codex/auth.ts
+++ b/src/backend/codex/auth.ts
@@ -45,7 +45,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 /** Detected auth mode. */
-export type CodexAuthMode = "api-key" | "chatgpt" | "none";
+type CodexAuthMode = "api-key" | "chatgpt" | "none";
 
 export type CodexApiKeySource =
   | "env:CODEX_API_KEY"
@@ -80,7 +80,7 @@ export interface DetectCodexAuthInput {
   env?: NodeJS.ProcessEnv;
 }
 
-export function normalizeCodexBaseUrl(
+function normalizeCodexBaseUrl(
   baseUrl: string | undefined,
 ): string | undefined {
   const trimmed = baseUrl?.trim();

--- a/src/backend/codex/constants.ts
+++ b/src/backend/codex/constants.ts
@@ -47,27 +47,6 @@ export const CODEX_DEFAULT_MODEL = "gpt-5-codex";
 export const CODEX_CHATGPT_DEFAULT_MODEL = "gpt-5.5";
 
 /**
- * Set of Codex models that require an API key (i.e. won't work under
- * ChatGPT OAuth). Used by the handler's recovery ladder to detect a
- * model-not-supported error and automatically fall back to a
- * chatgpt-compatible model on retry.
- *
- * Keep this list in sync with `CODEX_MODELS` in `models.ts` — every
- * entry there with `apiKeyOnly: true` should appear here.
- */
-export const CODEX_API_KEY_ONLY_MODELS: ReadonlySet<string> = new Set([
-  "gpt-5-codex",
-]);
-
-/**
- * Default working directory for thread runs. Codex enforces a git-repo
- * check by default; we set `skipGitRepoCheck: true` and use a known
- * directory under the user's Talon workspace.
- */
-export const CODEX_DEFAULT_WORKING_DIRECTORY =
-  process.env.HOME ?? process.cwd();
-
-/**
  * ThreadOptions permission settings shared by both the chat handler and
  * the heartbeat/dream one-shot path.
  *

--- a/src/backend/codex/handler/index.ts
+++ b/src/backend/codex/handler/index.ts
@@ -12,4 +12,3 @@
 
 export { handleMessage } from "./message.js";
 export { getActiveAbort } from "./state.js";
-export { CodexUsageExhaustedError } from "./usage.js";

--- a/src/backend/codex/mcp-config.ts
+++ b/src/backend/codex/mcp-config.ts
@@ -49,7 +49,7 @@ import { frontendsForChat } from "../shared/frontends.js";
  *                 short-circuits to `true` for this server. Equivalent
  *                 to saying "Talon trusts this server, don't ask."
  */
-export type CodexToolApprovalMode = "auto" | "prompt" | "approve";
+type CodexToolApprovalMode = "auto" | "prompt" | "approve";
 
 /** TOML-compatible record shape Codex's CLI accepts (HTTP transport). */
 export interface CodexMcpServer {
@@ -100,7 +100,7 @@ export function asCodexConfig(
  * reasoning. Exposed as a module-level constant rather than a
  * literal-everywhere so behaviour changes happen in exactly one place.
  */
-export const TALON_MCP_DEFAULT_APPROVAL: CodexToolApprovalMode = "approve";
+const TALON_MCP_DEFAULT_APPROVAL: CodexToolApprovalMode = "approve";
 
 /**
  * Build the Codex `mcp_servers` config map for a given chat.

--- a/src/backend/codex/plan-usage.ts
+++ b/src/backend/codex/plan-usage.ts
@@ -161,8 +161,3 @@ export async function getPlanUsage(): Promise<PlanUsage | undefined> {
   if (loaded) cache = { value: loaded, fetchedAt: loaded.fetchedAt };
   return loaded ?? cache?.value;
 }
-
-export function resetCodexPlanUsageForTest(): void {
-  cache = undefined;
-  inFlight = undefined;
-}

--- a/src/backend/codex/state.ts
+++ b/src/backend/codex/state.ts
@@ -20,7 +20,7 @@ import type { FrontendName } from "../../core/agent-runtime/backend-registry.js"
  * window, description); the api-key path (`/v1/models`) is sparse and
  * leaves these fields undefined.
  */
-export interface DiscoveredModelMetadata {
+interface DiscoveredModelMetadata {
   displayName?: string;
   contextWindow?: number;
   description?: string;

--- a/src/backend/codex/token-usage.ts
+++ b/src/backend/codex/token-usage.ts
@@ -47,7 +47,7 @@ export interface CodexLastTokenUsage {
  * want per-turn usage must snapshot before the turn and diff after
  * (see the terminator-abort fallback in `handler.ts`).
  */
-export interface CodexTokenTotals {
+interface CodexTokenTotals {
   inputTokens: number;
   cachedInputTokens: number;
   outputTokens: number;

--- a/src/backend/kilo/index.ts
+++ b/src/backend/kilo/index.ts
@@ -22,10 +22,6 @@
 
 // ── Models ─────────────────────────────────────────────────────────────────
 export {
-  type OpenCodeModelCatalogEntry,
-  type OpenCodeModelCatalog,
-  type OpenCodeModelResolution,
-  type ModelButton,
   getOpenCodeModelSelectionValue,
   resolveOpenCodeModelInput,
   getOpenCodeQuickPickModels,
@@ -36,8 +32,6 @@ export {
 export {
   summarizeKiloAssistantMessages,
   getKiloSessionSnapshot,
-  type KiloAssistantInfo,
-  type KiloSessionSnapshot,
 } from "./sessions.js";
 
 // ── Server / lifecycle ─────────────────────────────────────────────────────

--- a/src/backend/kilo/server.ts
+++ b/src/backend/kilo/server.ts
@@ -27,8 +27,6 @@ import { buildDeliveryContract } from "../shared/delivery-contract.js";
 import {
   guessProviderID,
   getBucketPriority,
-  normalizeModelLookup,
-  parseRemoteModelQuery as parseOpenCodeModelQuery,
 } from "../remote-server/model-catalog/index.js";
 import {
   createRemoteServerState,
@@ -44,23 +42,19 @@ import {
   resolveProviderID as resolveProviderIDShared,
   getRegisteredMcpServerNames as getRegisteredMcpServerNamesShared,
   errMsg as sharedErrMsg,
-  TALON_MCP_SERVER_NAME as SHARED_TALON_MCP_SERVER_NAME,
   type RemoteServerState,
 } from "../remote-server/index.js";
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
 /** Loopback hostname Talon binds the Kilo server on — never exposed externally. */
-export const KILO_HOSTNAME = "127.0.0.1";
+const KILO_HOSTNAME = "127.0.0.1";
 /** Default TCP port for the local Kilo server. Overridable via `KILO_PORT`
  *  env var so integration tests can spawn an isolated Kilo server alongside
  *  a running production Talon (which holds the default 4097). */
-export const KILO_PORT = Number(process.env.KILO_PORT ?? 4097);
+const KILO_PORT = Number(process.env.KILO_PORT ?? 4097);
 /** Convenience URL composed from KILO_HOSTNAME + KILO_PORT. */
 export const KILO_BASE_URL = `http://${KILO_HOSTNAME}:${KILO_PORT}`;
-/** Re-export of the chat MCP server name prefix shared across backends. */
-export const TALON_MCP_SERVER_NAME = SHARED_TALON_MCP_SERVER_NAME;
-
 /**
  * System-prompt suffix appended to the user-configured system prompt.
  *
@@ -314,21 +308,7 @@ export function getRegisteredMcpServerNames(): string[] {
   return getRegisteredMcpServerNamesShared(state);
 }
 
-export function getGatewayPortFn(): () => number {
-  return state.gatewayPortFn;
-}
-
-export function getFrontendName(): FrontendName {
-  return state.frontendName;
-}
-
 /** Common error→message helper, re-exported for legacy importers. */
 export const errMsg = sharedErrMsg;
 
 // Re-export the model-helper imports for kilo-internal consumers
-export {
-  guessProviderID,
-  getBucketPriority,
-  normalizeModelLookup,
-  parseOpenCodeModelQuery,
-};

--- a/src/backend/kilo/sessions.ts
+++ b/src/backend/kilo/sessions.ts
@@ -13,7 +13,6 @@
 
 import type { KiloClient } from "@kilocode/sdk/v2";
 import {
-  REMOTE_SESSION_MESSAGE_LIMIT,
   extractPartsSummary as extractPartsSummaryShared,
   extractAssistantUsage as extractAssistantUsageShared,
   summarizeAssistantMessages,
@@ -28,8 +27,6 @@ import {
 import { ensureServer } from "./server.js";
 
 // ── Constants / type aliases (Kilo-named surface) ──────────────────────────
-
-export const KILO_SESSION_MESSAGE_LIMIT = REMOTE_SESSION_MESSAGE_LIMIT;
 
 /** Subset of Kilo's `Message.info` used by Talon for usage accounting. */
 export type KiloAssistantInfo = RemoteAssistantInfo;

--- a/src/backend/openai-agents/handler/index.ts
+++ b/src/backend/openai-agents/handler/index.ts
@@ -10,4 +10,3 @@
  */
 
 export { handleMessage } from "./message.js";
-export { getActiveAbort } from "./state.js";

--- a/src/backend/openai-agents/handler/state.ts
+++ b/src/backend/openai-agents/handler/state.ts
@@ -6,8 +6,3 @@
  */
 
 export const activeAborts = new Map<string, AbortController>();
-
-/** Get the in-flight abort controller for a chat, if a turn is running. */
-export function getActiveAbort(chatId: string): AbortController | undefined {
-  return activeAborts.get(chatId);
-}

--- a/src/backend/openai-agents/init.ts
+++ b/src/backend/openai-agents/init.ts
@@ -48,7 +48,7 @@ import type { FrontendName } from "../../core/agent-runtime/backend-registry.js"
 import { log, logWarn } from "../../util/log.js";
 import { nonTerminalFrontends } from "../shared/frontends.js";
 import { getState } from "./state.js";
-import { startDiscovery, refreshDiscovery } from "./discovery.js";
+import { startDiscovery } from "./discovery.js";
 
 /**
  * Initialise the OpenAI Agents backend.
@@ -178,23 +178,6 @@ export function initOpenAIAgentsAgent(
   // render so the user doesn't see "0 models" just because the HTTP
   // call hasn't returned yet — see `discovery.ts#awaitDiscovery`.
   void startDiscovery(effectiveBaseURL, apiKey);
-}
-
-/**
- * Trigger a fresh discovery fetch using the resolved endpoint stored
- * on state at init time. Returns the new promise so callers can await
- * if they want; safe to fire-and-forget.
- *
- * Useful when the operator wants to refresh the catalog without
- * restarting Talon — e.g. after an endpoint outage clears or a new
- * model is published.
- */
-export function triggerDiscoveryRefresh(): Promise<void> {
-  const state = getState();
-  if (!state.baseURL) {
-    return Promise.resolve();
-  }
-  return refreshDiscovery(state.baseURL, state.apiKey);
 }
 
 /**

--- a/src/backend/opencode/index.ts
+++ b/src/backend/opencode/index.ts
@@ -9,10 +9,6 @@
  */
 
 export {
-  type OpenCodeModelCatalogEntry,
-  type OpenCodeModelCatalog,
-  type OpenCodeModelResolution,
-  type ModelButton,
   getOpenCodeModelSelectionValue,
   resolveOpenCodeModelInput,
   formatOpenCodeSelectionError,

--- a/src/backend/opencode/server.ts
+++ b/src/backend/opencode/server.ts
@@ -44,7 +44,6 @@ import {
   resolveProviderID as resolveProviderIDShared,
   getRegisteredMcpServerNames as getRegisteredMcpServerNamesShared,
   errMsg as sharedErrMsg,
-  TALON_MCP_SERVER_NAME as SHARED_TALON_MCP_SERVER_NAME,
   type RemoteServerState,
 } from "../remote-server/index.js";
 
@@ -55,7 +54,6 @@ const OPENCODE_HOSTNAME = "127.0.0.1";
 // isolated server alongside a running production Talon (which holds 4096).
 const OPENCODE_PORT = Number(process.env.OPENCODE_PORT ?? 4096);
 const OPENCODE_BASE_URL = `http://${OPENCODE_HOSTNAME}:${OPENCODE_PORT}`;
-const TALON_MCP_SERVER_NAME = SHARED_TALON_MCP_SERVER_NAME;
 // Text-preferred delivery: plain assistant text is the reply; tools
 // only for genuine side effects. Single-sourced from the shared
 // contract templates (prompts/system/contract-text-preferred.md).
@@ -238,11 +236,4 @@ export function getRegisteredMcpServerNames(): string[] {
 
 const errMsg = sharedErrMsg;
 
-export {
-  OPENCODE_HOSTNAME,
-  OPENCODE_PORT,
-  OPENCODE_BASE_URL,
-  TALON_MCP_SERVER_NAME,
-  OPENCODE_SYSTEM_PROMPT_SUFFIX,
-  errMsg,
-};
+export { OPENCODE_BASE_URL, OPENCODE_SYSTEM_PROMPT_SUFFIX, errMsg };

--- a/src/backend/opencode/sessions.ts
+++ b/src/backend/opencode/sessions.ts
@@ -11,7 +11,6 @@
 
 import type { OpencodeClient } from "@opencode-ai/sdk/v2";
 import {
-  REMOTE_SESSION_MESSAGE_LIMIT,
   extractPartsSummary as extractPartsSummaryShared,
   extractAssistantUsage as extractAssistantUsageShared,
   summarizeAssistantMessages,
@@ -26,8 +25,6 @@ import {
 import { ensureServer } from "./server.js";
 
 // ── Constants / type aliases (OpenCode-named surface) ──────────────────────
-
-export const OPENCODE_SESSION_MESSAGE_LIMIT = REMOTE_SESSION_MESSAGE_LIMIT;
 
 /** Subset of OpenCode's `Message.info` used by Talon for usage accounting. */
 export type OpenCodeAssistantInfo = RemoteAssistantInfo;

--- a/src/backend/remote-server/client.ts
+++ b/src/backend/remote-server/client.ts
@@ -20,7 +20,7 @@
  */
 
 /** Minimal MCP server config shapes both SDKs accept on `mcp.add`. */
-export type RemoteMcpServerConfig =
+type RemoteMcpServerConfig =
   | {
       type: "local";
       command: string[];

--- a/src/backend/remote-server/events.ts
+++ b/src/backend/remote-server/events.ts
@@ -365,7 +365,7 @@ export function maybeFireStreamDelta(
 // ── Sync-response parts backfill ───────────────────────────────────────────
 
 /** Shape returned by a backend's parts-summary extractor. */
-export interface PartsSummary {
+interface PartsSummary {
   text: string;
   toolCalls: number;
   syntheticErrorText?: string;

--- a/src/backend/remote-server/index.ts
+++ b/src/backend/remote-server/index.ts
@@ -30,31 +30,19 @@
  *     agnostic and live in `core/` and `backend/shared/`.
  */
 
-export type {
-  RemoteAgentClient,
-  RemoteMcpServerConfig,
-  RemotePermissionRule,
-} from "./client.js";
+export type { RemoteAgentClient } from "./client.js";
 
 export {
   type RemoteServerState,
-  type RemoteServerStateInputs,
   createRemoteServerState,
   errMsg,
 } from "./state.js";
 
-export {
-  type EnsureRemoteServerInputs,
-  ensureRemoteServer,
-  stopRemoteServer,
-} from "./lifecycle.js";
+export { ensureRemoteServer, stopRemoteServer } from "./lifecycle.js";
 
 export {
   TALON_MCP_SERVER_NAME,
-  TALON_PLUGIN_MCP_SERVER_NAME,
   getChatMcpServerName,
-  getPluginMcpServerName,
-  safeMcpNamePart,
   isTalonToolID,
   ensureChatMcpServer,
   ensurePluginMcpServers,
@@ -64,17 +52,6 @@ export {
   getRegisteredMcpServerNames,
 } from "./mcp.js";
 
-export {
-  buildPermissionRuleset,
-  ensureRemoteSession,
-  warmRemoteSession,
-  type RemoteWarmDeps,
-} from "./sessions.js";
+export { ensureRemoteSession, warmRemoteSession } from "./sessions.js";
 
-export { type ProviderResolverHooks, resolveProviderID } from "./providers.js";
-
-export {
-  RemoteTurnTimeoutError,
-  remoteTurnTimeoutMs,
-  awaitRemoteTurn,
-} from "./turn-timeout.js";
+export { resolveProviderID } from "./providers.js";

--- a/src/backend/remote-server/mcp.ts
+++ b/src/backend/remote-server/mcp.ts
@@ -92,10 +92,7 @@ export function safeMcpNamePart(value: string, fallback: string): string {
 }
 
 /** Per-chat registration name for a plugin-provided MCP server. */
-export function getPluginMcpServerName(
-  pluginName: string,
-  chatId: string,
-): string {
+function getPluginMcpServerName(pluginName: string, chatId: string): string {
   return `${TALON_PLUGIN_MCP_SERVER_NAME}-${safeMcpNamePart(chatId, "chat")}-${safeMcpNamePart(pluginName, "plugin")}`;
 }
 

--- a/src/backend/remote-server/model-catalog/catalog.ts
+++ b/src/backend/remote-server/model-catalog/catalog.ts
@@ -164,7 +164,7 @@ function extractReasoningLevels(rawModel: RemoteRawModel) {
   ]);
 }
 
-export function buildModelCatalog(
+function buildModelCatalog(
   providersData: RemoteRawProvidersData,
   authMap: Record<string, Array<RemoteAuthMethod>>,
 ): RemoteModelCatalog {

--- a/src/backend/remote-server/model-catalog/index.ts
+++ b/src/backend/remote-server/model-catalog/index.ts
@@ -25,20 +25,13 @@ import type {
 
 export type {
   ModelButton,
-  RemoteAuthMethod,
   RemoteModelCatalog,
   RemoteModelCatalogEntry,
   RemoteModelResolution,
-  RemoteProviderCatalogEntry,
-  RemoteProviderClient,
-  RemoteRawModel,
-  RemoteRawProvider,
-  RemoteRawProvidersData,
 } from "./types.js";
-export { buildModelCatalog, sortCatalogModels } from "./catalog.js";
+export { sortCatalogModels } from "./catalog.js";
 export {
   getBucketPriority,
-  getRemoteModelInfo,
   getRemoteModelSelectionValue,
   guessProviderID,
   normalizeModelLookup,
@@ -46,14 +39,7 @@ export {
   resolveRemoteModelInput,
 } from "./resolve.js";
 export { formatRemoteUnavailableModel } from "./presentation.js";
-export type { RemoteModelPresentation } from "./presentation.js";
 export { createRemoteModelProvider } from "./provider.js";
-export type {
-  RemoteModelProvider,
-  RemoteModelProviderDeps,
-} from "./provider.js";
-export type { RemoteModelCatalogStore } from "./catalog.js";
-
 export interface RemoteModelCatalogModuleOptions {
   /** Human label — "OpenCode" / "Kilo" — used in headers and errors. */
   label: string;

--- a/src/backend/remote-server/model-catalog/provider.ts
+++ b/src/backend/remote-server/model-catalog/provider.ts
@@ -12,7 +12,6 @@ import type {
   UnifiedModelInfo,
   UnifiedModelResolution,
   UnifiedProviderInfo,
-  ModelButton,
 } from "../../../core/types.js";
 import type {
   RemoteModelCatalog,

--- a/src/backend/remote-server/sse-stream.ts
+++ b/src/backend/remote-server/sse-stream.ts
@@ -68,9 +68,7 @@ export async function subscribeSseStream(
  * Pull the iterable `stream` field out of a `global.event()` response.
  * Exported for tests; production code should call `subscribeSseStream`.
  */
-export function narrowSseResult(
-  result: unknown,
-): AsyncIterable<unknown> | undefined {
+function narrowSseResult(result: unknown): AsyncIterable<unknown> | undefined {
   if (!result || typeof result !== "object") return undefined;
   const stream = (result as { stream?: unknown }).stream;
   if (!stream || typeof stream !== "object") return undefined;

--- a/src/backend/remote-server/turn-timeout.ts
+++ b/src/backend/remote-server/turn-timeout.ts
@@ -4,7 +4,7 @@ import { logWarn } from "../../util/log.js";
 
 const DEFAULT_REMOTE_TURN_TIMEOUT_MS = 10 * 60_000;
 
-export function remoteTurnTimeoutMs(): number {
+function remoteTurnTimeoutMs(): number {
   const configured = Number(process.env.TALON_REMOTE_TURN_TIMEOUT_MS);
   return Number.isFinite(configured) && configured > 0
     ? configured

--- a/src/backend/shared/index.ts
+++ b/src/backend/shared/index.ts
@@ -32,41 +32,26 @@
  *     (the spawn/env contract they share is `core/tools/mcp-env.ts`).
  */
 
-export {
-  normalizeForDedupe,
-  isDuplicateOfDelivered,
-  captureDeliveredText,
-} from "./delivered-text.js";
+export { captureDeliveredText } from "./delivered-text.js";
 
 export {
-  FLOW_VIOLATION_REMINDER,
   FLOW_VIOLATION_MAX_RETRIES,
   detectFlowViolation,
-  type FlowViolationInputs,
-  type FlowViolationResult,
 } from "./flow-violation.js";
 
-export { registerTurnInterrupt, interruptChatTurn } from "./turn-interrupt.js";
+export { registerTurnInterrupt } from "./turn-interrupt.js";
 
-export { formatUserPrompt, type PromptFormatInputs } from "./prompt-format.js";
+export { formatUserPrompt } from "./prompt-format.js";
 
 export {
   buildDeliveryContract,
   buildFlowViolationReminder,
   buildFirstTurnReminder,
-  deliveryToolsForFrontend,
-  registerFrontendDeliveryTools,
-  type DeliveryMode,
-  type DeliveryToolNames,
 } from "./delivery-contract.js";
 
 export { extractSessionName } from "../../util/session-name.js";
 
-export {
-  cacheHitPercent,
-  summarizeUsage,
-  type TokenUsageSnapshot,
-} from "./usage.js";
+export { summarizeUsage } from "./usage.js";
 
 // Only what is consumed THROUGH the barrel. Everything else in
 // cache-telemetry.ts is imported from the module directly, matching the
@@ -79,26 +64,15 @@ export {
   CACHE_LOOKBACK_BLOCKS,
 } from "./cache-telemetry.js";
 
-export {
-  prepareSystemPrompt,
-  appendBackendSuffix,
-  clearSystemPromptSnapshots,
-  type PrepareSystemPromptInputs,
-  type PreparedSystemPrompt,
-} from "./system-prompt.js";
+export { prepareSystemPrompt, appendBackendSuffix } from "./system-prompt.js";
 
-export {
-  classifyRetry,
-  type RetryDecision,
-  type ClassifyRetryInputs,
-} from "./model-retry.js";
+export { classifyRetry } from "./model-retry.js";
 
 export {
   createStreamState,
   appendText,
   closeCurrentSegment,
   markProgressDelivered,
-  undeliveredResponseText,
   recordToolUse,
   recordTokens,
   pushLiveUsage,
@@ -110,25 +84,15 @@ export {
   routeDelivery,
   buildDeliveryFailureReminder,
   TextBlockDeliveryError,
-  type DeliveryRoute,
-  type DeliveryDecision,
-  type RouteDeliveryInputs,
 } from "./delivery.js";
 
 export { sleep } from "./sleep.js";
-
-export { nonTerminalFrontends } from "./frontends.js";
 
 export {
   recordToolCall,
   recordTurnMetrics,
   recordFailedTurnAccounting,
   recordFlowViolation,
-  type TurnMetricInputs,
 } from "./metrics.js";
 
-export {
-  applyRetryDecision,
-  type ApplyRetryDecisionInputs,
-  type ApplyRetryDecisionResult,
-} from "./handle-retry.js";
+export { applyRetryDecision } from "./handle-retry.js";

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -17,7 +17,7 @@ const LEVEL_LABELS: Record<number, string> = {
   60: pc.bgRed(pc.white("FTL")),
 };
 
-export function formatLogLine(line: string): string {
+function formatLogLine(line: string): string {
   try {
     const obj = JSON.parse(line);
     const level = LEVEL_LABELS[obj.level as number] ?? pc.dim("???");

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -9,7 +9,7 @@ import { findRunningInstance } from "../core/daemon/discovery.js";
 import { printBanner, loadConfig } from "./config.js";
 import { CONFIG_FILE } from "./context.js";
 
-export function formatUptime(seconds: number): string {
+function formatUptime(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
   return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;

--- a/src/core/agent-runtime/backend-registry.ts
+++ b/src/core/agent-runtime/backend-registry.ts
@@ -58,7 +58,7 @@ export interface BackendInitContext {
 }
 
 /** Result returned by a backend factory's `init` step. */
-export interface BackendInstance {
+interface BackendInstance {
   /** The fully-wired `Backend` the dispatcher will route to. */
   backend: Backend;
   /**

--- a/src/core/agent-runtime/capabilities.ts
+++ b/src/core/agent-runtime/capabilities.ts
@@ -188,7 +188,7 @@ export interface SessionBackend {
  * the live registry. Returns the diff so the dispatcher can log
  * what changed.
  */
-export interface ToolRefreshResult {
+interface ToolRefreshResult {
   added: string[];
   removed: string[];
   errors: Record<string, string>;

--- a/src/core/agent-runtime/events.ts
+++ b/src/core/agent-runtime/events.ts
@@ -81,7 +81,7 @@ export interface AgentResult {
  * `core/errors.ts` already produces — keep the values stable so
  * downstream code can pattern-match deterministically.
  */
-export type AgentErrorKind =
+type AgentErrorKind =
   | "context_overflow"
   | "rate_limit"
   | "overload"

--- a/src/core/background/heartbeat/agent.ts
+++ b/src/core/background/heartbeat/agent.ts
@@ -83,7 +83,7 @@ export function buildHeartbeatSystemPrompt(): string {
  * the heartbeat is a global agent, so it sees every chat's open goals (with
  * chat ids for routing updates back). Exported for tests.
  */
-export function renderGoalsBlock(): { text: string; count: number } {
+function renderGoalsBlock(): { text: string; count: number } {
   let text = "(no open goals)";
   let count = 0;
   try {

--- a/src/core/background/heartbeat/index.ts
+++ b/src/core/background/heartbeat/index.ts
@@ -13,7 +13,6 @@
  * Re-exports the same public surface the old single-file module exposed.
  */
 
-export type { HeartbeatState } from "./state.js";
 export {
   initHeartbeat,
   startHeartbeatTimer,
@@ -22,4 +21,4 @@ export {
   forceHeartbeat,
   getHeartbeatStatus,
 } from "./scheduler.js";
-export { buildHeartbeatSystemPrompt, renderGoalsBlock } from "./agent.js";
+export { buildHeartbeatSystemPrompt } from "./agent.js";

--- a/src/core/background/isolated-agent.ts
+++ b/src/core/background/isolated-agent.ts
@@ -19,7 +19,7 @@ import type { OneShotAgentParams, OneShotUsage } from "../types.js";
 import { logWarn, logError } from "../../util/log.js";
 
 /** Default bounded grace after an abort before giving up on the backend. */
-export const DEFAULT_ABORT_GRACE_MS = 30 * 1000;
+const DEFAULT_ABORT_GRACE_MS = 30 * 1000;
 
 export interface IsolatedRunOptions {
   readonly background: BackgroundRunner;

--- a/src/core/background/triggers/exit.ts
+++ b/src/core/background/triggers/exit.ts
@@ -79,7 +79,7 @@ export async function shutdownTriggers(): Promise<void> {
   await new Promise((r) => setTimeout(r, 250));
 }
 
-export function killChild(id: string, child: ChildProcess): void {
+function killChild(id: string, child: ChildProcess): void {
   try {
     child.kill("SIGTERM");
   } catch {

--- a/src/core/background/triggers/index.ts
+++ b/src/core/background/triggers/index.ts
@@ -19,7 +19,7 @@ import { commandForLanguage } from "./command.js";
 import { handleStdoutLine } from "./output.js";
 import { handleTimeout, finalizeExit } from "./exit.js";
 
-export { initTriggers, getRunningCount, type TriggerDeps } from "./state.js";
+export { initTriggers, getRunningCount } from "./state.js";
 export { commandForLanguage } from "./command.js";
 export { spawnTrigger } from "./spawn.js";
 export { cancelTrigger, shutdownTriggers } from "./exit.js";

--- a/src/core/bus/events.ts
+++ b/src/core/bus/events.ts
@@ -32,7 +32,7 @@ export interface TaskSettledEvent {
 }
 
 /** A chat turn bound its warp and is about to run on the backend. */
-export interface TurnStartedEvent {
+interface TurnStartedEvent {
   readonly type: "turn.started";
   readonly chatId: string;
   readonly source: string;
@@ -41,7 +41,7 @@ export interface TurnStartedEvent {
 }
 
 /** A chat turn finished successfully (refusals and failures never emit this). */
-export interface TurnCompletedEvent {
+interface TurnCompletedEvent {
   readonly type: "turn.completed";
   readonly chatId: string;
   readonly source: string;

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -17,7 +17,7 @@ import { execFileSync } from "node:child_process";
 import { NATIVE_MODULES } from "../native/registry.js";
 import { dirs } from "../util/paths.js";
 
-export type DoctorStatus = "ok" | "warn" | "fail" | "info";
+type DoctorStatus = "ok" | "warn" | "fail" | "info";
 
 export interface DoctorCheck {
   label: string;

--- a/src/core/engine/backend-controller/index.ts
+++ b/src/core/engine/backend-controller/index.ts
@@ -28,7 +28,7 @@
  */
 
 export * from "./types.js";
-export { roleHolder, chatHolder } from "./holders.js";
+export { roleHolder } from "./holders.js";
 export {
   initBackendPool,
   hasBackendPool,
@@ -48,8 +48,6 @@ export {
   clearBackendChangeListenersForTest,
 } from "./pool.js";
 export {
-  rebindHolder,
-  releaseHolder,
   rebindRole,
   rebindChat,
   releaseChat,

--- a/src/core/engine/backend-controller/rebind.ts
+++ b/src/core/engine/backend-controller/rebind.ts
@@ -36,7 +36,7 @@ import type { BackendHolder, BackendRole, RebindResult } from "./types.js";
  *
  * Use `rebindRole` / `rebindChat` for typed wrappers.
  */
-export async function rebindHolder(
+async function rebindHolder(
   holder: BackendHolder,
   newId: string,
   config: TalonConfig,
@@ -113,7 +113,7 @@ export async function rebindHolder(
  * No-op when the holder isn't bound — useful for "clear my override"
  * flows that don't want to care whether the override was ever set.
  */
-export async function releaseHolder(holder: BackendHolder): Promise<void> {
+async function releaseHolder(holder: BackendHolder): Promise<void> {
   const id = bindings.get(holder);
   if (!id) return;
   bindings.delete(holder);

--- a/src/core/engine/dispatcher.ts
+++ b/src/core/engine/dispatcher.ts
@@ -11,12 +11,7 @@
 import type { ExecuteParams, ExecuteResult } from "../types.js";
 import { log } from "../../util/log.js";
 import { taskTable, type KillOutcome } from "../tasks/index.js";
-import {
-  initWeaver,
-  type Weaver,
-  type WeaverDeps,
-  type ThreadSnapshot,
-} from "../weaver/index.js";
+import { initWeaver, type Weaver, type WeaverDeps } from "../weaver/index.js";
 
 // ── Dependencies (injected at startup) ──────────────────────────────────────
 
@@ -47,15 +42,6 @@ export function initDispatcher(d: DispatcherDeps): void {
 /** Number of queries currently running. */
 export function getActiveCount(): number {
   return weaver?.getActiveCount() ?? 0;
-}
-
-/**
- * A live view of every Thread the Loom holds — model/backend warp, in-flight
- * count, and context state per chat. The hub's observability surface for
- * `/status`, drift detection, and remote frontends. Empty before init.
- */
-export function snapshot(): ThreadSnapshot[] {
-  return weaver?.snapshot() ?? [];
 }
 
 /**

--- a/src/core/engine/gateway-actions/index.ts
+++ b/src/core/engine/gateway-actions/index.ts
@@ -100,6 +100,3 @@ export async function handleChatFreeAction(
   if (!handler) return null;
   return handler(body, 0);
 }
-
-export { chatFreeActions };
-export type { SharedActionHandler, SharedActionHandlers } from "./types.js";

--- a/src/core/engine/gateway-actions/types.ts
+++ b/src/core/engine/gateway-actions/types.ts
@@ -9,7 +9,7 @@
 import type { ActionResult } from "../../types.js";
 import type { Backend } from "../../agent-runtime/capabilities.js";
 
-export type SharedActionHandler = (
+type SharedActionHandler = (
   body: Record<string, unknown>,
   chatId: number,
   backend?: Backend | null,

--- a/src/core/frontend-runtime/capabilities.ts
+++ b/src/core/frontend-runtime/capabilities.ts
@@ -58,5 +58,3 @@ export type FrontendCreate = (
 
 /** A fully-registered frontend: identity plus the factory. */
 export type FrontendFactory = FrontendDescriptor & { create: FrontendCreate };
-
-export type { FrontendDescriptor } from "./registry.js";

--- a/src/core/frontend-runtime/index.ts
+++ b/src/core/frontend-runtime/index.ts
@@ -9,12 +9,7 @@
 
 import "./builtins.js";
 
-export type {
-  Frontend,
-  FrontendCreate,
-  FrontendDescriptor,
-  FrontendFactory,
-} from "./capabilities.js";
+export type { Frontend } from "./capabilities.js";
 export {
   getFrontendDescriptor,
   hasFrontend,

--- a/src/core/frontend-runtime/routing.ts
+++ b/src/core/frontend-runtime/routing.ts
@@ -12,5 +12,4 @@ export {
   getFrontendDescriptor,
   resolveFrontendIdAmong,
   resolveOwnerFrontendId,
-  type FrontendDescriptor,
 } from "./registry.js";

--- a/src/core/mcp-hub/children.ts
+++ b/src/core/mcp-hub/children.ts
@@ -82,11 +82,6 @@ function failureBackoffMs(count: number): number {
   );
 }
 
-/** Test seam: forget recorded spawn failures. */
-export function resetSpawnFailures(): void {
-  spawnFailures.clear();
-}
-
 /** Idle TTL for hub children; tunable for tests / tight deployments. */
 function idleTtlMs(): number {
   const raw = Number(process.env.TALON_MCP_HUB_IDLE_MS);

--- a/src/core/mesh/index.ts
+++ b/src/core/mesh/index.ts
@@ -7,21 +7,4 @@
  */
 
 export { MeshRegistry } from "./registry.js";
-export {
-  MeshService,
-  getMeshService,
-  setMeshService,
-  type MeshTransport,
-  type MeshServiceOptions,
-  type MeshToolResult,
-} from "./service.js";
-export {
-  sanitizeCapabilities,
-  toDeviceInfo,
-  toDeviceLocation,
-  type DeviceCommand,
-  type DeviceCommandResult,
-  type DeviceInfo,
-  type DeviceLocation,
-  type DevicePlatform,
-} from "./types.js";
+export { MeshService, getMeshService, setMeshService } from "./service.js";

--- a/src/core/models/active-model.ts
+++ b/src/core/models/active-model.ts
@@ -307,25 +307,6 @@ export async function getActiveModelForChat(
   return model;
 }
 
-/**
- * Convenience: same as `resolveActiveModelForChat` but returns just
- * the `ModelRef` (or `null`). Use when the source tag isn't needed.
- */
-export async function getActiveModelRefForChat(
-  chatId: string,
-  backend: Backend | null,
-  backendId: string | null,
-  config: TalonConfig,
-): Promise<ModelRef | null> {
-  const { ref } = await resolveActiveModelForChat(
-    chatId,
-    backend,
-    backendId,
-    config,
-  );
-  return ref;
-}
-
 // ── ref enrichment ──────────────────────────────────────────────────────────
 
 /**

--- a/src/core/plugin/index.ts
+++ b/src/core/plugin/index.ts
@@ -20,7 +20,6 @@ export {
   getPlugin,
   getPluginCount,
   destroyPlugins,
-  registerPlugin,
   getPluginPromptAdditions,
 } from "./loader.js";
 export { loadBuiltinPlugins, reloadPlugins } from "./builtins.js";

--- a/src/core/plugin/registry.ts
+++ b/src/core/plugin/registry.ts
@@ -11,7 +11,7 @@ import { pathToFileURL } from "node:url";
 import { logError, logWarn } from "../../util/log.js";
 import type { LoadedPlugin, PluginMcpEntry } from "./types.js";
 
-export class PluginRegistry {
+class PluginRegistry {
   private readonly plugins: LoadedPlugin[] = [];
   private readonly standaloneMcpServers: PluginMcpEntry[] = [];
 

--- a/src/core/prompt/templates.ts
+++ b/src/core/prompt/templates.ts
@@ -117,8 +117,3 @@ export function loadSystemTemplate(
   }
   return liquid.renderSync(parsed, vars) as string;
 }
-
-/** Test seam: drop the parse cache (e.g. after writing fixture templates). */
-export function clearTemplateCache(): void {
-  parseCache.clear();
-}

--- a/src/core/scripting/lua-runner.ts
+++ b/src/core/scripting/lua-runner.ts
@@ -70,7 +70,7 @@ const FIRE_PREFIX = "TALON_FIRE:";
  * Throws on Lua errors (message shaped `<file>:<line>: <msg>` plus
  * traceback). Restores process.stdout.write before returning.
  */
-export async function runLuaScript(scriptPath: string): Promise<void> {
+async function runLuaScript(scriptPath: string): Promise<void> {
   const source = readFileSync(scriptPath, "utf-8");
 
   const originalWrite = process.stdout.write;

--- a/src/core/scripts/runner.ts
+++ b/src/core/scripts/runner.ts
@@ -19,7 +19,7 @@ import { commandForLanguage } from "../background/triggers/index.js";
 import type { Script } from "../../storage/script-store.js";
 
 export const DEFAULT_SCRIPT_TIMEOUT_SECONDS = 60;
-export const MAX_SCRIPT_TIMEOUT_SECONDS = 300;
+const MAX_SCRIPT_TIMEOUT_SECONDS = 300;
 
 /** Cap on captured stdout/stderr — keeps tool results context-friendly. */
 const OUTPUT_CAP_CHARS = 16_000;

--- a/src/core/soul/critic.ts
+++ b/src/core/soul/critic.ts
@@ -17,7 +17,7 @@
 
 import { estimateTokens } from "./projector.js";
 
-export type FailureMode = "wall-of-text" | "sycophancy" | "emoji-overload";
+type FailureMode = "wall-of-text" | "sycophancy" | "emoji-overload";
 
 export interface CritiqueFeatures {
   readonly tokens: number;

--- a/src/core/soul/embedder.ts
+++ b/src/core/soul/embedder.ts
@@ -23,13 +23,13 @@ export interface Embedder {
 
 // ── Vector math ──────────────────────────────────────────────────────────────
 
-export function dot(a: readonly number[], b: readonly number[]): number {
+function dot(a: readonly number[], b: readonly number[]): number {
   let s = 0;
   for (let i = 0; i < a.length; i++) s += a[i]! * b[i]!;
   return s;
 }
 
-export function norm(a: readonly number[]): number {
+function norm(a: readonly number[]): number {
   return Math.sqrt(dot(a, a));
 }
 

--- a/src/core/soul/governance.ts
+++ b/src/core/soul/governance.ts
@@ -18,7 +18,7 @@ import { randomUUID } from "node:crypto";
 import { hashPayload } from "./hash.js";
 import type { NodePayload } from "./types.js";
 
-export type ProposalStatus = "pending" | "approved" | "rejected";
+type ProposalStatus = "pending" | "approved" | "rejected";
 
 export interface Proposal {
   readonly id: string;

--- a/src/core/soul/hdc.ts
+++ b/src/core/soul/hdc.ts
@@ -25,7 +25,7 @@ import { createHash } from "node:crypto";
 
 export type Hypervector = Int8Array;
 
-export const DEFAULT_HD_DIM = 4096;
+const DEFAULT_HD_DIM = 4096;
 
 /** Deterministic ±1 hypervector for a symbol — the same token always maps here. */
 export function symbolVector(token: string, dim = DEFAULT_HD_DIM): Hypervector {

--- a/src/core/soul/reflex.ts
+++ b/src/core/soul/reflex.ts
@@ -48,7 +48,7 @@ const DELIVERY_ACTIONS = new Set(["end_turn", "send", "react"]);
  * Keep them small and total; compound conditions get their own named predicate
  * rather than being expressed in the data.
  */
-export const BUILTIN_PREDICATES: Readonly<Record<string, ReflexPredicate>> = {
+const BUILTIN_PREDICATES: Readonly<Record<string, ReflexPredicate>> = {
   /** Always-on trigger. */
   always: () => true,
 
@@ -85,7 +85,7 @@ function resolve(
 }
 
 /** Evaluate one reflex against a context. */
-export function evaluateReflex(
+function evaluateReflex(
   reflex: ReflexPayload,
   ctx: ReflexContext,
   overrides?: Readonly<Record<string, ReflexPredicate>>,

--- a/src/core/soul/retrieve.ts
+++ b/src/core/soul/retrieve.ts
@@ -32,7 +32,7 @@ export interface RetrievalWeights {
   readonly relevance: number;
 }
 
-export const DEFAULT_RETRIEVAL_WEIGHTS: RetrievalWeights = {
+const DEFAULT_RETRIEVAL_WEIGHTS: RetrievalWeights = {
   recency: 1,
   importance: 1,
   relevance: 1,

--- a/src/core/soul/signals.ts
+++ b/src/core/soul/signals.ts
@@ -14,7 +14,7 @@
 
 import type { Hash } from "./types.js";
 
-export interface ReactionSignal {
+interface ReactionSignal {
   readonly kind: "reaction";
   readonly at: number;
   readonly emoji: string;
@@ -22,7 +22,7 @@ export interface ReactionSignal {
   readonly activeNodes: readonly Hash[];
 }
 
-export interface EngagementSignal {
+interface EngagementSignal {
   readonly kind: "engagement";
   readonly at: number;
   /** Did the conversation continue after Talon's message, or die? */
@@ -56,14 +56,14 @@ export interface DirectiveSignal {
   readonly ref?: string;
 }
 
-export interface ReflexFireSignal {
+interface ReflexFireSignal {
   readonly kind: "reflex-fire";
   readonly at: number;
   readonly name: string;
   readonly severity: "block" | "warn" | "advise";
 }
 
-export interface ActivationSignal {
+interface ActivationSignal {
   readonly kind: "activation";
   readonly at: number;
   readonly activeNodes: readonly Hash[];

--- a/src/core/soul/types.ts
+++ b/src/core/soul/types.ts
@@ -45,7 +45,7 @@ export type NodeKind =
  * Where a piece of ground truth came from. Provenance is content, not metadata:
  * an evidence node's identity includes *who said it, when, and where*.
  */
-export interface EvidenceSource {
+interface EvidenceSource {
   /** Origin channel: a chat correction, a logged event, a diary line, etc. */
   readonly origin:
     | "correction" // someone (usually Dylan) corrected behavior

--- a/src/core/tasks/index.ts
+++ b/src/core/tasks/index.ts
@@ -10,11 +10,7 @@
 export { TaskTable, taskTable } from "./table.js";
 export type {
   KillOutcome,
-  TaskBinding,
   TaskHandle,
-  TaskKind,
   TaskRecord,
-  TaskSpec,
   TaskState,
-  TaskUsage,
 } from "./types.js";

--- a/src/core/tasks/types.ts
+++ b/src/core/tasks/types.ts
@@ -13,7 +13,7 @@
  */
 
 /** Which unit of agent work a task represents. */
-export type TaskKind = "turn" | "heartbeat" | "dream" | "cron" | "trigger";
+type TaskKind = "turn" | "heartbeat" | "dream" | "cron" | "trigger";
 
 /** Task lifecycle. `done`, `failed`, and `killed` are terminal. */
 export type TaskState = "queued" | "running" | "done" | "failed" | "killed";

--- a/src/core/tools/index.ts
+++ b/src/core/tools/index.ts
@@ -241,9 +241,4 @@ export function composeTools(options: ComposeOptions = {}): ToolDefinition[] {
 }
 
 // Re-export types for convenience
-export type {
-  ToolDefinition,
-  ToolFrontend,
-  ToolTag,
-  BridgeFunction,
-} from "./types.js";
+export type { ToolDefinition } from "./types.js";

--- a/src/core/tools/mcp-env.ts
+++ b/src/core/tools/mcp-env.ts
@@ -16,15 +16,11 @@
  * talon.json — carried to the subprocess as comma-separated env vars.
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
-import { isBunRuntime } from "../../util/runtime.js";
-
 // ── Env-var names (shared constants, not stringly-typed call sites) ────────
 
-export const ENV_BRIDGE_URL = "TALON_BRIDGE_URL";
-export const ENV_CHAT_ID = "TALON_CHAT_ID";
-export const ENV_FRONTEND = "TALON_FRONTEND";
+const ENV_BRIDGE_URL = "TALON_BRIDGE_URL";
+const ENV_CHAT_ID = "TALON_CHAT_ID";
+const ENV_FRONTEND = "TALON_FRONTEND";
 export const ENV_DISABLED_TOOLS = "TALON_DISABLED_TOOLS";
 export const ENV_DISABLED_TOOL_TAGS = "TALON_DISABLED_TOOL_TAGS";
 
@@ -61,32 +57,6 @@ export function buildTalonMcpEnv(
 }
 
 // ── Spawn spec ──────────────────────────────────────────────────────────────
-
-/**
- * The command line that launches Talon's unified MCP tool server.
- *
- * tsx as a Node loader is passed via `--import <file-url>`: Node
- * accepts URLs or absolute paths, but on Windows a raw backslash path
- * is ambiguous between path and URL — `pathToFileURL` always parses
- * as a loader URL. `node --import` (vs spawning `npx`/`tsx` directly)
- * also sidesteps the Node 20.19+ refusal to spawn `.cmd` shims
- * without `shell: true` (CVE-2024-27980 mitigation).
- *
- * Returns a fresh array: callers wrap it in their own supervisor
- * (`wrapMcpServer` / `wrapMcpCommand`) and may mutate it.
- */
-export function talonMcpServerCommand(): string[] {
-  const here = dirname(fileURLToPath(import.meta.url));
-  // Bun executes the TS entry natively — no loader, and use the running
-  // bun binary itself so the child matches the daemon's runtime.
-  if (isBunRuntime()) {
-    return [process.execPath, resolve(here, "mcp-server.ts")];
-  }
-  const tsxImport = pathToFileURL(
-    resolve(here, "../../../node_modules/tsx/dist/esm/index.mjs"),
-  ).href;
-  return ["node", "--import", tsxImport, resolve(here, "mcp-server.ts")];
-}
 
 // ── Parser (server side) ────────────────────────────────────────────────────
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -202,7 +202,7 @@ export interface ContextManager {
  * oversized-message), and a successful one by returning. This keeps
  * the ack settled even when no `onEvent` is supplied at all.
  */
-export type StreamEventSink = {
+type StreamEventSink = {
   onEvent?: (
     event: import("./agent-runtime/events.js").AgentEvent,
   ) => void | Promise<void>;

--- a/src/core/update/self-update.ts
+++ b/src/core/update/self-update.ts
@@ -41,7 +41,7 @@ export interface UpdateOptions {
 }
 
 /** One executed step in an update run. */
-export interface UpdateStep {
+interface UpdateStep {
   label: string;
   ok: boolean;
   output: string;

--- a/src/core/vfs/fusefs.ts
+++ b/src/core/vfs/fusefs.ts
@@ -91,7 +91,7 @@ export function namespaceFsStatus(): FuseStatus {
 }
 
 /** Test seam — force a status without a real mount. */
-export function _setNamespaceFsStatusForTesting(next: FuseStatus): void {
+function _setNamespaceFsStatusForTesting(next: FuseStatus): void {
   status = next;
 }
 

--- a/src/core/vfs/types.ts
+++ b/src/core/vfs/types.ts
@@ -22,7 +22,7 @@
  */
 
 /** What a path points at. */
-export type VfsNodeKind = "dir" | "file";
+type VfsNodeKind = "dir" | "file";
 
 /** Errno-style failure vocabulary — every operation fails with one of these. */
 export type VfsErrorCode =

--- a/src/core/weaver/index.ts
+++ b/src/core/weaver/index.ts
@@ -1,4 +1,4 @@
-export { Thread, type ThreadSnapshot } from "./thread.js";
+export { Thread } from "./thread.js";
 
 export { Loom, type ContextRegistry } from "./loom.js";
 export { carryTurnEvents } from "./shuttle.js";

--- a/src/core/weaver/typing-loop.ts
+++ b/src/core/weaver/typing-loop.ts
@@ -8,7 +8,7 @@
 import { logWarn } from "../../util/log.js";
 
 /** Platforms expire typing indicators after ~5s; refresh under that. */
-export const TYPING_REFRESH_MS = 4000;
+const TYPING_REFRESH_MS = 4000;
 
 export type SendTyping = (
   numericChatId: number,

--- a/src/frontend/discord/actions/types.ts
+++ b/src/frontend/discord/actions/types.ts
@@ -24,7 +24,7 @@ export interface DiscordActionContext {
   channel: TextBasedChannel | null;
 }
 
-export type DiscordActionHandler = (
+type DiscordActionHandler = (
   body: Record<string, unknown>,
   chatId: number,
   ctx: DiscordActionContext,

--- a/src/frontend/discord/commands/definitions.ts
+++ b/src/frontend/discord/commands/definitions.ts
@@ -17,7 +17,7 @@ import type { TalonConfig } from "../../../util/config.js";
 import { log, logError, logWarn } from "../../../util/log.js";
 import { getRepoRoot } from "../../../core/update/self-update.js";
 
-export function buildCommandDefinitions(devBuild = false): unknown[] {
+function buildCommandDefinitions(devBuild = false): unknown[] {
   return [
     new SlashCommandBuilder()
       .setName("start")

--- a/src/frontend/discord/handlers/access.ts
+++ b/src/frontend/discord/handlers/access.ts
@@ -19,7 +19,6 @@ import {
   userMessageTimestamps,
   RATE_LIMIT_WINDOW_MS,
   RATE_LIMIT_MAX_MESSAGES,
-  type AccessConfig,
 } from "./state.js";
 
 export function setAccessControl(cfg: {
@@ -40,10 +39,6 @@ export function setAccessControl(cfg: {
 
 export function isAdmin(userId: string): boolean {
   return accessState.access.adminUserIds.has(userId);
-}
-
-export function getAccessSnapshot(): AccessConfig {
-  return accessState.access;
 }
 
 export function trackDmUser(

--- a/src/frontend/discord/handlers/index.ts
+++ b/src/frontend/discord/handlers/index.ts
@@ -15,20 +15,7 @@
  * Re-exports the same public surface the old single-file module exposed.
  */
 
-export type { DiscordChatInfo } from "./registry.js";
-export {
-  registerDiscordChat,
-  lookupDiscordChat,
-  lookupDiscordChatByString,
-} from "./registry.js";
-export {
-  setAccessControl,
-  isAdmin,
-  getAccessSnapshot,
-  isAccessAllowed,
-  isInteractionAllowed,
-  shouldHandleInGuild,
-  isUserRateLimited,
-} from "./access.js";
+export { registerDiscordChat, lookupDiscordChat } from "./registry.js";
+export { setAccessControl, isAdmin, isInteractionAllowed } from "./access.js";
 export { getSenderName, sendChunked } from "./context.js";
 export { handleMessage } from "./messages.js";

--- a/src/frontend/discord/handlers/registry.ts
+++ b/src/frontend/discord/handlers/registry.ts
@@ -21,9 +21,3 @@ export function lookupDiscordChat(
 ): DiscordChatInfo | undefined {
   return chatRegistry.get(numericChatId);
 }
-
-export function lookupDiscordChatByString(
-  chatId: string,
-): DiscordChatInfo | undefined {
-  return chatRegistryByString.get(chatId);
-}

--- a/src/frontend/native/protocol.ts
+++ b/src/frontend/native/protocol.ts
@@ -26,7 +26,7 @@ export const BOT_SENDER_ID = 0;
 /** History sender id used for the human on the other end of a native chat. */
 export const USER_SENDER_ID = 1;
 
-export type ClientRole = "user" | "assistant" | "system";
+type ClientRole = "user" | "assistant" | "system";
 
 /** An inline button. `url` opens a link; `data` is an opaque callback token. */
 export type ClientButton = { text: string; url?: string; data?: string };
@@ -238,7 +238,6 @@ export type {
   DeviceCommandResult,
   DeviceInfo,
   DeviceLocation,
-  DevicePlatform,
 } from "../../core/mesh/types.js";
 import type { DeviceCommand as MeshDeviceCommand } from "../../core/mesh/types.js";
 
@@ -323,5 +322,3 @@ export function historyToClientMessage(
     ts: m.timestamp,
   };
 }
-
-export { toDeviceInfo, toDeviceLocation } from "../../core/mesh/types.js";

--- a/src/frontend/native/server.ts
+++ b/src/frontend/native/server.ts
@@ -48,7 +48,7 @@ import {
 import type { ConfigSnapshot } from "./settings.js";
 
 /** Optional attachment references carried alongside a sent message. */
-export type SendOptions = {
+type SendOptions = {
   /** Relative bridge path to render inline (e.g. `/media?id=…`). */
   imagePath?: string;
   /** Absolute on-disk path handed to the model so it can read the file. */

--- a/src/frontend/shared/status-context.ts
+++ b/src/frontend/shared/status-context.ts
@@ -292,7 +292,7 @@ export function buildCacheDisplay(input: {
 /** Figures older than this are labelled with their age in /status. */
 const PLAN_STALE_AFTER_MS = 5 * 60_000;
 
-export interface PlanWindowDisplay {
+interface PlanWindowDisplay {
   label: string;
   percent: number;
   bar: string;

--- a/src/frontend/telegram/actions/types.ts
+++ b/src/frontend/telegram/actions/types.ts
@@ -20,7 +20,7 @@ export interface TelegramActionContext {
   scheduledMessages: Map<string, ReturnType<typeof setTimeout>>;
 }
 
-export type TelegramActionHandler = (
+type TelegramActionHandler = (
   body: Record<string, unknown>,
   chatId: number,
   ctx: TelegramActionContext,

--- a/src/frontend/telegram/commands/index.ts
+++ b/src/frontend/telegram/commands/index.ts
@@ -24,7 +24,7 @@ import { registerSettingsCommands } from "./settings.js";
 import { registerAdminCommands } from "./admin.js";
 import { registerWhatsAppPairingCommand } from "./whatsapp-pairing.js";
 
-export { TELEGRAM_COMMANDS, telegramCommandMenu } from "./definitions.js";
+export { telegramCommandMenu } from "./definitions.js";
 export { setAdminUserId } from "./state.js";
 
 export function registerCommands(

--- a/src/frontend/telegram/commands/state.ts
+++ b/src/frontend/telegram/commands/state.ts
@@ -11,7 +11,7 @@ import type { Context } from "grammy";
 import type { Backend } from "../../../core/agent-runtime/capabilities.js";
 
 /** Admin user ID is set via talon.json or TALON_ADMIN_USER_ID env var. */
-export const adminState = { adminUserId: 0 };
+const adminState = { adminUserId: 0 };
 
 /** Set the admin user ID (called from config at startup). */
 export function setAdminUserId(id: number | undefined): void {

--- a/src/frontend/telegram/handlers/index.ts
+++ b/src/frontend/telegram/handlers/index.ts
@@ -16,7 +16,6 @@
 export {
   setAccessControl,
   shouldHandleInGroup,
-  isAccessAllowed,
   extractUnauthorizedPreview,
 } from "./access.js";
 export {

--- a/src/frontend/telegram/helpers/menu.ts
+++ b/src/frontend/telegram/helpers/menu.ts
@@ -75,7 +75,7 @@ export interface SettingsPager {
  * callback for disabled-edge buttons (Telegram requires every inline
  * button to carry callback data).
  */
-export function renderModelPickerControlRows(
+function renderModelPickerControlRows(
   pager: SettingsPager,
   navPrefix: string,
   noopData: string,

--- a/src/frontend/terminal/commands.ts
+++ b/src/frontend/terminal/commands.ts
@@ -62,10 +62,7 @@ export type CommandContext = {
   backend?: Backend | null;
 };
 
-export type CommandHandler = (
-  args: string,
-  ctx: CommandContext,
-) => Promise<void>;
+type CommandHandler = (args: string, ctx: CommandContext) => Promise<void>;
 
 export type Command = {
   name: string;

--- a/src/frontend/terminal/renderer.ts
+++ b/src/frontend/terminal/renderer.ts
@@ -11,7 +11,7 @@ import { formatUsd } from "../shared/format.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-export type StatusBarInfo = {
+type StatusBarInfo = {
   model: string;
   sessionName?: string;
   turns: number;

--- a/src/frontend/whatsapp/actions/chat-info.ts
+++ b/src/frontend/whatsapp/actions/chat-info.ts
@@ -6,7 +6,6 @@
  * assembled from the registry and the profile endpoints.
  */
 
-import { downloadMediaMessage } from "baileys";
 import { lookupMessage } from "../message-store.js";
 import { toUserJid, tryAction } from "./shared.js";
 import type { WhatsAppActionHandlers } from "./types.js";
@@ -224,5 +223,3 @@ export const chatInfoHandlers: WhatsAppActionHandlers = {
           };
     }),
 };
-
-export { downloadMediaMessage };

--- a/src/frontend/whatsapp/actions/messaging.ts
+++ b/src/frontend/whatsapp/actions/messaging.ts
@@ -11,11 +11,7 @@ import { randomUUID } from "node:crypto";
 import { proto } from "baileys";
 import { log } from "../../../util/log.js";
 import { toWhatsAppText } from "../formatting.js";
-import {
-  lookupMessage,
-  rememberMessage,
-  resolveKey,
-} from "../message-store.js";
+import { lookupMessage, resolveKey } from "../message-store.js";
 import { recordPin, listPins, forgetPin } from "../pins.js";
 import {
   resolveQuoted,
@@ -293,5 +289,3 @@ export const messagingHandlers: WhatsAppActionHandlers = {
     };
   },
 };
-
-export { rememberMessage };

--- a/src/frontend/whatsapp/actions/shared.ts
+++ b/src/frontend/whatsapp/actions/shared.ts
@@ -177,7 +177,7 @@ function outboundTextMarker(content: AnyMessageContent): string {
 const SEND_TIMEOUT_MS = 60_000;
 let sendTail: Promise<unknown> = Promise.resolve();
 
-export class WhatsAppSendTimeoutError extends Error {
+class WhatsAppSendTimeoutError extends Error {
   constructor(operation: string) {
     super(
       `WhatsApp ${operation} timed out after ${SEND_TIMEOUT_MS / 1000}s — ` +

--- a/src/frontend/whatsapp/actions/types.ts
+++ b/src/frontend/whatsapp/actions/types.ts
@@ -25,7 +25,7 @@ export interface WhatsAppActionContext {
   scheduledMessages: Map<string, ReturnType<typeof setTimeout>>;
 }
 
-export type WhatsAppActionHandler = (
+type WhatsAppActionHandler = (
   body: Record<string, unknown>,
   chatId: number,
   ctx: WhatsAppActionContext,

--- a/src/frontend/whatsapp/formatting.ts
+++ b/src/frontend/whatsapp/formatting.ts
@@ -17,7 +17,7 @@ import { marked, type Token, type Tokens } from "marked";
 import { splitMessage } from "../telegram/formatting.js";
 
 /** WhatsApp accepts far more, but long bubbles read badly on a phone. */
-export const WHATSAPP_MAX_TEXT = 4096;
+const WHATSAPP_MAX_TEXT = 4096;
 
 /** Rendered width of a table cell, for the monospace fallback. */
 const MAX_TABLE_CELL = 24;

--- a/src/frontend/whatsapp/media-store.ts
+++ b/src/frontend/whatsapp/media-store.ts
@@ -31,7 +31,7 @@ export type SavedMedia = {
 };
 
 /** The media kind carried by a message, if any. */
-export function mediaKindOf(
+function mediaKindOf(
   message: WAMessage,
 ): (typeof MEDIA_KINDS)[number] | undefined {
   const content = message.message;

--- a/src/frontend/whatsapp/pins.ts
+++ b/src/frontend/whatsapp/pins.ts
@@ -45,8 +45,3 @@ export function forgetPin(chatId: string, msgId: number): void {
 export function listPins(chatId: string): PinnedMessage[] {
   return pinsByChat.get(chatId) ?? [];
 }
-
-/** Test seam: forget every recorded pin. */
-export function resetPins(): void {
-  pinsByChat.clear();
-}

--- a/src/native/fusefs.ts
+++ b/src/native/fusefs.ts
@@ -20,7 +20,7 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
 /** One root symlink entry the mount serves (a file-backed mount). */
-export interface FuseSymlinkSpec {
+interface FuseSymlinkSpec {
   name: string;
   target: string;
 }
@@ -32,7 +32,7 @@ export interface FuseSymlinkSpec {
  * namespace-relative ("proc/tasks/7"). The reply JSON shapes are
  * defined by `serveNamespaceRequest` in core/vfs/fusefs.ts.
  */
-export type FuseBridgeHandler = (id: number, op: string, path: string) => void;
+type FuseBridgeHandler = (id: number, op: string, path: string) => void;
 
 /** The N-API surface exported by native/talon-fusefs. */
 export interface NativeFuseFs {
@@ -92,6 +92,6 @@ function loadNativeFuseFs(): NativeFuseFs | null {
 }
 
 /** Tests swap addons via TALON_FUSEFS_NODE and need the memo dropped. */
-export function _resetNativeFuseFsForTesting(): void {
+function _resetNativeFuseFsForTesting(): void {
   addon = undefined;
 }

--- a/src/native/scheduler-core.ts
+++ b/src/native/scheduler-core.ts
@@ -37,7 +37,7 @@ export function backoffDelayMs(
 
 // ── Circuit breaker ─────────────────────────────────────────────────────────
 
-export type BreakerState = "closed" | "open" | "half-open";
+type BreakerState = "closed" | "open" | "half-open";
 
 export type Breaker = {
   state: BreakerState;

--- a/src/native/warden.ts
+++ b/src/native/warden.ts
@@ -28,13 +28,13 @@ import { accessSync, constants } from "node:fs";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 
-export interface WardenStartEvent {
+interface WardenStartEvent {
   pid: number;
   /** Linux /proc/<pid>/stat field 22 (jiffies since boot); null off-Linux. */
   pidStarttime: number | null;
 }
 
-export interface WardenLineEvent {
+interface WardenLineEvent {
   stream: "stdout" | "stderr";
   text: string;
   /** True when the line exceeded the byte cap and its tail was dropped. */

--- a/src/plugins/mempalace/provision.ts
+++ b/src/plugins/mempalace/provision.ts
@@ -148,11 +148,7 @@ export function classifyExternalInstall(pythonPath: string): string {
  * version, per flavor. Works in both directions (a newer-than-pin
  * install reconciles down), hence the neutral name.
  */
-export function reconcileHint(
-  kind: string,
-  python: string,
-  target: string,
-): string {
+function reconcileHint(kind: string, python: string, target: string): string {
   if (kind === "uv-tool") {
     return `uv tool install --force 'mempalace==${target}'`;
   }

--- a/src/plugins/playwright/provision.ts
+++ b/src/plugins/playwright/provision.ts
@@ -57,7 +57,7 @@ export interface PlaywrightProvisionDeps {
 }
 
 /** One entry of playwright-core's browsers.json. */
-export interface BrowserDescriptor {
+interface BrowserDescriptor {
   name: string;
   revision: string;
   /** Per-host-platform revisions (e.g. webkit on older macOS). */

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -37,7 +37,7 @@ import { SCHEMA, dbSql } from "./sql/statements.generated.js";
  * statements with positional params, identical row object shapes,
  * multi-statement exec, FTS5 virtual tables).
  */
-export type SqlStatement = {
+type SqlStatement = {
   get(...params: unknown[]): unknown;
   all(...params: unknown[]): unknown[];
   run(...params: unknown[]): unknown;

--- a/src/storage/goal-store.ts
+++ b/src/storage/goal-store.ts
@@ -34,11 +34,7 @@ export const GOAL_STATUSES: readonly GoalStatus[] = [
   "completed",
   "abandoned",
 ];
-export const GOAL_PRIORITIES: readonly GoalPriority[] = [
-  "low",
-  "normal",
-  "high",
-];
+const GOAL_PRIORITIES: readonly GoalPriority[] = ["low", "normal", "high"];
 
 /** Statuses that count as "open" — shown to the heartbeat and listings. */
 export const OPEN_GOAL_STATUSES: readonly GoalStatus[] = ["active", "paused"];

--- a/src/storage/metrics.ts
+++ b/src/storage/metrics.ts
@@ -24,11 +24,6 @@ export function incrementCounter(name: string, amount = 1): void {
   legacyCounters.set(name, (legacyCounters.get(name) ?? 0) + amount);
 }
 
-export function recordHistogram(_name: string, _value: number): void {
-  // The old global histogram ring is intentionally gone. Chat-turn
-  // histograms are now latency aggregates on SessionMetrics.
-}
-
 function addCounter(
   counters: Record<string, number>,
   name: string,

--- a/src/storage/repositories/scripts-repo.ts
+++ b/src/storage/repositories/scripts-repo.ts
@@ -79,11 +79,6 @@ export function all(): Script[] {
   return rows.map(rowToScript);
 }
 
-export function count(): number {
-  const row = getDatabase().prepare(scriptsSql.count).get() as { n: number };
-  return row.n;
-}
-
 export function recordUse(name: string, when: number): void {
   getDatabase().prepare(scriptsSql.recordUse).run(when, name);
 }

--- a/src/storage/scheduled-store.ts
+++ b/src/storage/scheduled-store.ts
@@ -24,7 +24,7 @@ const KEY = "scheduled.messages";
  * "dinner in an hour" reminder is noise, not delivery. */
 export const MAX_OVERDUE_MS = 24 * 60 * 60 * 1000;
 
-export type ScheduledButtonRow = Array<{
+type ScheduledButtonRow = Array<{
   text: string;
   url?: string;
   callback_data?: string;
@@ -65,10 +65,6 @@ export function deleteScheduled(id: string): boolean {
   delete all[id];
   kvSet(KEY, all);
   return true;
-}
-
-export function getScheduled(id: string): ScheduledMessage | undefined {
-  return readAll()[id];
 }
 
 /** All pending entries for a frontend, soonest first. */

--- a/src/storage/script-store.ts
+++ b/src/storage/script-store.ts
@@ -25,11 +25,7 @@ import * as repo from "./repositories/scripts-repo.js";
 export type { Script, ScriptLanguage } from "./repositories/scripts-repo.js";
 import type { Script, ScriptLanguage } from "./repositories/scripts-repo.js";
 
-export const SCRIPT_LANGUAGES: readonly ScriptLanguage[] = [
-  "bash",
-  "python",
-  "node",
-];
+const SCRIPT_LANGUAGES: readonly ScriptLanguage[] = ["bash", "python", "node"];
 
 /**
  * Stricter than the trigger name rule: a script name doubles as its
@@ -81,16 +77,16 @@ export function validateScriptDescription(description: string): string | null {
 
 // ── Script files ────────────────────────────────────────────────────────────
 
-export function scriptsDir(): string {
+function scriptsDir(): string {
   return dirs.scripts;
 }
 
-export function scriptFilePath(name: string, lang: ScriptLanguage): string {
+function scriptFilePath(name: string, lang: ScriptLanguage): string {
   return resolve(scriptsDir(), `${name}.${EXTENSIONS[lang]}`);
 }
 
 /** Write a script's body, creating the scripts dir as needed. */
-export function writeScriptFile(
+function writeScriptFile(
   name: string,
   lang: ScriptLanguage,
   body: string,
@@ -104,7 +100,7 @@ export function writeScriptFile(
 
 // ── CRUD ────────────────────────────────────────────────────────────────────
 
-export function generateScriptId(): string {
+function generateScriptId(): string {
   return `script_${randomUUID()}`;
 }
 
@@ -150,10 +146,6 @@ export function getScript(name: string): Script | undefined {
 
 export function getAllScripts(): Script[] {
   return repo.all();
-}
-
-export function countScripts(): number {
-  return repo.count();
 }
 
 export function recordScriptUse(name: string): void {

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -28,11 +28,8 @@ export type {
   MetricsCounterSet,
   MetricsGrain,
   MetricsLatencyAgg,
-  SessionMetrics,
   SessionState,
-  SessionUsage,
 } from "./session-record.js";
-export { emptyMetrics, normaliseMetrics } from "./session-record.js";
 import {
   emptyCounters,
   emptyGrain,

--- a/src/storage/skill-store.ts
+++ b/src/storage/skill-store.ts
@@ -66,15 +66,15 @@ const BODY_MAX_BYTES = 128 * 1024;
 const PROMPT_LIST_LIMIT = 25;
 const SEARCH_RESULT_LIMIT = 10;
 
-export function skillsDir(): string {
+function skillsDir(): string {
   return dirs.skills;
 }
 
-export function skillDir(name: string): string {
+function skillDir(name: string): string {
   return resolve(skillsDir(), name);
 }
 
-export function skillFilePath(name: string): string {
+function skillFilePath(name: string): string {
   return resolve(skillDir(name), SKILL_FILE);
 }
 

--- a/src/util/exec-output.ts
+++ b/src/util/exec-output.ts
@@ -11,7 +11,7 @@
  */
 
 /** In-memory cap while capturing one child-process output stream. */
-export const MAX_EXEC_CAPTURE_BYTES = 4 * 1024 * 1024;
+const MAX_EXEC_CAPTURE_BYTES = 4 * 1024 * 1024;
 
 /** Ceiling on each rendered exec stream (stdout, stderr independently). */
 export const MAX_EXEC_RENDER_CHARS = 30_000;

--- a/src/util/mcp-launcher.ts
+++ b/src/util/mcp-launcher.ts
@@ -83,6 +83,9 @@ export const MCP_LAUNCH_SUBCOMMAND = "_mcp-launch";
  * `[command, ...argsPrefix]` that launches an entry which DOES dispatch
  * (e.g. `["node", "--import", "<tsx esm url>",
  * "<abs path to src/cli.ts>"]`).
+ *
+ * @public — consumed by embedders (and the integration probe), not by
+ * Talon's own graph, so knip must not report it.
  */
 export const SUPERVISOR_CMD_ENV = "TALON_MCP_SUPERVISOR_CMD";
 


### PR DESCRIPTION
## Summary

Closes item 4 of `docs/code-health.md` (255 unused exports, ungated).

- `knip --fix` stripped the `export` keyword / barrel re-export from 130 unused exports and 125 unused exported types.
- Declarations that thereby lost their last reference are **deleted**, not left private: unused test seams (`reset*ForTest`, `clearTemplateCache`, `resetPins`, `resetSpawnFailures`), duplicate `KILO_*` / `OPENCODE_*` aliases of remote-server constants, `talonMcpServerCommand` and its now-unused imports, `getActiveModelRefForChat`, `triggerDiscoveryRefresh`, the scripts repo `count()`, etc.
- `SUPERVISOR_CMD_ENV` stays exported, tagged `@public`: it is the embedder hook consumed from outside Talon's own graph (and by the integration probe in #801).
- `registerPlugin` is loader-internal; `plugin.test.ts` now reaches it on the loader module directly rather than via the barrel.
- `knip.json`: ignore `@swc/core` (dependency-cruiser's parser, invisible to knip) and the platform binaries CI scripts shell out to (`where.exe`, `gofmt`, `zig`, `umount`, …).
- **CI**: `npm run knip` added to the Code Quality workflow after the architecture gate. Tree is at zero, so any new dead export fails the build.

Net: 119 files, −538 / +156 lines.

## Verification

- `tsc --noEmit`, `oxlint` (only the pre-existing `no-irregular-whitespace` / prelude warnings remain), `npm run depcruise` (588 modules, 0 errors), `npm run knip` (0 issues), `format:check` all clean.
- Full `vitest run` locally: 4632 passed, 2 failed — both in `package.functional.test.ts`, and both fail identically on `main` on this machine: the spawned CLI inherits `NODE_USE_ENV_PROXY` from the shell and undici prints its experimental-agent warning on stderr, which the test asserts empty. Not related to this change; CI has no proxy env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTCdGWRqXDhdd89dc3Cnnb