### PR TITLE
refactor(frontend): share the access-gate primitives across frontends

### DIFF
--- a/src/__tests__/frontend-access-primitives.test.ts
+++ b/src/__tests__/frontend-access-primitives.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The access-gate primitives shared by the chat frontends — the sliding
+ * window rate limiter, the bounded first-seen DM tracker, and the notice
+ * cooldown. Behaviour-level: these used to be two copies each in
+ * telegram/ and discord/ and the handler suites still cover them through
+ * the message pipeline; this pins the contract of the one implementation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../util/log.js", () => ({
+  log: vi.fn(),
+  logDebug: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}));
+vi.mock("../storage/daily-log.js", () => ({ appendDailyLog: vi.fn() }));
+
+const { createRateLimiter, createDmUserTracker, createNoticeCooldown } =
+  await import("../frontend/shared/access.js");
+const { log } = await import("../util/log.js");
+const { appendDailyLog } = await import("../storage/daily-log.js");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-09-02T12:00:00Z"));
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("createRateLimiter", () => {
+  it("admits up to maxMessages inside the window, then limits", () => {
+    const limiter = createRateLimiter<number>({
+      windowMs: 60_000,
+      maxMessages: 3,
+    });
+    expect(limiter.isLimited(1)).toBe(false);
+    expect(limiter.isLimited(1)).toBe(false);
+    expect(limiter.isLimited(1)).toBe(false);
+    expect(limiter.isLimited(1)).toBe(true);
+    // Other senders are independent.
+    expect(limiter.isLimited(2)).toBe(false);
+  });
+
+  it("a limited message is not recorded, so the sender recovers as the oldest ages out", () => {
+    const limiter = createRateLimiter<string>({
+      windowMs: 60_000,
+      maxMessages: 2,
+    });
+    limiter.isLimited("a");
+    vi.advanceTimersByTime(30_000);
+    limiter.isLimited("a");
+    expect(limiter.isLimited("a")).toBe(true);
+    // 31s later the first timestamp is outside the window; one slot frees.
+    vi.advanceTimersByTime(31_000);
+    expect(limiter.isLimited("a")).toBe(false);
+    expect(limiter.isLimited("a")).toBe(true);
+  });
+
+  it("evicts stale senders once the map grows past evictAbove", () => {
+    const limiter = createRateLimiter<number>({
+      windowMs: 60_000,
+      maxMessages: 15,
+      evictAbove: 5,
+      evictTo: 2,
+      staleAfterMs: 10 * 60_000,
+    });
+    for (let i = 1; i <= 5; i++) limiter.isLimited(i);
+    // Eleven minutes on, a sixth sender pushes the map over the threshold;
+    // the five idle senders are stale and get swept down to evictTo.
+    vi.advanceTimersByTime(11 * 60_000);
+    expect(limiter.isLimited(6)).toBe(false);
+    // Sender 1's window is empty again, so it is admitted a full 15 times:
+    // proof its old entry (and timestamps) went away rather than lingering.
+    for (let i = 0; i < 15; i++) expect(limiter.isLimited(1)).toBe(false);
+    expect(limiter.isLimited(1)).toBe(true);
+  });
+});
+
+describe("createDmUserTracker", () => {
+  it("logs a sender once, with the tag in parentheses when given", () => {
+    const tracker = createDmUserTracker<number>(100);
+    tracker.track(7, "Ada", "@ada");
+    tracker.track(7, "Ada", "@ada");
+    tracker.track(8, "Bob");
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenNthCalledWith(
+      1,
+      "users",
+      "New DM user: Ada (@ada) [id:7]",
+    );
+    expect(log).toHaveBeenNthCalledWith(2, "users", "New DM user: Bob [id:8]");
+    expect(appendDailyLog).toHaveBeenCalledWith(
+      "System",
+      "New DM user: Ada (@ada) [id:7]",
+    );
+  });
+
+  it("evicts the oldest 10% at the cap, so the earliest sender is logged again", () => {
+    const tracker = createDmUserTracker<number>(10);
+    for (let i = 1; i <= 10; i++) tracker.track(i, `u${i}`);
+    expect(log).toHaveBeenCalledTimes(10);
+    // Cap reached: the 11th sender evicts sender 1 (oldest 10% = 1 entry).
+    tracker.track(11, "u11");
+    tracker.track(2, "u2"); // still remembered
+    tracker.track(1, "u1"); // forgotten → logged again
+    expect(log).toHaveBeenCalledTimes(12);
+  });
+});
+
+describe("createNoticeCooldown", () => {
+  it("fires once per key per ttl", () => {
+    const cooldown = createNoticeCooldown({ ttlMs: 10 * 60_000, cap: 100 });
+    expect(cooldown.shouldNotify("dm:1")).toBe(true);
+    expect(cooldown.shouldNotify("dm:1")).toBe(false);
+    expect(cooldown.shouldNotify("dm:2")).toBe(true);
+    vi.advanceTimersByTime(10 * 60_000);
+    expect(cooldown.shouldNotify("dm:1")).toBe(true);
+  });
+
+  it("clears everything at the cap rather than growing without bound", () => {
+    const cooldown = createNoticeCooldown({ ttlMs: 60_000, cap: 2 });
+    cooldown.shouldNotify("a");
+    cooldown.shouldNotify("b");
+    // Third distinct key hits the cap: the map is cleared, so "a" fires
+    // again immediately — the documented worst case.
+    expect(cooldown.shouldNotify("c")).toBe(true);
+    expect(cooldown.shouldNotify("a")).toBe(true);
+  });
+});

--- a/src/__tests__/package.functional.test.ts
+++ b/src/__tests__/package.functional.test.ts
@@ -102,10 +102,29 @@ function runNpm(
   });
 }
 
+/**
+ * Node process warnings are environment, not output: `NODE_USE_ENV_PROXY`
+ * makes undici print an experimental-agent notice on any machine that
+ * routes through a proxy, and Node adds its `--trace-warnings` hint under
+ * it. Neither says anything about the CLI, so they are stripped before
+ * the "stderr is empty" assertion — which otherwise fails on a developer
+ * box while CI (no proxy) stays green.
+ */
+function withoutNodeWarnings(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter(
+      (line) =>
+        !/^\(node:\d+\) /.test(line) &&
+        !line.startsWith("(Use `node --trace-warnings"),
+    )
+    .join("\n");
+}
+
 function expectOk(result: RunResult): void {
   expectExitOk(result);
   expect(
-    result.stderr,
+    withoutNodeWarnings(result.stderr),
     `process exited with ${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
   ).toBe("");
 }

--- a/src/frontend/discord/handlers/access.ts
+++ b/src/frontend/discord/handlers/access.ts
@@ -6,19 +6,13 @@
 
 import type { Client, Message } from "discord.js";
 import { ChannelType } from "discord.js";
-import { appendDailyLog } from "../../../storage/daily-log.js";
-import { log, logWarn, logDebug } from "../../../util/log.js";
+import { logWarn } from "../../../util/log.js";
 import { escapeMarkdown } from "../formatting.js";
 import {
   accessState,
-  knownDmUsers,
-  KNOWN_DM_USERS_CAP,
-  unauthorizedCooldown,
-  UNAUTHORIZED_COOLDOWN_MS,
-  MAX_UNAUTHORIZED_COOLDOWNS,
-  userMessageTimestamps,
-  RATE_LIMIT_WINDOW_MS,
-  RATE_LIMIT_MAX_MESSAGES,
+  dmUsers,
+  unauthorizedNotices,
+  rateLimiter,
 } from "./state.js";
 
 export function setAccessControl(cfg: {
@@ -46,21 +40,7 @@ export function trackDmUser(
   senderName: string,
   tag?: string,
 ): void {
-  if (knownDmUsers.has(senderId)) return;
-  if (knownDmUsers.size >= KNOWN_DM_USERS_CAP) {
-    const evictCount = Math.floor(KNOWN_DM_USERS_CAP * 0.1);
-    const iter = knownDmUsers.values();
-    for (let i = 0; i < evictCount; i++) {
-      knownDmUsers.delete(iter.next().value as string);
-    }
-  }
-  knownDmUsers.add(senderId);
-  const tagStr = tag ? ` (${tag})` : "";
-  log("users", `New DM user: ${senderName}${tagStr} [id:${senderId}]`);
-  appendDailyLog(
-    "System",
-    `New DM user: ${senderName}${tagStr} [id:${senderId}]`,
-  );
+  dmUsers.track(senderId, senderName, tag);
 }
 
 async function notifyUnauthorized(
@@ -77,13 +57,7 @@ async function notifyUnauthorized(
       : type === "guild"
         ? `guild:${guildId}`
         : `channel:${channelId}`;
-  const now = Date.now();
-  const last = unauthorizedCooldown.get(key);
-  if (last && now - last < UNAUTHORIZED_COOLDOWN_MS) return;
-  if (unauthorizedCooldown.size >= MAX_UNAUTHORIZED_COOLDOWNS) {
-    unauthorizedCooldown.clear();
-  }
-  unauthorizedCooldown.set(key, now);
+  if (!unauthorizedNotices.shouldNotify(key)) return;
 
   const senderTag = msg.author.username ? ` (@${msg.author.username})` : "";
   const senderName = msg.author.globalName || msg.author.username || "User";
@@ -216,28 +190,5 @@ export function shouldHandleInGuild(client: Client, msg: Message): boolean {
 }
 
 export function isUserRateLimited(senderId: string): boolean {
-  const now = Date.now();
-  let timestamps = userMessageTimestamps.get(senderId);
-  if (!timestamps) {
-    timestamps = [];
-    userMessageTimestamps.set(senderId, timestamps);
-  }
-  while (timestamps.length > 0 && timestamps[0] < now - RATE_LIMIT_WINDOW_MS) {
-    timestamps.shift();
-  }
-  if (timestamps.length >= RATE_LIMIT_MAX_MESSAGES) {
-    logDebug("bot", `Rate-limited user ${senderId}`);
-    return true;
-  }
-  timestamps.push(now);
-  if (userMessageTimestamps.size > 5_000) {
-    const cutoff = now - 10 * 60_000;
-    for (const [userId, ts] of userMessageTimestamps) {
-      if (ts.length === 0 || ts[ts.length - 1] < cutoff) {
-        userMessageTimestamps.delete(userId);
-      }
-      if (userMessageTimestamps.size <= 2_500) break;
-    }
-  }
-  return false;
+  return rateLimiter.isLimited(senderId);
 }

--- a/src/frontend/discord/handlers/state.ts
+++ b/src/frontend/discord/handlers/state.ts
@@ -7,6 +7,11 @@
 
 import type { TextBasedChannel } from "discord.js";
 import type { TalonConfig } from "../../../util/config.js";
+import {
+  createDmUserTracker,
+  createNoticeCooldown,
+  createRateLimiter,
+} from "../../shared/access.js";
 
 // ── Chat registry: numericChatId → Discord channel info ─────────────────────
 // The gateway/dispatcher uses numeric chatIds. Action handlers need to map
@@ -49,20 +54,22 @@ export const accessState: { access: AccessConfig } = {
 
 // ── First-time DM user tracking ──────────────────────────────────────────────
 
-export const knownDmUsers = new Set<string>();
-export const KNOWN_DM_USERS_CAP = 10_000;
+export const dmUsers = createDmUserTracker<string>(10_000);
 
 // ── Unauthorized notification cooldown (10 min) ──────────────────────────────
 
-export const unauthorizedCooldown = new Map<string, number>();
-export const UNAUTHORIZED_COOLDOWN_MS = 10 * 60 * 1000;
-export const MAX_UNAUTHORIZED_COOLDOWNS = 5000;
+export const unauthorizedNotices = createNoticeCooldown({
+  ttlMs: 10 * 60 * 1000,
+  cap: 5000,
+});
 
 // ── Per-user rate limiting ───────────────────────────────────────────────────
 
-export const userMessageTimestamps = new Map<string, number[]>();
-export const RATE_LIMIT_WINDOW_MS = 60_000;
-export const RATE_LIMIT_MAX_MESSAGES = 15;
+/** 15 messages per minute per user. */
+export const rateLimiter = createRateLimiter<string>({
+  windowMs: 60_000,
+  maxMessages: 15,
+});
 
 // ── Message queue (debounce rapid-fire messages per chat) ────────────────────
 

--- a/src/frontend/shared/access.ts
+++ b/src/frontend/shared/access.ts
@@ -1,0 +1,152 @@
+/**
+ * Access-gate primitives shared by the chat frontends.
+ *
+ * Telegram and Discord each carried their own copy of the same three
+ * mechanisms — a per-sender sliding-window rate limiter, a bounded
+ * first-seen set for "new DM user" logging, and a keyed cooldown for
+ * unauthorized-access notices — differing only in the sender-id type.
+ * The copies had identical bodies and identical magic numbers; this is
+ * the one implementation, generic over the id.
+ *
+ * What is NOT here: the allow/deny semantics themselves. Telegram gates
+ * on a user allowlist/denylist plus admin group membership; Discord on
+ * users, guilds, channels, and a respond mode. Those are platform
+ * policy and stay with each frontend.
+ */
+
+import { appendDailyLog } from "../../storage/daily-log.js";
+import { log, logDebug } from "../../util/log.js";
+
+// ── Rate limiter ────────────────────────────────────────────────────────────
+
+export interface RateLimiterOptions {
+  /** Sliding window length. */
+  windowMs: number;
+  /** Messages allowed per sender inside one window. */
+  maxMessages: number;
+  /**
+   * When the tracked-sender map grows past this, senders idle for
+   * `staleAfterMs` are evicted until the map is at `evictTo` or the scan
+   * completes. Bounds memory under a flood of distinct senders.
+   */
+  evictAbove?: number;
+  evictTo?: number;
+  staleAfterMs?: number;
+}
+
+export interface RateLimiter<Id> {
+  /**
+   * Record one message from `id` and report whether it exceeded the
+   * window. A limited message is NOT recorded, so the sender is admitted
+   * again as soon as the oldest timestamp ages out.
+   */
+  isLimited(id: Id): boolean;
+}
+
+export function createRateLimiter<Id>(
+  options: RateLimiterOptions,
+): RateLimiter<Id> {
+  const {
+    windowMs,
+    maxMessages,
+    evictAbove = 5_000,
+    evictTo = 2_500,
+    staleAfterMs = 10 * 60_000,
+  } = options;
+  const timestamps = new Map<Id, number[]>();
+
+  return {
+    isLimited(id) {
+      const now = Date.now();
+      let ts = timestamps.get(id);
+      if (!ts) {
+        ts = [];
+        timestamps.set(id, ts);
+      }
+      // Drop entries that have aged out of the window.
+      while (ts.length > 0 && ts[0] < now - windowMs) ts.shift();
+
+      if (ts.length >= maxMessages) {
+        logDebug("bot", `Rate-limited user ${String(id)}`);
+        return true;
+      }
+      ts.push(now);
+
+      if (timestamps.size > evictAbove) {
+        const cutoff = now - staleAfterMs;
+        for (const [sender, list] of timestamps) {
+          if (list.length === 0 || list[list.length - 1] < cutoff) {
+            timestamps.delete(sender);
+          }
+          if (timestamps.size <= evictTo) break;
+        }
+      }
+      return false;
+    },
+  };
+}
+
+// ── First-seen DM users ─────────────────────────────────────────────────────
+
+export interface DmUserTracker<Id> {
+  /**
+   * Log the first message from a sender (talon.log + daily log). No-op
+   * for senders already seen. `tag` is an optional handle rendered in
+   * parentheses after the name, e.g. `@alice`.
+   */
+  track(id: Id, senderName: string, tag?: string): void;
+}
+
+/**
+ * Insertion-ordered set capped at `cap`; on overflow the oldest 10% are
+ * evicted so a flood of one-off senders cannot grow it without bound.
+ */
+export function createDmUserTracker<Id>(cap: number): DmUserTracker<Id> {
+  const seen = new Set<Id>();
+  return {
+    track(id, senderName, tag) {
+      if (seen.has(id)) return;
+      if (seen.size >= cap) {
+        const evictCount = Math.floor(cap * 0.1);
+        const iter = seen.values();
+        for (let i = 0; i < evictCount; i++) {
+          seen.delete(iter.next().value as Id);
+        }
+      }
+      seen.add(id);
+      const tagStr = tag ? ` (${tag})` : "";
+      const line = `New DM user: ${senderName}${tagStr} [id:${String(id)}]`;
+      log("users", line);
+      appendDailyLog("System", line);
+    },
+  };
+}
+
+// ── Notice cooldown ─────────────────────────────────────────────────────────
+
+export interface NoticeCooldown {
+  /**
+   * Whether a notice for `key` should fire now. Returns true at most once
+   * per `ttlMs` per key, recording the send. The map is cleared outright
+   * at `cap` entries — cheaper than an LRU and the worst case is one
+   * extra notice per key.
+   */
+  shouldNotify(key: string): boolean;
+}
+
+export function createNoticeCooldown(options: {
+  ttlMs: number;
+  cap: number;
+}): NoticeCooldown {
+  const last = new Map<string, number>();
+  return {
+    shouldNotify(key) {
+      const now = Date.now();
+      const previous = last.get(key);
+      if (previous && now - previous < options.ttlMs) return false;
+      if (last.size >= options.cap) last.clear();
+      last.set(key, now);
+      return true;
+    },
+  };
+}

--- a/src/frontend/telegram/handlers/access.ts
+++ b/src/frontend/telegram/handlers/access.ts
@@ -8,15 +8,12 @@ import { appendDailyLog } from "../../../storage/daily-log.js";
 import { log, logWarn } from "../../../util/log.js";
 import { getSenderName } from "./context.js";
 import {
-  knownDmUsers,
-  KNOWN_DM_USERS_CAP,
+  dmUsers,
   accessConfig,
   verifiedGroups,
   MAX_VERIFIED_GROUPS,
   VERIFIED_GROUP_TTL_MS,
-  unauthorizedCooldown,
-  UNAUTHORIZED_COOLDOWN_MS,
-  MAX_UNAUTHORIZED_COOLDOWNS,
+  unauthorizedNotices,
 } from "./state.js";
 
 export function trackDmUser(
@@ -24,19 +21,11 @@ export function trackDmUser(
   senderName: string,
   senderUsername?: string,
 ): void {
-  if (knownDmUsers.has(senderId)) return;
-  // Evict oldest 10% when cap reached (Set maintains insertion order)
-  if (knownDmUsers.size >= KNOWN_DM_USERS_CAP) {
-    const evictCount = Math.floor(KNOWN_DM_USERS_CAP * 0.1);
-    const iter = knownDmUsers.values();
-    for (let i = 0; i < evictCount; i++) {
-      knownDmUsers.delete(iter.next().value as number);
-    }
-  }
-  knownDmUsers.add(senderId);
-  const tag = senderUsername ? ` (@${senderUsername})` : "";
-  log("users", `New DM user: ${senderName}${tag} [id:${senderId}]`);
-  appendDailyLog("System", `New DM user: ${senderName}${tag} [id:${senderId}]`);
+  dmUsers.track(
+    senderId,
+    senderName,
+    senderUsername ? `@${senderUsername}` : undefined,
+  );
 }
 
 export function setAccessControl(cfg: {
@@ -274,13 +263,7 @@ async function notifyUnauthorized(
   }
 
   const key = type === "dm" ? `dm:${ctx.from?.id}` : `group:${ctx.chat?.id}`;
-  const now = Date.now();
-  const lastWarned = unauthorizedCooldown.get(key);
-  if (lastWarned && now - lastWarned < UNAUTHORIZED_COOLDOWN_MS) return;
-  if (unauthorizedCooldown.size >= MAX_UNAUTHORIZED_COOLDOWNS) {
-    unauthorizedCooldown.clear();
-  }
-  unauthorizedCooldown.set(key, now);
+  if (!unauthorizedNotices.shouldNotify(key)) return;
 
   // Warn the user
   try {

--- a/src/frontend/telegram/handlers/queue.ts
+++ b/src/frontend/telegram/handlers/queue.ts
@@ -24,52 +24,20 @@ import {
   recordMessageReceived,
   recordError,
 } from "../../../util/watchdog.js";
-import { log, logError, logWarn, logDebug } from "../../../util/log.js";
+import { log, logError, logWarn } from "../../../util/log.js";
 import { appendDailyLog } from "../../../storage/daily-log.js";
 import { processAndReply, sendHtml } from "./delivery.js";
 import {
   messageQueues,
   lastHandledMessageIdByChat,
-  userMessageTimestamps,
+  rateLimiter,
   DEBOUNCE_MS,
   MAX_QUEUED_PER_CHAT,
-  RATE_LIMIT_WINDOW_MS,
-  RATE_LIMIT_MAX_MESSAGES,
   type QueuedMessage,
 } from "./state.js";
 
 export function isUserRateLimited(senderId: number): boolean {
-  const now = Date.now();
-  let timestamps = userMessageTimestamps.get(senderId);
-  if (!timestamps) {
-    timestamps = [];
-    userMessageTimestamps.set(senderId, timestamps);
-  }
-
-  // Remove old entries outside the window
-  while (timestamps.length > 0 && timestamps[0] < now - RATE_LIMIT_WINDOW_MS) {
-    timestamps.shift();
-  }
-
-  if (timestamps.length >= RATE_LIMIT_MAX_MESSAGES) {
-    logDebug("bot", `Rate-limited user ${senderId}`);
-    return true;
-  }
-
-  timestamps.push(now);
-
-  // Evict stale entries — remove users who haven't messaged in 10+ minutes
-  if (userMessageTimestamps.size > 5_000) {
-    const cutoff = now - 10 * 60_000;
-    for (const [userId, ts] of userMessageTimestamps) {
-      if (ts.length === 0 || ts[ts.length - 1] < cutoff) {
-        userMessageTimestamps.delete(userId);
-      }
-      if (userMessageTimestamps.size <= 2_500) break; // evict down to half
-    }
-  }
-
-  return false;
+  return rateLimiter.isLimited(senderId);
 }
 
 /**

--- a/src/frontend/telegram/handlers/state.ts
+++ b/src/frontend/telegram/handlers/state.ts
@@ -9,11 +9,15 @@
 
 import type { Bot } from "grammy";
 import type { TalonConfig } from "../../../util/config.js";
+import {
+  createDmUserTracker,
+  createNoticeCooldown,
+  createRateLimiter,
+} from "../../shared/access.js";
 
 // ── First-time DM user tracking ──────────────────────────────────────────────
 
-export const knownDmUsers = new Set<number>();
-export const KNOWN_DM_USERS_CAP = 10_000;
+export const dmUsers = createDmUserTracker<number>(10_000);
 
 // ── Access control ──────────────────────────────────────────────────────────
 
@@ -37,9 +41,10 @@ export const MAX_VERIFIED_GROUPS = 1000;
 export const VERIFIED_GROUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 // Rate-limit unauthorized access warnings (one per user/group per 10 minutes)
-export const unauthorizedCooldown = new Map<string, number>();
-export const UNAUTHORIZED_COOLDOWN_MS = 10 * 60 * 1000;
-export const MAX_UNAUTHORIZED_COOLDOWNS = 5000;
+export const unauthorizedNotices = createNoticeCooldown({
+  ttlMs: 10 * 60 * 1000,
+  cap: 5000,
+});
 
 // ── Message queue (debounce rapid-fire messages per chat) ─────────────────────
 
@@ -72,6 +77,8 @@ export const lastHandledMessageIdByChat = new Map<string, number>();
 
 // ── Per-user rate limiting ──────────────────────────────────────────────────
 
-export const userMessageTimestamps = new Map<number, number[]>();
-export const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute window
-export const RATE_LIMIT_MAX_MESSAGES = 15; // max 15 messages per minute per user
+/** 15 messages per minute per user. */
+export const rateLimiter = createRateLimiter<number>({
+  windowMs: 60_000,
+  maxMessages: 15,
+});


### PR DESCRIPTION
## Summary

Stacked on #820 (base moves to `main` once that merges). Item 3 of `docs/consolidation-plan.md`.

Telegram and Discord each carried their own copy of three mechanisms with identical bodies and identical magic numbers, differing only in the sender-id type:

| mechanism | numbers | was in |
| --- | --- | --- |
| per-user sliding-window rate limiter | 15/min; stale-sender eviction past 5,000 → 2,500 | `telegram/handlers/queue.ts`, `discord/handlers/access.ts` |
| bounded first-seen DM set ("New DM user" log line) | 10,000; oldest 10% evicted | both `access.ts` |
| keyed cooldown for unauthorized-access notices | 10 min; cleared at 5,000 | both `access.ts` |

`frontend/shared/access.ts` is now the one implementation — `createRateLimiter`, `createDmUserTracker`, `createNoticeCooldown` — generic over the id. Each frontend's `state.ts` instantiates them with its numbers; `isUserRateLimited` / `trackDmUser` keep their signatures for the call sites.

**Deliberately not shared:** the allow/deny policy. Telegram gates on user allowlist/denylist + admin group membership; Discord on users, guilds, channels, and a respond mode. That is platform policy.

**Also (plan §9):** `package.functional.test.ts` asserted the spawned CLI's stderr is exactly empty, which fails on any machine where Node prints a process warning (`NODE_USE_ENV_PROXY` → undici's experimental-agent notice) while CI stays green. Node warning lines are stripped before that assertion; anything else on stderr still fails it.

## Verification

- `tsc`, `oxlint`, `knip` (0) clean.
- `handlers.test.ts` (rate-limit windows, the >5,000-sender eviction path, first-DM logging with/without username tag), the Discord suites, and the new `frontend-access-primitives.test.ts` pass — 173 tests. The one local failure is `package.functional`'s tarball install on this machine's Node 22 vs the `>=24.15` engine pin (see `docs/code-health.md` §7); CI runs Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTCdGWRqXDhdd89dc3Cnnb