### PR TITLE
refactor(doctor): compose backend checks from the registry

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -141,18 +141,13 @@ module.exports = {
     {
       name: "doctor-probes-move-behind-registry",
       comment:
-        "TARGET: doctor.ts hardcodes which backends exist and reaches into " +
-        "them for health probes. The observable symptom is uneven coverage " +
-        "— only claude-sdk and codex are probed, so kilo, opencode, and " +
-        "openai-agents get no doctor checks at all. Ratchets to error when " +
-        "backends contribute their own checks through the registry and " +
-        "doctor composes whatever is bound. NOTE: every violating edge is " +
-        "an `await import()` inside a try block, so there is no load-order " +
-        "or bundle coupling here and nothing is paid when doctor is not " +
-        "run; the cost is purely that adding a backend does not add its " +
-        "checks. Kept visible rather than silenced with dependencyTypesNot " +
-        "for exactly that reason. Do not add new probes. ",
-      severity: "warn",
+        "DONE, now enforced: backends contribute their own checks through " +
+        "`BackendFactory.doctor` and doctor.ts composes whatever the " +
+        "registry holds — it names no backend and imports none. The rule " +
+        "stays as an error so a probe can't creep back into core: a new " +
+        "backend gets doctor coverage by implementing the slot, not by " +
+        "teaching doctor about itself.",
+      severity: "error",
       from: { path: "^src/core/doctor\\.ts$" },
       to: { path: "^src/backend/" },
     },

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -198,10 +198,15 @@ keep OpenAI-compatible endpoint credentials without hijacking Codex.
 2. The factory's `init` is called once at startup and returns a
    `Backend` composed via `composeBackend(...)`. Wire in as many of
    the capability slots as your SDK supports; `core/` falls back
-   gracefully when a slot is missing.
+   gracefully when a slot is missing. Implement `doctor(config,
+   isActive)` too — `talon doctor` composes each backend's own binary /
+   auth / catalog checks off the registry and knows nothing about any
+   backend itself, so a factory without the slot is reported as having
+   nothing to check.
 
-3. Add `await import("./backend/<name>/factory.js");` to
-   `bootstrap.ts`'s factory-loading block.
+3. Add `await import("./<name>/factory.js");` to
+   `backend/builtins.ts` — the one list bootstrap, `talon doctor`, and
+   the registry tests all load.
 
 4. Add `"<name>"` to the `backend` enum in
    `src/util/config.ts` so config validation accepts it.

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import {
   checkNativeModules,
@@ -39,6 +39,13 @@ describe("checkNativeModules", () => {
 });
 
 describe("collectDoctorReport", () => {
+  // Backend checks come from the factories' own doctor slots, so the
+  // registry has to hold them — exactly what `talon doctor` does.
+  beforeAll(async () => {
+    const { loadBuiltinBackends } = await import("../backend/builtins.js");
+    await loadBuiltinBackends();
+  });
+
   it("fails the config check when no config file exists", async () => {
     const report = await collectDoctorReport({ hasConfigFile: false });
     const labels = report.checks.map((c) => c.label);

--- a/src/__tests__/model-drift.test.ts
+++ b/src/__tests__/model-drift.test.ts
@@ -10,7 +10,7 @@
  * accounting lines.
  */
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { beforeAll, describe, it, expect, beforeEach, vi } from "vitest";
 
 const logWarnMock = vi.fn();
 vi.mock("../util/log.js", () => ({
@@ -253,6 +253,13 @@ describe("checkModelDrift", () => {
 });
 
 describe("doctor configured-model check (claude static catalog)", () => {
+  // The model probe lives in the claude-sdk factory's doctor slot, so the
+  // registry has to hold the builtins — exactly what `talon doctor` does.
+  beforeAll(async () => {
+    const { loadBuiltinBackends } = await import("../backend/builtins.js");
+    await loadBuiltinBackends();
+  });
+
   it("flags an unselectable pinned model as a warn-with-issue", async () => {
     const { collectDoctorReport } = await import("../core/doctor.js");
     const report = await collectDoctorReport({

--- a/src/backend/builtins.ts
+++ b/src/backend/builtins.ts
@@ -1,0 +1,16 @@
+/**
+ * Register every built-in backend with the registry.
+ *
+ * Each backend's `factory.ts` calls `registerBackend` as a side effect of
+ * being imported, so "loading" is importing. One list, used by the
+ * daemon's bootstrap, by `talon doctor` (which runs standalone and needs
+ * the factories' doctor checks), and by tests that exercise the registry.
+ * Adding a backend is adding a line here.
+ */
+export async function loadBuiltinBackends(): Promise<void> {
+  await import("./claude-sdk/factory.js");
+  await import("./opencode/factory.js");
+  await import("./kilo/factory.js");
+  await import("./codex/factory.js");
+  await import("./openai-agents/factory.js");
+}

--- a/src/backend/claude-sdk/doctor.ts
+++ b/src/backend/claude-sdk/doctor.ts
@@ -1,0 +1,108 @@
+/**
+ * `talon doctor` checks for the Claude SDK backend: the CLI binary, and —
+ * only for the backend actually serving chats, since it spawns a probe —
+ * the models pinned in config against the static catalog.
+ */
+
+import type {
+  DoctorCheck,
+  DoctorConfigSlice,
+} from "../../core/doctor-types.js";
+import { getModels } from "../../core/models/catalog.js";
+import { binaryOnPath } from "../../util/binary-on-path.js";
+import { resolveModel } from "./model-provider.js";
+import { registerClaudeModelsStatic } from "./models/discovery.js";
+import { CLAUDE_MODELS_STATIC } from "./models/static.js";
+
+export async function claudeDoctorChecks(
+  config: DoctorConfigSlice | undefined,
+  isActive: boolean,
+): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+  if (config?.claudeBinary) {
+    checks.push(
+      binaryOnPath(config.claudeBinary)
+        ? {
+            label: "Claude Code binary",
+            status: "ok",
+            detail: config.claudeBinary,
+          }
+        : {
+            label: "Claude Code binary not found",
+            status: "fail",
+            detail: config.claudeBinary,
+          },
+    );
+  } else {
+    checks.push(
+      binaryOnPath("claude")
+        ? { label: "Claude Code installed", status: "ok" }
+        : { label: "Claude Code not found", status: "fail" },
+    );
+  }
+  // Model resolution spawns a probe — worth it for the backend actually
+  // serving chats, wasteful for one nobody is using.
+  if (isActive) checks.push(...(await checkConfiguredModels(config)));
+  return checks;
+}
+
+/**
+ * Validate models pinned in config against the static catalog. A model
+ * that has been withdrawn from the catalog (it happens: deprecations,
+ * policy pulls) makes every turn silently run the backend default while
+ * the config keeps naming the dead id — this check is where that finally
+ * becomes visible. Claude-only: this catalog is a static import; other
+ * backends need a live server and are audited at boot instead
+ * (core/engine/model-audit.ts).
+ */
+async function checkConfiguredModels(
+  config: DoctorConfigSlice | undefined,
+): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+  const targets: Array<{ key: string; model?: string; backendId?: string }> = [
+    { key: "model", model: config?.model, backendId: config?.backend },
+    {
+      key: "heartbeatModel",
+      model: config?.heartbeatModel,
+      backendId: config?.heartbeatBackend ?? config?.backend,
+    },
+  ];
+  try {
+    // Doctor runs standalone — live SDK model discovery hasn't happened,
+    // so the registry may be empty. Seed the static catalog (the same
+    // list the setup wizard offers) so alias pins like "opus" resolve.
+    // The static list is a snapshot: a model can exist upstream and not
+    // here, which is why findings are warn-level, never fail.
+    if (getModels("anthropic").length === 0) {
+      registerClaudeModelsStatic(CLAUDE_MODELS_STATIC);
+    }
+    for (const { key, model, backendId } of targets) {
+      if (!model || model === "default") continue;
+      if ((backendId ?? "claude") !== "claude") continue;
+      const res = await resolveModel(model);
+      if (res.kind === "exact") {
+        checks.push({
+          label: `Model (${key}): ${model} → ${res.model.displayName}`,
+          status: "ok",
+        });
+      } else if (res.kind === "ambiguous") {
+        checks.push({
+          label: `Model (${key}): "${model}" is ambiguous`,
+          status: "warn",
+          detail: res.matches.map((m) => m.displayName).join(", "),
+          issue: true,
+        });
+      } else {
+        checks.push({
+          label: `Model (${key}): "${model}" not selectable on claude`,
+          status: "warn",
+          detail: "turns silently run the backend default — update config.json",
+          issue: true,
+        });
+      }
+    }
+  } catch {
+    /* catalog unavailable — skip, never break doctor */
+  }
+  return checks;
+}

--- a/src/backend/claude-sdk/factory.ts
+++ b/src/backend/claude-sdk/factory.ts
@@ -43,6 +43,7 @@ import {
 import { waitForMcpServersReady } from "./mcp-ready.js";
 
 import * as modelProvider from "./model-provider.js";
+import { claudeDoctorChecks } from "./doctor.js";
 
 const claudeSdkFactory: BackendFactory = {
   // The config schema uses `"claude"` for backward compatibility with
@@ -50,6 +51,7 @@ const claudeSdkFactory: BackendFactory = {
   // no migration is needed.
   id: "claude",
   label: "Anthropic",
+  doctor: (config, isActive) => claudeDoctorChecks(config, isActive),
 
   async init(config, ctx) {
     await initClaudeAgent(config, ctx.getBridgePort);

--- a/src/backend/codex/doctor.ts
+++ b/src/backend/codex/doctor.ts
@@ -1,0 +1,50 @@
+/**
+ * `talon doctor` checks for the Codex backend: the CLI binary and how it
+ * will authenticate.
+ */
+
+import type {
+  DoctorCheck,
+  DoctorConfigSlice,
+} from "../../core/doctor-types.js";
+import { binaryOnPath } from "../../util/binary-on-path.js";
+import { detectCodexAuth } from "./auth.js";
+
+export async function codexDoctorChecks(
+  config: DoctorConfigSlice | undefined,
+): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+  if (!binaryOnPath("codex")) {
+    checks.push({
+      label: "Codex CLI not found",
+      status: "fail",
+      detail: "npm i -g @openai/codex",
+    });
+    return checks;
+  }
+  checks.push({ label: "Codex CLI installed", status: "ok" });
+  const auth = detectCodexAuth({
+    codexApiKey: config?.codexApiKey,
+    openaiApiKey: config?.openaiApiKey,
+    openaiBaseUrl: config?.openaiBaseUrl,
+  });
+  for (const diagnostic of auth.diagnostics) {
+    checks.push({ label: diagnostic, status: "warn" });
+  }
+  if (auth.mode !== "none") {
+    checks.push({
+      label: "Codex auth",
+      status: "ok",
+      detail: auth.baseUrl ? `${auth.source} (${auth.baseUrl})` : auth.source,
+    });
+  } else {
+    checks.push({
+      label: "Codex auth missing",
+      status: "warn",
+      detail:
+        "set CODEX_API_KEY, TALON_CODEX_KEY, codexApiKey, or run `codex login`",
+      issue: true,
+    });
+  }
+  return checks;
+}

--- a/src/backend/codex/factory.ts
+++ b/src/backend/codex/factory.ts
@@ -7,6 +7,7 @@
  */
 
 import { registerBackend } from "../../core/agent-runtime/backend-registry.js";
+import { codexDoctorChecks } from "./doctor.js";
 import type { BackendFactory } from "../../core/agent-runtime/backend-registry.js";
 import { log } from "../../util/log.js";
 import { handlerToEvents } from "../shared/handler-to-events.js";
@@ -41,6 +42,7 @@ import {
 const codexFactory: BackendFactory = {
   id: "codex",
   label: "Codex",
+  doctor: (config) => codexDoctorChecks(config),
 
   async init(config, ctx) {
     initCodexAgent(config, ctx.getBridgePort, ctx.frontendName);

--- a/src/backend/openai-agents/doctor.ts
+++ b/src/backend/openai-agents/doctor.ts
@@ -1,0 +1,51 @@
+/**
+ * `talon doctor` checks for the OpenAI Agents backend: the SDK is bundled,
+ * so this is about the API key and which endpoint it will talk to.
+ */
+
+import type {
+  DoctorCheck,
+  DoctorConfigSlice,
+} from "../../core/doctor-types.js";
+
+export async function openAIAgentsDoctorChecks(
+  config: DoctorConfigSlice | undefined,
+): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [
+    { label: "OpenAI Agents SDK bundled", status: "ok" },
+  ];
+  const hasEnvKey = Boolean(process.env.OPENAI_API_KEY);
+  const hasCfgKey = Boolean(config?.openaiApiKey);
+  if (hasEnvKey || hasCfgKey) {
+    const sources: string[] = [];
+    if (hasEnvKey) sources.push("OPENAI_API_KEY env");
+    if (hasCfgKey) sources.push("openaiApiKey in talon.json");
+    checks.push({
+      label: "OpenAI Agents auth",
+      status: "ok",
+      detail: sources.join(", "),
+    });
+  } else {
+    checks.push({
+      label: "OpenAI Agents auth missing",
+      status: "warn",
+      detail: "set OPENAI_API_KEY or openaiApiKey in talon.json",
+      issue: true,
+    });
+  }
+  const envBase = process.env.OPENAI_BASE_URL;
+  const cfgBase = config?.openaiBaseUrl;
+  if (envBase || cfgBase) {
+    checks.push({
+      label: "OpenAI-compatible endpoint",
+      status: "ok",
+      detail: envBase ? `env (${envBase})` : `config (${cfgBase})`,
+    });
+  } else {
+    checks.push({
+      label: "Endpoint: api.openai.com (default)",
+      status: "info",
+    });
+  }
+  return checks;
+}

--- a/src/backend/openai-agents/factory.ts
+++ b/src/backend/openai-agents/factory.ts
@@ -10,6 +10,7 @@
  */
 
 import { registerBackend } from "../../core/agent-runtime/backend-registry.js";
+import { openAIAgentsDoctorChecks } from "./doctor.js";
 import type { BackendFactory } from "../../core/agent-runtime/backend-registry.js";
 import { log } from "../../util/log.js";
 import { handlerToEvents } from "../shared/handler-to-events.js";
@@ -39,6 +40,7 @@ import {
 const openAIAgentsFactory: BackendFactory = {
   id: "openai-agents",
   label: "OpenAI Agents",
+  doctor: (config) => openAIAgentsDoctorChecks(config),
 
   async init(config, ctx) {
     initOpenAIAgentsAgent(config, ctx.getBridgePort, ctx.frontendName);

--- a/src/backend/remote-server/factory.ts
+++ b/src/backend/remote-server/factory.ts
@@ -26,6 +26,7 @@ import {
 } from "../../core/agent-runtime/capabilities.js";
 import type { OneShotAgentParams, OneShotUsage } from "../../core/types.js";
 import type { TalonConfig } from "../../util/config.js";
+import { binaryOnPath } from "../../util/binary-on-path.js";
 import { log } from "../../util/log.js";
 import { handlerToEvents } from "../shared/handler-to-events.js";
 import type { QueryParams, QueryResult } from "../shared/handler-types.js";
@@ -64,6 +65,22 @@ export function createRemoteBackendFactory(
   return {
     id,
     label,
+    // The SDK ships as an npm dep but only talks to a server it spawns from
+    // the CLI of the same name (`cross-spawn` → PATH lookup). A present
+    // package with an absent binary fails at the first turn with a bare
+    // ENOENT, so doctor checks what actually gets executed.
+    async doctor() {
+      return [
+        binaryOnPath(id)
+          ? { label: `${label} CLI installed`, status: "ok" }
+          : {
+              label: `${label} CLI not found`,
+              status: "fail",
+              detail: `the ${label} SDK spawns \`${id}\` — install it or this backend cannot start`,
+              issue: true,
+            },
+      ];
+    },
     async init(config, ctx) {
       inputs.init(config, ctx.getBridgePort, ctx.frontendName);
       log("bot", `Backend: ${label} (${inputs.sdkPackage})`);

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -171,14 +171,11 @@ export async function initBackendAndDispatcher(
 ): Promise<BackendAndDispatcherResult> {
   const frontends = normalizeFrontends(frontend);
 
-  // Register all built-in backends via side-effect import. Adding a new
-  // backend is now strictly additive: drop a `factory.ts` under the new
-  // backend dir and import it here. No conditionals here change.
-  await import("./backend/claude-sdk/factory.js");
-  await import("./backend/opencode/factory.js");
-  await import("./backend/kilo/factory.js");
-  await import("./backend/codex/factory.js");
-  await import("./backend/openai-agents/factory.js");
+  // Register all built-in backends. Adding a new backend is strictly
+  // additive: drop a `factory.ts` under the new backend dir and list it in
+  // backend/builtins.ts. No conditionals here change.
+  const { loadBuiltinBackends } = await import("./backend/builtins.js");
+  await loadBuiltinBackends();
 
   const {
     initBackendPool,

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -20,6 +20,10 @@ export async function runDoctor(): Promise<void> {
   printBanner();
   console.log(`  ${pc.bold("Environment check")}\n`);
   const { collectDoctorReport } = await import("../core/doctor.js");
+  // Doctor composes each backend's own checks off the registry, and the
+  // CLI runs standalone — nothing else has registered them yet.
+  const { loadBuiltinBackends } = await import("../backend/builtins.js");
+  await loadBuiltinBackends();
   const hasConfigFile = existsSync(CONFIG_FILE);
   const report = await collectDoctorReport({
     config: hasConfigFile ? loadConfig() : undefined,

--- a/src/core/agent-runtime/backend-registry.ts
+++ b/src/core/agent-runtime/backend-registry.ts
@@ -30,6 +30,7 @@
  */
 
 import type { Backend } from "./capabilities.js";
+import type { DoctorCheck, DoctorConfigSlice } from "../doctor-types.js";
 import type { TalonConfig } from "../../util/config.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -77,6 +78,17 @@ export interface BackendFactory {
   label: string;
   /** Initialise the backend; called exactly once per Talon process. */
   init(config: TalonConfig, ctx: BackendInitContext): Promise<BackendInstance>;
+  /**
+   * `talon doctor` checks for this backend — binary, auth, catalog probes.
+   * `isActive` is true for the backend serving chats; probes that cost a
+   * process spawn (model resolution) should run only then. Doctor composes
+   * whatever is registered, so a backend without this slot is reported as
+   * having nothing to check rather than silently skipped.
+   */
+  doctor?(
+    config: DoctorConfigSlice | undefined,
+    isActive: boolean,
+  ): Promise<DoctorCheck[]>;
 }
 
 // ── State ───────────────────────────────────────────────────────────────────

--- a/src/core/doctor-types.ts
+++ b/src/core/doctor-types.ts
@@ -1,0 +1,82 @@
+/**
+ * The doctor's data shapes, on their own so a backend factory can declare
+ * its checks (`BackendFactory.doctor`) without importing the collector —
+ * `core/doctor.ts` reads the registry, so the types living there would
+ * close a cycle. Checks are pure data (label / status / detail); renderers
+ * decide presentation.
+ */
+
+type DoctorStatus = "ok" | "warn" | "fail" | "info";
+
+export interface DoctorCheck {
+  label: string;
+  status: DoctorStatus;
+  detail?: string;
+  /**
+   * Counts toward the issue total even when status is "warn" — used
+   * for soft failures like missing backend auth where the bot still
+   * starts but a backend won't work.
+   */
+  issue?: boolean;
+  /**
+   * A backend that is configured but not serving chats. Renderers group
+   * these away from the environment so a handful of idle providers can't
+   * bury the checks that describe the running deployment.
+   */
+  inactive?: boolean;
+}
+
+/** One embedded native module: provenance plus a live self-test result. */
+export interface NativeModuleCheck {
+  name: string;
+  /** Source language ("Rust", "Zig", "C", "C++", "Gleam"). */
+  language: string;
+  /** Compile target ("wasm32-unknown-unknown", "wasm32-freestanding", "JavaScript"). */
+  target: string;
+  /** Embedded artifact size, when the module ships as wasm bytes. */
+  sizeBytes?: number;
+  ok: boolean;
+  /** Failure detail when !ok. */
+  note?: string;
+}
+
+export interface DoctorReport {
+  checks: DoctorCheck[];
+  native: NativeModuleCheck[];
+  /** Failed checks + warn-with-issue checks + failed native modules. */
+  issues: number;
+}
+
+/**
+ * The slice of config doctor reads. Both the CLI's local Config and
+ * TalonConfig satisfy this structurally.
+ */
+export interface DoctorConfigSlice {
+  frontend: string | string[];
+  backend?: string;
+  /** Backends config exposes. Empty / absent means every registered one. */
+  enabledBackends?: string[];
+  model?: string;
+  heartbeatModel?: string;
+  heartbeatBackend?: string;
+  botToken?: string;
+  teamsWebhookUrl?: string;
+  discord?: { botToken?: string };
+  whatsapp?: object;
+  claudeBinary?: string;
+  codexApiKey?: string;
+  openaiApiKey?: string;
+  openaiBaseUrl?: string;
+  mempalace?: {
+    enabled?: boolean;
+    pythonPath?: string;
+    version?: string;
+  };
+  playwright?: {
+    enabled?: boolean;
+    browser?: string;
+    endpoint?: string;
+    endpointFile?: string;
+  };
+  github?: { enabled?: boolean; imageTag?: string };
+}

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -13,84 +13,22 @@
 
 import { existsSync } from "node:fs";
 import { stat } from "node:fs/promises";
-import { execFileSync } from "node:child_process";
 import { NATIVE_MODULES } from "../native/registry.js";
 import { dirs } from "../util/paths.js";
+import { getBackend, listBackends } from "./agent-runtime/backend-registry.js";
+import type {
+  DoctorCheck,
+  DoctorConfigSlice,
+  DoctorReport,
+  NativeModuleCheck,
+} from "./doctor-types.js";
 
-type DoctorStatus = "ok" | "warn" | "fail" | "info";
-
-export interface DoctorCheck {
-  label: string;
-  status: DoctorStatus;
-  detail?: string;
-  /**
-   * Counts toward the issue total even when status is "warn" — used
-   * for soft failures like missing backend auth where the bot still
-   * starts but a backend won't work.
-   */
-  issue?: boolean;
-  /**
-   * A backend that is configured but not serving chats. Renderers group
-   * these away from the environment so a handful of idle providers can't
-   * bury the checks that describe the running deployment.
-   */
-  inactive?: boolean;
-}
-
-/** One embedded native module: provenance plus a live self-test result. */
-export interface NativeModuleCheck {
-  name: string;
-  /** Source language ("Rust", "Zig", "C", "C++", "Gleam"). */
-  language: string;
-  /** Compile target ("wasm32-unknown-unknown", "wasm32-freestanding", "JavaScript"). */
-  target: string;
-  /** Embedded artifact size, when the module ships as wasm bytes. */
-  sizeBytes?: number;
-  ok: boolean;
-  /** Failure detail when !ok. */
-  note?: string;
-}
-
-export interface DoctorReport {
-  checks: DoctorCheck[];
-  native: NativeModuleCheck[];
-  /** Failed checks + warn-with-issue checks + failed native modules. */
-  issues: number;
-}
-
-/**
- * The slice of config doctor reads. Both the CLI's local Config and
- * TalonConfig satisfy this structurally.
- */
-export interface DoctorConfigSlice {
-  frontend: string | string[];
-  backend?: string;
-  /** Backends config exposes. Empty / absent means every registered one. */
-  enabledBackends?: string[];
-  model?: string;
-  heartbeatModel?: string;
-  heartbeatBackend?: string;
-  botToken?: string;
-  teamsWebhookUrl?: string;
-  discord?: { botToken?: string };
-  whatsapp?: object;
-  claudeBinary?: string;
-  codexApiKey?: string;
-  openaiApiKey?: string;
-  openaiBaseUrl?: string;
-  mempalace?: {
-    enabled?: boolean;
-    pythonPath?: string;
-    version?: string;
-  };
-  playwright?: {
-    enabled?: boolean;
-    browser?: string;
-    endpoint?: string;
-    endpointFile?: string;
-  };
-  github?: { enabled?: boolean; imageTag?: string };
-}
+export type {
+  DoctorCheck,
+  DoctorConfigSlice,
+  DoctorReport,
+  NativeModuleCheck,
+} from "./doctor-types.js";
 
 function errorNote(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -230,85 +168,6 @@ async function checkNamespaceDir(): Promise<DoctorCheck> {
   };
 }
 
-function binaryOnPath(name: string): boolean {
-  try {
-    const lookupCmd = process.platform === "win32" ? "where" : "which";
-    execFileSync(lookupCmd, [name], { stdio: "pipe" });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Validate models pinned in config against the Claude backend's static
- * catalog. A model that has been withdrawn from the catalog (it
- * happens: deprecations, policy pulls) makes every turn silently run
- * the backend default while the config keeps naming the dead id —
- * this check is where that finally becomes visible. Claude-only: this
- * catalog is a static import; other backends need a live server and
- * are audited at boot instead (core/engine/model-audit.ts).
- */
-async function checkClaudeConfiguredModels(
-  config: DoctorConfigSlice | undefined,
-): Promise<DoctorCheck[]> {
-  const checks: DoctorCheck[] = [];
-  const targets: Array<{ key: string; model?: string; backendId?: string }> = [
-    { key: "model", model: config?.model, backendId: config?.backend },
-    {
-      key: "heartbeatModel",
-      model: config?.heartbeatModel,
-      backendId: config?.heartbeatBackend ?? config?.backend,
-    },
-  ];
-  try {
-    const { resolveModel } =
-      await import("../backend/claude-sdk/model-provider.js");
-    // Doctor runs standalone — live SDK model discovery hasn't happened,
-    // so the registry may be empty. Seed the static catalog (the same
-    // list the setup wizard offers) so alias pins like "opus" resolve.
-    // The static list is a snapshot: a model can exist upstream and not
-    // here, which is why findings are warn-level, never fail.
-    const { getModels } = await import("./models/catalog.js");
-    if (getModels("anthropic").length === 0) {
-      const [{ registerClaudeModelsStatic }, { CLAUDE_MODELS_STATIC }] =
-        await Promise.all([
-          import("../backend/claude-sdk/models/discovery.js"),
-          import("../backend/claude-sdk/models/static.js"),
-        ]);
-      registerClaudeModelsStatic(CLAUDE_MODELS_STATIC);
-    }
-    for (const { key, model, backendId } of targets) {
-      if (!model || model === "default") continue;
-      if ((backendId ?? "claude") !== "claude") continue;
-      const res = await resolveModel(model);
-      if (res.kind === "exact") {
-        checks.push({
-          label: `Model (${key}): ${model} → ${res.model.displayName}`,
-          status: "ok",
-        });
-      } else if (res.kind === "ambiguous") {
-        checks.push({
-          label: `Model (${key}): "${model}" is ambiguous`,
-          status: "warn",
-          detail: res.matches.map((m) => m.displayName).join(", "),
-          issue: true,
-        });
-      } else {
-        checks.push({
-          label: `Model (${key}): "${model}" not selectable on claude`,
-          status: "warn",
-          detail: "turns silently run the backend default — update config.json",
-          issue: true,
-        });
-      }
-    }
-  } catch {
-    /* catalog unavailable — skip, never break doctor */
-  }
-  return checks;
-}
-
 /**
  * Native plugin runtimes (MemPalace's venv, Playwright's browser build,
  * GitHub's Docker image) — the artifacts the provisioners own. The
@@ -337,17 +196,12 @@ async function checkPluginRuntimes(
   return checks;
 }
 
-/** Every backend id doctor knows how to inspect. */
-const KNOWN_BACKENDS = [
-  "claude",
-  "codex",
-  "kilo",
-  "opencode",
-  "openai-agents",
-] as const;
-
 /**
- * Binary / auth checks across every backend the config exposes.
+ * Binary / auth checks across every backend the config exposes, each
+ * supplied by its own factory (`BackendFactory.doctor`) — doctor composes
+ * whatever is registered and hardcodes nothing about any backend. The
+ * caller must have loaded the factories (`loadBuiltinBackends`); an active
+ * backend that is not registered is reported as such, loudly.
  *
  * Only the active one counts toward the issue total; the rest are reported
  * so a switch doesn't have to be the thing that discovers a backend can't
@@ -361,11 +215,11 @@ async function checkBackend(
   const active = config?.backend ?? "claude";
   const exposed = config?.enabledBackends?.length
     ? config.enabledBackends
-    : [...KNOWN_BACKENDS];
+    : listBackends().map((b) => b.id);
 
   const checks = await checkOneBackend(active, config, true);
   for (const id of exposed) {
-    if (id === active || !KNOWN_BACKENDS.includes(id as never)) continue;
+    if (id === active || !getBackend(id)) continue;
     // An idle backend's missing binary is a heads-up, not a fault of this
     // deployment: downgrade it and keep it out of the issue count.
     for (const check of await checkOneBackend(id, config, false)) {
@@ -385,121 +239,35 @@ async function checkOneBackend(
   config: DoctorConfigSlice | undefined,
   isActive: boolean,
 ): Promise<DoctorCheck[]> {
-  const checks: DoctorCheck[] = [];
-
-  if (backend === "claude") {
-    if (config?.claudeBinary) {
-      checks.push(
-        binaryOnPath(config.claudeBinary)
-          ? {
-              label: "Claude Code binary",
-              status: "ok",
-              detail: config.claudeBinary,
-            }
-          : {
-              label: "Claude Code binary not found",
-              status: "fail",
-              detail: config.claudeBinary,
-            },
-      );
-    } else {
-      checks.push(
-        binaryOnPath("claude")
-          ? { label: "Claude Code installed", status: "ok" }
-          : { label: "Claude Code not found", status: "fail" },
-      );
-    }
-    // Model resolution spawns a probe — worth it for the backend actually
-    // serving chats, wasteful for one nobody is using.
-    if (isActive) checks.push(...(await checkClaudeConfiguredModels(config)));
-  } else if (backend === "codex") {
-    if (!binaryOnPath("codex")) {
-      checks.push({
-        label: "Codex CLI not found",
+  const factory = getBackend(backend);
+  if (!factory) {
+    const known = listBackends().map((b) => b.id);
+    return [
+      {
+        label: `Backend "${backend}" is not registered`,
         status: "fail",
-        detail: "npm i -g @openai/codex",
-      });
-      return checks;
-    }
-    checks.push({ label: "Codex CLI installed", status: "ok" });
-    const { detectCodexAuth } = await import("../backend/codex/auth.js");
-    const auth = detectCodexAuth({
-      codexApiKey: config?.codexApiKey,
-      openaiApiKey: config?.openaiApiKey,
-      openaiBaseUrl: config?.openaiBaseUrl,
-    });
-    for (const diagnostic of auth.diagnostics) {
-      checks.push({ label: diagnostic, status: "warn" });
-    }
-    if (auth.mode !== "none") {
-      checks.push({
-        label: "Codex auth",
-        status: "ok",
-        detail: auth.baseUrl ? `${auth.source} (${auth.baseUrl})` : auth.source,
-      });
-    } else {
-      checks.push({
-        label: "Codex auth missing",
-        status: "warn",
-        detail:
-          "set CODEX_API_KEY, TALON_CODEX_KEY, codexApiKey, or run `codex login`",
+        detail: known.length
+          ? `known: ${known.join(", ")}`
+          : "no backends loaded — call loadBuiltinBackends() first",
         issue: true,
-      });
-    }
-  } else if (backend === "kilo" || backend === "opencode") {
-    // The SDK ships as an npm dep but only talks to a server it spawns from
-    // the CLI of the same name (`cross-spawn` → PATH lookup). A present
-    // package with an absent binary fails at the first turn with a bare
-    // ENOENT, so check what actually gets executed.
-    const label = backend === "kilo" ? "Kilo" : "OpenCode";
-    checks.push(
-      binaryOnPath(backend)
-        ? { label: `${label} CLI installed`, status: "ok" }
-        : {
-            label: `${label} CLI not found`,
-            status: "fail",
-            detail: `the ${label} SDK spawns \`${backend}\` — install it or this backend cannot start`,
-            issue: true,
-          },
-    );
-  } else if (backend === "openai-agents") {
-    checks.push({ label: "OpenAI Agents SDK bundled", status: "ok" });
-    const hasEnvKey = Boolean(process.env.OPENAI_API_KEY);
-    const hasCfgKey = Boolean(config?.openaiApiKey);
-    if (hasEnvKey || hasCfgKey) {
-      const sources: string[] = [];
-      if (hasEnvKey) sources.push("OPENAI_API_KEY env");
-      if (hasCfgKey) sources.push("openaiApiKey in talon.json");
-      checks.push({
-        label: "OpenAI Agents auth",
-        status: "ok",
-        detail: sources.join(", "),
-      });
-    } else {
-      checks.push({
-        label: "OpenAI Agents auth missing",
-        status: "warn",
-        detail: "set OPENAI_API_KEY or openaiApiKey in talon.json",
-        issue: true,
-      });
-    }
-    const envBase = process.env.OPENAI_BASE_URL;
-    const cfgBase = config?.openaiBaseUrl;
-    if (envBase || cfgBase) {
-      checks.push({
-        label: "OpenAI-compatible endpoint",
-        status: "ok",
-        detail: envBase ? `env (${envBase})` : `config (${cfgBase})`,
-      });
-    } else {
-      checks.push({
-        label: "Endpoint: api.openai.com (default)",
-        status: "info",
-      });
-    }
+      },
+    ];
   }
-
-  return checks;
+  if (!factory.doctor) {
+    return [{ label: `${factory.label}: no doctor checks`, status: "info" }];
+  }
+  try {
+    return await factory.doctor(config, isActive);
+  } catch (err) {
+    return [
+      {
+        label: `${factory.label} doctor check errored`,
+        status: "warn",
+        detail: errorNote(err),
+        issue: isActive,
+      },
+    ];
+  }
 }
 
 /**

--- a/src/util/binary-on-path.ts
+++ b/src/util/binary-on-path.ts
@@ -1,0 +1,12 @@
+import { execFileSync } from "node:child_process";
+
+/** Whether `name` resolves on PATH (`which` / `where`), without running it. */
+export function binaryOnPath(name: string): boolean {
+  try {
+    const lookupCmd = process.platform === "win32" ? "where" : "which";
+    execFileSync(lookupCmd, [name], { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Item 6b of `docs/consolidation-plan.md` — the `doctor-probes-move-behind-registry` migration `.dependency-cruiser.cjs` has carried as a warning.

`core/doctor.ts` hardcoded the five backend ids and reached into `backend/claude-sdk` and `backend/codex` through dynamic imports for the model audit and auth detection. Adding a backend did not add its checks unless doctor was taught about it.

- **`BackendFactory.doctor?(config, isActive)`** — each built-in supplies its own probes, moved verbatim: `claude-sdk/doctor.ts` (CLI binary + configured-model audit, active backend only), `codex/doctor.ts` (CLI + `detectCodexAuth`), `openai-agents/doctor.ts` (key source + endpoint), and the shared "SDK spawns a CLI of the same name" check in `remote-server/factory.ts` for Kilo and OpenCode.
- **`doctor.ts` composes the registry:** active backend in full; every other registered / config-exposed backend as `inactive` with failures downgraded; an active backend that is not registered is a `fail` naming the known ids; a factory without the slot is an `info` line rather than a silent skip; a throwing probe becomes a `warn` check instead of killing the report.
- **`core/doctor-types.ts`** holds the shared types so the registry can declare the slot without importing the collector (`doctor.ts` re-exports them). `binaryOnPath` → `util/binary-on-path.ts`.
- **`backend/builtins.ts`** — one `loadBuiltinBackends()` used by bootstrap, by `talon doctor` (standalone, so it must register them itself), and by `doctor.test.ts`.
- **depcruise rule ratcheted to `error`**: 594 modules, 0 errors; in-flight warnings 18 → 13.
- `docs/backends.md` "adding a backend" now says to implement the slot and list the factory in `builtins.ts`.

## Verification

`tsc`, `oxlint`, `knip`, `format:check`, `depcruise` clean; `doctor`, `backend-registry-parity`, and the cli/bootstrap/plugin suites pass (13 files, 195 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTCdGWRqXDhdd89dc3Cnnb